### PR TITLE
ci: remove RUST_TEST_THREADS=1 (fixes editor stack overflow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,4 @@ jobs:
       - name: Test
         env:
           RUST_MIN_STACK: 8388608
-          # kira/WASAPI AudioManager drop from parallel threads causes
-          # STATUS_ACCESS_VIOLATION on Windows; run tests serially to prevent it.
-          RUST_TEST_THREADS: 1
         run: cargo test --all


### PR DESCRIPTION
## Summary
- Remove `RUST_TEST_THREADS=1` from CI test step
- The kira WASAPI tests that caused `STATUS_ACCESS_VIOLATION` are now `#[cfg_attr(windows, ignore)]`, so serial execution is no longer needed
- Running 774 bsengine-editor tests serially on one thread caused `STATUS_STACK_OVERFLOW`

## Test plan
- [ ] All CI checks pass on Ubuntu and Windows