### PR TITLE
feat: Phase 460 — select_entities_with_tag_count_equal / deselect_entities_with_tag_count_equal MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1666,6 +1666,62 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // select_entities_with_tag_count_equal
+            let snap_sewtceq = snapshot.clone();
+            let sel_sewtceq = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "select_entities_with_tag_count_equal".to_string(),
+                description: "Select entities that have exactly the given number of tags; returns {added_count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "count": { "type": "integer", "minimum": 0 }
+                    },
+                    "required": ["count"]
+                })),
+                handler: Box::new(move |input| {
+                    let target = input["count"].as_u64().unwrap_or(0) as usize;
+                    let s = snap_sewtceq.lock().unwrap();
+                    let to_add: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.tags.len() == target)
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_add.len() as u64;
+                    drop(s);
+                    let mut sel = sel_sewtceq.lock().unwrap();
+                    for id in to_add { sel.insert(id); }
+                    McpToolOutput::success(json!({"added_count": count}))
+                }),
+            });
+
+            // deselect_entities_with_tag_count_equal
+            let snap_dewtceq = snapshot.clone();
+            let sel_dewtceq = selection.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "deselect_entities_with_tag_count_equal".to_string(),
+                description: "Deselect entities that have exactly the given number of tags; returns {removed_count}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "count": { "type": "integer", "minimum": 0 }
+                    },
+                    "required": ["count"]
+                })),
+                handler: Box::new(move |input| {
+                    let target = input["count"].as_u64().unwrap_or(0) as usize;
+                    let s = snap_dewtceq.lock().unwrap();
+                    let to_remove: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.tags.len() == target)
+                        .map(|e| e.id)
+                        .collect();
+                    let count = to_remove.len() as u64;
+                    drop(s);
+                    let mut sel = sel_dewtceq.lock().unwrap();
+                    for id in &to_remove { sel.remove(id); }
+                    McpToolOutput::success(json!({"removed_count": count}))
+                }),
+            });
+
             // deselect_entities_with_tag_count_above
             let snap_dewtca = snapshot.clone();
             let sel_dewtca = selection.clone();
@@ -23708,6 +23764,89 @@ mod tests {
             .collect();
         assert!(ids.contains(&cam_id), "camera selected");
         assert!(!ids.contains(&plain_id), "non-camera not selected");
+    }
+
+    #[test]
+    fn mcp_select_and_deselect_tag_count_equal() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        // A → 0 tags, B → 2 tags, C → 2 tags, D → 3 tags
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("batch_spawn", json!({"entities": [
+                {"name": "A", "position": [1.0, 0.0, 0.0]},
+                {"name": "B", "position": [2.0, 0.0, 0.0]},
+                {"name": "C", "position": [3.0, 0.0, 0.0]},
+                {"name": "D", "position": [4.0, 0.0, 0.0]},
+            ]})).unwrap();
+        }
+        app.update(); app.update();
+
+        let (id_a, id_b, id_c, id_d) = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let entities = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap()
+                .content["entities"].as_array().unwrap().clone();
+            let id_a = entities.iter().find(|e| e["name"].as_str() == Some("A")).unwrap()["id"].as_u64().unwrap();
+            let id_b = entities.iter().find(|e| e["name"].as_str() == Some("B")).unwrap()["id"].as_u64().unwrap();
+            let id_c = entities.iter().find(|e| e["name"].as_str() == Some("C")).unwrap()["id"].as_u64().unwrap();
+            let id_d = entities.iter().find(|e| e["name"].as_str() == Some("D")).unwrap()["id"].as_u64().unwrap();
+            (id_a, id_b, id_c, id_d)
+        };
+        for (id, tag) in [(id_b, "t1"), (id_b, "t2"), (id_c, "t1"), (id_c, "t2"), (id_d, "t1"), (id_d, "t2"), (id_d, "t3")] {
+            {
+                let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+                mcp.0.lock().unwrap().execute("tag_entity", json!({"entity_id": id, "tag": tag})).unwrap();
+            }
+            app.update(); app.update();
+        }
+
+        // select_entities_with_tag_count_equal 2 → B, C; added_count=2
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("select_entities_with_tag_count_equal", json!({"count": 2})).unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["added_count"].as_u64().unwrap(), 2);
+        }
+        app.update(); app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let sel = mcp.0.lock().unwrap().execute("get_selected_entities", json!({})).unwrap();
+            let ids: std::collections::HashSet<u64> = sel.content["entities"].as_array().unwrap()
+                .iter().map(|v| v["id"].as_u64().unwrap()).collect();
+            assert!(!ids.contains(&id_a));
+            assert!(ids.contains(&id_b));
+            assert!(ids.contains(&id_c));
+            assert!(!ids.contains(&id_d));
+        }
+
+        // select all, then deselect_entities_with_tag_count_equal 2 → removes B, C; removed_count=2
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("select_all", json!({})).unwrap();
+        }
+        app.update(); app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap()
+                .execute("deselect_entities_with_tag_count_equal", json!({"count": 2})).unwrap();
+            assert!(out.is_ok());
+            assert_eq!(out.content["removed_count"].as_u64().unwrap(), 2);
+        }
+        app.update(); app.update();
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let sel = mcp.0.lock().unwrap().execute("get_selected_entities", json!({})).unwrap();
+            let ids: std::collections::HashSet<u64> = sel.content["entities"].as_array().unwrap()
+                .iter().map(|v| v["id"].as_u64().unwrap()).collect();
+            assert!(ids.contains(&id_a));
+            assert!(!ids.contains(&id_b));
+            assert!(!ids.contains(&id_c));
+            assert!(ids.contains(&id_d));
+        }
+        let _ = (id_a, id_b, id_c, id_d);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `select_entities_with_tag_count_equal(count)` — select entities with exactly the given number of tags; returns `{added_count}`
- `deselect_entities_with_tag_count_equal(count)` — deselect entities with exactly the given number of tags; returns `{removed_count}`

## Test plan

- [x] `mcp_select_and_deselect_tag_count_equal`
- [x] 736 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)