### PR TITLE
feat: Phase 387 — deselect_entities_with_no_light / get_entities_with_no_camera MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,53 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // deselect_entities_with_no_light
+            let snap_dewnl = snapshot.clone();
+            let sel_dewnl = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_with_no_light".to_string(),
+                description:
+                    "Deselect all entities that have no light component; returns {removed_count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_dewnl.lock().unwrap();
+                    let to_remove: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.light_type.is_none())
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_dewnl.lock().unwrap();
+                    for id in &to_remove {
+                        sel.remove(id);
+                    }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
+            // get_entities_with_no_camera
+            let snap_gewnc = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_no_camera".to_string(),
+                description:
+                    "Return IDs of entities that have no camera component; returns {entity_ids}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_gewnc.lock().unwrap();
+                    let ids: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.camera_fov.is_none())
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // count_entities_with_no_light
             let snap_cnwnl = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -19829,6 +19876,144 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_deselect_no_light_and_get_no_camera() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "A", "position": [1.0, 0.0, 0.0]},
+                        {"name": "B"},
+                    ]}),
+                )
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "spawn_camera",
+                    json!({"fov_y_degrees": 60.0, "position": [0.0, 0.0, 5.0]}),
+                )
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "spawn_point_light",
+                    json!({
+                        "color": [1.0, 1.0, 1.0], "intensity": 100.0,
+                        "range": 10.0, "position": [0.0, 5.0, 0.0]
+                    }),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // select all, deselect_entities_with_no_light → only light entity remains selected
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("deselect_entities_with_no_light", json!({}))
+                .unwrap();
+            assert!(out.is_ok());
+            // A, B, camera all have no light → 3 removed
+            assert!(out.content["removed_count"].as_u64().unwrap() >= 2);
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let a_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("A"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let light_sel = entities
+                .iter()
+                .filter(|e| e["light_type"].is_string())
+                .any(|e| e["selected"].as_bool().unwrap_or(false));
+            assert!(!a_sel, "A deselected (no light)");
+            assert!(light_sel, "light entity still selected");
+        }
+
+        // get_entities_with_no_camera → A, B, and light (camera excluded)
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let cam_ids: std::collections::HashSet<u64> = entities
+                .iter()
+                .filter(|e| e["camera_fov"].is_number())
+                .map(|e| e["id"].as_u64().unwrap())
+                .collect();
+            let id_a = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("A"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            let nc_out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("get_entities_with_no_camera", json!({}))
+                .unwrap();
+            assert!(nc_out.is_ok());
+            let ids: std::collections::HashSet<u64> = nc_out.content["entity_ids"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_u64().unwrap())
+                .collect();
+            assert!(ids.contains(&id_a), "A has no camera");
+            assert!(
+                cam_ids.iter().all(|cid| !ids.contains(cid)),
+                "camera excluded"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `deselect_entities_with_no_light()` — deselect all entities with no light component; returns `{removed_count}`
- `get_entities_with_no_camera()` — return IDs of entities with no camera component; returns `{entity_ids}`

## Test plan

- [x] `mcp_deselect_no_light_and_get_no_camera`
- [x] 663 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)