### PR TITLE
feat: content pipeline — GltfPlugin, texture loading, demo binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bsengine-demo"
+version = "0.1.0"
+dependencies = [
+ "bevy_ecs",
+ "bsengine-app",
+ "bsengine-core",
+ "bsengine-gltf",
+ "bsengine-render",
+ "bsengine-rhi-wgpu",
+ "bsengine-window",
+ "glam 0.29.3",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "bsengine-ecs"
 version = "0.1.0"
 dependencies = [
@@ -544,9 +560,12 @@ version = "0.1.0"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
+ "bsengine-app",
  "bsengine-core",
+ "bsengine-render",
  "bsengine-rhi-wgpu",
  "gltf",
+ "pollster",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/bsengine-plugin",
     "crates/bsengine-mcp",
     "crates/bsengine-gltf",
+    "crates/bsengine-demo",
     "crates/bsengine-editor",
 ]
 

--- a/crates/bsengine-demo/Cargo.toml
+++ b/crates/bsengine-demo/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bsengine-demo"
+description = "BSEngine demo — spinning cube with lighting"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "demo"
+path = "src/main.rs"
+
+[dependencies]
+bsengine-app.workspace = true
+bsengine-core.workspace = true
+bsengine-gltf.workspace = true
+bsengine-render.workspace = true
+bsengine-rhi-wgpu.workspace = true
+bsengine-window.workspace = true
+bevy_ecs.workspace = true
+glam.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/bsengine-demo/src/main.rs
+++ b/crates/bsengine-demo/src/main.rs
@@ -1,0 +1,74 @@
+use bevy_ecs::prelude::*;
+use bsengine_app::{new_app, Update};
+use bsengine_core::{Camera, DirectionalLight, GlobalTransform, Material, Transform};
+use bsengine_gltf::GltfPlugin;
+use bsengine_render::{MeshRenderer, RenderPlugin};
+use bsengine_rhi_wgpu::{cube_vertices, GpuMeshRegistry, WgpuRHIPlugin};
+use bsengine_window::{WindowDescriptor, WindowPlugin};
+use glam::{Quat, Vec3};
+
+fn setup(
+    mut commands: Commands,
+    registry: Option<ResMut<GpuMeshRegistry>>,
+    mut done: Local<bool>,
+) {
+    if *done {
+        return;
+    }
+    let Some(mut reg) = registry else {
+        return;
+    };
+
+    let (verts, indices) = cube_vertices();
+    let mesh_id = reg.register(&verts, &indices);
+
+    commands.spawn((
+        MeshRenderer { mesh_id },
+        Transform::from_translation(Vec3::new(0.0, 0.0, -4.0)),
+        GlobalTransform::default(),
+        Material {
+            metallic: 0.1,
+            roughness: 0.6,
+            ..Default::default()
+        },
+    ));
+
+    commands.spawn((
+        Camera::default(),
+        Transform::from_translation(Vec3::new(0.0, 1.5, 3.0)),
+    ));
+
+    commands.spawn(DirectionalLight {
+        direction: Vec3::new(-0.5, -1.0, -0.5).normalize(),
+        color: Vec3::ONE,
+        ambient: Vec3::splat(0.15),
+    });
+
+    tracing::info!("Demo scene ready — cube spawned");
+    *done = true;
+}
+
+fn spin(mut query: Query<&mut Transform, With<MeshRenderer>>) {
+    for mut t in query.iter_mut() {
+        t.rotation *= Quat::from_rotation_y(0.01);
+    }
+}
+
+fn main() {
+    bsengine_core::init_logging();
+
+    let mut app = new_app();
+    app.add_plugins(WindowPlugin {
+        descriptor: WindowDescriptor {
+            title: "BSEngine Demo".to_string(),
+            width: 1280,
+            height: 720,
+            resizable: true,
+        },
+    });
+    app.add_plugins(WgpuRHIPlugin);
+    app.add_plugins(RenderPlugin);
+    app.add_plugins(GltfPlugin);
+    app.add_systems(Update, (setup, spin));
+    app.run();
+}

--- a/crates/bsengine-demo/src/main.rs
+++ b/crates/bsengine-demo/src/main.rs
@@ -7,11 +7,7 @@ use bsengine_rhi_wgpu::{cube_vertices, GpuMeshRegistry, WgpuRHIPlugin};
 use bsengine_window::{WindowDescriptor, WindowPlugin};
 use glam::{Quat, Vec3};
 
-fn setup(
-    mut commands: Commands,
-    registry: Option<ResMut<GpuMeshRegistry>>,
-    mut done: Local<bool>,
-) {
+fn setup(mut commands: Commands, registry: Option<ResMut<GpuMeshRegistry>>, mut done: Local<bool>) {
     if *done {
         return;
     }

--- a/crates/bsengine-gltf/Cargo.toml
+++ b/crates/bsengine-gltf/Cargo.toml
@@ -6,8 +6,13 @@ edition.workspace = true
 
 [dependencies]
 bsengine-core.workspace = true
+bsengine-render.workspace = true
 bsengine-rhi-wgpu.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 gltf.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+bsengine-app.workspace = true
+pollster.workspace = true

--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod loader;
+pub mod plugin;
 
-pub use loader::{GltfLoader, MeshData};
+pub use loader::{GltfImageData, GltfLoader, LoadedGltf, MeshData};
+pub use plugin::{GltfAsset, GltfPlugin};

--- a/crates/bsengine-gltf/src/loader.rs
+++ b/crates/bsengine-gltf/src/loader.rs
@@ -1,4 +1,5 @@
 use bsengine_rhi_wgpu::Vertex;
+use gltf::image::Format as GltfFormat;
 
 pub struct MeshData {
     pub name: String,
@@ -6,16 +7,54 @@ pub struct MeshData {
     pub indices: Vec<u32>,
 }
 
+pub struct GltfImageData {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Vec<u8>,
+}
+
+pub struct LoadedGltf {
+    pub meshes: Vec<MeshData>,
+    pub images: Vec<GltfImageData>,
+    pub mesh_tex_indices: Vec<Option<usize>>,
+}
+
 pub struct GltfLoader;
 
 impl GltfLoader {
     pub fn load(path: &str) -> Result<Vec<MeshData>, String> {
-        let (doc, buffers, _) = gltf::import(path).map_err(|e| format!("gltf: {e}"))?;
-        let mut result = Vec::new();
+        Ok(Self::load_full(path)?.meshes)
+    }
+
+    pub fn load_full(path: &str) -> Result<LoadedGltf, String> {
+        let (doc, buffers, raw_images) =
+            gltf::import(path).map_err(|e| format!("gltf: {e}"))?;
+
+        let images: Vec<GltfImageData> = raw_images
+            .iter()
+            .map(|img| {
+                let rgba = gltf_pixels_to_rgba(&img.pixels, img.format, img.width, img.height);
+                GltfImageData {
+                    width: img.width,
+                    height: img.height,
+                    rgba,
+                }
+            })
+            .collect();
+
+        let mut meshes = Vec::new();
+        let mut mesh_tex_indices = Vec::new();
+
         for mesh in doc.meshes() {
             let name = mesh.name().unwrap_or("mesh").to_string();
             for primitive in mesh.primitives() {
                 let reader = primitive.reader(|b| Some(&buffers[b.index()]));
+
+                let tex_idx = primitive
+                    .material()
+                    .pbr_metallic_roughness()
+                    .base_color_texture()
+                    .map(|info| info.texture().source().index());
 
                 let positions: Vec<[f32; 3]> = reader
                     .read_positions()
@@ -56,14 +95,35 @@ impl GltfLoader {
                     })
                     .collect();
 
-                result.push(MeshData {
+                meshes.push(MeshData {
                     name: name.clone(),
                     vertices,
                     indices,
                 });
+                mesh_tex_indices.push(tex_idx);
             }
         }
-        Ok(result)
+
+        Ok(LoadedGltf {
+            meshes,
+            images,
+            mesh_tex_indices,
+        })
+    }
+}
+
+fn gltf_pixels_to_rgba(pixels: &[u8], format: GltfFormat, width: u32, height: u32) -> Vec<u8> {
+    match format {
+        GltfFormat::R8G8B8A8 => pixels.to_vec(),
+        GltfFormat::R8G8B8 => {
+            let mut out = Vec::with_capacity((width * height * 4) as usize);
+            for chunk in pixels.chunks(3) {
+                out.extend_from_slice(chunk);
+                out.push(255);
+            }
+            out
+        }
+        _ => vec![255u8; (width * height * 4) as usize],
     }
 }
 
@@ -73,7 +133,25 @@ mod tests {
 
     #[test]
     fn load_nonexistent_file_returns_error() {
-        let result = GltfLoader::load("nonexistent.gltf");
-        assert!(result.is_err());
+        assert!(GltfLoader::load("nonexistent.gltf").is_err());
+    }
+
+    #[test]
+    fn load_full_nonexistent_returns_error() {
+        assert!(GltfLoader::load_full("nonexistent.gltf").is_err());
+    }
+
+    #[test]
+    fn gltf_pixels_rgb_to_rgba_adds_alpha() {
+        let rgb = vec![255u8, 0, 0, 0, 255, 0];
+        let out = gltf_pixels_to_rgba(&rgb, GltfFormat::R8G8B8, 2, 1);
+        assert_eq!(out, vec![255, 0, 0, 255, 0, 255, 0, 255]);
+    }
+
+    #[test]
+    fn gltf_pixels_rgba_passthrough() {
+        let rgba = vec![1u8, 2, 3, 4];
+        let out = gltf_pixels_to_rgba(&rgba, GltfFormat::R8G8B8A8, 1, 1);
+        assert_eq!(out, rgba);
     }
 }

--- a/crates/bsengine-gltf/src/loader.rs
+++ b/crates/bsengine-gltf/src/loader.rs
@@ -27,8 +27,7 @@ impl GltfLoader {
     }
 
     pub fn load_full(path: &str) -> Result<LoadedGltf, String> {
-        let (doc, buffers, raw_images) =
-            gltf::import(path).map_err(|e| format!("gltf: {e}"))?;
+        let (doc, buffers, raw_images) = gltf::import(path).map_err(|e| format!("gltf: {e}"))?;
 
         let images: Vec<GltfImageData> = raw_images
             .iter()

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -1,0 +1,129 @@
+use bevy_app::{App, Plugin, Update};
+use bevy_ecs::prelude::*;
+use bsengine_core::{GlobalTransform, Material, Transform};
+use bsengine_render::MeshRenderer;
+use bsengine_rhi_wgpu::{GpuMeshRegistry, GpuTextureRegistry};
+use tracing::warn;
+
+use crate::loader::GltfLoader;
+
+#[derive(Component, Clone, Debug)]
+pub struct GltfAsset {
+    pub path: String,
+}
+
+impl GltfAsset {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+pub struct GltfPlugin;
+
+impl Plugin for GltfPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, load_gltf_assets);
+    }
+}
+
+fn load_gltf_assets(
+    mut commands: Commands,
+    query: Query<(Entity, &GltfAsset, Option<&Transform>), Without<MeshRenderer>>,
+    mesh_registry: Option<ResMut<GpuMeshRegistry>>,
+    tex_registry: Option<ResMut<GpuTextureRegistry>>,
+) {
+    let Some(mut mesh_reg) = mesh_registry else {
+        return;
+    };
+    let mut tex_reg = tex_registry;
+
+    for (entity, asset, existing_transform) in query.iter() {
+        match GltfLoader::load_full(&asset.path) {
+            Ok(loaded) => {
+                let tex_ids: Vec<Option<u64>> = if let Some(ref mut tr) = tex_reg {
+                    loaded
+                        .images
+                        .iter()
+                        .map(|img| Some(tr.load_from_rgba(img.width, img.height, &img.rgba)))
+                        .collect()
+                } else {
+                    vec![None; loaded.images.len()]
+                };
+
+                let mut first = true;
+                for (mesh_data, tex_idx) in
+                    loaded.meshes.into_iter().zip(loaded.mesh_tex_indices.iter())
+                {
+                    let mesh_id = mesh_reg.register(&mesh_data.vertices, &mesh_data.indices);
+                    let texture_id = tex_idx.and_then(|i| tex_ids.get(i).copied().flatten());
+                    let mat = Material {
+                        texture_id,
+                        ..Default::default()
+                    };
+
+                    if first {
+                        let mut e = commands.entity(entity);
+                        e.insert((MeshRenderer { mesh_id }, mat));
+                        e.remove::<GltfAsset>();
+                        if existing_transform.is_none() {
+                            e.insert((Transform::default(), GlobalTransform::default()));
+                        }
+                        first = false;
+                    } else {
+                        let t = existing_transform.cloned().unwrap_or_default();
+                        commands.spawn((MeshRenderer { mesh_id }, mat, t, GlobalTransform::default()));
+                    }
+                }
+
+                if first {
+                    commands.entity(entity).remove::<GltfAsset>();
+                    warn!("GLTF {} has no meshes", asset.path);
+                }
+            }
+            Err(e) => {
+                warn!("Failed to load GLTF {}: {e}", asset.path);
+                commands.entity(entity).remove::<GltfAsset>();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_app::new_app;
+    use bsengine_rhi_wgpu::WgpuRHIPlugin;
+
+    #[test]
+    fn gltf_plugin_builds_and_runs() {
+        let mut app = new_app();
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(GltfPlugin);
+        app.update();
+    }
+
+    #[test]
+    fn no_registry_leaves_gltf_asset_intact() {
+        let mut app = new_app();
+        app.add_plugins(GltfPlugin);
+        let e = app.world_mut().spawn(GltfAsset::new("missing.gltf")).id();
+        app.update();
+        assert!(
+            app.world().get::<GltfAsset>(e).is_some(),
+            "GltfAsset should remain when GpuMeshRegistry is unavailable"
+        );
+    }
+
+    #[test]
+    fn with_rhi_plugin_but_no_window_gltf_asset_stays() {
+        // WgpuRHIPlugin creates headless RHI but GpuMeshRegistry requires a
+        // WindowHandle (created by winit). Without a window, load_gltf_assets
+        // returns early and the GltfAsset marker stays on the entity.
+        let mut app = new_app();
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(GltfPlugin);
+        let e = app.world_mut().spawn(GltfAsset::new("bad.gltf")).id();
+        app.update();
+        assert!(app.world().get::<GltfAsset>(e).is_some());
+    }
+}

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -51,8 +51,10 @@ fn load_gltf_assets(
                 };
 
                 let mut first = true;
-                for (mesh_data, tex_idx) in
-                    loaded.meshes.into_iter().zip(loaded.mesh_tex_indices.iter())
+                for (mesh_data, tex_idx) in loaded
+                    .meshes
+                    .into_iter()
+                    .zip(loaded.mesh_tex_indices.iter())
                 {
                     let mesh_id = mesh_reg.register(&mesh_data.vertices, &mesh_data.indices);
                     let texture_id = tex_idx.and_then(|i| tex_ids.get(i).copied().flatten());
@@ -71,7 +73,12 @@ fn load_gltf_assets(
                         first = false;
                     } else {
                         let t = existing_transform.cloned().unwrap_or_default();
-                        commands.spawn((MeshRenderer { mesh_id }, mat, t, GlobalTransform::default()));
+                        commands.spawn((
+                            MeshRenderer { mesh_id },
+                            mat,
+                            t,
+                            GlobalTransform::default(),
+                        ));
                     }
                 }
 

--- a/crates/bsengine-rhi-wgpu/src/texture.rs
+++ b/crates/bsengine-rhi-wgpu/src/texture.rs
@@ -67,14 +67,17 @@ impl GpuTextureRegistry {
         let img = image::load_from_memory(bytes).map_err(|e| format!("image decode: {e}"))?;
         let rgba = img.to_rgba8();
         let (width, height) = rgba.dimensions();
+        Ok(self.upload_rgba(width, height, &rgba))
+    }
 
+    pub fn load_from_rgba(&mut self, width: u32, height: u32, rgba: &[u8]) -> u64 {
+        self.upload_rgba(width, height, rgba)
+    }
+
+    fn upload_rgba(&mut self, width: u32, height: u32, rgba: &[u8]) -> u64 {
         let texture = self.device.create_texture(&wgpu::TextureDescriptor {
             label: Some("user texture"),
-            size: wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
+            size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
@@ -84,19 +87,14 @@ impl GpuTextureRegistry {
         });
         self.queue.write_texture(
             texture.as_image_copy(),
-            &rgba,
+            rgba,
             wgpu::ImageDataLayout {
                 offset: 0,
                 bytes_per_row: Some(4 * width),
                 rows_per_image: None,
             },
-            wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
+            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
         );
-
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("user tex bg"),
@@ -112,18 +110,10 @@ impl GpuTextureRegistry {
                 },
             ],
         });
-
         let id = self.next_id;
         self.next_id += 1;
-        self.textures.insert(
-            id,
-            GpuTexture {
-                _texture: texture,
-                _view: view,
-                bind_group,
-            },
-        );
-        Ok(id)
+        self.textures.insert(id, GpuTexture { _texture: texture, _view: view, bind_group });
+        id
     }
 
     pub fn get_bind_group(&self, id: u64) -> Option<&wgpu::BindGroup> {

--- a/crates/bsengine-rhi-wgpu/src/texture.rs
+++ b/crates/bsengine-rhi-wgpu/src/texture.rs
@@ -77,7 +77,11 @@ impl GpuTextureRegistry {
     fn upload_rgba(&mut self, width: u32, height: u32, rgba: &[u8]) -> u64 {
         let texture = self.device.create_texture(&wgpu::TextureDescriptor {
             label: Some("user texture"),
-            size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
@@ -93,7 +97,11 @@ impl GpuTextureRegistry {
                 bytes_per_row: Some(4 * width),
                 rows_per_image: None,
             },
-            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
         );
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -112,7 +120,14 @@ impl GpuTextureRegistry {
         });
         let id = self.next_id;
         self.next_id += 1;
-        self.textures.insert(id, GpuTexture { _texture: texture, _view: view, bind_group });
+        self.textures.insert(
+            id,
+            GpuTexture {
+                _texture: texture,
+                _view: view,
+                bind_group,
+            },
+        );
         id
     }
 


### PR DESCRIPTION
## Summary

- **`GpuTextureRegistry::load_from_rgba`** — direct pixel upload without re-encoding; `load_from_bytes` refactored to share the `upload_rgba` helper
- **`GltfLoader::load_full`** — extends GLTF loading to return decoded RGBA image data + per-primitive texture indices alongside mesh data
- **`GltfPlugin` + `GltfAsset`** — component-driven GLTF → GPU pipeline: spawn entity with `GltfAsset { path }`, system automatically registers mesh/textures and inserts `MeshRenderer + Material`
- **`bsengine-demo`** — new binary crate: 1280×720 window, procedural cube, directional light, camera, spinning each frame

## Test plan

- [ ] CI passes (all crates including bsengine-gltf 7 tests, bsengine-rhi-wgpu 16 tests)
- [ ] `cargo run -p bsengine-demo --bin demo` opens window and shows spinning RGB cube
- [ ] GLTF files with textures load correctly via `GltfAsset::new("model.gltf")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)