### PR TITLE
feat: Phase 307 — count_entities_with_rotation / count_entities_with_scale MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,36 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // count_entities_with_rotation
+            let snap_cewr = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_rotation".to_string(),
+                description:
+                    "Return the count of entities that have a rotation component; returns {count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_cewr.lock().unwrap();
+                    let count = s.entities.iter().filter(|e| e.rotation.is_some()).count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
+            // count_entities_with_scale
+            let snap_cews = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_scale".to_string(),
+                description:
+                    "Return the count of entities that have a scale component; returns {count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}})),
+                handler: Box::new(move |_input| {
+                    let s = snap_cews.lock().unwrap();
+                    let count = s.entities.iter().filter(|e| e.scale.is_some()).count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
             // count_selected_cameras
             let snap_csca = snapshot.clone();
             let sel_csca = selection.clone();
@@ -15968,6 +15998,81 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_count_entities_with_rotation_returns_correct_count() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "WithTransformA", "position": [0.0, 0.0, 0.0]},
+                        {"name": "WithTransformB", "position": [1.0, 0.0, 0.0]},
+                        {"name": "NoTransform"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("count_entities_with_rotation", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        assert_eq!(
+            out.content["count"], 2,
+            "entities with position have rotation; entity without position does not"
+        );
+    }
+
+    #[test]
+    fn mcp_count_entities_with_scale_returns_correct_count() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "WithTransform", "position": [0.0, 0.0, 0.0]},
+                        {"name": "NoTransform"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("count_entities_with_scale", json!({}))
+            .unwrap();
+        assert!(out.is_ok());
+        assert_eq!(
+            out.content["count"], 1,
+            "only entity with position has scale in snapshot"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `count_entities_with_rotation()` — count entities with a rotation component in snapshot; returns `{count}`
- `count_entities_with_scale()` — count entities with a scale component in snapshot; returns `{count}`

## Test plan

- [x] `mcp_count_entities_with_rotation_returns_correct_count`
- [x] `mcp_count_entities_with_scale_returns_correct_count`
- [x] 551 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)