### PR TITLE
feat: Phase 19 — spot lights with cone attenuation

### DIFF
--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -8,7 +8,7 @@ pub mod transform;
 
 pub use camera::Camera;
 pub use global_transform::GlobalTransform;
-pub use light::{DirectionalLight, PointLight};
+pub use light::{DirectionalLight, PointLight, SpotLight};
 pub use logging::init_logging;
 pub use material::Material;
 pub use parent::Parent;

--- a/crates/bsengine-core/src/light.rs
+++ b/crates/bsengine-core/src/light.rs
@@ -35,6 +35,29 @@ impl Default for PointLight {
     }
 }
 
+#[derive(Component, Debug, Clone)]
+pub struct SpotLight {
+    pub color: Vec3,
+    pub intensity: f32,
+    pub range: f32,
+    /// Inner cone half-angle (radians) — full brightness inside.
+    pub inner_angle: f32,
+    /// Outer cone half-angle (radians) — zero brightness outside.
+    pub outer_angle: f32,
+}
+
+impl Default for SpotLight {
+    fn default() -> Self {
+        Self {
+            color: Vec3::ONE,
+            intensity: 1.0,
+            range: 10.0,
+            inner_angle: std::f32::consts::PI / 8.0, // 22.5°
+            outer_angle: std::f32::consts::PI / 6.0, // 30°
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,5 +74,23 @@ mod tests {
         assert_eq!(pl.color, Vec3::ONE);
         assert!((pl.intensity - 1.0).abs() < 1e-6);
         assert!((pl.range - 10.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn spot_light_inner_angle_less_than_outer() {
+        let sl = SpotLight::default();
+        assert!(
+            sl.inner_angle < sl.outer_angle,
+            "inner must be narrower than outer"
+        );
+    }
+
+    #[test]
+    fn spot_light_inner_cos_greater_than_outer_cos() {
+        let sl = SpotLight::default();
+        assert!(
+            sl.inner_angle.cos() > sl.outer_angle.cos(),
+            "cos(inner) > cos(outer) because inner < outer"
+        );
     }
 }

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1,11 +1,12 @@
 use bevy_app::{App, Plugin, PostUpdate, Update};
 use bevy_ecs::prelude::{Entity, EventReader, IntoSystemConfigs, ParamSet, Query, Without};
 use bsengine_core::{
-    Camera, DirectionalLight, GlobalTransform, Material, Parent, PointLight, Transform,
+    Camera, DirectionalLight, GlobalTransform, Material, Parent, PointLight, SpotLight, Transform,
 };
 use bsengine_ecs::Res;
 use bsengine_rhi_wgpu::{
-    GpuMeshRegistry, GpuTextureRegistry, LightData, PointLightEntry, WgpuSurfaceResource,
+    GpuMeshRegistry, GpuTextureRegistry, LightData, PointLightEntry, SpotLightEntry,
+    WgpuSurfaceResource,
 };
 use bsengine_window::WindowResized;
 use glam::{Mat4, Vec3};
@@ -90,6 +91,7 @@ fn render_frame(
     )>,
     light_query: Query<&DirectionalLight>,
     point_light_query: Query<(&PointLight, Option<&GlobalTransform>, &Transform)>,
+    spot_light_query: Query<(&SpotLight, Option<&GlobalTransform>, &Transform)>,
 ) {
     let (Some(surface), Some(registry)) = (surface, registry) else {
         return;
@@ -138,16 +140,39 @@ fn render_frame(
         })
         .collect();
 
+    let collected_spot_lights: Vec<SpotLightEntry> = spot_light_query
+        .iter()
+        .map(|(sl, gt, t)| {
+            let pos = gt
+                .map(|g| g.to_matrix().w_axis.truncate())
+                .unwrap_or(t.translation);
+            let dir = gt
+                .map(|g| -glam::Mat3::from_mat4(g.to_matrix()).z_axis)
+                .unwrap_or_else(|| t.rotation * Vec3::NEG_Z);
+            SpotLightEntry {
+                position: pos,
+                direction: dir,
+                color: sl.color,
+                intensity: sl.intensity,
+                range: sl.range,
+                inner_angle: sl.inner_angle,
+                outer_angle: sl.outer_angle,
+            }
+        })
+        .collect();
+
     let light = if let Some(l) = light_query.iter().next() {
         LightData {
             direction: l.direction,
             color: l.color,
             ambient: l.ambient,
             point_lights: collected_point_lights,
+            spot_lights: collected_spot_lights,
         }
     } else {
         LightData {
             point_lights: collected_point_lights,
+            spot_lights: collected_spot_lights,
             ..Default::default()
         }
     };
@@ -244,6 +269,24 @@ mod tests {
                 range: 5.0,
             },
             Transform::from_translation(Vec3::new(0.0, 2.0, 0.0)),
+        ));
+        app.update();
+    }
+
+    #[test]
+    fn render_plugin_accepts_spot_lights() {
+        use bsengine_core::SpotLight;
+        let mut app = new_app();
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+        app.world_mut().spawn((
+            SpotLight {
+                color: Vec3::new(0.9, 0.9, 1.0),
+                intensity: 3.0,
+                range: 12.0,
+                ..Default::default()
+            },
+            Transform::from_translation(Vec3::new(0.0, 5.0, 0.0)),
         ));
         app.update();
     }

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -6,5 +6,5 @@ pub mod texture;
 pub use mesh::{cube_vertices, triangle_vertices, GpuMeshRegistry, Vertex};
 pub use plugin::{RhiResource, WgpuRHIPlugin};
 pub use rhi::WgpuRHI;
-pub use surface::{LightData, PointLightEntry, WgpuSurfaceResource};
+pub use surface::{LightData, PointLightEntry, SpotLightEntry, WgpuSurfaceResource};
 pub use texture::GpuTextureRegistry;

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -4,9 +4,11 @@ use glam::{Mat4, Vec3};
 use std::sync::Arc;
 
 const MAX_POINT_LIGHTS: usize = 8;
+const MAX_SPOT_LIGHTS: usize = 8;
 
 const MESH_WGSL: &str = r#"
 const MAX_POINT_LIGHTS: u32 = 8u;
+const MAX_SPOT_LIGHTS: u32 = 8u;
 struct CameraUniform {
     view_proj: mat4x4<f32>,
     light_view_proj: mat4x4<f32>,
@@ -24,6 +26,18 @@ struct PointLightEntry {
     _pad2: f32,
     _pad3: f32,
 };
+struct SpotLightEntry {
+    position: vec3<f32>,
+    _pad0: f32,
+    direction: vec3<f32>,
+    inner_cos: f32,
+    color: vec3<f32>,
+    outer_cos: f32,
+    intensity: f32,
+    range: f32,
+    _pad1: f32,
+    _pad2: f32,
+};
 struct LightUniform {
     direction: vec3<f32>,
     _pad0: f32,
@@ -32,6 +46,11 @@ struct LightUniform {
     ambient: vec3<f32>,
     num_point_lights: u32,
     point_lights: array<PointLightEntry, 8>,
+    num_spot_lights: u32,
+    _pad2: f32,
+    _pad3: f32,
+    _pad4: f32,
+    spot_lights: array<SpotLightEntry, 8>,
 };
 @group(0) @binding(0) var<uniform> camera: CameraUniform;
 @group(1) @binding(0) var<uniform> model_data: ModelUniform;
@@ -102,6 +121,23 @@ fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
         }
     }
 
+    for (var j: u32 = 0u; j < light.num_spot_lights; j++) {
+        let sl = light.spot_lights[j];
+        let to_light = sl.position - in.world_pos;
+        let dist = length(to_light);
+        if dist < sl.range {
+            let light_dir = normalize(to_light);
+            let cos_angle = dot(-light_dir, sl.direction);
+            let spot_factor = smoothstep(sl.outer_cos, sl.inner_cos, cos_angle);
+            if spot_factor > 0.0 {
+                let t = 1.0 - dist / sl.range;
+                let attenuation = t * t;
+                let diff_sl = max(dot(n, light_dir), 0.0);
+                radiance += tex_color * in.col * diff_sl * sl.color * sl.intensity * attenuation * spot_factor;
+            }
+        }
+    }
+
     return vec4<f32>(radiance, 1.0);
 }
 "#;
@@ -137,8 +173,9 @@ const MAX_OBJECTS: usize = 1024;
 const MODEL_STRIDE: u64 = 256;
 // view_proj(64) + light_view_proj(64) = 128
 const CAMERA_UNIFORM_SIZE: u64 = 128;
-// direction(16) + color(16) + ambient+count(16) + 8×PointLightGpu(48) = 432
-const LIGHT_UNIFORM_SIZE: u64 = 432;
+// direction(16) + color(16) + ambient+count(16) + 8×PointLightGpu(48=384) +
+// num_spot+pad(16) + 8×SpotLightGpu(64=512) = 960
+const LIGHT_UNIFORM_SIZE: u64 = 960;
 // Vertex stride: position(12) + color(12) + normal(12) + uv(8) = 44 bytes
 const VERTEX_STRIDE: u64 = 44;
 const SHADOW_MAP_SIZE: u32 = 2048;
@@ -158,12 +195,24 @@ pub struct PointLightEntry {
     pub range: f32,
 }
 
+/// A single spot light entry for the GPU buffer.
+pub struct SpotLightEntry {
+    pub position: Vec3,
+    pub direction: Vec3,
+    pub color: Vec3,
+    pub intensity: f32,
+    pub range: f32,
+    pub inner_angle: f32,
+    pub outer_angle: f32,
+}
+
 /// Light parameters passed per frame.
 pub struct LightData {
     pub direction: Vec3,
     pub color: Vec3,
     pub ambient: Vec3,
     pub point_lights: Vec<PointLightEntry>,
+    pub spot_lights: Vec<SpotLightEntry>,
 }
 
 impl Default for LightData {
@@ -173,6 +222,7 @@ impl Default for LightData {
             color: Vec3::ONE,
             ambient: Vec3::splat(0.15),
             point_lights: Vec::new(),
+            spot_lights: Vec::new(),
         }
     }
 }
@@ -192,6 +242,21 @@ struct PointLightGpu {
 
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct SpotLightGpu {
+    position: [f32; 3],
+    _pad0: f32,
+    direction: [f32; 3],
+    inner_cos: f32,
+    color: [f32; 3],
+    outer_cos: f32,
+    intensity: f32,
+    range: f32,
+    _pad1: f32,
+    _pad2: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 struct LightUniformData {
     direction: [f32; 3],
     _pad0: f32,
@@ -200,6 +265,11 @@ struct LightUniformData {
     ambient: [f32; 3],
     num_point_lights: u32,
     point_lights: [PointLightGpu; 8],
+    num_spot_lights: u32,
+    _pad2: f32,
+    _pad3: f32,
+    _pad4: f32,
+    spot_lights: [SpotLightGpu; 8],
 }
 
 pub struct WgpuSurface {
@@ -722,6 +792,33 @@ impl WgpuSurface {
                 _pad3: 0.0,
             };
         }
+        let mut spot_lights_gpu = [SpotLightGpu {
+            position: [0.0; 3],
+            _pad0: 0.0,
+            direction: [0.0, -1.0, 0.0],
+            inner_cos: 0.0,
+            color: [0.0; 3],
+            outer_cos: 0.0,
+            intensity: 0.0,
+            range: 0.0,
+            _pad1: 0.0,
+            _pad2: 0.0,
+        }; 8];
+        let num_spot_lights = light.spot_lights.len().min(MAX_SPOT_LIGHTS) as u32;
+        for (i, sl) in light.spot_lights.iter().enumerate().take(MAX_SPOT_LIGHTS) {
+            spot_lights_gpu[i] = SpotLightGpu {
+                position: sl.position.to_array(),
+                _pad0: 0.0,
+                direction: sl.direction.normalize().to_array(),
+                inner_cos: sl.inner_angle.cos(),
+                color: sl.color.to_array(),
+                outer_cos: sl.outer_angle.cos(),
+                intensity: sl.intensity,
+                range: sl.range,
+                _pad1: 0.0,
+                _pad2: 0.0,
+            };
+        }
         let light_data = LightUniformData {
             direction: light.direction.normalize().to_array(),
             _pad0: 0.0,
@@ -730,6 +827,11 @@ impl WgpuSurface {
             ambient: light.ambient.to_array(),
             num_point_lights,
             point_lights: point_lights_gpu,
+            num_spot_lights,
+            _pad2: 0.0,
+            _pad3: 0.0,
+            _pad4: 0.0,
+            spot_lights: spot_lights_gpu,
         };
         self.queue
             .write_buffer(&self.light_buffer, 0, bytemuck::cast_slice(&[light_data]));


### PR DESCRIPTION
## Summary

- `SpotLight` component: `color`, `intensity`, `range`, `inner_angle`, `outer_angle` (half-angles in radians)
- Direction derived from entity's `GlobalTransform` rotation (−Z axis), falling back to local `Transform.rotation`
- GPU `SpotLightGpu` is 64 bytes; up to 8 spot lights packed in `LightUniform` (size 432 → 960 bytes)
- WGSL fragment shader applies `smoothstep(outer_cos, inner_cos, cos_angle)` cone falloff × quadratic distance attenuation
- 2 `SpotLight` unit tests + 1 render integration test

## Test plan

- [x] `cargo test --all` — all pass
- [x] `cargo fmt --all` — clean
- [x] Shader compiles in headless wgpu

🤖 Generated with [Claude Code](https://claude.com/claude-code)