### PR TITLE
feat: Phase 315 — select_entities_in_sphere / deselect_entities_in_sphere MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,64 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // select_entities_in_sphere
+            let snap_seis = snapshot.clone();
+            let sel_seis = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "select_entities_in_sphere".to_string(),
+                description: "Add to selection all entities within a sphere defined by center (x,y,z) and radius; returns {added_count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "x": {"type": "number"}, "y": {"type": "number"}, "z": {"type": "number"},
+                    "radius": {"type": "number"}
+                }, "required": ["x","y","z","radius"]})),
+                handler: Box::new(move |input| {
+                    let px = input["x"].as_f64().unwrap_or(0.0) as f32;
+                    let py = input["y"].as_f64().unwrap_or(0.0) as f32;
+                    let pz = input["z"].as_f64().unwrap_or(0.0) as f32;
+                    let r = input["radius"].as_f64().unwrap_or(0.0) as f32;
+                    let s = snap_seis.lock().unwrap();
+                    let to_add: Vec<u64> = s.entities.iter()
+                        .filter_map(|e| e.position.map(|[ex, ey, ez]| {
+                            if ((ex-px).powi(2)+(ey-py).powi(2)+(ez-pz).powi(2)).sqrt() <= r { Some(e.id) } else { None }
+                        }))
+                        .flatten()
+                        .collect();
+                    let count = to_add.len() as u64;
+                    let mut sel = sel_seis.lock().unwrap();
+                    for id in to_add { sel.insert(id); }
+                    McpToolOutput::success(json!({"added_count": count}))
+                }),
+            });
+
+            // deselect_entities_in_sphere
+            let snap_deis = snapshot.clone();
+            let sel_deis = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_in_sphere".to_string(),
+                description: "Remove from selection all entities within a sphere defined by center (x,y,z) and radius; returns {removed_count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "x": {"type": "number"}, "y": {"type": "number"}, "z": {"type": "number"},
+                    "radius": {"type": "number"}
+                }, "required": ["x","y","z","radius"]})),
+                handler: Box::new(move |input| {
+                    let px = input["x"].as_f64().unwrap_or(0.0) as f32;
+                    let py = input["y"].as_f64().unwrap_or(0.0) as f32;
+                    let pz = input["z"].as_f64().unwrap_or(0.0) as f32;
+                    let r = input["radius"].as_f64().unwrap_or(0.0) as f32;
+                    let s = snap_deis.lock().unwrap();
+                    let to_remove: Vec<u64> = s.entities.iter()
+                        .filter_map(|e| e.position.map(|[ex, ey, ez]| {
+                            if ((ex-px).powi(2)+(ey-py).powi(2)+(ez-pz).powi(2)).sqrt() <= r { Some(e.id) } else { None }
+                        }))
+                        .flatten()
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    let mut sel = sel_deis.lock().unwrap();
+                    for id in to_remove { sel.remove(&id); }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
             // count_entities_in_sphere
             let snap_ceis = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -16329,6 +16387,183 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_select_entities_in_sphere_adds_to_selection() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Inside", "position": [1.0, 0.0, 0.0]},
+                        {"name": "Outside", "position": [100.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (inside_id, outside_id) = (id_of("Inside"), id_of("Outside"));
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "select_entities_in_sphere",
+                    json!({"x": 0.0, "y": 0.0, "z": 0.0, "radius": 10.0}),
+                )
+                .unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["added_count"], 1);
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let entities = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("list_entities", json!({}))
+            .unwrap()
+            .content["entities"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let find = |id: u64| {
+            entities
+                .iter()
+                .find(|e| e["id"].as_u64() == Some(id))
+                .unwrap()
+                .clone()
+        };
+        assert_eq!(find(inside_id)["selected"], true);
+        assert_eq!(find(outside_id)["selected"], false);
+    }
+
+    #[test]
+    fn mcp_deselect_entities_in_sphere_removes_from_selection() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Inside", "position": [1.0, 0.0, 0.0]},
+                        {"name": "Outside", "position": [100.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let all = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone()
+        };
+        let id_of = |name: &str| {
+            all.iter()
+                .find(|e| e["name"].as_str() == Some(name))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap()
+        };
+        let (inside_id, outside_id) = (id_of("Inside"), id_of("Outside"));
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "deselect_entities_in_sphere",
+                    json!({"x": 0.0, "y": 0.0, "z": 0.0, "radius": 10.0}),
+                )
+                .unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["removed_count"], 1);
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let entities = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("list_entities", json!({}))
+            .unwrap()
+            .content["entities"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let find = |id: u64| {
+            entities
+                .iter()
+                .find(|e| e["id"].as_u64() == Some(id))
+                .unwrap()
+                .clone()
+        };
+        assert_eq!(find(inside_id)["selected"], false);
+        assert_eq!(find(outside_id)["selected"], true);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `select_entities_in_sphere(x,y,z,radius)` — add to selection entities within sphere; returns `{added_count}`
- `deselect_entities_in_sphere(x,y,z,radius)` — remove from selection entities within sphere; returns `{removed_count}`

## Test plan

- [x] `mcp_select_entities_in_sphere_adds_to_selection`
- [x] `mcp_deselect_entities_in_sphere_removes_from_selection`
- [x] 567 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)