### PR TITLE
feat: Phase 354 — deselect_entities_sharing_all_tags / deselect_entities_with_any_of_tags MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1647,6 +1647,80 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // deselect_entities_sharing_all_tags
+            let snap_deast = snapshot.clone();
+            let sel_deast = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_sharing_all_tags".to_string(),
+                description:
+                    "Deselect entities that have ALL of the specified tags; returns {removed_count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "tags": {"type": "array", "items": {"type": "string"}}
+                }, "required": ["tags"]})),
+                handler: Box::new(move |input| {
+                    let required: Vec<String> = input["tags"]
+                        .as_array()
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let s = snap_deast.lock().unwrap();
+                    let to_remove: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| required.iter().all(|r| e.tags.contains(r)))
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_deast.lock().unwrap();
+                    for id in &to_remove {
+                        sel.remove(id);
+                    }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
+            // deselect_entities_with_any_of_tags
+            let snap_dewat = snapshot.clone();
+            let sel_dewat = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_with_any_of_tags".to_string(),
+                description:
+                    "Deselect entities that have any of the specified tags; returns {removed_count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "tags": {"type": "array", "items": {"type": "string"}}
+                }, "required": ["tags"]})),
+                handler: Box::new(move |input| {
+                    let any_of: Vec<String> = input["tags"]
+                        .as_array()
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let s = snap_dewat.lock().unwrap();
+                    let to_remove: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| any_of.iter().any(|t| e.tags.contains(t)))
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_dewat.lock().unwrap();
+                    for id in &to_remove {
+                        sel.remove(id);
+                    }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
             // select_entities_sharing_all_tags
             let snap_seast = snapshot.clone();
             let sel_seast = selection.clone();
@@ -18040,6 +18114,204 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_deselect_entities_sharing_all_tags_and_with_any_of_tags() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Both"}, {"name": "Alpha_only"}, {"name": "Neither"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // Both: [alpha, beta], Alpha_only: [alpha], Neither: []
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let id_both = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Both"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            let id_a = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Alpha_only"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("tag_entity", json!({"entity_id": id_both, "tag": "alpha"}))
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("tag_entity", json!({"entity_id": id_a, "tag": "alpha"}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let id_both = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Both"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("tag_entity", json!({"entity_id": id_both, "tag": "beta"}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // --- test deselect_entities_sharing_all_tags ---
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "deselect_entities_sharing_all_tags",
+                    json!({"tags": ["alpha", "beta"]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let both_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Both"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let alpha_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Alpha_only"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            assert!(!both_sel, "Both deselected (has all tags)");
+            assert!(alpha_sel, "Alpha_only still selected");
+        }
+
+        // --- test deselect_entities_with_any_of_tags ---
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "deselect_entities_with_any_of_tags",
+                    json!({"tags": ["beta"]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+        let entities = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("list_entities", json!({}))
+            .unwrap()
+            .content["entities"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let both_sel = entities
+            .iter()
+            .find(|e| e["name"].as_str() == Some("Both"))
+            .unwrap()["selected"]
+            .as_bool()
+            .unwrap();
+        let alpha_sel = entities
+            .iter()
+            .find(|e| e["name"].as_str() == Some("Alpha_only"))
+            .unwrap()["selected"]
+            .as_bool()
+            .unwrap();
+        let neither_sel = entities
+            .iter()
+            .find(|e| e["name"].as_str() == Some("Neither"))
+            .unwrap()["selected"]
+            .as_bool()
+            .unwrap();
+        assert!(!both_sel, "Both deselected (has beta)");
+        assert!(alpha_sel, "Alpha_only still selected");
+        assert!(neither_sel, "Neither still selected");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `deselect_entities_sharing_all_tags(tags)` — deselect entities with ALL given tags; returns `{removed_count}`
- `deselect_entities_with_any_of_tags(tags)` — deselect entities with any of the given tags; returns `{removed_count}`

## Test plan

- [x] `mcp_deselect_entities_sharing_all_tags_and_with_any_of_tags`
- [x] 630 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)