### PR TITLE
feat: update Camera aspect ratio on WindowResized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "bsengine-ecs",
  "bsengine-rhi",
  "bsengine-rhi-wgpu",
+ "bsengine-window",
  "glam",
  "tracing",
 ]

--- a/crates/bsengine-render/Cargo.toml
+++ b/crates/bsengine-render/Cargo.toml
@@ -8,6 +8,7 @@ bsengine-core.workspace = true
 bsengine-ecs.workspace = true
 bsengine-rhi.workspace = true
 bsengine-rhi-wgpu.workspace = true
+bsengine-window.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 glam.workspace = true

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -34,10 +34,7 @@ fn render_frame(
     }
 }
 
-fn update_camera_aspect(
-    mut events: EventReader<WindowResized>,
-    mut cameras: Query<&mut Camera>,
-) {
+fn update_camera_aspect(mut events: EventReader<WindowResized>, mut cameras: Query<&mut Camera>) {
     for ev in events.read() {
         for mut cam in cameras.iter_mut() {
             cam.update_aspect_ratio(ev.width, ev.height);
@@ -88,8 +85,10 @@ mod tests {
 
         let cam_entity = app.world_mut().spawn(Camera::default()).id();
         // 800x600 (4:3) is different from the default 16:9
-        app.world_mut()
-            .send_event(WindowResized { width: 800, height: 600 });
+        app.world_mut().send_event(WindowResized {
+            width: 800,
+            height: 600,
+        });
         app.update();
 
         let cam = app.world().get::<Camera>(cam_entity).unwrap();

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1,8 +1,9 @@
-use bevy_app::{App, Plugin, PostUpdate};
-use bevy_ecs::prelude::Query;
+use bevy_app::{App, Plugin, PostUpdate, Update};
+use bevy_ecs::prelude::{EventReader, Query};
 use bsengine_core::{Camera, Transform};
 use bsengine_ecs::Res;
 use bsengine_rhi_wgpu::{GpuMeshRegistry, WgpuSurfaceResource};
+use bsengine_window::WindowResized;
 use glam::Mat4;
 
 use crate::components::MeshRenderer;
@@ -33,10 +34,23 @@ fn render_frame(
     }
 }
 
+fn update_camera_aspect(
+    mut events: EventReader<WindowResized>,
+    mut cameras: Query<&mut Camera>,
+) {
+    for ev in events.read() {
+        for mut cam in cameras.iter_mut() {
+            cam.update_aspect_ratio(ev.width, ev.height);
+        }
+    }
+}
+
 pub struct RenderPlugin;
 
 impl Plugin for RenderPlugin {
     fn build(&self, app: &mut App) {
+        app.add_event::<WindowResized>();
+        app.add_systems(Update, update_camera_aspect);
         app.add_systems(PostUpdate, render_frame);
     }
 }
@@ -45,7 +59,9 @@ impl Plugin for RenderPlugin {
 mod tests {
     use super::RenderPlugin;
     use bsengine_app::new_app;
+    use bsengine_core::Camera;
     use bsengine_rhi_wgpu::WgpuRHIPlugin;
+    use bsengine_window::WindowResized;
 
     #[test]
     fn render_plugin_runs_without_surface() {
@@ -62,5 +78,22 @@ mod tests {
         app.update();
         app.update();
         app.update();
+    }
+
+    #[test]
+    fn camera_aspect_updates_on_window_resize() {
+        let mut app = new_app();
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+
+        let cam_entity = app.world_mut().spawn(Camera::default()).id();
+        // 800x600 (4:3) is different from the default 16:9
+        app.world_mut()
+            .send_event(WindowResized { width: 800, height: 600 });
+        app.update();
+
+        let cam = app.world().get::<Camera>(cam_entity).unwrap();
+        let expected = 800.0_f32 / 600.0_f32;
+        assert!((cam.aspect_ratio - expected).abs() < 1e-4);
     }
 }


### PR DESCRIPTION
## Summary
- `RenderPlugin` now subscribes to `WindowResized` events via `bsengine-window`
- `update_camera_aspect` system updates all `Camera` components' `aspect_ratio` each time the window is resized
- Projection matrix stays correct at any window size (was previously locked to the spawn-time 16:9)

## Test plan
- [ ] `cargo test --workspace` passes (Ubuntu + Windows CI)
- [ ] New test `camera_aspect_updates_on_window_resize` verifies 800×600 → aspect_ratio ≈ 1.333

🤖 Generated with [Claude Code](https://claude.com/claude-code)