### PR TITLE
feat: Phase 455 — get_entities_with_tag_count_above / get_entities_with_tag_count_below MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,52 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // get_entities_with_tag_count_above
+            let snap_gewtca = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_tag_count_above".to_string(),
+                description: "Return entities that have strictly more than the given number of tags; returns {entities: [{id, name, tag_count}]}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "count": { "type": "integer", "minimum": 0 }
+                    },
+                    "required": ["count"]
+                })),
+                handler: Box::new(move |input| {
+                    let threshold = input["count"].as_u64().unwrap_or(0) as usize;
+                    let s = snap_gewtca.lock().unwrap();
+                    let result: Vec<serde_json::Value> = s.entities.iter()
+                        .filter(|e| e.tags.len() > threshold)
+                        .map(|e| json!({"id": e.id, "name": e.name.clone().unwrap_or_default(), "tag_count": e.tags.len()}))
+                        .collect();
+                    McpToolOutput::success(json!({"entities": result}))
+                }),
+            });
+
+            // get_entities_with_tag_count_below
+            let snap_gewtcb = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_tag_count_below".to_string(),
+                description: "Return entities that have strictly fewer than the given number of tags; returns {entities: [{id, name, tag_count}]}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "count": { "type": "integer", "minimum": 0 }
+                    },
+                    "required": ["count"]
+                })),
+                handler: Box::new(move |input| {
+                    let threshold = input["count"].as_u64().unwrap_or(0) as usize;
+                    let s = snap_gewtcb.lock().unwrap();
+                    let result: Vec<serde_json::Value> = s.entities.iter()
+                        .filter(|e| e.tags.len() < threshold)
+                        .map(|e| json!({"id": e.id, "name": e.name.clone().unwrap_or_default(), "tag_count": e.tags.len()}))
+                        .collect();
+                    McpToolOutput::success(json!({"entities": result}))
+                }),
+            });
+
             // select_entities_with_name_not_containing
             let snap_sewntnc = snapshot.clone();
             let sel_sewntnc = selection.clone();
@@ -23461,6 +23507,68 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_tag_count_above_and_below() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        // A → 0 tags, B → 1 tag, C → 3 tags
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("batch_spawn", json!({"entities": [
+                {"name": "A", "position": [1.0, 0.0, 0.0]},
+                {"name": "B", "position": [2.0, 0.0, 0.0]},
+                {"name": "C", "position": [3.0, 0.0, 0.0]},
+            ]})).unwrap();
+        }
+        app.update(); app.update();
+
+        let (id_a, id_b, id_c) = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap()
+                .content["entities"].as_array().unwrap().clone();
+            let id_a = entities.iter().find(|e| e["name"].as_str() == Some("A")).unwrap()["id"].as_u64().unwrap();
+            let id_b = entities.iter().find(|e| e["name"].as_str() == Some("B")).unwrap()["id"].as_u64().unwrap();
+            let id_c = entities.iter().find(|e| e["name"].as_str() == Some("C")).unwrap()["id"].as_u64().unwrap();
+            (id_a, id_b, id_c)
+        };
+        for (id, tag) in [(id_b, "t1"), (id_c, "t1"), (id_c, "t2"), (id_c, "t3")] {
+            {
+                let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+                mcp.0.lock().unwrap().execute("tag_entity", json!({"entity_id": id, "tag": tag})).unwrap();
+            }
+            app.update(); app.update();
+        }
+
+        // get_entities_with_tag_count_above 1 → C (3 tags)
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("get_entities_with_tag_count_above", json!({"count": 1})).unwrap();
+            assert!(out.is_ok());
+            let ids: std::collections::HashSet<u64> = out.content["entities"].as_array().unwrap()
+                .iter().map(|v| v["id"].as_u64().unwrap()).collect();
+            assert!(!ids.contains(&id_a));
+            assert!(!ids.contains(&id_b));
+            assert!(ids.contains(&id_c));
+        }
+
+        // get_entities_with_tag_count_below 2 → A(0), B(1)
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("get_entities_with_tag_count_below", json!({"count": 2})).unwrap();
+            assert!(out.is_ok());
+            let ids: std::collections::HashSet<u64> = out.content["entities"].as_array().unwrap()
+                .iter().map(|v| v["id"].as_u64().unwrap()).collect();
+            assert!(ids.contains(&id_a));
+            assert!(ids.contains(&id_b));
+            assert!(!ids.contains(&id_c));
+        }
+        let _ = (id_a, id_b, id_c);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `get_entities_with_tag_count_above(count)` — entities with strictly more than the given number of tags; returns `{entities: [{id, name, tag_count}]}`
- `get_entities_with_tag_count_below(count)` — entities with strictly fewer than the given number of tags; returns `{entities: [{id, name, tag_count}]}`

## Test plan

- [x] `mcp_tag_count_above_and_below`
- [x] 731 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)