### PR TITLE
feat: Phase 262 — deselect_siblings_of / get_root_entities_of_selection MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,58 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // deselect_siblings_of
+            let snap_dsof = snapshot.clone();
+            let sel_dsof = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_siblings_of".to_string(),
+                description: "Remove all siblings of the given entity (same parent, excluding itself) from the selection; returns {deselected_count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "entity_id": { "type": "integer" } },
+                    "required": ["entity_id"]
+                })),
+                handler: Box::new(move |input| {
+                    let target = match input["entity_id"].as_u64() {
+                        Some(id) => id,
+                        None => return McpToolOutput::error("missing entity_id"),
+                    };
+                    let s = snap_dsof.lock().unwrap();
+                    let parent_id = s.entities.iter()
+                        .find(|e| e.id == target)
+                        .and_then(|e| e.parent_id);
+                    let siblings: Vec<u64> = match parent_id {
+                        Some(pid) => s.entities.iter()
+                            .filter(|e| e.parent_id == Some(pid) && e.id != target)
+                            .map(|e| e.id)
+                            .collect(),
+                        None => vec![],
+                    };
+                    let count = siblings.len() as u64;
+                    let mut sel = sel_dsof.lock().unwrap();
+                    for id in siblings { sel.remove(&id); }
+                    McpToolOutput::success(json!({"deselected_count": count}))
+                }),
+            });
+
+            // get_root_entities_of_selection
+            let snap_gros = snapshot.clone();
+            let sel_gros = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_root_entities_of_selection".to_string(),
+                description: "Return selected entity IDs that have no parent (root entities in the selection); returns {entity_ids}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_gros.lock().unwrap();
+                    let sel = sel_gros.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| sel.contains(&e.id) && e.parent_id.is_none())
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // select_siblings_of
             let snap_ssof = snapshot.clone();
             let sel_ssof = selection.clone();
@@ -13641,6 +13693,203 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_deselect_siblings_of_removes_siblings_from_selection() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Parent"},
+                        {"name": "SibA"},
+                        {"name": "SibB"},
+                        {"name": "Target"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (parent_id, sib_a, sib_b, target_id) = (
+            id_of("Parent"),
+            id_of("SibA"),
+            id_of("SibB"),
+            id_of("Target"),
+        );
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let mut reg = mcp.0.lock().unwrap();
+            reg.execute(
+                "set_parent",
+                json!({"entity_id": sib_a, "parent_id": parent_id}),
+            )
+            .unwrap();
+            reg.execute(
+                "set_parent",
+                json!({"entity_id": sib_b, "parent_id": parent_id}),
+            )
+            .unwrap();
+            reg.execute(
+                "set_parent",
+                json!({"entity_id": target_id, "parent_id": parent_id}),
+            )
+            .unwrap();
+            // select all siblings and target
+            reg.execute("select_entity", json!({"entity_id": sib_a}))
+                .unwrap();
+            reg.execute("select_entity", json!({"entity_id": sib_b}))
+                .unwrap();
+            reg.execute("select_entity", json!({"entity_id": target_id}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("deselect_siblings_of", json!({"entity_id": target_id}))
+            .unwrap();
+        assert!(out.is_ok());
+        assert_eq!(out.content["deselected_count"], 2);
+
+        let sel = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("get_selection", json!({}))
+            .unwrap();
+        let ids: Vec<u64> = sel.content["selected_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        assert!(!ids.contains(&sib_a), "SibA deselected");
+        assert!(!ids.contains(&sib_b), "SibB deselected");
+        assert!(ids.contains(&target_id), "Target still selected (self)");
+    }
+
+    #[test]
+    fn mcp_get_root_entities_of_selection_returns_roots() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Root1"},
+                        {"name": "Root2"},
+                        {"name": "Child"},
+                        {"name": "Unselected"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (root1_id, root2_id, child_id, unsel_id) = (
+            id_of("Root1"),
+            id_of("Root2"),
+            id_of("Child"),
+            id_of("Unselected"),
+        );
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let mut reg = mcp.0.lock().unwrap();
+            reg.execute(
+                "set_parent",
+                json!({"entity_id": child_id, "parent_id": root1_id}),
+            )
+            .unwrap();
+            reg.execute("select_entity", json!({"entity_id": root1_id}))
+                .unwrap();
+            reg.execute("select_entity", json!({"entity_id": root2_id}))
+                .unwrap();
+            reg.execute("select_entity", json!({"entity_id": child_id}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("get_root_entities_of_selection", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        let ids: Vec<u64> = out.content["entity_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        assert_eq!(ids.len(), 2, "two roots selected");
+        assert!(ids.contains(&root1_id), "Root1 included");
+        assert!(ids.contains(&root2_id), "Root2 included");
+        assert!(!ids.contains(&child_id), "Child excluded (has parent)");
+        assert!(!ids.contains(&unsel_id), "Unselected excluded");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `deselect_siblings_of(entity_id)` — removes siblings (same parent, excluding self) from selection; returns `{deselected_count}`
- `get_root_entities_of_selection()` — selected entities with no parent; returns `{entity_ids}`

## Test plan

- [x] `mcp_deselect_siblings_of_removes_siblings_from_selection`
- [x] `mcp_get_root_entities_of_selection_returns_roots`
- [x] 461 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)