### PR TITLE
feat: Phase 466 — get_entities_with_rotation_x/y/z_below MCP tools

### DIFF
--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -15119,6 +15119,69 @@ impl Plugin for EditorPlugin {
                 }),
             });
 
+            // get_entities_with_rotation_x_below
+            let snap_gewrxb = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_rotation_x_below".to_string(),
+                description: "Return entity IDs whose X rotation (degrees) is strictly below the threshold; returns {entity_ids}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "threshold": { "type": "number" } },
+                    "required": ["threshold"]
+                })),
+                handler: Box::new(move |input| {
+                    let threshold = input["threshold"].as_f64().unwrap_or(0.0) as f32;
+                    let s = snap_gewrxb.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.rotation.map(|r| r[0] < threshold).unwrap_or(false))
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
+            // get_entities_with_rotation_y_below
+            let snap_gewryb = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_rotation_y_below".to_string(),
+                description: "Return entity IDs whose Y rotation (degrees) is strictly below the threshold; returns {entity_ids}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "threshold": { "type": "number" } },
+                    "required": ["threshold"]
+                })),
+                handler: Box::new(move |input| {
+                    let threshold = input["threshold"].as_f64().unwrap_or(0.0) as f32;
+                    let s = snap_gewryb.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.rotation.map(|r| r[1] < threshold).unwrap_or(false))
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
+            // get_entities_with_rotation_z_below
+            let snap_gewrzb = snapshot.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "get_entities_with_rotation_z_below".to_string(),
+                description: "Return entity IDs whose Z rotation (degrees) is strictly below the threshold; returns {entity_ids}".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": { "threshold": { "type": "number" } },
+                    "required": ["threshold"]
+                })),
+                handler: Box::new(move |input| {
+                    let threshold = input["threshold"].as_f64().unwrap_or(0.0) as f32;
+                    let s = snap_gewrzb.lock().unwrap();
+                    let ids: Vec<u64> = s.entities.iter()
+                        .filter(|e| e.rotation.map(|r| r[2] < threshold).unwrap_or(false))
+                        .map(|e| e.id)
+                        .collect();
+                    McpToolOutput::success(json!({"entity_ids": ids}))
+                }),
+            });
+
             // rename_selection_replace
             let snap_rsr2 = snapshot.clone();
             let sel_rsr2 = selection.clone();
@@ -58602,6 +58665,75 @@ mod tests {
             "NonUniform(2,3,1) has non-uniform scale"
         );
         assert!(!ids.contains(&uniform_id), "Uniform(2,2,2) excluded");
+    }
+
+    #[test]
+    fn mcp_rotation_xyz_below_filters() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        // Spawn 3 entities with distinct rotations
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("batch_spawn", json!({"entities": [
+                {"name": "A", "position": [0.0, 0.0, 0.0]},
+                {"name": "B", "position": [1.0, 0.0, 0.0]},
+                {"name": "C", "position": [2.0, 0.0, 0.0]},
+            ]})).unwrap();
+        }
+        app.update(); app.update();
+
+        let (id_a, id_b, id_c) = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let es = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap()
+                .content["entities"].as_array().unwrap().clone();
+            let id_a = es.iter().find(|e| e["name"].as_str() == Some("A")).unwrap()["id"].as_u64().unwrap();
+            let id_b = es.iter().find(|e| e["name"].as_str() == Some("B")).unwrap()["id"].as_u64().unwrap();
+            let id_c = es.iter().find(|e| e["name"].as_str() == Some("C")).unwrap()["id"].as_u64().unwrap();
+            (id_a, id_b, id_c)
+        };
+
+        // Set rotations: A=(10,20,30), B=(40,50,60), C=(70,80,90)
+        for (id, rx, ry, rz) in [(id_a, 10.0f64, 20.0f64, 30.0f64), (id_b, 40.0, 50.0, 60.0), (id_c, 70.0, 80.0, 90.0)] {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0.lock().unwrap().execute("set_rotation", json!({"entity_id": id, "rx": rx, "ry": ry, "rz": rz})).unwrap();
+            app.update(); app.update();
+        }
+
+        // rotation_x_below(50) → A(10), B(40)
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap().execute("get_entities_with_rotation_x_below", json!({"threshold": 50.0})).unwrap();
+            assert!(out.is_ok());
+            let ids: Vec<u64> = out.content["entity_ids"].as_array().unwrap().iter().map(|v| v.as_u64().unwrap()).collect();
+            assert!(ids.contains(&id_a),  "A(rx=10) < 50");
+            assert!(ids.contains(&id_b),  "B(rx=40) < 50");
+            assert!(!ids.contains(&id_c), "C(rx=70) not < 50");
+        }
+
+        // rotation_y_below(60) → A(20), B(50)
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap().execute("get_entities_with_rotation_y_below", json!({"threshold": 60.0})).unwrap();
+            assert!(out.is_ok());
+            let ids: Vec<u64> = out.content["entity_ids"].as_array().unwrap().iter().map(|v| v.as_u64().unwrap()).collect();
+            assert!(ids.contains(&id_a),  "A(ry=20) < 60");
+            assert!(ids.contains(&id_b),  "B(ry=50) < 60");
+            assert!(!ids.contains(&id_c), "C(ry=80) not < 60");
+        }
+
+        // rotation_z_below(70) → A(30), B(60)
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp.0.lock().unwrap().execute("get_entities_with_rotation_z_below", json!({"threshold": 70.0})).unwrap();
+            assert!(out.is_ok());
+            let ids: Vec<u64> = out.content["entity_ids"].as_array().unwrap().iter().map(|v| v.as_u64().unwrap()).collect();
+            assert!(ids.contains(&id_a),  "A(rz=30) < 70");
+            assert!(ids.contains(&id_b),  "B(rz=60) < 70");
+            assert!(!ids.contains(&id_c), "C(rz=90) not < 70");
+        }
+        let _ = (id_a, id_b, id_c);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes below-threshold queries for per-axis rotation (complementing the existing `_above` variants):
- `get_entities_with_rotation_x_below(threshold)`
- `get_entities_with_rotation_y_below(threshold)`
- `get_entities_with_rotation_z_below(threshold)`

## Test plan

- [x] `mcp_rotation_xyz_below_filters`
- [x] 742 bsengine-editor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)