### PR TITLE
feat: Phase 9 — Camera/Mesh components + GLTF loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,12 @@ checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -440,6 +446,7 @@ name = "bsengine-core"
 version = "0.1.0"
 dependencies = [
  "bevy_ecs",
+ "glam",
  "tracing",
  "tracing-subscriber",
 ]
@@ -450,6 +457,18 @@ version = "0.1.0"
 dependencies = [
  "bevy_ecs",
  "bsengine-core",
+]
+
+[[package]]
+name = "bsengine-gltf"
+version = "0.1.0"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bsengine-core",
+ "bsengine-rhi-wgpu",
+ "gltf",
+ "tracing",
 ]
 
 [[package]]
@@ -501,6 +520,7 @@ dependencies = [
  "bsengine-ecs",
  "bsengine-rhi",
  "bsengine-rhi-wgpu",
+ "glam",
  "tracing",
 ]
 
@@ -523,6 +543,7 @@ dependencies = [
  "bsengine-rhi",
  "bsengine-window",
  "bytemuck",
+ "glam",
  "pollster",
  "tracing",
  "wgpu",
@@ -594,6 +615,18 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1097,6 +1130,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1155,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -1320,6 +1372,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1393,45 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "gltf"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ce1918195723ce6ac74e80542c5a96a40c2b26162c1957a5cd70799b8cacf7"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "gltf-json",
+ "image",
+ "lazy_static",
+ "serde_json",
+ "urlencoding",
+]
+
+[[package]]
+name = "gltf-derive"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14070e711538afba5d6c807edb74bcb84e5dbb9211a3bf5dea0dfab5b24f4c51"
+dependencies = [
+ "inflections",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "gltf-json"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6176f9d60a7eab0a877e8e96548605dedbde9190a7ae1e80bbcc1c9af03ab14"
+dependencies = [
+ "gltf-derive",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -1631,6 +1728,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1753,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inventory"
@@ -1908,6 +2026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1919,6 +2038,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -2390,6 +2519,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2601,12 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
@@ -2791,6 +2939,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -3372,6 +3526,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -4190,4 +4350,19 @@ dependencies = [
  "potential_utf",
  "resb",
  "serde",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/bsengine-scripting",
     "crates/bsengine-plugin",
     "crates/bsengine-mcp",
+    "crates/bsengine-gltf",
 ]
 
 [workspace.package]
@@ -49,3 +50,6 @@ winit             = "0.30"
 wgpu              = "22"
 pollster          = "0.3"
 bytemuck          = { version = "1", features = ["derive"] }
+glam              = "0.29"
+gltf              = "1"
+bsengine-gltf     = { path = "crates/bsengine-gltf" }

--- a/crates/bsengine-core/Cargo.toml
+++ b/crates/bsengine-core/Cargo.toml
@@ -7,3 +7,4 @@ edition.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 bevy_ecs.workspace = true
+glam.workspace = true

--- a/crates/bsengine-core/src/camera.rs
+++ b/crates/bsengine-core/src/camera.rs
@@ -1,0 +1,63 @@
+use bevy_ecs::prelude::Component;
+use glam::Mat4;
+
+#[derive(Component, Debug, Clone)]
+pub struct Camera {
+    pub fov_y_radians: f32,
+    pub aspect_ratio: f32,
+    pub near: f32,
+    pub far: f32,
+}
+
+impl Camera {
+    pub fn perspective(fov_y_degrees: f32, aspect_ratio: f32) -> Self {
+        Self {
+            fov_y_radians: fov_y_degrees.to_radians(),
+            aspect_ratio,
+            near: 0.1,
+            far: 1000.0,
+        }
+    }
+
+    pub fn projection_matrix(&self) -> Mat4 {
+        Mat4::perspective_rh(self.fov_y_radians, self.aspect_ratio, self.near, self.far)
+    }
+
+    pub fn update_aspect_ratio(&mut self, width: u32, height: u32) {
+        if height > 0 {
+            self.aspect_ratio = width as f32 / height as f32;
+        }
+    }
+}
+
+impl Default for Camera {
+    fn default() -> Self {
+        Self::perspective(60.0, 16.0 / 9.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_camera_has_60_fov() {
+        let cam = Camera::default();
+        assert!((cam.fov_y_radians - 60_f32.to_radians()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn projection_matrix_is_non_identity() {
+        let cam = Camera::default();
+        let proj = cam.projection_matrix();
+        assert!(!proj.abs_diff_eq(Mat4::IDENTITY, 1e-6));
+    }
+
+    #[test]
+    fn update_aspect_ratio_ignores_zero_height() {
+        let mut cam = Camera::default();
+        let original = cam.aspect_ratio;
+        cam.update_aspect_ratio(1920, 0);
+        assert_eq!(cam.aspect_ratio, original);
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod camera;
 pub mod logging;
 pub mod transform;
 
+pub use camera::Camera;
 pub use logging::init_logging;
 pub use transform::Transform;

--- a/crates/bsengine-core/src/transform.rs
+++ b/crates/bsengine-core/src/transform.rs
@@ -1,47 +1,79 @@
 use bevy_ecs::prelude::Component;
+use glam::{Mat4, Quat, Vec3};
 
 #[derive(Component, Debug, Clone, PartialEq)]
 pub struct Transform {
-    pub translation: [f32; 3],
-    pub rotation: [f32; 4],
-    pub scale: [f32; 3],
+    pub translation: Vec3,
+    pub rotation: Quat,
+    pub scale: Vec3,
 }
 
 impl Default for Transform {
     fn default() -> Self {
         Self {
-            translation: [0.0, 0.0, 0.0],
-            rotation: [0.0, 0.0, 0.0, 1.0],
-            scale: [1.0, 1.0, 1.0],
+            translation: Vec3::ZERO,
+            rotation: Quat::IDENTITY,
+            scale: Vec3::ONE,
         }
     }
 }
 
 impl Transform {
-    pub fn from_translation(x: f32, y: f32, z: f32) -> Self {
+    pub fn from_translation(translation: Vec3) -> Self {
         Self {
-            translation: [x, y, z],
-            ..Self::default()
+            translation,
+            ..Default::default()
         }
+    }
+
+    pub fn looking_at(mut self, target: Vec3, up: Vec3) -> Self {
+        let dir = (target - self.translation).normalize();
+        let right = up.cross(dir).normalize();
+        let up = dir.cross(right);
+        self.rotation = Quat::from_mat3(&glam::Mat3::from_cols(right, up, dir));
+        self
+    }
+
+    pub fn to_matrix(&self) -> Mat4 {
+        Mat4::from_scale_rotation_translation(self.scale, self.rotation, self.translation)
+    }
+
+    pub fn view_matrix(&self) -> Mat4 {
+        self.to_matrix().inverse()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Transform;
+    use super::*;
 
     #[test]
     fn default_is_identity() {
         let t = Transform::default();
-        assert_eq!(t.translation, [0.0, 0.0, 0.0]);
-        assert_eq!(t.rotation, [0.0, 0.0, 0.0, 1.0]);
-        assert_eq!(t.scale, [1.0, 1.0, 1.0]);
+        assert_eq!(t.translation, Vec3::ZERO);
+        assert_eq!(t.rotation, Quat::IDENTITY);
+        assert_eq!(t.scale, Vec3::ONE);
+    }
+
+    #[test]
+    fn to_matrix_identity_for_default() {
+        let t = Transform::default();
+        assert!(t.to_matrix().abs_diff_eq(Mat4::IDENTITY, 1e-6));
     }
 
     #[test]
     fn from_translation_sets_position() {
-        let t = Transform::from_translation(1.0, 2.0, 3.0);
-        assert_eq!(t.translation, [1.0, 2.0, 3.0]);
-        assert_eq!(t.scale, [1.0, 1.0, 1.0]);
+        let t = Transform::from_translation(Vec3::new(1.0, 2.0, 3.0));
+        assert_eq!(t.translation, Vec3::new(1.0, 2.0, 3.0));
+        assert_eq!(t.scale, Vec3::ONE);
+    }
+
+    #[test]
+    fn view_matrix_is_inverse_of_model() {
+        let t = Transform::from_translation(Vec3::new(0.0, 0.0, 5.0));
+        let model = t.to_matrix();
+        let view = t.view_matrix();
+        let product = model * view;
+        assert!(product.abs_diff_eq(Mat4::IDENTITY, 1e-5));
     }
 }

--- a/crates/bsengine-gltf/Cargo.toml
+++ b/crates/bsengine-gltf/Cargo.toml
@@ -1,18 +1,12 @@
 [package]
-name = "bsengine-render"
+name = "bsengine-gltf"
 version.workspace = true
 edition.workspace = true
 
 [dependencies]
 bsengine-core.workspace = true
-bsengine-ecs.workspace = true
-bsengine-rhi.workspace = true
 bsengine-rhi-wgpu.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
-glam.workspace = true
+gltf.workspace = true
 tracing.workspace = true
-
-[dev-dependencies]
-bsengine-app.workspace = true
-bsengine-rhi-wgpu.workspace = true

--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod loader;
+
+pub use loader::{GltfLoader, MeshData};

--- a/crates/bsengine-gltf/src/loader.rs
+++ b/crates/bsengine-gltf/src/loader.rs
@@ -1,0 +1,63 @@
+use bsengine_rhi_wgpu::Vertex;
+
+pub struct MeshData {
+    pub name: String,
+    pub vertices: Vec<Vertex>,
+    pub indices: Vec<u32>,
+}
+
+pub struct GltfLoader;
+
+impl GltfLoader {
+    pub fn load(path: &str) -> Result<Vec<MeshData>, String> {
+        let (doc, buffers, _) = gltf::import(path).map_err(|e| format!("gltf: {e}"))?;
+        let mut result = Vec::new();
+        for mesh in doc.meshes() {
+            let name = mesh.name().unwrap_or("mesh").to_string();
+            for primitive in mesh.primitives() {
+                let reader = primitive.reader(|b| Some(&buffers[b.index()]));
+
+                let positions: Vec<[f32; 3]> = reader
+                    .read_positions()
+                    .ok_or("primitive has no positions")?
+                    .collect();
+
+                let indices: Vec<u32> = reader
+                    .read_indices()
+                    .ok_or("primitive has no indices")?
+                    .into_u32()
+                    .collect();
+
+                // Use vertex colors if available, otherwise default gray
+                let colors: Vec<[f32; 3]> = reader
+                    .read_colors(0)
+                    .map(|c| c.into_rgb_f32().collect())
+                    .unwrap_or_else(|| vec![[0.8, 0.8, 0.8]; positions.len()]);
+
+                let vertices: Vec<Vertex> = positions
+                    .into_iter()
+                    .zip(colors.into_iter())
+                    .map(|(position, color)| Vertex { position, color })
+                    .collect();
+
+                result.push(MeshData {
+                    name: name.clone(),
+                    vertices,
+                    indices,
+                });
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_nonexistent_file_returns_error() {
+        let result = GltfLoader::load("nonexistent.gltf");
+        assert!(result.is_err());
+    }
+}

--- a/crates/bsengine-render/src/components.rs
+++ b/crates/bsengine-render/src/components.rs
@@ -1,0 +1,17 @@
+use bevy_ecs::prelude::Component;
+
+#[derive(Component, Debug, Clone)]
+pub struct MeshRenderer {
+    pub mesh_id: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mesh_renderer_stores_id() {
+        let mr = MeshRenderer { mesh_id: 42 };
+        assert_eq!(mr.mesh_id, 42);
+    }
+}

--- a/crates/bsengine-render/src/lib.rs
+++ b/crates/bsengine-render/src/lib.rs
@@ -1,3 +1,5 @@
-// bsengine-render
+pub mod components;
 pub mod plugin;
+
+pub use components::MeshRenderer;
 pub use plugin::RenderPlugin;

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1,10 +1,34 @@
 use bevy_app::{App, Plugin, PostUpdate};
+use bevy_ecs::prelude::Query;
+use bsengine_core::{Camera, Transform};
 use bsengine_ecs::Res;
-use bsengine_rhi_wgpu::WgpuSurfaceResource;
+use bsengine_rhi_wgpu::{GpuMeshRegistry, WgpuSurfaceResource};
+use glam::Mat4;
 
-fn render_frame(surface: Option<Res<WgpuSurfaceResource>>) {
-    let Some(surface) = surface else { return };
-    if let Err(e) = surface.0.render_frame() {
+use crate::components::MeshRenderer;
+
+fn render_frame(
+    surface: Option<Res<WgpuSurfaceResource>>,
+    registry: Option<Res<GpuMeshRegistry>>,
+    camera_query: Query<(&Camera, &Transform)>,
+    mesh_query: Query<(&MeshRenderer, &Transform)>,
+) {
+    let (Some(surface), Some(registry)) = (surface, registry) else {
+        return;
+    };
+
+    let view_proj = camera_query
+        .iter()
+        .next()
+        .map(|(cam, t)| cam.projection_matrix() * t.view_matrix())
+        .unwrap_or(Mat4::IDENTITY);
+
+    let draw_calls: Vec<(u64, Mat4)> = mesh_query
+        .iter()
+        .map(|(mr, t)| (mr.mesh_id, t.to_matrix()))
+        .collect();
+
+    if let Err(e) = surface.0.render_frame(view_proj, &draw_calls, &registry) {
         tracing::warn!("render_frame error: {e}");
     }
 }
@@ -24,7 +48,7 @@ mod tests {
     use bsengine_rhi_wgpu::WgpuRHIPlugin;
 
     #[test]
-    fn render_plugin_runs_without_rhi() {
+    fn render_plugin_runs_without_surface() {
         let mut app = new_app();
         app.add_plugins(RenderPlugin);
         app.update();

--- a/crates/bsengine-rhi-wgpu/Cargo.toml
+++ b/crates/bsengine-rhi-wgpu/Cargo.toml
@@ -13,6 +13,7 @@ bevy_ecs.workspace = true
 wgpu.workspace = true
 winit.workspace = true
 bytemuck.workspace = true
+glam.workspace = true
 pollster.workspace = true
 tracing.workspace = true
 

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod mesh;
 pub mod plugin;
 pub mod rhi;
 pub mod surface;
+pub use mesh::{cube_vertices, triangle_vertices, GpuMeshRegistry, Vertex};
 pub use plugin::{RhiResource, WgpuRHIPlugin};
 pub use rhi::WgpuRHI;
 pub use surface::WgpuSurfaceResource;

--- a/crates/bsengine-rhi-wgpu/src/mesh.rs
+++ b/crates/bsengine-rhi-wgpu/src/mesh.rs
@@ -1,0 +1,153 @@
+use bsengine_ecs::Resource;
+use std::collections::HashMap;
+use std::sync::Arc;
+use wgpu::util::DeviceExt;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Vertex {
+    pub position: [f32; 3],
+    pub color: [f32; 3],
+}
+
+pub struct GpuMesh {
+    pub vertex_buffer: wgpu::Buffer,
+    pub index_buffer: wgpu::Buffer,
+    pub index_count: u32,
+}
+
+#[derive(Resource)]
+pub struct GpuMeshRegistry {
+    device: Arc<wgpu::Device>,
+    meshes: HashMap<u64, GpuMesh>,
+    next_id: u64,
+}
+
+impl GpuMeshRegistry {
+    pub fn new(device: Arc<wgpu::Device>) -> Self {
+        Self {
+            device,
+            meshes: HashMap::new(),
+            next_id: 1,
+        }
+    }
+
+    pub fn register(&mut self, vertices: &[Vertex], indices: &[u32]) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        let vertex_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("mesh vbo"),
+                contents: bytemuck::cast_slice(vertices),
+                usage: wgpu::BufferUsages::VERTEX,
+            });
+        let index_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("mesh ibo"),
+                contents: bytemuck::cast_slice(indices),
+                usage: wgpu::BufferUsages::INDEX,
+            });
+
+        self.meshes.insert(
+            id,
+            GpuMesh {
+                vertex_buffer,
+                index_buffer,
+                index_count: indices.len() as u32,
+            },
+        );
+        id
+    }
+
+    pub fn get(&self, id: u64) -> Option<&GpuMesh> {
+        self.meshes.get(&id)
+    }
+}
+
+pub fn triangle_vertices() -> (Vec<Vertex>, Vec<u32>) {
+    let vertices = vec![
+        Vertex {
+            position: [0.0, 0.5, 0.0],
+            color: [1.0, 0.0, 0.0],
+        },
+        Vertex {
+            position: [-0.5, -0.5, 0.0],
+            color: [0.0, 1.0, 0.0],
+        },
+        Vertex {
+            position: [0.5, -0.5, 0.0],
+            color: [0.0, 0.0, 1.0],
+        },
+    ];
+    let indices = vec![0, 1, 2];
+    (vertices, indices)
+}
+
+pub fn cube_vertices() -> (Vec<Vertex>, Vec<u32>) {
+    // 8 unique corners, colored by face normal direction
+    let v = |pos: [f32; 3], col: [f32; 3]| Vertex {
+        position: pos,
+        color: col,
+    };
+    #[rustfmt::skip]
+    let vertices = vec![
+        // front face (+Z) — red
+        v([-0.5, -0.5,  0.5], [1.0, 0.2, 0.2]),
+        v([ 0.5, -0.5,  0.5], [1.0, 0.2, 0.2]),
+        v([ 0.5,  0.5,  0.5], [1.0, 0.2, 0.2]),
+        v([-0.5,  0.5,  0.5], [1.0, 0.2, 0.2]),
+        // back face (-Z) — green
+        v([ 0.5, -0.5, -0.5], [0.2, 1.0, 0.2]),
+        v([-0.5, -0.5, -0.5], [0.2, 1.0, 0.2]),
+        v([-0.5,  0.5, -0.5], [0.2, 1.0, 0.2]),
+        v([ 0.5,  0.5, -0.5], [0.2, 1.0, 0.2]),
+        // top face (+Y) — blue
+        v([-0.5,  0.5,  0.5], [0.2, 0.2, 1.0]),
+        v([ 0.5,  0.5,  0.5], [0.2, 0.2, 1.0]),
+        v([ 0.5,  0.5, -0.5], [0.2, 0.2, 1.0]),
+        v([-0.5,  0.5, -0.5], [0.2, 0.2, 1.0]),
+        // bottom face (-Y) — yellow
+        v([-0.5, -0.5, -0.5], [1.0, 1.0, 0.2]),
+        v([ 0.5, -0.5, -0.5], [1.0, 1.0, 0.2]),
+        v([ 0.5, -0.5,  0.5], [1.0, 1.0, 0.2]),
+        v([-0.5, -0.5,  0.5], [1.0, 1.0, 0.2]),
+        // right face (+X) — magenta
+        v([ 0.5, -0.5,  0.5], [1.0, 0.2, 1.0]),
+        v([ 0.5, -0.5, -0.5], [1.0, 0.2, 1.0]),
+        v([ 0.5,  0.5, -0.5], [1.0, 0.2, 1.0]),
+        v([ 0.5,  0.5,  0.5], [1.0, 0.2, 1.0]),
+        // left face (-X) — cyan
+        v([-0.5, -0.5, -0.5], [0.2, 1.0, 1.0]),
+        v([-0.5, -0.5,  0.5], [0.2, 1.0, 1.0]),
+        v([-0.5,  0.5,  0.5], [0.2, 1.0, 1.0]),
+        v([-0.5,  0.5, -0.5], [0.2, 1.0, 1.0]),
+    ];
+    #[rustfmt::skip]
+    let indices: Vec<u32> = (0..6u32).flat_map(|face| {
+        let b = face * 4;
+        [b, b+1, b+2, b, b+2, b+3]
+    }).collect();
+    (vertices, indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn triangle_has_three_verts() {
+        let (verts, indices) = triangle_vertices();
+        assert_eq!(verts.len(), 3);
+        assert_eq!(indices.len(), 3);
+    }
+
+    #[test]
+    fn cube_has_24_verts_and_36_indices() {
+        let (verts, indices) = cube_vertices();
+        assert_eq!(verts.len(), 24);
+        assert_eq!(indices.len(), 36);
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/plugin.rs
+++ b/crates/bsengine-rhi-wgpu/src/plugin.rs
@@ -1,3 +1,4 @@
+use crate::mesh::GpuMeshRegistry;
 use crate::rhi::WgpuRHI;
 use crate::surface::{WgpuSurface, WgpuSurfaceResource};
 use bevy_app::{App, Plugin, Startup, Update};
@@ -28,8 +29,10 @@ fn create_surface_system(world: &mut World) {
     if let Some(handle) = handle {
         match pollster::block_on(WgpuSurface::new(handle.0)) {
             Ok(surface) => {
+                let registry = GpuMeshRegistry::new(surface.device.clone());
                 world.insert_resource(WgpuSurfaceResource(surface));
-                tracing::info!("wgpu surface ready");
+                world.insert_resource(registry);
+                tracing::info!("wgpu surface and mesh registry ready");
             }
             Err(e) => {
                 tracing::warn!("wgpu surface not created: {e}");
@@ -54,7 +57,6 @@ fn handle_window_resize(
 #[cfg(test)]
 mod tests {
     use super::{RhiResource, WgpuRHIPlugin};
-
     use bsengine_app::new_app;
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1,10 +1,20 @@
+use crate::mesh::GpuMeshRegistry;
 use bsengine_ecs::Resource;
+use glam::Mat4;
 use std::sync::Arc;
-use wgpu::util::DeviceExt;
 
-const TRIANGLE_WGSL: &str = r#"
+const MESH_WGSL: &str = r#"
+struct CameraUniform {
+    view_proj: mat4x4<f32>,
+};
+struct ModelUniform {
+    model: mat4x4<f32>,
+};
+@group(0) @binding(0) var<uniform> camera: CameraUniform;
+@group(1) @binding(0) var<uniform> model_data: ModelUniform;
+
 struct VertIn {
-    @location(0) pos: vec2<f32>,
+    @location(0) pos: vec3<f32>,
     @location(1) col: vec3<f32>,
 }
 struct VertOut {
@@ -14,7 +24,7 @@ struct VertOut {
 @vertex
 fn vs_main(in: VertIn) -> VertOut {
     var out: VertOut;
-    out.clip_pos = vec4<f32>(in.pos, 0.0, 1.0);
+    out.clip_pos = camera.view_proj * model_data.model * vec4<f32>(in.pos, 1.0);
     out.col = in.col;
     return out;
 }
@@ -24,24 +34,23 @@ fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
 }
 "#;
 
-// NDC triangle: top red, bottom-left green, bottom-right blue
-#[rustfmt::skip]
-const TRIANGLE_VERTS: &[f32] = &[
-     0.0,  0.5,  1.0, 0.0, 0.0,
-    -0.5, -0.5,  0.0, 1.0, 0.0,
-     0.5, -0.5,  0.0, 0.0, 1.0,
-];
-
-const VERT_STRIDE: u64 = 5 * 4;
+const MAX_OBJECTS: usize = 1024;
+// Padded to 256 bytes (typical min_uniform_buffer_offset_alignment).
+// Mat4 = 64 bytes; pad to 256 so dynamic offsets work on all devices.
+const MODEL_STRIDE: u64 = 256;
+const CAMERA_UNIFORM_SIZE: u64 = 64;
 
 pub struct WgpuSurface {
     _window: Arc<winit::window::Window>,
-    surface: wgpu::Surface<'static>,
+    pub(crate) surface: wgpu::Surface<'static>,
     config: wgpu::SurfaceConfiguration,
-    device: wgpu::Device,
-    queue: wgpu::Queue,
+    pub(crate) device: Arc<wgpu::Device>,
+    pub(crate) queue: Arc<wgpu::Queue>,
     pipeline: wgpu::RenderPipeline,
-    vertex_buffer: wgpu::Buffer,
+    camera_buffer: wgpu::Buffer,
+    camera_bind_group: wgpu::BindGroup,
+    model_buffer: wgpu::Buffer,
+    model_bind_group: wgpu::BindGroup,
 }
 
 impl WgpuSurface {
@@ -77,6 +86,9 @@ impl WgpuSurface {
             .await
             .map_err(|e| format!("Device request failed: {e}"))?;
 
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+
         let size = window.inner_size();
         let caps = surface.get_capabilities(&adapter);
         let format = caps
@@ -98,37 +110,97 @@ impl WgpuSurface {
         };
         surface.configure(&device, &config);
 
-        let shader = Self::compile_shader(&device, TRIANGLE_WGSL);
-        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("triangle vbo"),
-            contents: bytemuck::cast_slice(TRIANGLE_VERTS),
-            usage: wgpu::BufferUsages::VERTEX,
+        // Camera uniform buffer (group 0)
+        let camera_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("camera uniform"),
+            size: CAMERA_UNIFORM_SIZE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let camera_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("camera bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(CAMERA_UNIFORM_SIZE),
+                },
+                count: None,
+            }],
+        });
+        let camera_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("camera bg"),
+            layout: &camera_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: camera_buffer.as_entire_binding(),
+            }],
+        });
+
+        // Model uniform buffer with dynamic offsets (group 1)
+        let model_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("model uniform"),
+            size: MODEL_STRIDE * MAX_OBJECTS as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let model_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("model bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    min_binding_size: wgpu::BufferSize::new(64),
+                },
+                count: None,
+            }],
+        });
+        let model_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("model bg"),
+            layout: &model_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &model_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(64),
+                }),
+            }],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("mesh shader"),
+            source: wgpu::ShaderSource::Wgsl(MESH_WGSL.into()),
         });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("triangle layout"),
-            bind_group_layouts: &[],
+            label: Some("mesh pipeline layout"),
+            bind_group_layouts: &[&camera_bgl, &model_bgl],
             push_constant_ranges: &[],
         });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("triangle pipeline"),
+            label: Some("mesh pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
                 buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: VERT_STRIDE,
+                    array_stride: 24, // 6 x f32
                     step_mode: wgpu::VertexStepMode::Vertex,
                     attributes: &[
                         wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Float32x2,
+                            format: wgpu::VertexFormat::Float32x3,
                             offset: 0,
                             shader_location: 0,
                         },
                         wgpu::VertexAttribute {
                             format: wgpu::VertexFormat::Float32x3,
-                            offset: 8,
+                            offset: 12,
                             shader_location: 1,
                         },
                     ],
@@ -147,9 +219,8 @@ impl WgpuSurface {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
-                strip_index_format: None,
+                cull_mode: Some(wgpu::Face::Back),
                 front_face: wgpu::FrontFace::Ccw,
-                cull_mode: None,
                 ..Default::default()
             },
             depth_stencil: None,
@@ -165,18 +236,38 @@ impl WgpuSurface {
             device,
             queue,
             pipeline,
-            vertex_buffer,
+            camera_buffer,
+            camera_bind_group,
+            model_buffer,
+            model_bind_group,
         })
     }
 
-    pub fn compile_shader(device: &wgpu::Device, src: &str) -> wgpu::ShaderModule {
-        device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("wgsl shader"),
-            source: wgpu::ShaderSource::Wgsl(src.into()),
-        })
-    }
+    /// Render a frame. `draw_calls` is a list of `(mesh_id, model_matrix)`.
+    pub fn render_frame(
+        &self,
+        view_proj: Mat4,
+        draw_calls: &[(u64, Mat4)],
+        registry: &GpuMeshRegistry,
+    ) -> Result<(), String> {
+        // Upload camera matrix
+        let camera_data: [[f32; 4]; 4] = view_proj.to_cols_array_2d();
+        self.queue
+            .write_buffer(&self.camera_buffer, 0, bytemuck::cast_slice(&camera_data));
 
-    pub fn render_frame(&self) -> Result<(), String> {
+        // Upload model matrices (padded to MODEL_STRIDE)
+        for (i, (_, model)) in draw_calls.iter().enumerate() {
+            if i >= MAX_OBJECTS {
+                break;
+            }
+            let data: [[f32; 4]; 4] = model.to_cols_array_2d();
+            self.queue.write_buffer(
+                &self.model_buffer,
+                i as u64 * MODEL_STRIDE,
+                bytemuck::cast_slice(&data),
+            );
+        }
+
         let output = self
             .surface
             .get_current_texture()
@@ -197,9 +288,9 @@ impl WgpuSurface {
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color {
-                            r: 0.1,
-                            g: 0.1,
-                            b: 0.1,
+                            r: 0.08,
+                            g: 0.08,
+                            b: 0.08,
                             a: 1.0,
                         }),
                         store: wgpu::StoreOp::Store,
@@ -209,9 +300,23 @@ impl WgpuSurface {
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });
+
             pass.set_pipeline(&self.pipeline);
-            pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-            pass.draw(0..3, 0..1);
+            pass.set_bind_group(0, &self.camera_bind_group, &[]);
+
+            for (i, (mesh_id, _)) in draw_calls.iter().enumerate() {
+                if i >= MAX_OBJECTS {
+                    break;
+                }
+                let Some(mesh) = registry.get(*mesh_id) else {
+                    continue;
+                };
+                let offset = (i as u64 * MODEL_STRIDE) as u32;
+                pass.set_bind_group(1, &self.model_bind_group, &[offset]);
+                pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                pass.set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+                pass.draw_indexed(0..mesh.index_count, 0, 0..1);
+            }
         }
         self.queue.submit(std::iter::once(encoder.finish()));
         output.present();
@@ -226,6 +331,13 @@ impl WgpuSurface {
         self.config.height = height;
         self.surface.configure(&self.device, &self.config);
     }
+
+    pub fn compile_shader(device: &wgpu::Device, src: &str) -> wgpu::ShaderModule {
+        device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("wgsl shader"),
+            source: wgpu::ShaderSource::Wgsl(src.into()),
+        })
+    }
 }
 
 #[derive(Resource)]
@@ -237,13 +349,8 @@ mod tests {
     use crate::rhi::WgpuRHI;
 
     #[test]
-    fn triangle_shader_compiles() {
+    fn mesh_shader_compiles() {
         let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
-        let _module = WgpuSurface::compile_shader(&rhi.device, TRIANGLE_WGSL);
-    }
-
-    #[test]
-    fn triangle_vertex_data_has_three_verts() {
-        assert_eq!(TRIANGLE_VERTS.len(), 15);
+        let _module = WgpuSurface::compile_shader(&rhi.device, MESH_WGSL);
     }
 }


### PR DESCRIPTION
## Summary

- **Transform** upgraded to `glam` types (`Vec3`/`Quat`/`Mat4`) with `to_matrix()` and `view_matrix()`
- **Camera** component: perspective projection, `projection_matrix()`, `update_aspect_ratio()`
- **Vertex** type: `#[repr(C)]` Pod struct (position + color, each `[f32; 3]`)
- **GpuMeshRegistry**: shared-device mesh registry, `register(vertices, indices) -> u64`; `cube_vertices()` and `triangle_vertices()` helpers
- **WgpuSurface** rewritten: camera uniform (group 0) + dynamic model uniform (group 1), `render_frame(view_proj, draw_calls, registry)`, 3D WGSL mesh shader with camera × model × position
- **MeshRenderer** component: links an ECS entity to a `mesh_id`
- **RenderPlugin** updated: queries all `(Camera, Transform)` + `(MeshRenderer, Transform)` entities each frame and submits draw calls
- **bsengine-gltf** new crate: `GltfLoader::load(path)` extracts meshes from `.gltf`/`.glb` files

## Test plan

- [ ] `cargo test --all` — all tests pass (Transform/Camera math, cube/triangle mesh counts, shader compilation, headless render)
- [ ] `cargo clippy --all-targets` — no errors
- [ ] Run `bsengine-app` binary — window opens, cube visible in 3D with camera perspective

🤖 Generated with [Claude Code](https://claude.com/claude-code)