### PR TITLE
feat: Phase 226 — detach_selection_from_parent / reparent_selection MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,54 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // detach_selection_from_parent
+            let sel_dsfp = selection.clone();
+            let queue76 = cmd_queue.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "detach_selection_from_parent".to_string(),
+                description: "Remove the parent from all selected entities (move to root); returns {affected_count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let selected: Vec<u64> = sel_dsfp.lock().unwrap().iter().copied().collect();
+                    let count = selected.len() as u64;
+                    let mut q = queue76.lock().unwrap();
+                    for id in selected {
+                        q.push(EditorCommand::RemoveParent { entity_id: id });
+                    }
+                    McpToolOutput::success(json!({"affected_count": count}))
+                }),
+            });
+
+            // reparent_selection
+            let sel_rs = selection.clone();
+            let queue77 = cmd_queue.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "reparent_selection".to_string(),
+                description: "Set a new parent for all selected entities; returns {affected_count}"
+                    .to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "parent_id": { "type": "integer" } },
+                    "required": ["parent_id"]
+                })),
+                handler: Box::new(move |input| {
+                    let parent_id = match input["parent_id"].as_u64() {
+                        Some(id) => id,
+                        None => return McpToolOutput::error("missing parent_id"),
+                    };
+                    let selected: Vec<u64> = sel_rs.lock().unwrap().iter().copied().collect();
+                    let count = selected.len() as u64;
+                    let mut q = queue77.lock().unwrap();
+                    for id in selected {
+                        q.push(EditorCommand::SetParent {
+                            entity_id: id,
+                            parent_id,
+                        });
+                    }
+                    McpToolOutput::success(json!({"affected_count": count}))
+                }),
+            });
+
             // set_light_intensity
             let snap_sli = snapshot.clone();
             let queue74 = cmd_queue.clone();
@@ -11719,6 +11767,199 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_detach_selection_from_parent_removes_parent_from_selected() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Parent", "position": [0.0, 0.0, 0.0]},
+                        {"name": "ChildA", "position": [1.0, 0.0, 0.0]},
+                        {"name": "ChildB", "position": [2.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (parent_id, a_id, b_id) = (id_of("Parent"), id_of("ChildA"), id_of("ChildB"));
+
+        // Attach both children to parent
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let m = mcp.0.lock().unwrap();
+            m.execute(
+                "set_parent",
+                json!({"entity_id": a_id, "parent_id": parent_id}),
+            )
+            .unwrap();
+            m.execute(
+                "set_parent",
+                json!({"entity_id": b_id, "parent_id": parent_id}),
+            )
+            .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // Select and detach
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let m = mcp.0.lock().unwrap();
+            m.execute("select_entity", json!({"entity_id": a_id}))
+                .unwrap();
+            m.execute("select_entity", json!({"entity_id": b_id}))
+                .unwrap();
+        }
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("detach_selection_from_parent", json!({}))
+                .unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["affected_count"].as_u64().unwrap(), 2);
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let updated = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("list_entities", json!({}))
+            .unwrap()
+            .content["entities"]
+            .as_array()
+            .unwrap()
+            .clone();
+        for e in &updated {
+            if e["id"].as_u64().unwrap() == a_id || e["id"].as_u64().unwrap() == b_id {
+                assert!(e["parent_id"].is_null(), "parent should be removed");
+            }
+        }
+    }
+
+    #[test]
+    fn mcp_reparent_selection_sets_new_parent_for_all_selected() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "NewParent", "position": [0.0, 0.0, 0.0]},
+                        {"name": "A", "position": [1.0, 0.0, 0.0]},
+                        {"name": "B", "position": [2.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (new_parent_id, a_id, b_id) = (id_of("NewParent"), id_of("A"), id_of("B"));
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let m = mcp.0.lock().unwrap();
+            m.execute("select_entity", json!({"entity_id": a_id}))
+                .unwrap();
+            m.execute("select_entity", json!({"entity_id": b_id}))
+                .unwrap();
+        }
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("reparent_selection", json!({"parent_id": new_parent_id}))
+                .unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["affected_count"].as_u64().unwrap(), 2);
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let updated = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("list_entities", json!({}))
+            .unwrap()
+            .content["entities"]
+            .as_array()
+            .unwrap()
+            .clone();
+        for e in &updated {
+            if e["id"].as_u64().unwrap() == a_id || e["id"].as_u64().unwrap() == b_id {
+                assert_eq!(
+                    e["parent_id"].as_u64().unwrap(),
+                    new_parent_id,
+                    "parent should be NewParent"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `detach_selection_from_parent()` — removes parent from all selected entities; returns `{affected_count}`
- `reparent_selection(parent_id)` — sets a new parent for all selected entities; returns `{affected_count}`

## Test plan

- [x] `mcp_detach_selection_from_parent_removes_parent_from_selected`
- [x] `mcp_reparent_selection_sets_new_parent_for_all_selected`
- [x] 389 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)