### PR TITLE
feat: Phase 27 — McpTool inputSchema for Claude-readable tool signatures

### DIFF
--- a/crates/bsengine-app/tests/mcp.rs
+++ b/crates/bsengine-app/tests/mcp.rs
@@ -32,6 +32,7 @@ fn mcp_full_tool_workflow() {
         reg.lock().unwrap().register(McpTool {
             name: "custom_tool".to_string(),
             description: "A custom game tool".to_string(),
+            input_schema: None,
             handler: Box::new(|_| McpToolOutput::success(json!({"status": "custom_ok"}))),
         });
     }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -119,6 +119,7 @@ impl Plugin for EditorPlugin {
             mcp.0.lock().unwrap().register(McpTool {
                 name: "list_entities".to_string(),
                 description: "List all entities with their IDs, names, and positions".to_string(),
+                input_schema: Some(json!({ "type": "object" })),
                 handler: Box::new(move |_input| {
                     let s = snap.lock().unwrap();
                     McpToolOutput::success(json!({
@@ -136,6 +137,11 @@ impl Plugin for EditorPlugin {
             mcp.0.lock().unwrap().register(McpTool {
                 name: "get_entity".to_string(),
                 description: "Get detailed info for a specific entity by ID".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "id": { "type": "number", "description": "Entity ID" } },
+                    "required": ["id"]
+                })),
                 handler: Box::new(move |input| {
                     let id = match input["id"].as_u64() {
                         Some(v) => v,
@@ -158,6 +164,11 @@ impl Plugin for EditorPlugin {
             mcp.0.lock().unwrap().register(McpTool {
                 name: "spawn_entity".to_string(),
                 description: "Spawn a new named entity (applied next frame)".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "name": { "type": "string", "description": "Entity name" } },
+                    "required": ["name"]
+                })),
                 handler: Box::new(move |input| {
                     let name = input["name"].as_str().unwrap_or("Entity").to_string();
                     queue
@@ -174,6 +185,16 @@ impl Plugin for EditorPlugin {
                 name: "set_transform".to_string(),
                 description: "Set the world position of an entity by ID (applied next frame)"
                     .to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "number", "description": "Entity ID" },
+                        "x": { "type": "number" },
+                        "y": { "type": "number" },
+                        "z": { "type": "number" }
+                    },
+                    "required": ["id", "x", "y", "z"]
+                })),
                 handler: Box::new(move |input| {
                     let id = match input["id"].as_u64() {
                         Some(v) => v,
@@ -199,6 +220,11 @@ impl Plugin for EditorPlugin {
             mcp.0.lock().unwrap().register(McpTool {
                 name: "despawn_entity".to_string(),
                 description: "Despawn an entity by ID (applied next frame)".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "id": { "type": "number", "description": "Entity ID" } },
+                    "required": ["id"]
+                })),
                 handler: Box::new(move |input| {
                     let id = match input["id"].as_u64() {
                         Some(v) => v,
@@ -217,6 +243,11 @@ impl Plugin for EditorPlugin {
             mcp.0.lock().unwrap().register(McpTool {
                 name: "save_scene".to_string(),
                 description: "Serialize current named entities to a RON scene file".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "path": { "type": "string", "description": "Destination file path (.ron)" } },
+                    "required": ["path"]
+                })),
                 handler: Box::new(move |input| {
                     let path = match input["path"].as_str() {
                         Some(p) => p.to_string(),
@@ -264,6 +295,11 @@ impl Plugin for EditorPlugin {
                 name: "load_scene".to_string(),
                 description: "Load and spawn entities from a RON scene file (applied next frame)"
                     .to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "path": { "type": "string", "description": "Source file path (.ron)" } },
+                    "required": ["path"]
+                })),
                 handler: Box::new(move |input| {
                     let path = match input["path"].as_str() {
                         Some(p) => p.to_string(),

--- a/crates/bsengine-mcp/src/plugin.rs
+++ b/crates/bsengine-mcp/src/plugin.rs
@@ -17,6 +17,7 @@ impl Plugin for McpPlugin {
         registry.register(McpTool {
             name: "get_world_state".to_string(),
             description: "Returns current ECS world entity count and state summary".to_string(),
+            input_schema: None,
             handler: Box::new(|_input| {
                 McpToolOutput::success(json!({
                     "entity_count": 0,
@@ -28,6 +29,7 @@ impl Plugin for McpPlugin {
         registry.register(McpTool {
             name: "list_plugins".to_string(),
             description: "Lists all registered engine plugins".to_string(),
+            input_schema: None,
             handler: Box::new(|_input| {
                 McpToolOutput::success(json!({
                     "plugins": []

--- a/crates/bsengine-mcp/src/registry.rs
+++ b/crates/bsengine-mcp/src/registry.rs
@@ -46,6 +46,7 @@ mod tests {
         McpTool {
             name: "echo".to_string(),
             description: "Echoes input".to_string(),
+            input_schema: None,
             handler: Box::new(|input| McpToolOutput::success(json!({"echo": input}))),
         }
     }
@@ -83,6 +84,7 @@ mod tests {
         reg.register(McpTool {
             name: "version".to_string(),
             description: "Returns version".to_string(),
+            input_schema: None,
             handler: Box::new(|_| McpToolOutput::success(json!({"version": "0.1.0"}))),
         });
         assert_eq!(reg.list_tools().len(), 2);

--- a/crates/bsengine-mcp/src/server.rs
+++ b/crates/bsengine-mcp/src/server.rs
@@ -84,10 +84,14 @@ impl McpServer {
             .list_tools()
             .iter()
             .map(|t| {
+                let schema = t
+                    .input_schema
+                    .clone()
+                    .unwrap_or_else(|| json!({ "type": "object" }));
                 json!({
                     "name": t.name,
                     "description": t.description,
-                    "inputSchema": { "type": "object" },
+                    "inputSchema": schema,
                 })
             })
             .collect();
@@ -146,6 +150,7 @@ mod tests {
         reg.register(McpTool {
             name: "ping".to_string(),
             description: "Returns pong".to_string(),
+            input_schema: None,
             handler: Box::new(|_| McpToolOutput::success(json!({"pong": true}))),
         });
         McpServer::new(Arc::new(Mutex::new(reg)))
@@ -228,6 +233,38 @@ mod tests {
             .handle_message(json!({ "jsonrpc": "2.0", "id": 6 }))
             .unwrap();
         assert_eq!(resp["error"]["code"], -32600);
+    }
+
+    #[test]
+    fn tool_with_custom_schema_reflects_in_list() {
+        let mut reg = McpToolRegistry::new();
+        reg.register(McpTool {
+            name: "add".to_string(),
+            description: "Adds two numbers".to_string(),
+            input_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "a": { "type": "number" },
+                    "b": { "type": "number" }
+                },
+                "required": ["a", "b"]
+            })),
+            handler: Box::new(|input| {
+                let a = input["a"].as_f64().unwrap_or(0.0);
+                let b = input["b"].as_f64().unwrap_or(0.0);
+                McpToolOutput::success(json!({ "result": a + b }))
+            }),
+        });
+        let server = McpServer::new(Arc::new(Mutex::new(reg)));
+        let resp = server
+            .handle_message(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}
+            }))
+            .unwrap();
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["inputSchema"]["type"], "object");
+        assert!(tools[0]["inputSchema"]["properties"]["a"].is_object());
+        assert_eq!(tools[0]["inputSchema"]["required"][0], "a");
     }
 
     #[test]

--- a/crates/bsengine-mcp/src/tool.rs
+++ b/crates/bsengine-mcp/src/tool.rs
@@ -29,6 +29,7 @@ impl McpToolOutput {
 pub struct McpTool {
     pub name: String,
     pub description: String,
+    pub input_schema: Option<Value>,
     pub handler: Box<dyn Fn(Value) -> McpToolOutput + Send + Sync>,
 }
 
@@ -56,6 +57,7 @@ mod tests {
         let tool = McpTool {
             name: "get_world_state".to_string(),
             description: "Returns current ECS world state".to_string(),
+            input_schema: None,
             handler: Box::new(|_input| McpToolOutput::success(json!({}))),
         };
         assert_eq!(tool.name, "get_world_state");
@@ -67,6 +69,7 @@ mod tests {
         let tool = McpTool {
             name: "echo".to_string(),
             description: "Echoes input".to_string(),
+            input_schema: None,
             handler: Box::new(|input| McpToolOutput::success(json!({"echo": input}))),
         };
         let result = (tool.handler)(json!({"msg": "hello"}));


### PR DESCRIPTION
## Summary

- `McpTool` gains `input_schema: Option<Value>` field
- `tools/list` response now uses the schema (default: `{"type":"object"}`)
- All 7 editor tools carry full JSON Schema: properties + required array
- `tool_with_custom_schema_reflects_in_list` verifies the round-trip

## Tool schemas added

| Tool | Required params |
|---|---|
| `list_entities` | — |
| `get_entity` | `id` |
| `spawn_entity` | `name` |
| `set_transform` | `id`, `x`, `y`, `z` |
| `despawn_entity` | `id` |
| `save_scene` | `path` |
| `load_scene` | `path` |

## Test plan

- [x] `tool_with_custom_schema_reflects_in_list` — new test
- [x] All 20 bsengine-mcp tests pass
- [x] All 13 bsengine-editor tests pass
- [x] `cargo test --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)