### PR TITLE
feat: Phase 393 — deselect_entities_hidden / get_entities_with_position_in_range MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,62 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // deselect_entities_hidden
+            let snap_deh = snapshot.clone();
+            let sel_deh = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_hidden".to_string(),
+                description: "Deselect all hidden entities; returns {removed_count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_deh.lock().unwrap();
+                    let to_remove: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| !e.visible)
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_deh.lock().unwrap();
+                    for id in &to_remove {
+                        sel.remove(id);
+                    }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
+            // get_entities_with_position_in_range
+            let snap_gepir = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_position_in_range".to_string(),
+                description: "Return IDs of entities whose position is within the given AABB [min, max]; returns {entity_ids}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "min": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3},
+                    "max": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3}
+                }, "required": ["min", "max"]})),
+                handler: Box::new(move |input| {
+                    let min_x = input["min"][0].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let min_y = input["min"][1].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let min_z = input["min"][2].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let max_x = input["max"][0].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let max_y = input["max"][1].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let max_z = input["max"][2].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let s = snap_gepir.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| {
+                            if let Some([x, y, z]) = e.position {
+                                x >= min_x && x <= max_x && y >= min_y && y <= max_y && z >= min_z && z <= max_z
+                            } else {
+                                false
+                            }
+                        })
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // select_entities_hidden
             let snap_seh = snapshot.clone();
             let sel_seh = selection.clone();
@@ -20084,6 +20140,159 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_deselect_hidden_and_get_entities_in_position_range() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Near", "position": [1.0, 0.0, 0.0]},
+                        {"name": "Far", "position": [100.0, 0.0, 0.0]},
+                        {"name": "Hidden"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // Hide Hidden
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let id_hidden = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Hidden"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("hide_entity", json!({"entity_id": id_hidden}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // select all, deselect_entities_hidden → Hidden deselected
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("select_all", json!({}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("deselect_entities_hidden", json!({}))
+                .unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["removed_count"], 1);
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let near_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Near"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let hidden_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Hidden"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            assert!(near_sel, "Near still selected");
+            assert!(!hidden_sel, "Hidden deselected");
+        }
+
+        // get_entities_with_position_in_range: min=[0,0,0] max=[10,10,10] → only Near
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let id_near = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Near"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            let id_far = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Far"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            let range_out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "get_entities_with_position_in_range",
+                    json!({
+                        "min": [0.0, -1.0, -1.0],
+                        "max": [10.0, 1.0, 1.0]
+                    }),
+                )
+                .unwrap();
+            assert!(range_out.is_ok());
+            let ids: std::collections::HashSet<u64> = range_out.content["entity_ids"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_u64().unwrap())
+                .collect();
+            assert!(ids.contains(&id_near), "Near in range");
+            assert!(!ids.contains(&id_far), "Far out of range");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `deselect_entities_hidden()` — deselect all hidden entities; returns `{removed_count}`
- `get_entities_with_position_in_range(min, max)` — return IDs of entities within AABB; returns `{entity_ids}`

## Test plan

- [x] `mcp_deselect_hidden_and_get_entities_in_position_range`
- [x] 669 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)