### PR TITLE
feat: Phase 454 — select_entities_with_name_not_containing / deselect_entities_with_name_not_containing MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,62 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // select_entities_with_name_not_containing
+            let snap_sewntnc = snapshot.clone();
+            let sel_sewntnc = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "select_entities_with_name_not_containing".to_string(),
+                description: "Select entities whose name does NOT contain the given substring; returns {added_count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "substring": { "type": "string" }
+                    },
+                    "required": ["substring"]
+                })),
+                handler: Box::new(move |input| {
+                    let sub = input["substring"].as_str().unwrap_or("").to_string();
+                    let s = snap_sewntnc.lock().unwrap();
+                    let to_add: Vec<u64> = s.entities.iter()
+                        .filter(|e| !e.name.as_deref().unwrap_or("").contains(&*sub))
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_add.len() as u64;
+                    drop(s);
+                    let mut sel = sel_sewntnc.lock().unwrap();
+                    for id in to_add { sel.insert(id); }
+                    McpToolOutput::success(json!({"added_count": count}))
+                }),
+            });
+
+            // deselect_entities_with_name_not_containing
+            let snap_dewntnc = snapshot.clone();
+            let sel_dewntnc = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_with_name_not_containing".to_string(),
+                description: "Deselect entities whose name does NOT contain the given substring; returns {removed_count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "substring": { "type": "string" }
+                    },
+                    "required": ["substring"]
+                })),
+                handler: Box::new(move |input| {
+                    let sub = input["substring"].as_str().unwrap_or("").to_string();
+                    let s = snap_dewntnc.lock().unwrap();
+                    let to_remove: Vec<u64> = s.entities.iter()
+                        .filter(|e| !e.name.as_deref().unwrap_or("").contains(&*sub))
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_dewntnc.lock().unwrap();
+                    for id in &to_remove { sel.remove(id); }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
             // get_entities_with_name_not_containing
             let snap_gewntnc = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -23405,6 +23461,77 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_select_and_deselect_name_not_containing() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("batch_spawn", json!({"entities": [
+                {"name": "Enemy_A", "position": [1.0, 0.0, 0.0]},
+                {"name": "Enemy_B", "position": [2.0, 0.0, 0.0]},
+                {"name": "Player",  "position": [3.0, 0.0, 0.0]},
+            ]})).unwrap();
+        }
+        app.update(); app.update();
+
+        let (id_ea, id_eb, id_player) = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap()
+                .content["entities"].as_array().unwrap().clone();
+            let id_ea = entities.iter().find(|e| e["name"].as_str() == Some("Enemy_A")).unwrap()["id"].as_u64().unwrap();
+            let id_eb = entities.iter().find(|e| e["name"].as_str() == Some("Enemy_B")).unwrap()["id"].as_u64().unwrap();
+            let id_player = entities.iter().find(|e| e["name"].as_str() == Some("Player")).unwrap()["id"].as_u64().unwrap();
+            (id_ea, id_eb, id_player)
+        };
+
+        // select_entities_with_name_not_containing "Enemy" → Player only; added_count=1
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("select_entities_with_name_not_containing", json!({"substring": "Enemy"})).unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["added_count"].as_u64().unwrap(), 1);
+        }
+        app.update(); app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let sel = mcp.0.lock().unwrap().execute("get_selected_entities", json!({})).unwrap();
+            let ids: std::collections::HashSet<u64> = sel.content["entities"].as_array().unwrap()
+                .iter().map(|v| v["id"].as_u64().unwrap()).collect();
+            assert!(!ids.contains(&id_ea));
+            assert!(!ids.contains(&id_eb));
+            assert!(ids.contains(&id_player));
+        }
+
+        // select all, then deselect_entities_with_name_not_containing "Enemy" → removes Player; removed_count=1
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("select_all", json!({})).unwrap();
+        }
+        app.update(); app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("deselect_entities_with_name_not_containing", json!({"substring": "Enemy"})).unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["removed_count"].as_u64().unwrap(), 1);
+        }
+        app.update(); app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let sel = mcp.0.lock().unwrap().execute("get_selected_entities", json!({})).unwrap();
+            let ids: std::collections::HashSet<u64> = sel.content["entities"].as_array().unwrap()
+                .iter().map(|v| v["id"].as_u64().unwrap()).collect();
+            assert!(ids.contains(&id_ea));
+            assert!(ids.contains(&id_eb));
+            assert!(!ids.contains(&id_player));
+        }
+        let _ = (id_ea, id_eb, id_player);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `select_entities_with_name_not_containing(substring)` — select entities whose name does NOT contain the given substring; returns `{added_count}`
- `deselect_entities_with_name_not_containing(substring)` — deselect entities whose name does NOT contain the given substring; returns `{removed_count}`

## Test plan

- [x] `mcp_select_and_deselect_name_not_containing`
- [x] 730 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)