### PR TITLE
feat: Phase 314 — count_entities_in_sphere / get_entities_in_sphere MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,55 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // count_entities_in_sphere
+            let snap_ceis = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_in_sphere".to_string(),
+                description: "Return the count of entities within a sphere defined by center (x,y,z) and radius; returns {count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "x": {"type": "number"}, "y": {"type": "number"}, "z": {"type": "number"},
+                    "radius": {"type": "number"}
+                }, "required": ["x","y","z","radius"]})),
+                handler: Box::new(move |input| {
+                    let px = input["x"].as_f64().unwrap_or(0.0) as f32;
+                    let py = input["y"].as_f64().unwrap_or(0.0) as f32;
+                    let pz = input["z"].as_f64().unwrap_or(0.0) as f32;
+                    let r = input["radius"].as_f64().unwrap_or(0.0) as f32;
+                    let s = snap_ceis.lock().unwrap();
+                    let count = s.entities.iter()
+                        .filter(|e| e.position.map(|[ex, ey, ez]| {
+                            ((ex-px).powi(2)+(ey-py).powi(2)+(ez-pz).powi(2)).sqrt() <= r
+                        }).unwrap_or(false))
+                        .count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
+            // get_entities_in_sphere
+            let snap_geis = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_in_sphere".to_string(),
+                description: "Return entity IDs within a sphere defined by center (x,y,z) and radius; returns {entity_ids}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "x": {"type": "number"}, "y": {"type": "number"}, "z": {"type": "number"},
+                    "radius": {"type": "number"}
+                }, "required": ["x","y","z","radius"]})),
+                handler: Box::new(move |input| {
+                    let px = input["x"].as_f64().unwrap_or(0.0) as f32;
+                    let py = input["y"].as_f64().unwrap_or(0.0) as f32;
+                    let pz = input["z"].as_f64().unwrap_or(0.0) as f32;
+                    let r = input["radius"].as_f64().unwrap_or(0.0) as f32;
+                    let s = snap_geis.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter_map(|e| e.position.map(|[ex, ey, ez]| {
+                            if ((ex-px).powi(2)+(ey-py).powi(2)+(ez-pz).powi(2)).sqrt() <= r { Some(e.id) } else { None }
+                        }))
+                        .flatten()
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // count_entities_by_name_prefix
             let snap_cebnp = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -16280,6 +16329,108 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_count_entities_in_sphere_returns_correct_count() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Inside", "position": [1.0, 0.0, 0.0]},
+                        {"name": "Outside", "position": [100.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute(
+                "count_entities_in_sphere",
+                json!({"x": 0.0, "y": 0.0, "z": 0.0, "radius": 10.0}),
+            )
+            .unwrap();
+        assert!(out.is_ok());
+        assert_eq!(out.content["count"], 1);
+    }
+
+    #[test]
+    fn mcp_get_entities_in_sphere_returns_matching_ids() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Inside", "position": [1.0, 0.0, 0.0]},
+                        {"name": "Outside", "position": [100.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (inside_id, outside_id) = (id_of("Inside"), id_of("Outside"));
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let out = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute(
+                "get_entities_in_sphere",
+                json!({"x": 0.0, "y": 0.0, "z": 0.0, "radius": 10.0}),
+            )
+            .unwrap();
+        assert!(out.is_ok());
+        let ids: Vec<u64> = out.content["entity_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap())
+            .collect();
+        assert!(ids.contains(&inside_id));
+        assert!(!ids.contains(&outside_id));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `count_entities_in_sphere(x,y,z,radius)` — count entities within sphere; returns `{count}`
- `get_entities_in_sphere(x,y,z,radius)` — return entity IDs within sphere; returns `{entity_ids}`

## Test plan

- [x] `mcp_count_entities_in_sphere_returns_correct_count`
- [x] `mcp_get_entities_in_sphere_returns_matching_ids`
- [x] 565 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)