### PR TITLE
feat: Phase 378 — deselect_entities_with_mesh / count_entities_with_camera MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,47 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // deselect_entities_with_mesh
+            let snap_delwm = snapshot.clone();
+            let sel_delwm = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_with_mesh".to_string(),
+                description:
+                    "Deselect all entities that have a mesh renderer; returns {removed_count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_delwm.lock().unwrap();
+                    let to_remove: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.mesh_id.is_some())
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_delwm.lock().unwrap();
+                    for id in &to_remove {
+                        sel.remove(id);
+                    }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
+            // count_entities_with_camera
+            let snap_cntwc = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_camera".to_string(),
+                description: "Count entities that have a camera component; returns {count}"
+                    .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_cntwc.lock().unwrap();
+                    let count = s.entities.iter().filter(|e| e.camera_fov.is_some()).count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
             // count_entities_with_light
             let snap_cntwl = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -19467,6 +19508,136 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_deselect_with_mesh_and_count_with_camera() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        // Spawn entities, attach mesh to one, spawn camera
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "MeshEntity"}, {"name": "Plain"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let id_mesh = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("MeshEntity"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("attach_mesh", json!({"entity_id": id_mesh, "mesh_id": 1}))
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "spawn_camera",
+                    json!({"fov_y_degrees": 60.0, "position": [0.0, 0.0, 5.0]}),
+                )
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "spawn_camera",
+                    json!({"fov_y_degrees": 90.0, "position": [1.0, 0.0, 5.0]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+
+        // count_entities_with_camera → 2
+        let count_cam = mcp
+            .0
+            .lock()
+            .unwrap()
+            .execute("count_entities_with_camera", json!({}))
+            .unwrap();
+        assert!(count_cam.is_ok());
+        assert_eq!(count_cam.content["count"], 2, "2 camera entities");
+
+        // select all, deselect_entities_with_mesh → mesh entity deselected
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("deselect_entities_with_mesh", json!({}))
+                .unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["removed_count"], 1);
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let plain_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Plain"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let mesh_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("MeshEntity"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            assert!(plain_sel, "Plain still selected");
+            assert!(!mesh_sel, "MeshEntity deselected");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `deselect_entities_with_mesh()` — deselect all entities that have a mesh renderer; returns `{removed_count}`
- `count_entities_with_camera()` — count entities with a camera component; returns `{count}`

## Test plan

- [x] `mcp_deselect_with_mesh_and_count_with_camera`
- [x] 654 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)