### PR TITLE
feat: Phase 240 — get_entities_at_x_zero / get_entities_at_y_zero MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,38 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // get_entities_at_x_zero
+            let snap_geaxz = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_at_x_zero".to_string(),
+                description: "Return entity IDs where position.x is zero (within 0.001 epsilon); returns {entity_ids}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_geaxz.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.position.map(|p| p[0].abs() < 0.001).unwrap_or(true))
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
+            // get_entities_at_y_zero
+            let snap_geayz = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_at_y_zero".to_string(),
+                description: "Return entity IDs where position.y is zero (within 0.001 epsilon); returns {entity_ids}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_geayz.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.position.map(|p| p[1].abs() < 0.001).unwrap_or(true))
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // select_all_leaves
             let snap_sal = snapshot.clone();
             let sel_sal = selection.clone();
@@ -12570,6 +12602,130 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_get_entities_at_x_zero_returns_entities_with_zero_x_position() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "OnX", "position": [0.0, 5.0, 3.0]},
+                        {"name": "OffX", "position": [1.0, 5.0, 3.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (on_id, off_id) = (id_of("OnX"), id_of("OffX"));
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("get_entities_at_x_zero", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        let ids: Vec<u64> = out.content["entity_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        assert!(ids.contains(&on_id), "OnX included (x=0)");
+        assert!(!ids.contains(&off_id), "OffX excluded (x=1)");
+    }
+
+    #[test]
+    fn mcp_get_entities_at_y_zero_returns_entities_with_zero_y_position() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "OnY",  "position": [5.0, 0.0, 3.0]},
+                        {"name": "OffY", "position": [5.0, 2.0, 3.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (on_id, off_id) = (id_of("OnY"), id_of("OffY"));
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("get_entities_at_y_zero", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        let ids: Vec<u64> = out.content["entity_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        assert!(ids.contains(&on_id), "OnY included (y=0)");
+        assert!(!ids.contains(&off_id), "OffY excluded (y=2)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `get_entities_at_x_zero()` — entity IDs where position.x ≈ 0; returns `{entity_ids}`
- `get_entities_at_y_zero()` — entity IDs where position.y ≈ 0; returns `{entity_ids}`

## Test plan

- [x] `mcp_get_entities_at_x_zero_returns_entities_with_zero_x_position`
- [x] `mcp_get_entities_at_y_zero_returns_entities_with_zero_y_position`
- [x] 417 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)