### PR TITLE
feat: Phase 8 — real wgpu surface rendering + Transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
 name = "bsengine-core"
 version = "0.1.0"
 dependencies = [
+ "bevy_ecs",
  "tracing",
  "tracing-subscriber",
 ]
@@ -500,6 +501,7 @@ dependencies = [
  "bsengine-ecs",
  "bsengine-rhi",
  "bsengine-rhi-wgpu",
+ "tracing",
 ]
 
 [[package]]
@@ -519,8 +521,12 @@ dependencies = [
  "bsengine-core",
  "bsengine-ecs",
  "bsengine-rhi",
+ "bsengine-window",
+ "bytemuck",
  "pollster",
+ "tracing",
  "wgpu",
+ "winit",
 ]
 
 [[package]]
@@ -574,6 +580,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "bytes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 winit             = "0.30"
 wgpu              = "22"
 pollster          = "0.3"
+bytemuck          = { version = "1", features = ["derive"] }

--- a/crates/bsengine-core/Cargo.toml
+++ b/crates/bsengine-core/Cargo.toml
@@ -6,3 +6,4 @@ edition.workspace = true
 [dependencies]
 tracing.workspace = true
 tracing-subscriber.workspace = true
+bevy_ecs.workspace = true

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod logging;
+pub mod transform;
 
 pub use logging::init_logging;
+pub use transform::Transform;

--- a/crates/bsengine-core/src/transform.rs
+++ b/crates/bsengine-core/src/transform.rs
@@ -1,0 +1,47 @@
+use bevy_ecs::prelude::Component;
+
+#[derive(Component, Debug, Clone, PartialEq)]
+pub struct Transform {
+    pub translation: [f32; 3],
+    pub rotation: [f32; 4],
+    pub scale: [f32; 3],
+}
+
+impl Default for Transform {
+    fn default() -> Self {
+        Self {
+            translation: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            scale: [1.0, 1.0, 1.0],
+        }
+    }
+}
+
+impl Transform {
+    pub fn from_translation(x: f32, y: f32, z: f32) -> Self {
+        Self {
+            translation: [x, y, z],
+            ..Self::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Transform;
+
+    #[test]
+    fn default_is_identity() {
+        let t = Transform::default();
+        assert_eq!(t.translation, [0.0, 0.0, 0.0]);
+        assert_eq!(t.rotation, [0.0, 0.0, 0.0, 1.0]);
+        assert_eq!(t.scale, [1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn from_translation_sets_position() {
+        let t = Transform::from_translation(1.0, 2.0, 3.0);
+        assert_eq!(t.translation, [1.0, 2.0, 3.0]);
+        assert_eq!(t.scale, [1.0, 1.0, 1.0]);
+    }
+}

--- a/crates/bsengine-render/Cargo.toml
+++ b/crates/bsengine-render/Cargo.toml
@@ -10,6 +10,7 @@ bsengine-rhi.workspace = true
 bsengine-rhi-wgpu.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 bsengine-app.workspace = true

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1,18 +1,19 @@
 use bevy_app::{App, Plugin, PostUpdate};
 use bsengine_ecs::Res;
-use bsengine_rhi_wgpu::RhiResource;
+use bsengine_rhi_wgpu::WgpuSurfaceResource;
 
-fn clear_pass(_rhi: Option<Res<RhiResource>>) {
-    let Some(_rhi) = _rhi else { return };
-    // Placeholder: real surface clear will be added in Phase 4
-    // when wgpu Surface is wired from the winit window handle.
+fn render_frame(surface: Option<Res<WgpuSurfaceResource>>) {
+    let Some(surface) = surface else { return };
+    if let Err(e) = surface.0.render_frame() {
+        tracing::warn!("render_frame error: {e}");
+    }
 }
 
 pub struct RenderPlugin;
 
 impl Plugin for RenderPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PostUpdate, clear_pass);
+        app.add_systems(PostUpdate, render_frame);
     }
 }
 
@@ -24,14 +25,13 @@ mod tests {
 
     #[test]
     fn render_plugin_runs_without_rhi() {
-        // RenderPlugin must not panic when RhiResource is absent
         let mut app = new_app();
         app.add_plugins(RenderPlugin);
         app.update();
     }
 
     #[test]
-    fn render_plugin_runs_with_rhi() {
+    fn render_plugin_runs_with_rhi_headless() {
         let mut app = new_app();
         app.add_plugins(WgpuRHIPlugin);
         app.add_plugins(RenderPlugin);

--- a/crates/bsengine-rhi-wgpu/Cargo.toml
+++ b/crates/bsengine-rhi-wgpu/Cargo.toml
@@ -7,10 +7,14 @@ edition.workspace = true
 bsengine-core.workspace = true
 bsengine-ecs.workspace = true
 bsengine-rhi.workspace = true
+bsengine-window.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 wgpu.workspace = true
+winit.workspace = true
+bytemuck.workspace = true
 pollster.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 bsengine-app.workspace = true

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod plugin;
 pub mod rhi;
+pub mod surface;
 pub use plugin::{RhiResource, WgpuRHIPlugin};
 pub use rhi::WgpuRHI;
+pub use surface::WgpuSurfaceResource;

--- a/crates/bsengine-rhi-wgpu/src/plugin.rs
+++ b/crates/bsengine-rhi-wgpu/src/plugin.rs
@@ -1,7 +1,10 @@
 use crate::rhi::WgpuRHI;
-use bevy_app::{App, Plugin};
+use crate::surface::{WgpuSurface, WgpuSurfaceResource};
+use bevy_app::{App, Plugin, Startup, Update};
+use bevy_ecs::prelude::{EventReader, ResMut, World};
 use bsengine_ecs::Resource;
 use bsengine_rhi::RHI;
+use bsengine_window::{WindowHandle, WindowResized};
 use std::sync::Arc;
 
 #[derive(Resource)]
@@ -14,6 +17,37 @@ impl Plugin for WgpuRHIPlugin {
         let rhi =
             pollster::block_on(WgpuRHI::new_headless()).expect("Failed to initialize WgpuRHI");
         app.insert_resource(RhiResource(Arc::new(rhi)));
+        app.add_event::<WindowResized>();
+        app.add_systems(Startup, create_surface_system);
+        app.add_systems(Update, handle_window_resize);
+    }
+}
+
+fn create_surface_system(world: &mut World) {
+    let handle = world.get_resource::<WindowHandle>().cloned();
+    if let Some(handle) = handle {
+        match pollster::block_on(WgpuSurface::new(handle.0)) {
+            Ok(surface) => {
+                world.insert_resource(WgpuSurfaceResource(surface));
+                tracing::info!("wgpu surface ready");
+            }
+            Err(e) => {
+                tracing::warn!("wgpu surface not created: {e}");
+            }
+        }
+    }
+}
+
+fn handle_window_resize(
+    mut events: EventReader<WindowResized>,
+    surface: Option<ResMut<WgpuSurfaceResource>>,
+) {
+    let Some(mut surface) = surface else {
+        for _ in events.read() {}
+        return;
+    };
+    for ev in events.read() {
+        surface.0.resize(ev.width, ev.height);
     }
 }
 

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1,0 +1,249 @@
+use bsengine_ecs::Resource;
+use std::sync::Arc;
+use wgpu::util::DeviceExt;
+
+const TRIANGLE_WGSL: &str = r#"
+struct VertIn {
+    @location(0) pos: vec2<f32>,
+    @location(1) col: vec3<f32>,
+}
+struct VertOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) col: vec3<f32>,
+}
+@vertex
+fn vs_main(in: VertIn) -> VertOut {
+    var out: VertOut;
+    out.clip_pos = vec4<f32>(in.pos, 0.0, 1.0);
+    out.col = in.col;
+    return out;
+}
+@fragment
+fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
+    return vec4<f32>(in.col, 1.0);
+}
+"#;
+
+// NDC triangle: top red, bottom-left green, bottom-right blue
+#[rustfmt::skip]
+const TRIANGLE_VERTS: &[f32] = &[
+     0.0,  0.5,  1.0, 0.0, 0.0,
+    -0.5, -0.5,  0.0, 1.0, 0.0,
+     0.5, -0.5,  0.0, 0.0, 1.0,
+];
+
+const VERT_STRIDE: u64 = 5 * 4;
+
+pub struct WgpuSurface {
+    _window: Arc<winit::window::Window>,
+    surface: wgpu::Surface<'static>,
+    config: wgpu::SurfaceConfiguration,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+}
+
+impl WgpuSurface {
+    pub async fn new(window: Arc<winit::window::Window>) -> Result<Self, String> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+
+        let surface = instance
+            .create_surface(window.clone())
+            .map_err(|e| e.to_string())?;
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::None,
+                compatible_surface: Some(&surface),
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok_or("No adapter found compatible with surface")?;
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("BSEngine surface device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::downlevel_defaults(),
+                    memory_hints: wgpu::MemoryHints::default(),
+                },
+                None,
+            )
+            .await
+            .map_err(|e| format!("Device request failed: {e}"))?;
+
+        let size = window.inner_size();
+        let caps = surface.get_capabilities(&adapter);
+        let format = caps
+            .formats
+            .iter()
+            .copied()
+            .find(|f| f.is_srgb())
+            .unwrap_or(caps.formats[0]);
+
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width: size.width.max(1),
+            height: size.height.max(1),
+            present_mode: wgpu::PresentMode::Fifo,
+            alpha_mode: caps.alpha_modes[0],
+            view_formats: vec![],
+            desired_maximum_frame_latency: 2,
+        };
+        surface.configure(&device, &config);
+
+        let shader = Self::compile_shader(&device, TRIANGLE_WGSL);
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("triangle vbo"),
+            contents: bytemuck::cast_slice(TRIANGLE_VERTS),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("triangle layout"),
+            bind_group_layouts: &[],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("triangle pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: VERT_STRIDE,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x2,
+                            offset: 0,
+                            shader_location: 0,
+                        },
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x3,
+                            offset: 8,
+                            shader_location: 1,
+                        },
+                    ],
+                }],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        Ok(Self {
+            _window: window,
+            surface,
+            config,
+            device,
+            queue,
+            pipeline,
+            vertex_buffer,
+        })
+    }
+
+    pub fn compile_shader(device: &wgpu::Device, src: &str) -> wgpu::ShaderModule {
+        device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("wgsl shader"),
+            source: wgpu::ShaderSource::Wgsl(src.into()),
+        })
+    }
+
+    pub fn render_frame(&self) -> Result<(), String> {
+        let output = self
+            .surface
+            .get_current_texture()
+            .map_err(|e| e.to_string())?;
+        let view = output
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("render encoder"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("render pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.1,
+                            g: 0.1,
+                            b: 0.1,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+            pass.draw(0..3, 0..1);
+        }
+        self.queue.submit(std::iter::once(encoder.finish()));
+        output.present();
+        Ok(())
+    }
+
+    pub fn resize(&mut self, width: u32, height: u32) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        self.config.width = width;
+        self.config.height = height;
+        self.surface.configure(&self.device, &self.config);
+    }
+}
+
+#[derive(Resource)]
+pub struct WgpuSurfaceResource(pub WgpuSurface);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rhi::WgpuRHI;
+
+    #[test]
+    fn triangle_shader_compiles() {
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
+        let _module = WgpuSurface::compile_shader(&rhi.device, TRIANGLE_WGSL);
+    }
+
+    #[test]
+    fn triangle_vertex_data_has_three_verts() {
+        assert_eq!(TRIANGLE_VERTS.len(), 15);
+    }
+}

--- a/crates/bsengine-window/src/lib.rs
+++ b/crates/bsengine-window/src/lib.rs
@@ -3,4 +3,4 @@ pub mod runner;
 pub mod types;
 
 pub use plugin::WindowPlugin;
-pub use types::{WindowClosed, WindowCreated, WindowDescriptor, WindowResized};
+pub use types::{WindowClosed, WindowCreated, WindowDescriptor, WindowHandle, WindowResized};

--- a/crates/bsengine-window/src/runner.rs
+++ b/crates/bsengine-window/src/runner.rs
@@ -6,7 +6,7 @@ use winit::event::WindowEvent;
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::{Window, WindowId};
 
-use crate::types::{WindowClosed, WindowCreated, WindowDescriptor, WindowResized};
+use crate::types::{WindowClosed, WindowCreated, WindowDescriptor, WindowHandle, WindowResized};
 
 struct BsWinitApp {
     ecs_app: App,
@@ -36,6 +36,9 @@ impl ApplicationHandler for BsWinitApp {
                 .expect("Failed to create window"),
         );
         self.window = Some(window.clone());
+        self.ecs_app
+            .world_mut()
+            .insert_resource(WindowHandle(window.clone()));
         window.request_redraw();
 
         {

--- a/crates/bsengine-window/src/types.rs
+++ b/crates/bsengine-window/src/types.rs
@@ -1,4 +1,9 @@
 use bsengine_ecs::{Event, Resource};
+use std::sync::Arc;
+use winit::window::Window;
+
+#[derive(Resource, Clone)]
+pub struct WindowHandle(pub Arc<Window>);
 
 #[derive(Resource, Debug, Clone)]
 pub struct WindowDescriptor {


### PR DESCRIPTION
## Summary

- **WgpuSurface**: window-backed wgpu surface, swapchain, WGSL triangle shader (RGB vertex colors), vertex buffer
- **WgpuRHIPlugin**: Startup system creates surface from `WindowHandle`; `handle_window_resize` system wired to `WindowResized` events
- **RenderPlugin**: real `render_frame` (dark clear + RGB triangle draw call) replaces the Phase 3 stub
- **WindowHandle** resource: inserted by `winit_runner` in `resumed()` so Startup systems can find it
- **Transform** component in `bsengine-core`: translation `[f32; 3]`, rotation quaternion `[f32; 4]`, scale `[f32; 3]` with identity default

## Test plan

- [ ] `cargo test --all` — all tests pass (Transform defaults, shader compilation, headless render frames)
- [ ] `cargo clippy --all-targets` — no errors
- [ ] Run `bsengine-app` binary — window opens with dark background + RGB triangle

🤖 Generated with [Claude Code](https://claude.com/claude-code)