### PR TITLE
feat: Phase 245 — get_entities_with_positive_x / get_entities_with_negative_x MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,44 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // get_entities_with_positive_x
+            let snap_gewpx = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_positive_x".to_string(),
+                description: "Return entity IDs where position.x > 0; returns {entity_ids}"
+                    .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_gewpx.lock().unwrap();
+                    let ids: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.position.map(|p| p[0] > 0.0).unwrap_or(false))
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
+            // get_entities_with_negative_x
+            let snap_gewnx = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_negative_x".to_string(),
+                description: "Return entity IDs where position.x < 0; returns {entity_ids}"
+                    .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_gewnx.lock().unwrap();
+                    let ids: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.position.map(|p| p[0] < 0.0).unwrap_or(false))
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // count_visible_entities
             let snap_cve = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -12754,6 +12792,134 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_get_entities_with_positive_x_returns_entities_with_x_greater_than_zero() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "PosX", "position": [5.0, 0.0, 0.0]},
+                        {"name": "Zero", "position": [0.0, 0.0, 0.0]},
+                        {"name": "NegX", "position": [-3.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (pos_id, zero_id, neg_id) = (id_of("PosX"), id_of("Zero"), id_of("NegX"));
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("get_entities_with_positive_x", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        let ids: Vec<u64> = out.content["entity_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        assert!(ids.contains(&pos_id), "PosX included (x=5)");
+        assert!(!ids.contains(&zero_id), "Zero excluded (x=0)");
+        assert!(!ids.contains(&neg_id), "NegX excluded (x=-3)");
+    }
+
+    #[test]
+    fn mcp_get_entities_with_negative_x_returns_entities_with_x_less_than_zero() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "PosX", "position": [5.0, 0.0, 0.0]},
+                        {"name": "Zero", "position": [0.0, 0.0, 0.0]},
+                        {"name": "NegX", "position": [-3.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (pos_id, zero_id, neg_id) = (id_of("PosX"), id_of("Zero"), id_of("NegX"));
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("get_entities_with_negative_x", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        let ids: Vec<u64> = out.content["entity_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        assert!(!ids.contains(&pos_id), "PosX excluded (x=5)");
+        assert!(!ids.contains(&zero_id), "Zero excluded (x=0)");
+        assert!(ids.contains(&neg_id), "NegX included (x=-3)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `get_entities_with_positive_x()` — entity IDs where position.x > 0; returns `{entity_ids}`
- `get_entities_with_negative_x()` — entity IDs where position.x < 0; returns `{entity_ids}`

## Test plan

- [x] `mcp_get_entities_with_positive_x_returns_entities_with_x_greater_than_zero`
- [x] `mcp_get_entities_with_negative_x_returns_entities_with_x_less_than_zero`
- [x] 427 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)