### PR TITLE
feat: Phase 375 — deselect_entities_by_name_starts_with / deselect_entities_by_name_ends_with MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,60 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // deselect_entities_by_name_starts_with
+            let snap_delnamestart = snapshot.clone();
+            let sel_delnamestart = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_by_name_starts_with".to_string(),
+                description: "Deselect entities whose name starts with the given prefix (case-sensitive); returns {removed_count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "prefix": {"type": "string"}
+                }, "required": ["prefix"]})),
+                handler: Box::new(move |input| {
+                    let prefix = match input["prefix"].as_str() {
+                        Some(s) => s.to_string(),
+                        None => return McpToolOutput::error("missing prefix"),
+                    };
+                    let s = snap_delnamestart.lock().unwrap();
+                    let to_remove: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.name.as_deref().map(|n| n.starts_with(&*prefix)).unwrap_or(false))
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_delnamestart.lock().unwrap();
+                    for id in &to_remove { sel.remove(id); }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
+            // deselect_entities_by_name_ends_with
+            let snap_delnameend = snapshot.clone();
+            let sel_delnameend = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_by_name_ends_with".to_string(),
+                description: "Deselect entities whose name ends with the given suffix (case-sensitive); returns {removed_count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "suffix": {"type": "string"}
+                }, "required": ["suffix"]})),
+                handler: Box::new(move |input| {
+                    let suffix = match input["suffix"].as_str() {
+                        Some(s) => s.to_string(),
+                        None => return McpToolOutput::error("missing suffix"),
+                    };
+                    let s = snap_delnameend.lock().unwrap();
+                    let to_remove: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.name.as_deref().map(|n| n.ends_with(&*suffix)).unwrap_or(false))
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_delnameend.lock().unwrap();
+                    for id in &to_remove { sel.remove(id); }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
             // select_entities_by_name_starts_with
             let snap_selnamestart = snapshot.clone();
             let sel_selnamestart = selection.clone();
@@ -19330,6 +19384,145 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_deselect_entities_by_name_starts_and_ends_with() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Enemy_A"}, {"name": "Enemy_B"}, {"name": "Player"},
+                        {"name": "Wall_Left"}, {"name": "Wall_Right"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // select all, deselect_entities_by_name_starts_with("Enemy") → Enemy_A, Enemy_B deselected
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "deselect_entities_by_name_starts_with",
+                    json!({"prefix": "Enemy"}),
+                )
+                .unwrap();
+            assert!(out.is_ok());
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let ea_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Enemy_A"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let eb_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Enemy_B"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let player_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Player"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            assert!(!ea_sel, "Enemy_A deselected");
+            assert!(!eb_sel, "Enemy_B deselected");
+            assert!(player_sel, "Player still selected");
+        }
+
+        // select all, deselect_entities_by_name_ends_with("Right") → Wall_Right deselected
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "deselect_entities_by_name_ends_with",
+                    json!({"suffix": "Right"}),
+                )
+                .unwrap();
+            assert!(out.is_ok());
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let right_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Wall_Right"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let left_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Wall_Left"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            assert!(!right_sel, "Wall_Right deselected");
+            assert!(left_sel, "Wall_Left still selected");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `deselect_entities_by_name_starts_with(prefix)` — deselect entities whose name starts with prefix (case-sensitive); returns `{removed_count}`
- `deselect_entities_by_name_ends_with(suffix)` — deselect entities whose name ends with suffix (case-sensitive); returns `{removed_count}`

## Test plan

- [x] `mcp_deselect_entities_by_name_starts_and_ends_with`
- [x] 651 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)