### PR TITLE
feat: Phase 394 — select/count_entities_with_position_in_range MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,68 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // select_entities_with_position_in_range
+            let snap_sepir = snapshot.clone();
+            let sel_sepir = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "select_entities_with_position_in_range".to_string(),
+                description: "Select all entities whose position is within the given AABB [min, max]; returns {added_count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "min": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3},
+                    "max": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3}
+                }, "required": ["min", "max"]})),
+                handler: Box::new(move |input| {
+                    let min_x = input["min"][0].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let min_y = input["min"][1].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let min_z = input["min"][2].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let max_x = input["max"][0].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let max_y = input["max"][1].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let max_z = input["max"][2].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let s = snap_sepir.lock().unwrap();
+                    let to_add: Vec<u64> = s.entities.iter()
+                        .filter(|e| {
+                            if let Some([x, y, z]) = e.position {
+                                x >= min_x && x <= max_x && y >= min_y && y <= max_y && z >= min_z && z <= max_z
+                            } else { false }
+                        })
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_add.len() as u64;
+                    drop(s);
+                    let mut sel = sel_sepir.lock().unwrap();
+                    for id in to_add { sel.insert(id); }
+                    McpToolOutput::success(json!({"added_count": count}))
+                }),
+            });
+
+            // count_entities_with_position_in_range
+            let snap_cepir = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_position_in_range".to_string(),
+                description: "Count entities whose position is within the given AABB [min, max]; returns {count}".to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {
+                    "min": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3},
+                    "max": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3}
+                }, "required": ["min", "max"]})),
+                handler: Box::new(move |input| {
+                    let min_x = input["min"][0].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let min_y = input["min"][1].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let min_z = input["min"][2].as_f64().unwrap_or(f64::NEG_INFINITY) as f32;
+                    let max_x = input["max"][0].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let max_y = input["max"][1].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let max_z = input["max"][2].as_f64().unwrap_or(f64::INFINITY) as f32;
+                    let s = snap_cepir.lock().unwrap();
+                    let count = s.entities.iter()
+                        .filter(|e| {
+                            if let Some([x, y, z]) = e.position {
+                                x >= min_x && x <= max_x && y >= min_y && y <= max_y && z >= min_z && z <= max_z
+                            } else { false }
+                        })
+                        .count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
             // deselect_entities_hidden
             let snap_deh = snapshot.clone();
             let sel_deh = selection.clone();
@@ -20140,6 +20202,96 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_select_and_count_entities_with_position_in_range() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "Near", "position": [1.0, 0.0, 0.0]},
+                        {"name": "Far",  "position": [100.0, 0.0, 0.0]},
+                        {"name": "NoPos"},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+
+            // count_entities_with_position_in_range → 1 (Near)
+            let cnt_out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "count_entities_with_position_in_range",
+                    json!({
+                        "min": [0.0, -1.0, -1.0],
+                        "max": [10.0, 1.0, 1.0]
+                    }),
+                )
+                .unwrap();
+            assert!(cnt_out.is_ok());
+            assert_eq!(cnt_out.content["count"], 1, "only Near is in range");
+
+            // select_entities_with_position_in_range → Near selected
+            let sel_out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "select_entities_with_position_in_range",
+                    json!({
+                        "min": [0.0, -1.0, -1.0],
+                        "max": [10.0, 1.0, 1.0]
+                    }),
+                )
+                .unwrap();
+            assert!(sel_out.is_ok());
+            assert_eq!(sel_out.content["added_count"], 1);
+        }
+        app.update();
+        app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let near_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Near"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            let far_sel = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("Far"))
+                .unwrap()["selected"]
+                .as_bool()
+                .unwrap();
+            assert!(near_sel, "Near selected");
+            assert!(!far_sel, "Far not selected");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `select_entities_with_position_in_range(min, max)` — select entities within AABB; returns `{added_count}`
- `count_entities_with_position_in_range(min, max)` — count entities within AABB; returns `{count}`

## Test plan

- [x] `mcp_select_and_count_entities_with_position_in_range`
- [x] 670 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)