### PR TITLE
feat: Phase 386 — count_entities_with_no_light / select_entities_with_no_light MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,47 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // count_entities_with_no_light
+            let snap_cnwnl = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_no_light".to_string(),
+                description: "Count entities that have no light component; returns {count}"
+                    .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_cnwnl.lock().unwrap();
+                    let count = s.entities.iter().filter(|e| e.light_type.is_none()).count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
+            // select_entities_with_no_light
+            let snap_sewnl = snapshot.clone();
+            let sel_sewnl = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "select_entities_with_no_light".to_string(),
+                description:
+                    "Select all entities that have no light component; returns {added_count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_sewnl.lock().unwrap();
+                    let to_add: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.light_type.is_none())
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_add.len() as u64;
+                    drop(s);
+                    let mut sel = sel_sewnl.lock().unwrap();
+                    for id in to_add {
+                        sel.insert(id);
+                    }
+                    McpToolOutput::success(json!({"added_count": count}))
+                }),
+            });
+
             // deselect_entities_with_no_mesh
             let snap_dewnm = snapshot.clone();
             let sel_dewnm = selection.clone();
@@ -19788,6 +19829,99 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_count_and_select_entities_with_no_light() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "A", "position": [1.0, 0.0, 0.0]},
+                        {"name": "B"},
+                    ]}),
+                )
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "spawn_point_light",
+                    json!({
+                        "color": [1.0, 1.0, 1.0], "intensity": 100.0,
+                        "range": 10.0, "position": [0.0, 5.0, 0.0]
+                    }),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+
+            // count_entities_with_no_light → A and B (light entity excluded)
+            let cnt_out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("count_entities_with_no_light", json!({}))
+                .unwrap();
+            assert!(cnt_out.is_ok());
+            assert_eq!(cnt_out.content["count"], 2, "A and B have no light");
+
+            // select_entities_with_no_light → A and B selected
+            let sel_out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("select_entities_with_no_light", json!({}))
+                .unwrap();
+            assert!(sel_out.is_ok());
+            assert_eq!(sel_out.content["added_count"], 2);
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let a_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("A"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let b_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("B"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let light_any_sel = entities
+                .iter()
+                .filter(|e| e["light_type"].is_string())
+                .any(|e| e["selected"].as_bool().unwrap_or(false));
+            assert!(a_sel, "A selected");
+            assert!(b_sel, "B selected");
+            assert!(!light_any_sel, "light entity not selected");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `count_entities_with_no_light()` — count entities with no light component; returns `{count}`
- `select_entities_with_no_light()` — select all entities with no light component; returns `{added_count}`

## Test plan

- [x] `mcp_count_and_select_entities_with_no_light`
- [x] 662 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)