### PR TITLE
feat: Phase 302 — count_entities_with_position / count_entities_without_position MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,36 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // count_entities_with_position
+            let snap_cewp = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_position".to_string(),
+                description:
+                    "Return the count of entities that have a position component; returns {count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_cewp.lock().unwrap();
+                    let count = s.entities.iter().filter(|e| e.position.is_some()).count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
+            // count_entities_without_position
+            let snap_cewnp = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_without_position".to_string(),
+                description:
+                    "Return the count of entities that have no position component; returns {count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_cewnp.lock().unwrap();
+                    let count = s.entities.iter().filter(|e| e.position.is_none()).count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
             // deselect_entities_below_z
             let snap_debz = snapshot.clone();
             let sel_debz = selection.clone();
@@ -15816,6 +15846,77 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_count_entities_with_position_returns_correct_count() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "HasPos1", "position": [1.0, 0.0, 0.0]},
+                        {"name": "HasPos2", "position": [2.0, 0.0, 0.0]},
+                        {"name": "NoPos1"},
+                        {"name": "NoPos2"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("count_entities_with_position", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        assert_eq!(out.content["count"], 2);
+    }
+
+    #[test]
+    fn mcp_count_entities_without_position_returns_correct_count() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "HasPos", "position": [1.0, 0.0, 0.0]},
+                        {"name": "NoPos1"},
+                        {"name": "NoPos2"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("count_entities_without_position", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        assert_eq!(out.content["count"], 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `count_entities_with_position()` — count entities that have a position component; returns `{count}`
- `count_entities_without_position()` — count entities that have no position component; returns `{count}`

## Test plan

- [x] `mcp_count_entities_with_position_returns_correct_count`
- [x] `mcp_count_entities_without_position_returns_correct_count`
- [x] 541 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)