### PR TITLE
feat: Phase 25 — MCP runtime integration in app binary

### DIFF
--- a/crates/bsengine-app/Cargo.toml
+++ b/crates/bsengine-app/Cargo.toml
@@ -15,6 +15,8 @@ bsengine-window.workspace = true
 bsengine-input.workspace = true
 bsengine-rhi-wgpu.workspace = true
 bsengine-render.workspace = true
+bsengine-mcp.workspace = true
+bsengine-editor.workspace = true
 glam.workspace = true
 
 [dev-dependencies]

--- a/crates/bsengine-app/src/main.rs
+++ b/crates/bsengine-app/src/main.rs
@@ -1,8 +1,10 @@
 use bevy_app::PostStartup;
 use bsengine_app::new_app;
 use bsengine_core::{Camera, DirectionalLight, GlobalTransform, Parent, PointLight, Transform};
-use bsengine_ecs::{Commands, ResMut};
+use bsengine_ecs::{Commands, Res, ResMut};
+use bsengine_editor::EditorPlugin;
 use bsengine_input::InputPlugin;
+use bsengine_mcp::{McpPlugin, McpRegistryResource, McpServer};
 use bsengine_render::{MeshRenderer, RenderPlugin};
 use bsengine_rhi_wgpu::{cube_vertices, GpuMeshRegistry, WgpuRHIPlugin};
 use bsengine_window::WindowPlugin;
@@ -14,8 +16,17 @@ fn main() {
         .add_plugins(WindowPlugin::default())
         .add_plugins(InputPlugin)
         .add_plugins(RenderPlugin)
-        .add_systems(PostStartup, setup)
+        .add_plugins(McpPlugin)
+        .add_plugins(EditorPlugin)
+        .add_systems(PostStartup, (setup, start_mcp_server))
         .run();
+}
+
+fn start_mcp_server(registry: Res<McpRegistryResource>) {
+    let arc = registry.0.clone();
+    std::thread::spawn(move || {
+        McpServer::new(arc).run_stdio();
+    });
 }
 
 fn setup(mut commands: Commands, registry: Option<ResMut<GpuMeshRegistry>>) {

--- a/crates/bsengine-app/tests/mcp.rs
+++ b/crates/bsengine-app/tests/mcp.rs
@@ -10,8 +10,9 @@ fn mcp_full_tool_workflow() {
 
     // Verify built-in tools exist
     {
-        let reg = &app.world().resource::<McpRegistryResource>().0;
-        let tools = reg.list_tools();
+        let reg = app.world().resource::<McpRegistryResource>().0.clone();
+        let locked = reg.lock().unwrap();
+        let tools = locked.list_tools();
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
         assert!(
             names.contains(&"get_world_state"),
@@ -27,8 +28,8 @@ fn mcp_full_tool_workflow() {
 
     // Register custom tool at runtime
     {
-        let mut reg = app.world_mut().resource_mut::<McpRegistryResource>();
-        reg.0.register(McpTool {
+        let reg = app.world().resource::<McpRegistryResource>().0.clone();
+        reg.lock().unwrap().register(McpTool {
             name: "custom_tool".to_string(),
             description: "A custom game tool".to_string(),
             handler: Box::new(|_| McpToolOutput::success(json!({"status": "custom_ok"}))),
@@ -37,8 +38,10 @@ fn mcp_full_tool_workflow() {
 
     // Execute custom tool
     {
-        let reg = &app.world().resource::<McpRegistryResource>().0;
+        let reg = app.world().resource::<McpRegistryResource>().0.clone();
         let result = reg
+            .lock()
+            .unwrap()
             .execute("custom_tool", json!({}))
             .expect("custom tool not found");
         assert!(result.is_ok());

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -113,10 +113,10 @@ impl Plugin for EditorPlugin {
         app.add_systems(Update, update_editor_snapshot);
         app.add_systems(Update, process_editor_commands);
 
-        if let Some(mut mcp) = app.world_mut().get_resource_mut::<McpRegistryResource>() {
+        if let Some(mcp) = app.world_mut().get_resource_mut::<McpRegistryResource>() {
             // list_entities
             let snap = snapshot.clone();
-            mcp.0.register(McpTool {
+            mcp.0.lock().unwrap().register(McpTool {
                 name: "list_entities".to_string(),
                 description: "List all entities with their IDs, names, and positions".to_string(),
                 handler: Box::new(move |_input| {
@@ -133,7 +133,7 @@ impl Plugin for EditorPlugin {
 
             // get_entity
             let snap2 = snapshot.clone();
-            mcp.0.register(McpTool {
+            mcp.0.lock().unwrap().register(McpTool {
                 name: "get_entity".to_string(),
                 description: "Get detailed info for a specific entity by ID".to_string(),
                 handler: Box::new(move |input| {
@@ -155,7 +155,7 @@ impl Plugin for EditorPlugin {
 
             // spawn_entity
             let queue = cmd_queue.clone();
-            mcp.0.register(McpTool {
+            mcp.0.lock().unwrap().register(McpTool {
                 name: "spawn_entity".to_string(),
                 description: "Spawn a new named entity (applied next frame)".to_string(),
                 handler: Box::new(move |input| {
@@ -170,7 +170,7 @@ impl Plugin for EditorPlugin {
 
             // set_transform
             let queue2 = cmd_queue.clone();
-            mcp.0.register(McpTool {
+            mcp.0.lock().unwrap().register(McpTool {
                 name: "set_transform".to_string(),
                 description: "Set the world position of an entity by ID (applied next frame)"
                     .to_string(),
@@ -196,7 +196,7 @@ impl Plugin for EditorPlugin {
 
             // despawn_entity
             let queue3 = cmd_queue.clone();
-            mcp.0.register(McpTool {
+            mcp.0.lock().unwrap().register(McpTool {
                 name: "despawn_entity".to_string(),
                 description: "Despawn an entity by ID (applied next frame)".to_string(),
                 handler: Box::new(move |input| {
@@ -214,7 +214,7 @@ impl Plugin for EditorPlugin {
 
             // save_scene
             let snap3 = snapshot.clone();
-            mcp.0.register(McpTool {
+            mcp.0.lock().unwrap().register(McpTool {
                 name: "save_scene".to_string(),
                 description: "Serialize current named entities to a RON scene file".to_string(),
                 handler: Box::new(move |input| {
@@ -260,7 +260,7 @@ impl Plugin for EditorPlugin {
 
             // load_scene
             let queue4 = cmd_queue.clone();
-            mcp.0.register(McpTool {
+            mcp.0.lock().unwrap().register(McpTool {
                 name: "load_scene".to_string(),
                 description: "Load and spawn entities from a RON scene file (applied next frame)"
                     .to_string(),
@@ -362,6 +362,8 @@ mod tests {
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
         let result = mcp
             .0
+            .lock()
+            .unwrap()
             .execute("list_entities", json!({}))
             .expect("list_entities not found");
         assert!(result.is_ok());
@@ -378,6 +380,8 @@ mod tests {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
             let result = mcp
                 .0
+                .lock()
+                .unwrap()
                 .execute("spawn_entity", json!({"name": "Sword"}))
                 .expect("spawn_entity not found");
             assert!(result.is_ok());
@@ -408,6 +412,8 @@ mod tests {
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
         let result = mcp
             .0
+            .lock()
+            .unwrap()
             .execute("get_entity", json!({"id": eid.index() as u64}))
             .expect("get_entity not found");
         assert!(result.is_ok(), "error: {:?}", result.error);
@@ -427,6 +433,8 @@ mod tests {
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
             mcp.0
+                .lock()
+                .unwrap()
                 .execute("despawn_entity", json!({"id": eid.index() as u64}))
                 .expect("despawn_entity not found");
         }
@@ -455,6 +463,8 @@ mod tests {
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
         let result = mcp
             .0
+            .lock()
+            .unwrap()
             .execute("save_scene", json!({"path": path}))
             .expect("save_scene not found");
         assert!(result.is_ok(), "save error: {:?}", result.error);
@@ -481,7 +491,12 @@ mod tests {
             ));
             app.update();
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let r = mcp.0.execute("save_scene", json!({"path": path})).unwrap();
+            let r = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("save_scene", json!({"path": path}))
+                .unwrap();
             assert!(r.is_ok(), "{:?}", r.error);
         }
 
@@ -493,6 +508,8 @@ mod tests {
             {
                 let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
                 mcp.0
+                    .lock()
+                    .unwrap()
                     .execute("load_scene", json!({"path": path}))
                     .expect("load_scene not found");
             }
@@ -528,6 +545,8 @@ mod tests {
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
             mcp.0
+                .lock()
+                .unwrap()
                 .execute(
                     "set_transform",
                     json!({"id": eid.index() as u64, "x": 10.0, "y": 0.0, "z": 0.0}),

--- a/crates/bsengine-mcp/src/plugin.rs
+++ b/crates/bsengine-mcp/src/plugin.rs
@@ -3,9 +3,10 @@ use crate::tool::{McpTool, McpToolOutput};
 use bevy_app::{App, Plugin};
 use bsengine_ecs::Resource;
 use serde_json::json;
+use std::sync::{Arc, Mutex};
 
-#[derive(Resource)]
-pub struct McpRegistryResource(pub McpToolRegistry);
+#[derive(Resource, Clone)]
+pub struct McpRegistryResource(pub Arc<Mutex<McpToolRegistry>>);
 
 pub struct McpPlugin;
 
@@ -34,7 +35,7 @@ impl Plugin for McpPlugin {
             }),
         });
 
-        app.insert_resource(McpRegistryResource(registry));
+        app.insert_resource(McpRegistryResource(Arc::new(Mutex::new(registry))));
     }
 }
 
@@ -55,8 +56,10 @@ mod tests {
     fn mcp_plugin_has_builtin_get_world_state() {
         let mut app = new_app();
         app.add_plugins(McpPlugin);
-        let reg = &app.world().resource::<McpRegistryResource>().0;
+        let reg = app.world().resource::<McpRegistryResource>().0.clone();
         let result = reg
+            .lock()
+            .unwrap()
             .execute("get_world_state", json!({}))
             .expect("tool not found");
         assert!(result.is_ok());
@@ -67,8 +70,10 @@ mod tests {
     fn mcp_plugin_has_builtin_list_plugins() {
         let mut app = new_app();
         app.add_plugins(McpPlugin);
-        let reg = &app.world().resource::<McpRegistryResource>().0;
+        let reg = app.world().resource::<McpRegistryResource>().0.clone();
         let result = reg
+            .lock()
+            .unwrap()
             .execute("list_plugins", json!({}))
             .expect("tool not found");
         assert!(result.is_ok());


### PR DESCRIPTION
## Summary

- `McpRegistryResource` changed from `McpToolRegistry` to `Arc<Mutex<McpToolRegistry>>` + `Clone`
- `McpPlugin::build` wraps registry in `Arc<Mutex<>>`
- `EditorPlugin` tool registration uses `.lock().unwrap()` via the mutex
- `start_mcp_server` PostStartup system: clones the Arc, spawns a daemon thread running `McpServer::new(arc).run_stdio()`
- `bsengine-app` binary now has full MCP stack: `McpPlugin` + `EditorPlugin` + stdio server thread
- All tests updated to use `.0.clone()` + `.lock().unwrap()` pattern

## Test plan

- [x] All 13 bsengine-editor tests pass
- [x] All 17 bsengine-mcp tests pass
- [x] bsengine-app integration test `mcp_full_tool_workflow` passes
- [x] `cargo build -p bsengine-app` succeeds
- [x] `cargo test --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)