### PR TITLE
feat: Phase 389 — deselect_entities_with_no_camera / get_entities_visible MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,52 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // deselect_entities_with_no_camera
+            let snap_dewnc = snapshot.clone();
+            let sel_dewnc = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_with_no_camera".to_string(),
+                description:
+                    "Deselect all entities that have no camera component; returns {removed_count}"
+                        .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_dewnc.lock().unwrap();
+                    let to_remove: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.camera_fov.is_none())
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_dewnc.lock().unwrap();
+                    for id in &to_remove {
+                        sel.remove(id);
+                    }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
+            // get_entities_visible
+            let snap_gev = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_visible".to_string(),
+                description: "Return IDs of entities that are visible; returns {entity_ids}"
+                    .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_gev.lock().unwrap();
+                    let ids: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.visible)
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // count_entities_with_no_camera
             let snap_cnwnc = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -19917,6 +19963,158 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_deselect_no_camera_and_get_visible_entities() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "A", "position": [1.0, 0.0, 0.0]},
+                        {"name": "B"},
+                    ]}),
+                )
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "spawn_camera",
+                    json!({"fov_y_degrees": 60.0, "position": [0.0, 0.0, 5.0]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // Hide B
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let id_b = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("B"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("hide_entity", json!({"entity_id": id_b}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // select all, deselect_entities_with_no_camera → camera remains, A and B deselected
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("deselect_entities_with_no_camera", json!({}))
+                .unwrap();
+            assert!(out.is_ok());
+            assert!(out.content["removed_count"].as_u64().unwrap() >= 2);
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let a_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("A"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let cam_sel = entities
+                .iter()
+                .filter(|e| e["camera_fov"].is_number())
+                .any(|e| e["selected"].as_bool().unwrap_or(false));
+            assert!(!a_sel, "A deselected (no camera)");
+            assert!(cam_sel, "camera still selected");
+        }
+
+        // get_entities_visible → A and camera (B is hidden)
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let id_a = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("A"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            let id_b = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("B"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            let vis_out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("get_entities_visible", json!({}))
+                .unwrap();
+            assert!(vis_out.is_ok());
+            let vis_ids: std::collections::HashSet<u64> = vis_out.content["entity_ids"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_u64().unwrap())
+                .collect();
+            assert!(vis_ids.contains(&id_a), "A is visible");
+            assert!(!vis_ids.contains(&id_b), "B is hidden");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `deselect_entities_with_no_camera()` — deselect all entities with no camera; returns `{removed_count}`
- `get_entities_visible()` — return IDs of visible entities; returns `{entity_ids}`

## Test plan

- [x] `mcp_deselect_no_camera_and_get_visible_entities`
- [x] 665 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)