### PR TITLE
feat: Phase 457 — count_entities_with_tag_count_above / count_entities_with_tag_count_below MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,50 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // count_entities_with_tag_count_above
+            let snap_cewtca = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_tag_count_above".to_string(),
+                description: "Count entities that have strictly more than the given number of tags; returns {count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "count": { "type": "integer", "minimum": 0 }
+                    },
+                    "required": ["count"]
+                })),
+                handler: Box::new(move |input| {
+                    let threshold = input["count"].as_u64().unwrap_or(0) as usize;
+                    let s = snap_cewtca.lock().unwrap();
+                    let count = s.entities.iter()
+                        .filter(|e| e.tags.len() > threshold)
+                        .count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
+            // count_entities_with_tag_count_below
+            let snap_cewtcb = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "count_entities_with_tag_count_below".to_string(),
+                description: "Count entities that have strictly fewer than the given number of tags; returns {count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "count": { "type": "integer", "minimum": 0 }
+                    },
+                    "required": ["count"]
+                })),
+                handler: Box::new(move |input| {
+                    let threshold = input["count"].as_u64().unwrap_or(0) as usize;
+                    let s = snap_cewtcb.lock().unwrap();
+                    let count = s.entities.iter()
+                        .filter(|e| e.tags.len() < threshold)
+                        .count() as u64;
+                    McpToolOutput::success(json!({"count": count}))
+                }),
+            });
+
             // get_entities_with_tag_count_equal
             let snap_gewtceq = snapshot.clone();
             mcp.0.lock().unwrap().register(McpTool {
@@ -23552,6 +23596,62 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_count_tag_count_above_and_below() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        // A → 0 tags, B → 1 tag, C → 2 tags, D → 3 tags
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("batch_spawn", json!({"entities": [
+                {"name": "A", "position": [1.0, 0.0, 0.0]},
+                {"name": "B", "position": [2.0, 0.0, 0.0]},
+                {"name": "C", "position": [3.0, 0.0, 0.0]},
+                {"name": "D", "position": [4.0, 0.0, 0.0]},
+            ]})).unwrap();
+        }
+        app.update(); app.update();
+
+        let (id_a, id_b, id_c, id_d) = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap()
+                .content["entities"].as_array().unwrap().clone();
+            let id_a = entities.iter().find(|e| e["name"].as_str() == Some("A")).unwrap()["id"].as_u64().unwrap();
+            let id_b = entities.iter().find(|e| e["name"].as_str() == Some("B")).unwrap()["id"].as_u64().unwrap();
+            let id_c = entities.iter().find(|e| e["name"].as_str() == Some("C")).unwrap()["id"].as_u64().unwrap();
+            let id_d = entities.iter().find(|e| e["name"].as_str() == Some("D")).unwrap()["id"].as_u64().unwrap();
+            (id_a, id_b, id_c, id_d)
+        };
+        for (id, tag) in [(id_b, "t1"), (id_c, "t1"), (id_c, "t2"), (id_d, "t1"), (id_d, "t2"), (id_d, "t3")] {
+            {
+                let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+                mcp.0.lock().unwrap().execute("tag_entity", json!({"entity_id": id, "tag": tag})).unwrap();
+            }
+            app.update(); app.update();
+        }
+
+        // count_entities_with_tag_count_above 1 → C(2), D(3) = 2
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("count_entities_with_tag_count_above", json!({"count": 1})).unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["count"].as_u64().unwrap(), 2);
+        }
+
+        // count_entities_with_tag_count_below 2 → A(0), B(1) = 2
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("count_entities_with_tag_count_below", json!({"count": 2})).unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["count"].as_u64().unwrap(), 2);
+        }
+        let _ = (id_a, id_b, id_c, id_d);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `count_entities_with_tag_count_above(count)` — count entities with strictly more than the given number of tags; returns `{count}`
- `count_entities_with_tag_count_below(count)` — count entities with strictly fewer than the given number of tags; returns `{count}`

## Test plan

- [x] `mcp_count_tag_count_above_and_below`
- [x] 733 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)