### PR TITLE
feat: Phase 17 — frustum culling via bounding sphere test

### DIFF
--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -8,10 +8,35 @@ use bsengine_rhi_wgpu::{
     GpuMeshRegistry, GpuTextureRegistry, LightData, PointLightEntry, WgpuSurfaceResource,
 };
 use bsengine_window::WindowResized;
-use glam::Mat4;
+use glam::{Mat4, Vec3};
 use std::collections::HashMap;
 
 use crate::components::MeshRenderer;
+
+/// Returns false if the sphere is completely outside the view frustum.
+/// Uses Gribb-Hartmann plane extraction from the view-projection matrix
+/// (assumes perspective_rh / −1..1 clip depth convention).
+fn sphere_visible_in_frustum(view_proj: Mat4, world_center: Vec3, world_radius: f32) -> bool {
+    let r0 = view_proj.row(0);
+    let r1 = view_proj.row(1);
+    let r2 = view_proj.row(2);
+    let r3 = view_proj.row(3);
+    let planes = [
+        r3 + r0, // left
+        r3 - r0, // right
+        r3 + r1, // bottom
+        r3 - r1, // top
+        r3 + r2, // near  (perspective_rh: near maps to −1)
+        r3 - r2, // far
+    ];
+    let p = world_center.extend(1.0);
+    for plane in &planes {
+        if plane.dot(p) < -world_radius * plane.truncate().length() {
+            return false;
+        }
+    }
+    true
+}
 
 /// Pass 1: root entities (no Parent) get GlobalTransform = local Transform.
 fn propagate_roots(mut query: Query<(&Transform, &mut GlobalTransform), Without<Parent>>) {
@@ -63,10 +88,23 @@ fn render_frame(
 
     let draw_calls: Vec<(u64, Mat4, Option<u64>)> = mesh_query
         .iter()
-        .map(|(mr, t, gt, mat)| {
+        .filter_map(|(mr, t, gt, mat)| {
             let model = gt.map(|g| g.to_matrix()).unwrap_or_else(|| t.to_matrix());
+            if let Some((local_center, local_radius)) = registry.get_bounds(mr.mesh_id) {
+                let world_center = (model * local_center.extend(1.0)).truncate();
+                let max_scale = model
+                    .x_axis
+                    .truncate()
+                    .length()
+                    .max(model.y_axis.truncate().length())
+                    .max(model.z_axis.truncate().length());
+                let world_radius = local_radius * max_scale.max(1.0);
+                if !sphere_visible_in_frustum(view_proj, world_center, world_radius) {
+                    return None;
+                }
+            }
             let tex_id = mat.and_then(|m| m.texture_id);
-            (mr.mesh_id, model, tex_id)
+            Some((mr.mesh_id, model, tex_id))
         })
         .collect();
 
@@ -188,5 +226,41 @@ mod tests {
             Transform::from_translation(Vec3::new(0.0, 2.0, 0.0)),
         ));
         app.update();
+    }
+
+    #[test]
+    fn frustum_cull_sphere_in_front_is_visible() {
+        use super::sphere_visible_in_frustum;
+        use glam::Mat4;
+        let vp = Mat4::perspective_rh(std::f32::consts::FRAC_PI_3, 1.0, 0.1, 100.0);
+        assert!(sphere_visible_in_frustum(
+            vp,
+            Vec3::new(0.0, 0.0, -5.0),
+            0.5
+        ));
+    }
+
+    #[test]
+    fn frustum_cull_sphere_behind_camera_is_culled() {
+        use super::sphere_visible_in_frustum;
+        use glam::Mat4;
+        let vp = Mat4::perspective_rh(std::f32::consts::FRAC_PI_3, 1.0, 0.1, 100.0);
+        assert!(!sphere_visible_in_frustum(
+            vp,
+            Vec3::new(0.0, 0.0, 5.0),
+            0.5
+        ));
+    }
+
+    #[test]
+    fn frustum_cull_sphere_past_far_plane_is_culled() {
+        use super::sphere_visible_in_frustum;
+        use glam::Mat4;
+        let vp = Mat4::perspective_rh(std::f32::consts::FRAC_PI_3, 1.0, 0.1, 100.0);
+        assert!(!sphere_visible_in_frustum(
+            vp,
+            Vec3::new(0.0, 0.0, -150.0),
+            0.5
+        ));
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/mesh.rs
+++ b/crates/bsengine-rhi-wgpu/src/mesh.rs
@@ -1,4 +1,5 @@
 use bsengine_ecs::Resource;
+use glam::Vec3;
 use std::collections::HashMap;
 use std::sync::Arc;
 use wgpu::util::DeviceExt;
@@ -12,10 +13,29 @@ pub struct Vertex {
     pub uv: [f32; 2],
 }
 
+/// Computes a bounding sphere (center, radius) in local mesh space.
+pub fn compute_bounding_sphere(vertices: &[Vertex]) -> (Vec3, f32) {
+    if vertices.is_empty() {
+        return (Vec3::ZERO, 0.0);
+    }
+    let center = vertices
+        .iter()
+        .map(|v| Vec3::from(v.position))
+        .fold(Vec3::ZERO, |a, p| a + p)
+        / vertices.len() as f32;
+    let radius = vertices
+        .iter()
+        .map(|v| (Vec3::from(v.position) - center).length())
+        .fold(0.0_f32, f32::max);
+    (center, radius)
+}
+
 pub struct GpuMesh {
     pub vertex_buffer: wgpu::Buffer,
     pub index_buffer: wgpu::Buffer,
     pub index_count: u32,
+    /// Local-space bounding sphere (center, radius).
+    pub bounds: (Vec3, f32),
 }
 
 #[derive(Resource)]
@@ -53,12 +73,14 @@ impl GpuMeshRegistry {
                 usage: wgpu::BufferUsages::INDEX,
             });
 
+        let bounds = compute_bounding_sphere(vertices);
         self.meshes.insert(
             id,
             GpuMesh {
                 vertex_buffer,
                 index_buffer,
                 index_count: indices.len() as u32,
+                bounds,
             },
         );
         id
@@ -66,6 +88,10 @@ impl GpuMeshRegistry {
 
     pub fn get(&self, id: u64) -> Option<&GpuMesh> {
         self.meshes.get(&id)
+    }
+
+    pub fn get_bounds(&self, id: u64) -> Option<(Vec3, f32)> {
+        self.meshes.get(&id).map(|m| m.bounds)
     }
 }
 
@@ -186,5 +212,56 @@ mod tests {
                 v.uv[1]
             );
         }
+    }
+
+    fn make_vert(pos: [f32; 3]) -> Vertex {
+        Vertex {
+            position: pos,
+            color: [1.0; 3],
+            normal: [0.0, 1.0, 0.0],
+            uv: [0.0; 2],
+        }
+    }
+
+    #[test]
+    fn bounding_sphere_center_is_centroid() {
+        let verts = vec![
+            make_vert([1.0, 0.0, 0.0]),
+            make_vert([-1.0, 0.0, 0.0]),
+            make_vert([0.0, 0.0, 0.0]),
+        ];
+        let (center, _) = compute_bounding_sphere(&verts);
+        assert!(
+            center.length() < 1e-5,
+            "center should be origin, got {:?}",
+            center
+        );
+    }
+
+    #[test]
+    fn bounding_sphere_radius_covers_all_verts() {
+        let verts = vec![
+            make_vert([2.0, 0.0, 0.0]),
+            make_vert([-2.0, 0.0, 0.0]),
+            make_vert([0.0, 0.0, 0.0]),
+        ];
+        let (center, radius) = compute_bounding_sphere(&verts);
+        for v in &verts {
+            let d = (Vec3::from(v.position) - center).length();
+            assert!(
+                d <= radius + 1e-5,
+                "vertex outside sphere: d={d} radius={radius}"
+            );
+        }
+    }
+
+    #[test]
+    fn cube_bounding_sphere_center_near_origin() {
+        let (verts, _) = cube_vertices();
+        let (center, radius) = compute_bounding_sphere(&verts);
+        assert!(center.length() < 1e-4, "cube center should be origin");
+        assert!(radius > 0.0, "radius should be positive");
+        // cube goes from -0.5 to 0.5, max distance is sqrt(3)*0.5 ≈ 0.866
+        assert!(radius < 1.0, "radius for unit cube should be < 1.0");
     }
 }


### PR DESCRIPTION
## Summary

- `GpuMesh` now stores a local-space bounding sphere `(center, radius)` computed at registration via `compute_bounding_sphere()`
- `GpuMeshRegistry::get_bounds(id)` exposes bounds per mesh
- `render_frame` filters draw calls using Gribb-Hartmann plane extraction from the view-projection matrix — objects whose world-space bounding sphere is fully outside any frustum plane are skipped
- 3 frustum culling unit tests: sphere in front (visible), sphere behind (culled), sphere past far plane (culled)

## Test plan

- [x] `cargo clippy --all-targets` — no errors
- [x] `cargo test --all` — all tests pass (8 render, 16 rhi-wgpu)
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)