### PR TITLE
feat: add bsengine-physics crate with Rapier3d

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && steps.cache-rusty-v8.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/.rusty_v8
-          curl -fL "https://github.com/denoland/rusty_v8/releases/download/v${{ steps.v8ver.outputs.ver }}/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz" \
+          curl -fL "https://github.com/denoland/rusty_v8/releases/download/v${{ steps.v8ver.outputs.ver }}/librusty_v8_simdutf_release_x86_64-unknown-linux-gnu.a.gz" \
             -o ~/.rusty_v8/librusty_v8.a.gz
 
       - name: Download rusty_v8 (Windows)
@@ -64,7 +64,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force "$env:USERPROFILE\.rusty_v8" | Out-Null
-          Invoke-WebRequest "https://github.com/denoland/rusty_v8/releases/download/v${{ steps.v8ver.outputs.ver }}/rusty_v8_release_x86_64-pc-windows-msvc.lib.gz" `
+          Invoke-WebRequest "https://github.com/denoland/rusty_v8/releases/download/v${{ steps.v8ver.outputs.ver }}/rusty_v8_simdutf_release_x86_64-pc-windows-msvc.lib.gz" `
             -OutFile "$env:USERPROFILE\.rusty_v8\rusty_v8.lib.gz"
 
       - name: Set RUSTY_V8_ARCHIVE (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,17 @@ jobs:
           # Cache key includes OS so Windows/Linux don't share V8 artifacts
           key: ${{ matrix.os }}
 
+      # Cache librusty_v8.a separately so a Cargo.lock change (e.g. adding a
+      # new crate) does not force a fresh download of the ~100 MB V8 binary.
+      # The restore-key falls back to any previous entry for this OS.
+      - name: Cache rusty_v8 prebuilt binary
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/target/debug/gn_out
+          key: rusty-v8-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            rusty-v8-${{ runner.os }}-
+
       - name: Install Vulkan software driver (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y mesa-vulkan-drivers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,45 @@ jobs:
           # Cache key includes OS so Windows/Linux don't share V8 artifacts
           key: ${{ matrix.os }}
 
-      # Cache librusty_v8.a separately so a Cargo.lock change (e.g. adding a
-      # new crate) does not force a fresh download of the ~100 MB V8 binary.
-      # The restore-key falls back to any previous entry for this OS.
+      # Cache librusty_v8.a keyed by v8 crate version + OS, independent of
+      # Cargo.lock so adding unrelated crates never forces a re-download.
+      - name: Resolve v8 crate version
+        id: v8ver
+        shell: bash
+        run: |
+          VER=$(grep -A 2 'name = "v8"' Cargo.lock | grep 'version =' | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "ver=$VER" >> $GITHUB_OUTPUT
+
       - name: Cache rusty_v8 prebuilt binary
+        id: cache-rusty-v8
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/target/debug/gn_out
-          key: rusty-v8-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            rusty-v8-${{ runner.os }}-
+          path: ~/.rusty_v8
+          key: rusty-v8-${{ runner.os }}-${{ steps.v8ver.outputs.ver }}
+
+      - name: Download rusty_v8 (Linux)
+        if: matrix.os == 'ubuntu-latest' && steps.cache-rusty-v8.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.rusty_v8
+          curl -fL "https://github.com/denoland/rusty_v8/releases/download/v${{ steps.v8ver.outputs.ver }}/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz" \
+            -o ~/.rusty_v8/librusty_v8.a.gz
+
+      - name: Download rusty_v8 (Windows)
+        if: matrix.os == 'windows-latest' && steps.cache-rusty-v8.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force "$env:USERPROFILE\.rusty_v8" | Out-Null
+          Invoke-WebRequest "https://github.com/denoland/rusty_v8/releases/download/v${{ steps.v8ver.outputs.ver }}/rusty_v8_release_x86_64-pc-windows-msvc.lib.gz" `
+            -OutFile "$env:USERPROFILE\.rusty_v8\rusty_v8.lib.gz"
+
+      - name: Set RUSTY_V8_ARCHIVE (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: echo "RUSTY_V8_ARCHIVE=$HOME/.rusty_v8/librusty_v8.a.gz" >> $GITHUB_ENV
+
+      - name: Set RUSTY_V8_ARCHIVE (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: echo "RUSTY_V8_ARCHIVE=$env:USERPROFILE\.rusty_v8\rusty_v8.lib.gz" >> $env:GITHUB_ENV
 
       - name: Install Vulkan software driver (Ubuntu)
         if: matrix.os == 'ubuntu-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,7 +205,7 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "console_error_panic_hook",
- "downcast-rs",
+ "downcast-rs 1.2.1",
  "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
@@ -418,6 +427,7 @@ dependencies = [
  "bsengine-asset",
  "bsengine-core",
  "bsengine-ecs",
+ "bsengine-editor",
  "bsengine-input",
  "bsengine-mcp",
  "bsengine-plugin",
@@ -427,7 +437,7 @@ dependencies = [
  "bsengine-scene",
  "bsengine-scripting",
  "bsengine-window",
- "glam",
+ "glam 0.29.3",
  "serde_json",
 ]
 
@@ -447,7 +457,7 @@ name = "bsengine-core"
 version = "0.1.0"
 dependencies = [
  "bevy_ecs",
- "glam",
+ "glam 0.29.3",
  "tracing",
  "tracing-subscriber",
 ]
@@ -458,6 +468,25 @@ version = "0.1.0"
 dependencies = [
  "bevy_ecs",
  "bsengine-core",
+]
+
+[[package]]
+name = "bsengine-editor"
+version = "0.1.0"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bsengine-app",
+ "bsengine-core",
+ "bsengine-ecs",
+ "bsengine-mcp",
+ "bsengine-render",
+ "bsengine-scene",
+ "glam 0.29.3",
+ "ron",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -498,6 +527,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bsengine-physics"
+version = "0.1.0"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bsengine-app",
+ "bsengine-core",
+ "bsengine-ecs",
+ "glam 0.29.3",
+ "rapier3d",
+ "tracing",
+]
+
+[[package]]
 name = "bsengine-plugin"
 version = "0.1.0"
 dependencies = [
@@ -522,7 +565,7 @@ dependencies = [
  "bsengine-rhi",
  "bsengine-rhi-wgpu",
  "bsengine-window",
- "glam",
+ "glam 0.29.3",
  "tracing",
 ]
 
@@ -545,7 +588,7 @@ dependencies = [
  "bsengine-rhi",
  "bsengine-window",
  "bytemuck",
- "glam",
+ "glam 0.29.3",
  "image",
  "pollster",
  "tracing",
@@ -1099,6 +1142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1158,15 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -1174,6 +1232,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1381,6 +1445,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
 
 [[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
+dependencies = [
+ "approx",
+ "libm",
+]
+
+[[package]]
+name = "glamx"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9847f980afb0628849bcd6a406cdffd29eb9d53fca83e1646005901a9acd4c5c"
+dependencies = [
+ "approx",
+ "glam 0.33.1",
+ "nalgebra",
+ "num-traits",
+ "simba",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1613,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,7 +1638,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1532,6 +1657,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hassle-rs"
@@ -1546,6 +1674,16 @@ dependencies = [
  "thiserror 1.0.69",
  "widestring",
  "winapi",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1987,6 +2125,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2223,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
+dependencies = [
+ "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.1",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,11 +2329,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2165,6 +2375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2418,6 +2629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2679,34 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parry3d"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fa77de549af010eddaf4bcb365b39aee96f93f65489b9a49b2de616fc664e8"
+dependencies = [
+ "approx",
+ "arrayvec",
+ "bitflags 2.13.0",
+ "downcast-rs 2.0.2",
+ "either",
+ "ena",
+ "foldhash 0.2.0",
+ "glamx",
+ "hashbrown 0.17.1",
+ "log",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "rstar",
+ "simba",
+ "slab",
+ "smallvec",
+ "spade",
+ "static_assertions",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2604,6 +2852,19 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "pxfm"
@@ -2663,10 +2924,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
+name = "rapier3d"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9038df6d760a6448b39adf6286744acdb54e2a0edf04b8ab6a9f5e9998968317"
+dependencies = [
+ "approx",
+ "bitflags 2.13.0",
+ "glamx",
+ "log",
+ "nalgebra",
+ "num-traits",
+ "parry3d",
+ "profiling",
+ "serde",
+ "simba",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "wide",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -2741,6 +3029,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,6 +3044,17 @@ dependencies = [
  "bitflags 2.13.0",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rstar"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5912b862fa5ffb462607bfd1e35036c458c537921f508c8235a83d5f3987edfe"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -2804,6 +3109,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -2944,6 +3258,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,6 +3372,18 @@ dependencies = [
  "serde_json",
  "unicode-id-start",
  "url",
+]
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]
@@ -3488,6 +3826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,7 +4028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
- "downcast-rs",
+ "downcast-rs 1.2.1",
  "rustix 1.1.4",
  "scoped-tls",
  "smallvec",
@@ -3922,6 +4266,16 @@ dependencies = [
  "home",
  "rustix 0.38.44",
  "winsafe",
+]
+
+[[package]]
+name = "wide"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/bsengine-scene",
     "crates/bsengine-asset",
     "crates/bsengine-scripting",
+    "crates/bsengine-physics",
     "crates/bsengine-plugin",
     "crates/bsengine-mcp",
     "crates/bsengine-gltf",
@@ -56,3 +57,5 @@ gltf              = "1"
 image             = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 bsengine-gltf     = { path = "crates/bsengine-gltf" }
 bsengine-editor   = { path = "crates/bsengine-editor" }
+bsengine-physics  = { path = "crates/bsengine-physics" }
+rapier3d          = { version = "0.33", features = ["default"] }

--- a/crates/bsengine-physics/Cargo.toml
+++ b/crates/bsengine-physics/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bsengine-physics"
+description = "Rigid-body physics via Rapier3d — RigidBody/Collider components and PhysicsPlugin"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+bsengine-core    = { workspace = true }
+bsengine-ecs     = { workspace = true }
+bevy_app         = { workspace = true }
+bevy_ecs         = { workspace = true }
+rapier3d         = { workspace = true }
+glam             = { workspace = true }
+tracing          = { workspace = true }
+
+[dev-dependencies]
+bsengine-app = { workspace = true }

--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -1,0 +1,112 @@
+use bevy_ecs::prelude::Component;
+use glam::{Quat, Vec3};
+use rapier3d::prelude::{ColliderHandle, RigidBodyHandle};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RigidBodyType {
+    Dynamic,
+    Static,
+    KinematicPosition,
+}
+
+#[derive(Component, Debug, Clone)]
+pub struct RigidBody {
+    pub body_type: RigidBodyType,
+    pub linear_damping: f32,
+    pub angular_damping: f32,
+}
+
+impl RigidBody {
+    pub fn dynamic() -> Self {
+        Self { body_type: RigidBodyType::Dynamic, linear_damping: 0.0, angular_damping: 0.0 }
+    }
+
+    pub fn fixed() -> Self {
+        Self { body_type: RigidBodyType::Static, linear_damping: 0.0, angular_damping: 0.0 }
+    }
+
+    pub fn kinematic() -> Self {
+        Self { body_type: RigidBodyType::KinematicPosition, linear_damping: 0.0, angular_damping: 0.0 }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ColliderShape {
+    Box { half_extents: Vec3 },
+    Sphere { radius: f32 },
+    Capsule { half_height: f32, radius: f32 },
+}
+
+#[derive(Component, Debug, Clone)]
+pub struct Collider {
+    pub shape: ColliderShape,
+    pub restitution: f32,
+    pub friction: f32,
+    pub density: f32,
+}
+
+impl Collider {
+    pub fn cuboid(hx: f32, hy: f32, hz: f32) -> Self {
+        Self {
+            shape: ColliderShape::Box { half_extents: Vec3::new(hx, hy, hz) },
+            restitution: 0.0,
+            friction: 0.5,
+            density: 1.0,
+        }
+    }
+
+    pub fn ball(radius: f32) -> Self {
+        Self {
+            shape: ColliderShape::Sphere { radius },
+            restitution: 0.0,
+            friction: 0.5,
+            density: 1.0,
+        }
+    }
+
+    pub fn capsule(half_height: f32, radius: f32) -> Self {
+        Self {
+            shape: ColliderShape::Capsule { half_height, radius },
+            restitution: 0.0,
+            friction: 0.5,
+            density: 1.0,
+        }
+    }
+
+    pub fn with_restitution(mut self, restitution: f32) -> Self {
+        self.restitution = restitution;
+        self
+    }
+
+    pub fn with_friction(mut self, friction: f32) -> Self {
+        self.friction = friction;
+        self
+    }
+}
+
+/// Written by the physics system after each step — read this to get simulated position/rotation.
+#[derive(Component, Debug, Clone, Default)]
+pub struct PhysicsTransform {
+    pub translation: Vec3,
+    pub rotation: Quat,
+}
+
+/// Input transform for the physics system — set this to teleport or drive kinematic bodies.
+#[derive(Component, Debug, Clone)]
+pub struct PhysicsInput {
+    pub translation: Vec3,
+    pub rotation: Quat,
+}
+
+impl Default for PhysicsInput {
+    fn default() -> Self {
+        Self { translation: Vec3::ZERO, rotation: Quat::IDENTITY }
+    }
+}
+
+/// Internal: Rapier handles stored per entity after body creation.
+#[derive(Component)]
+pub(crate) struct PhysicsHandles {
+    pub body_handle: RigidBodyHandle,
+    pub collider_handle: ColliderHandle,
+}

--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -18,15 +18,27 @@ pub struct RigidBody {
 
 impl RigidBody {
     pub fn dynamic() -> Self {
-        Self { body_type: RigidBodyType::Dynamic, linear_damping: 0.0, angular_damping: 0.0 }
+        Self {
+            body_type: RigidBodyType::Dynamic,
+            linear_damping: 0.0,
+            angular_damping: 0.0,
+        }
     }
 
     pub fn fixed() -> Self {
-        Self { body_type: RigidBodyType::Static, linear_damping: 0.0, angular_damping: 0.0 }
+        Self {
+            body_type: RigidBodyType::Static,
+            linear_damping: 0.0,
+            angular_damping: 0.0,
+        }
     }
 
     pub fn kinematic() -> Self {
-        Self { body_type: RigidBodyType::KinematicPosition, linear_damping: 0.0, angular_damping: 0.0 }
+        Self {
+            body_type: RigidBodyType::KinematicPosition,
+            linear_damping: 0.0,
+            angular_damping: 0.0,
+        }
     }
 }
 
@@ -48,7 +60,9 @@ pub struct Collider {
 impl Collider {
     pub fn cuboid(hx: f32, hy: f32, hz: f32) -> Self {
         Self {
-            shape: ColliderShape::Box { half_extents: Vec3::new(hx, hy, hz) },
+            shape: ColliderShape::Box {
+                half_extents: Vec3::new(hx, hy, hz),
+            },
             restitution: 0.0,
             friction: 0.5,
             density: 1.0,
@@ -66,7 +80,10 @@ impl Collider {
 
     pub fn capsule(half_height: f32, radius: f32) -> Self {
         Self {
-            shape: ColliderShape::Capsule { half_height, radius },
+            shape: ColliderShape::Capsule {
+                half_height,
+                radius,
+            },
             restitution: 0.0,
             friction: 0.5,
             density: 1.0,
@@ -100,7 +117,10 @@ pub struct PhysicsInput {
 
 impl Default for PhysicsInput {
     fn default() -> Self {
-        Self { translation: Vec3::ZERO, rotation: Quat::IDENTITY }
+        Self {
+            translation: Vec3::ZERO,
+            rotation: Quat::IDENTITY,
+        }
     }
 }
 

--- a/crates/bsengine-physics/src/lib.rs
+++ b/crates/bsengine-physics/src/lib.rs
@@ -1,0 +1,134 @@
+pub mod components;
+pub mod plugin;
+pub mod world;
+
+pub use components::{
+    Collider, ColliderShape, PhysicsInput, PhysicsTransform, RigidBody, RigidBodyType,
+};
+pub use plugin::PhysicsPlugin;
+pub use world::PhysicsWorld;
+
+#[cfg(test)]
+mod tests {
+    use bevy_app::prelude::*;
+    use glam::Vec3;
+
+    use super::*;
+
+    fn new_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(PhysicsPlugin);
+        app
+    }
+
+    #[test]
+    fn dynamic_body_falls_under_gravity() {
+        let mut app = new_app();
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                RigidBody::dynamic(),
+                Collider::ball(0.5),
+                PhysicsInput {
+                    translation: Vec3::new(0.0, 10.0, 0.0),
+                    rotation: Default::default(),
+                },
+            ))
+            .id();
+
+        for _ in 0..30 {
+            app.update();
+        }
+
+        let transform = app.world().get::<PhysicsTransform>(entity).unwrap();
+        assert!(
+            transform.translation.y < 9.0,
+            "expected body to fall, got y={}",
+            transform.translation.y
+        );
+    }
+
+    #[test]
+    fn static_body_does_not_move() {
+        let mut app = new_app();
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                RigidBody::fixed(),
+                Collider::cuboid(1.0, 1.0, 1.0),
+                PhysicsInput {
+                    translation: Vec3::new(0.0, 0.0, 0.0),
+                    rotation: Default::default(),
+                },
+            ))
+            .id();
+
+        for _ in 0..30 {
+            app.update();
+        }
+
+        let transform = app.world().get::<PhysicsTransform>(entity).unwrap();
+        assert!(
+            transform.translation.y.abs() < 0.01,
+            "static body should not move, got y={}",
+            transform.translation.y
+        );
+    }
+
+    #[test]
+    fn body_lands_on_floor() {
+        let mut app = new_app();
+
+        app.world_mut().spawn((
+            RigidBody::fixed(),
+            Collider::cuboid(10.0, 0.1, 10.0),
+            PhysicsInput {
+                translation: Vec3::new(0.0, 0.0, 0.0),
+                rotation: Default::default(),
+            },
+        ));
+
+        let ball = app
+            .world_mut()
+            .spawn((
+                RigidBody::dynamic(),
+                Collider::ball(0.5),
+                PhysicsInput {
+                    translation: Vec3::new(0.0, 5.0, 0.0),
+                    rotation: Default::default(),
+                },
+            ))
+            .id();
+
+        for _ in 0..200 {
+            app.update();
+        }
+
+        let transform = app.world().get::<PhysicsTransform>(ball).unwrap();
+        assert!(
+            transform.translation.y < 2.0,
+            "ball should land on floor, got y={}",
+            transform.translation.y
+        );
+        assert!(
+            transform.translation.y > 0.0,
+            "ball should rest above floor, got y={}",
+            transform.translation.y
+        );
+    }
+
+    #[test]
+    fn physics_world_gravity_default() {
+        let world = PhysicsWorld::default();
+        assert!((world.gravity() - 9.81).abs() < 0.001);
+    }
+
+    #[test]
+    fn physics_world_set_gravity() {
+        let mut world = PhysicsWorld::new(9.81);
+        world.set_gravity(1.62);
+        assert!((world.gravity() - 1.62).abs() < 0.001);
+    }
+}

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -16,10 +16,7 @@ pub struct PhysicsPlugin;
 impl Plugin for PhysicsPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(PhysicsWorld::default());
-        app.add_systems(
-            Update,
-            (spawn_bodies, step_world, sync_from_rapier).chain(),
-        );
+        app.add_systems(Update, (spawn_bodies, step_world, sync_from_rapier).chain());
     }
 }
 
@@ -46,10 +43,7 @@ fn from_rapier_rot(r: Rotation) -> Quat {
 fn spawn_bodies(
     mut world: ResMut<PhysicsWorld>,
     mut commands: Commands,
-    query: Query<
-        (Entity, &RigidBody, &Collider, Option<&PhysicsInput>),
-        Without<PhysicsHandles>,
-    >,
+    query: Query<(Entity, &RigidBody, &Collider, Option<&PhysicsInput>), Without<PhysicsHandles>>,
 ) {
     for (entity, rigid_body, collider, input) in query.iter() {
         let pos = input.map(|i| i.translation).unwrap_or(Vec3::ZERO);
@@ -64,9 +58,9 @@ fn spawn_bodies(
                 .angular_damping(rigid_body.angular_damping)
                 .build(),
             RigidBodyType::Static => RigidBodyBuilder::fixed().position(pose).build(),
-            RigidBodyType::KinematicPosition => {
-                RigidBodyBuilder::kinematic_position_based().position(pose).build()
-            }
+            RigidBodyType::KinematicPosition => RigidBodyBuilder::kinematic_position_based()
+                .position(pose)
+                .build(),
         };
 
         let body_handle = world.rigid_body_set.insert(rb);
@@ -81,8 +75,14 @@ fn spawn_bodies(
         let collider_handle = world.add_collider(coll, body_handle);
 
         commands.entity(entity).insert((
-            PhysicsHandles { body_handle, collider_handle },
-            PhysicsTransform { translation: pos, rotation: rot },
+            PhysicsHandles {
+                body_handle,
+                collider_handle,
+            },
+            PhysicsTransform {
+                translation: pos,
+                rotation: rot,
+            },
         ));
     }
 }
@@ -123,8 +123,9 @@ fn make_shape(shape: &ColliderShape) -> SharedShape {
             SharedShape::cuboid(half_extents.x, half_extents.y, half_extents.z)
         }
         ColliderShape::Sphere { radius } => SharedShape::ball(*radius),
-        ColliderShape::Capsule { half_height, radius } => {
-            SharedShape::capsule_y(*half_height, *radius)
-        }
+        ColliderShape::Capsule {
+            half_height,
+            radius,
+        } => SharedShape::capsule_y(*half_height, *radius),
     }
 }

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -1,0 +1,130 @@
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use glam::{Quat, Vec3};
+use rapier3d::prelude::*;
+
+use crate::{
+    components::{
+        Collider, ColliderShape, PhysicsHandles, PhysicsInput, PhysicsTransform, RigidBody,
+        RigidBodyType,
+    },
+    world::PhysicsWorld,
+};
+
+pub struct PhysicsPlugin;
+
+impl Plugin for PhysicsPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PhysicsWorld::default());
+        app.add_systems(
+            Update,
+            (spawn_bodies, step_world, sync_from_rapier).chain(),
+        );
+    }
+}
+
+// Convert project glam 0.29 Vec3 → rapier math Vec3 (glam 0.33) via raw floats
+fn to_rapier_vec(v: Vec3) -> Vector {
+    Vector::new(v.x, v.y, v.z)
+}
+
+// Convert project glam 0.29 Quat → rapier Rotation (glam 0.33 Quat) via raw floats
+fn to_rapier_rot(q: Quat) -> Rotation {
+    Rotation::from_xyzw(q.x, q.y, q.z, q.w)
+}
+
+// Convert rapier math Vec3 (glam 0.33) → project glam 0.29 Vec3
+fn from_rapier_vec(v: Vector) -> Vec3 {
+    Vec3::new(v.x, v.y, v.z)
+}
+
+// Convert rapier Rotation (glam 0.33 Quat) → project glam 0.29 Quat
+fn from_rapier_rot(r: Rotation) -> Quat {
+    Quat::from_xyzw(r.x, r.y, r.z, r.w)
+}
+
+fn spawn_bodies(
+    mut world: ResMut<PhysicsWorld>,
+    mut commands: Commands,
+    query: Query<
+        (Entity, &RigidBody, &Collider, Option<&PhysicsInput>),
+        Without<PhysicsHandles>,
+    >,
+) {
+    for (entity, rigid_body, collider, input) in query.iter() {
+        let pos = input.map(|i| i.translation).unwrap_or(Vec3::ZERO);
+        let rot = input.map(|i| i.rotation).unwrap_or(Quat::IDENTITY);
+
+        let pose = Pose::from_parts(to_rapier_vec(pos), to_rapier_rot(rot));
+
+        let rb = match rigid_body.body_type {
+            RigidBodyType::Dynamic => RigidBodyBuilder::dynamic()
+                .position(pose)
+                .linear_damping(rigid_body.linear_damping)
+                .angular_damping(rigid_body.angular_damping)
+                .build(),
+            RigidBodyType::Static => RigidBodyBuilder::fixed().position(pose).build(),
+            RigidBodyType::KinematicPosition => {
+                RigidBodyBuilder::kinematic_position_based().position(pose).build()
+            }
+        };
+
+        let body_handle = world.rigid_body_set.insert(rb);
+
+        let shape = make_shape(&collider.shape);
+        let coll = ColliderBuilder::new(shape)
+            .restitution(collider.restitution)
+            .friction(collider.friction)
+            .density(collider.density)
+            .build();
+
+        let collider_handle = world.add_collider(coll, body_handle);
+
+        commands.entity(entity).insert((
+            PhysicsHandles { body_handle, collider_handle },
+            PhysicsTransform { translation: pos, rotation: rot },
+        ));
+    }
+}
+
+fn step_world(
+    mut world: ResMut<PhysicsWorld>,
+    query: Query<(&PhysicsHandles, &PhysicsInput), With<RigidBody>>,
+) {
+    for (handles, input) in query.iter() {
+        if let Some(body) = world.rigid_body_set.get_mut(handles.body_handle) {
+            if body.is_kinematic() {
+                body.set_next_kinematic_position(Pose::from_parts(
+                    to_rapier_vec(input.translation),
+                    to_rapier_rot(input.rotation),
+                ));
+            }
+        }
+    }
+
+    world.step();
+}
+
+fn sync_from_rapier(
+    world: Res<PhysicsWorld>,
+    mut query: Query<(&PhysicsHandles, &mut PhysicsTransform)>,
+) {
+    for (handles, mut transform) in query.iter_mut() {
+        if let Some(body) = world.rigid_body_set.get(handles.body_handle) {
+            transform.translation = from_rapier_vec(body.translation());
+            transform.rotation = from_rapier_rot(*body.rotation());
+        }
+    }
+}
+
+fn make_shape(shape: &ColliderShape) -> SharedShape {
+    match shape {
+        ColliderShape::Box { half_extents } => {
+            SharedShape::cuboid(half_extents.x, half_extents.y, half_extents.z)
+        }
+        ColliderShape::Sphere { radius } => SharedShape::ball(*radius),
+        ColliderShape::Capsule { half_height, radius } => {
+            SharedShape::capsule_y(*half_height, *radius)
+        }
+    }
+}

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -1,0 +1,74 @@
+use bevy_ecs::prelude::Resource;
+use rapier3d::prelude::*;
+
+#[derive(Resource)]
+pub struct PhysicsWorld {
+    pub(crate) rigid_body_set: RigidBodySet,
+    pub(crate) collider_set: ColliderSet,
+    gravity: Vector,
+    integration_parameters: IntegrationParameters,
+    physics_pipeline: PhysicsPipeline,
+    island_manager: IslandManager,
+    broad_phase: BroadPhaseBvh,
+    narrow_phase: NarrowPhase,
+    impulse_joint_set: ImpulseJointSet,
+    multibody_joint_set: MultibodyJointSet,
+    ccd_solver: CCDSolver,
+}
+
+impl Default for PhysicsWorld {
+    fn default() -> Self {
+        Self::new(9.81)
+    }
+}
+
+impl PhysicsWorld {
+    pub fn new(gravity_magnitude: f32) -> Self {
+        Self {
+            rigid_body_set: RigidBodySet::new(),
+            collider_set: ColliderSet::new(),
+            gravity: Vector::new(0.0, -gravity_magnitude, 0.0),
+            integration_parameters: IntegrationParameters::default(),
+            physics_pipeline: PhysicsPipeline::new(),
+            island_manager: IslandManager::new(),
+            broad_phase: BroadPhaseBvh::new(),
+            narrow_phase: NarrowPhase::new(),
+            impulse_joint_set: ImpulseJointSet::new(),
+            multibody_joint_set: MultibodyJointSet::new(),
+            ccd_solver: CCDSolver::new(),
+        }
+    }
+
+    pub fn step(&mut self) {
+        self.physics_pipeline.step(
+            self.gravity,
+            &self.integration_parameters,
+            &mut self.island_manager,
+            &mut self.broad_phase,
+            &mut self.narrow_phase,
+            &mut self.rigid_body_set,
+            &mut self.collider_set,
+            &mut self.impulse_joint_set,
+            &mut self.multibody_joint_set,
+            &mut self.ccd_solver,
+            &(),
+            &(),
+        );
+    }
+
+    pub(crate) fn add_collider(
+        &mut self,
+        coll: rapier3d::geometry::Collider,
+        body_handle: RigidBodyHandle,
+    ) -> ColliderHandle {
+        self.collider_set.insert_with_parent(coll, body_handle, &mut self.rigid_body_set)
+    }
+
+    pub fn gravity(&self) -> f32 {
+        -self.gravity.y
+    }
+
+    pub fn set_gravity(&mut self, magnitude: f32) {
+        self.gravity = Vector::new(0.0, -magnitude, 0.0);
+    }
+}

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -61,7 +61,8 @@ impl PhysicsWorld {
         coll: rapier3d::geometry::Collider,
         body_handle: RigidBodyHandle,
     ) -> ColliderHandle {
-        self.collider_set.insert_with_parent(coll, body_handle, &mut self.rigid_body_set)
+        self.collider_set
+            .insert_with_parent(coll, body_handle, &mut self.rigid_body_set)
     }
 
     pub fn gravity(&self) -> f32 {


### PR DESCRIPTION
## Summary
- New `bsengine-physics` crate using Rapier3d 0.33
- `PhysicsPlugin` integrates with bevy_app Update loop
- `RigidBody` component: Dynamic / Static / KinematicPosition
- `Collider` component: Box / Sphere / Capsule shapes
- `PhysicsWorld` resource wrapping Rapier pipeline, island manager, broad/narrow phase
- `PhysicsTransform` output component — written each step for rendering integration
- Glam 0.29↔0.33 boundary bridged via raw x/y/z/w float conversions

## Test plan
- [x] `dynamic_body_falls_under_gravity` — body at y=10 falls below y=9 after 30 steps
- [x] `static_body_does_not_move` — fixed body stays at origin
- [x] `body_lands_on_floor` — dynamic ball drops onto static floor and rests
- [x] `physics_world_gravity_default` — gravity defaults to 9.81
- [x] `physics_world_set_gravity` — gravity setter works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)