### PR TITLE
feat: Phase 268 — get_entities_between_depths / count_entities_between_depths MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,85 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // get_entities_between_depths
+            let snap_gebd = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_between_depths".to_string(),
+                description: "Return entity IDs whose hierarchy depth is in [min_depth, max_depth] inclusive; returns {entity_ids}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "min_depth": { "type": "integer" },
+                        "max_depth": { "type": "integer" }
+                    },
+                    "required": ["min_depth", "max_depth"]
+                })),
+                handler: Box::new(move |input| {
+                    let min_d = match input["min_depth"].as_u64() {
+                        Some(v) => v,
+                        None => return McpToolOutput::error("missing min_depth"),
+                    };
+                    let max_d = match input["max_depth"].as_u64() {
+                        Some(v) => v,
+                        None => return McpToolOutput::error("missing max_depth"),
+                    };
+                    let s = snap_gebd.lock().unwrap();
+                    let depth_of = |start: u64| -> u64 {
+                        let mut d: u64 = 0;
+                        let mut cur = start;
+                        loop {
+                            let p = s.entities.iter().find(|e| e.id == cur).and_then(|e| e.parent_id);
+                            match p { Some(pid) => { d += 1; cur = pid; } None => break, }
+                        }
+                        d
+                    };
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| { let d = depth_of(e.id); d >= min_d && d <= max_d })
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
+            // count_entities_between_depths
+            let snap_cebd = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_between_depths".to_string(),
+                description: "Return the count of entities whose hierarchy depth is in [min_depth, max_depth] inclusive; returns {count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "min_depth": { "type": "integer" },
+                        "max_depth": { "type": "integer" }
+                    },
+                    "required": ["min_depth", "max_depth"]
+                })),
+                handler: Box::new(move |input| {
+                    let min_d = match input["min_depth"].as_u64() {
+                        Some(v) => v,
+                        None => return McpToolOutput::error("missing min_depth"),
+                    };
+                    let max_d = match input["max_depth"].as_u64() {
+                        Some(v) => v,
+                        None => return McpToolOutput::error("missing max_depth"),
+                    };
+                    let s = snap_cebd.lock().unwrap();
+                    let depth_of = |start: u64| -> u64 {
+                        let mut d: u64 = 0;
+                        let mut cur = start;
+                        loop {
+                            let p = s.entities.iter().find(|e| e.id == cur).and_then(|e| e.parent_id);
+                            match p { Some(pid) => { d += 1; cur = pid; } None => break, }
+                        }
+                        d
+                    };
+                    let count = s.entities.iter()
+                        .filter(|e| { let d = depth_of(e.id); d >= min_d && d <= max_d })
+                        .count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
             // get_max_hierarchy_depth
             let snap_gmhd = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -13927,6 +14006,162 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_get_entities_between_depths_returns_entities_in_range() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "D0"},
+                        {"name": "D1"},
+                        {"name": "D2"},
+                        {"name": "D3"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (d0, d1, d2, d3) = (id_of("D0"), id_of("D1"), id_of("D2"), id_of("D3"));
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let mut reg = mcp.0.lock().unwrap();
+            reg.execute("set_parent", json!({"entity_id": d1, "parent_id": d0}))
+                .unwrap();
+            reg.execute("set_parent", json!({"entity_id": d2, "parent_id": d1}))
+                .unwrap();
+            reg.execute("set_parent", json!({"entity_id": d3, "parent_id": d2}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute(
+                "get_entities_between_depths",
+                json!({"min_depth": 1, "max_depth": 2}),
+            )
+            .unwrap();
+        assert!(out.is_ok());
+        let ids: Vec<u64> = out.content["entity_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&d1), "D1 at depth 1");
+        assert!(ids.contains(&d2), "D2 at depth 2");
+        assert!(!ids.contains(&d0), "D0 excluded (depth 0)");
+        assert!(!ids.contains(&d3), "D3 excluded (depth 3)");
+    }
+
+    #[test]
+    fn mcp_count_entities_between_depths_returns_count_in_range() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "A"},
+                        {"name": "B"},
+                        {"name": "C"},
+                        {"name": "D"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (a, b, c, d) = (id_of("A"), id_of("B"), id_of("C"), id_of("D"));
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let mut reg = mcp.0.lock().unwrap();
+            reg.execute("set_parent", json!({"entity_id": b, "parent_id": a}))
+                .unwrap();
+            reg.execute("set_parent", json!({"entity_id": c, "parent_id": b}))
+                .unwrap();
+            reg.execute("set_parent", json!({"entity_id": d, "parent_id": c}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute(
+                "count_entities_between_depths",
+                json!({"min_depth": 0, "max_depth": 2}),
+            )
+            .unwrap();
+        assert!(out.is_ok());
+        assert_eq!(out.content["count"], 3, "A(0), B(1), C(2)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `get_entities_between_depths(min_depth, max_depth)` — entity IDs at depths in [min, max]; returns `{entity_ids}`
- `count_entities_between_depths(min_depth, max_depth)` — count of entities in depth range; returns `{count}`

## Test plan

- [x] `mcp_get_entities_between_depths_returns_entities_in_range`
- [x] `mcp_count_entities_between_depths_returns_count_in_range`
- [x] 473 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)