### PR TITLE
feat: Phase 403 — select_entities_with_no_tags / deselect_entities_with_no_tags MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,58 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // select_entities_with_no_tags
+            let snap_sewnt = snapshot.clone();
+            let sel_sewnt = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "select_entities_with_no_tags".to_string(),
+                description: "Select all entities that have no tags; returns {added_count}"
+                    .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_sewnt.lock().unwrap();
+                    let to_add: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.tags.is_empty())
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_add.len() as u64;
+                    drop(s);
+                    let mut sel = sel_sewnt.lock().unwrap();
+                    for id in to_add {
+                        sel.insert(id);
+                    }
+                    McpToolOutput::success(json!({"added_count": count}))
+                }),
+            });
+
+            // deselect_entities_with_no_tags
+            let snap_dewnt = snapshot.clone();
+            let sel_dewnt = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_with_no_tags".to_string(),
+                description: "Deselect all entities that have no tags; returns {removed_count}"
+                    .to_string(),
+                input_schema: Some(json!({"type": "object", "properties": {}, "required": []})),
+                handler: Box::new(move |_input| {
+                    let s = snap_dewnt.lock().unwrap();
+                    let to_remove: Vec<u64> = s
+                        .entities
+                        .iter()
+                        .filter(|e| e.tags.is_empty())
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_dewnt.lock().unwrap();
+                    for id in &to_remove {
+                        sel.remove(id);
+                    }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
             // select_entities_with_any_tag
             let snap_sewat = snapshot.clone();
             let sel_sewat = selection.clone();
@@ -20574,6 +20626,88 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_select_and_deselect_entities_with_no_tags() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute(
+                    "batch_spawn",
+                    json!({"entities": [
+                        {"name": "A", "position": [1.0, 0.0, 0.0]},
+                        {"name": "B", "position": [2.0, 0.0, 0.0]},
+                    ]}),
+                )
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // Tag A — only B has no tags
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("list_entities", json!({}))
+                .unwrap()
+                .content["entities"]
+                .as_array()
+                .unwrap()
+                .clone();
+            let id_a = entities
+                .iter()
+                .find(|e| e["name"].as_str() == Some("A"))
+                .unwrap()["id"]
+                .as_u64()
+                .unwrap();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("tag_entity", json!({"entity_id": id_a, "tag": "tagged"}))
+                .unwrap();
+        }
+        app.update();
+        app.update();
+
+        // select_entities_with_no_tags — B gets selected (no tags)
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("select_entities_with_no_tags", json!({}))
+                .unwrap();
+            assert!(out.is_ok());
+            let added = out.content["added_count"].as_u64().unwrap();
+            assert!(added >= 1, "B should be selected (no tags)");
+        }
+        app.update();
+        app.update();
+
+        // deselect_entities_with_no_tags — B removed from selection
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("deselect_entities_with_no_tags", json!({}))
+                .unwrap();
+            assert!(out.is_ok());
+            let removed = out.content["removed_count"].as_u64().unwrap();
+            assert!(removed >= 1, "B should be deselected");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `select_entities_with_no_tags()` — select all entities with no tags; returns `{added_count}`
- `deselect_entities_with_no_tags()` — deselect all entities with no tags; returns `{removed_count}`

## Test plan

- [x] `mcp_select_and_deselect_entities_with_no_tags`
- [x] 679 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)