### PR TITLE
feat: Phase 438 — count_entities_with_tag_in_list / get_entities_with_all_tags_in_list MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,61 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // count_entities_with_tag_in_list
+            let snap_cewtil = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_tag_in_list".to_string(),
+                description: "Count entities that have at least one tag from the given list; returns {count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "tags": { "type": "array", "items": { "type": "string" } }
+                    },
+                    "required": ["tags"]
+                })),
+                handler: Box::new(move |input| {
+                    let tag_list: std::collections::HashSet<String> = input["tags"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect();
+                    let s = snap_cewtil.lock().unwrap();
+                    let count = s.entities.iter()
+                        .filter(|e| e.tags.iter().any(|t| tag_list.contains(t)))
+                        .count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
+            // get_entities_with_all_tags_in_list
+            let snap_gewatil = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_all_tags_in_list".to_string(),
+                description: "Return IDs of entities that have ALL tags from the given list; returns {entity_ids}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "tags": { "type": "array", "items": { "type": "string" } }
+                    },
+                    "required": ["tags"]
+                })),
+                handler: Box::new(move |input| {
+                    let tag_list: Vec<String> = input["tags"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect();
+                    let s = snap_gewatil.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| tag_list.iter().all(|t| e.tags.contains(t)))
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // select_entities_with_tag_in_list
             let snap_sewtil = snapshot.clone();
             let sel_sewtil = selection.clone();
@@ -22569,6 +22624,77 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_count_tag_in_list_and_get_all_tags_in_list() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("batch_spawn", json!({"entities": [
+                {"name": "A", "position": [1.0, 0.0, 0.0]},
+                {"name": "B", "position": [2.0, 0.0, 0.0]},
+                {"name": "C", "position": [3.0, 0.0, 0.0]},
+            ]})).unwrap();
+        }
+        app.update(); app.update();
+
+        // A → [x, y, z], B → [x, y], C → [x]
+        let (id_a, id_b, id_c) = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap()
+                .content["entities"].as_array().unwrap().clone();
+            let id_a = entities.iter().find(|e| e["name"].as_str() == Some("A")).unwrap()["id"].as_u64().unwrap();
+            let id_b = entities.iter().find(|e| e["name"].as_str() == Some("B")).unwrap()["id"].as_u64().unwrap();
+            let id_c = entities.iter().find(|e| e["name"].as_str() == Some("C")).unwrap()["id"].as_u64().unwrap();
+            (id_a, id_b, id_c)
+        };
+        for (id, tag) in [(id_a, "x"), (id_a, "y"), (id_a, "z"), (id_b, "x"), (id_b, "y"), (id_c, "x")] {
+            {
+                let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+                mcp.0.lock().unwrap().execute("tag_entity", json!({"entity_id": id, "tag": tag})).unwrap();
+            }
+            app.update(); app.update();
+        }
+
+        // count_entities_with_tag_in_list [y, z] → A (has y,z), B (has y) = 2; C only has x = not counted
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("count_entities_with_tag_in_list", json!({"tags": ["y", "z"]})).unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["count"].as_u64().unwrap(), 2);
+        }
+
+        // get_entities_with_all_tags_in_list [x, y] → A and B (both have x and y); C only has x
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("get_entities_with_all_tags_in_list", json!({"tags": ["x", "y"]})).unwrap();
+            assert!(out.is_ok());
+            let ids: Vec<u64> = out.content["entity_ids"].as_array().unwrap()
+                .iter().map(|v| v.as_u64().unwrap()).collect();
+            assert_eq!(ids.len(), 2);
+            assert!(ids.contains(&id_a));
+            assert!(ids.contains(&id_b));
+            assert!(!ids.contains(&id_c));
+        }
+
+        // get_entities_with_all_tags_in_list [x, y, z] → only A has all three
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("get_entities_with_all_tags_in_list", json!({"tags": ["x", "y", "z"]})).unwrap();
+            assert!(out.is_ok());
+            let ids: Vec<u64> = out.content["entity_ids"].as_array().unwrap()
+                .iter().map(|v| v.as_u64().unwrap()).collect();
+            assert_eq!(ids.len(), 1);
+            assert!(ids.contains(&id_a));
+        }
+        let _ = (id_a, id_b, id_c);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `count_entities_with_tag_in_list(tags)` — count entities having at least one tag from the list; returns `{count}`
- `get_entities_with_all_tags_in_list(tags)` — return IDs of entities having ALL tags from the list; returns `{entity_ids}`

## Test plan

- [x] `mcp_count_tag_in_list_and_get_all_tags_in_list`
- [x] 714 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)