### PR TITLE
feat: scene system — typed Transform, GLTF, Camera, Light components in RON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,8 @@ dependencies = [
  "bsengine-app",
  "bsengine-core",
  "bsengine-ecs",
+ "bsengine-gltf",
+ "glam 0.29.3",
  "ron",
  "serde",
 ]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -693,6 +693,10 @@ impl Plugin for EditorPlugin {
                                 EntityDescriptor {
                                     name: name.clone(),
                                     components,
+                                    transform: None,
+                                    gltf: None,
+                                    camera: false,
+                                    directional_light: None,
                                 }
                             })
                         })

--- a/crates/bsengine-scene/Cargo.toml
+++ b/crates/bsengine-scene/Cargo.toml
@@ -7,8 +7,10 @@ edition.workspace = true
 [dependencies]
 bsengine-core.workspace = true
 bsengine-ecs.workspace = true
+bsengine-gltf.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+glam.workspace = true
 ron.workspace = true
 serde.workspace = true
 

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -1,5 +1,7 @@
-// bsengine-scene
 pub mod plugin;
 pub mod types;
+
 pub use plugin::{Name, ScenePlugin};
-pub use types::{EntityDescriptor, SceneDescriptor};
+pub use types::{
+    DirectionalLightDescriptor, EntityDescriptor, SceneDescriptor, TransformDescriptor,
+};

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -1,6 +1,9 @@
 use crate::types::SceneDescriptor;
 use bevy_app::{App, Plugin, Startup};
 use bevy_ecs::prelude::{Commands, Component};
+use bsengine_core::{Camera, DirectionalLight, GlobalTransform, Transform};
+use bsengine_gltf::GltfAsset;
+use glam::{Quat, Vec3};
 
 #[derive(Component, Debug, Clone)]
 pub struct Name(pub String);
@@ -25,8 +28,39 @@ impl Plugin for ScenePlugin {
                 .unwrap_or_else(|e| panic!("Failed to read scene {path}: {e}"));
             let scene: SceneDescriptor = ron::from_str(&content)
                 .unwrap_or_else(|e| panic!("Failed to parse scene {path}: {e}"));
+
             for entity in &scene.entities {
-                commands.spawn(Name(entity.name.clone()));
+                let mut builder = commands.spawn(Name(entity.name.clone()));
+
+                if let Some(t) = &entity.transform {
+                    let transform = Transform {
+                        translation: Vec3::from(t.translation),
+                        rotation: Quat::from_xyzw(
+                            t.rotation[0],
+                            t.rotation[1],
+                            t.rotation[2],
+                            t.rotation[3],
+                        ),
+                        scale: Vec3::from(t.scale),
+                    };
+                    builder.insert((transform, GlobalTransform::default()));
+                }
+
+                if let Some(path) = &entity.gltf {
+                    builder.insert(GltfAsset::new(path.clone()));
+                }
+
+                if entity.camera {
+                    builder.insert(Camera::default());
+                }
+
+                if let Some(dl) = &entity.directional_light {
+                    builder.insert(DirectionalLight {
+                        direction: Vec3::from(dl.direction),
+                        color: Vec3::from(dl.color),
+                        ambient: Vec3::from(dl.ambient),
+                    });
+                }
             }
         });
     }
@@ -36,6 +70,7 @@ impl Plugin for ScenePlugin {
 mod tests {
     use super::{Name, ScenePlugin};
     use bsengine_app::new_app;
+    use bsengine_core::{Camera, DirectionalLight, GlobalTransform, Transform};
 
     fn write_temp_scene(filename: &str, content: &str) -> String {
         let path = std::env::temp_dir().join(filename);
@@ -77,5 +112,87 @@ mod tests {
 
         let mut q = app.world_mut().query::<&Name>();
         assert_eq!(q.iter(app.world()).count(), 0);
+    }
+
+    #[test]
+    fn scene_plugin_spawns_transform() {
+        let ron = r#"SceneDescriptor(entities: [
+            EntityDescriptor(
+                name: "Cube",
+                transform: Some((translation: (1.0, 2.0, 3.0))),
+            )
+        ])"#;
+        let path = write_temp_scene("test_transform.ron", ron);
+
+        let mut app = new_app();
+        app.add_plugins(ScenePlugin::from_file(&path));
+        app.update();
+
+        let mut q = app
+            .world_mut()
+            .query::<(&Name, &Transform, &GlobalTransform)>();
+        let results: Vec<_> = q.iter(app.world()).collect();
+        assert_eq!(results.len(), 1);
+        let (name, t, _) = &results[0];
+        assert_eq!(name.0, "Cube");
+        assert!((t.translation.x - 1.0).abs() < 1e-5);
+        assert!((t.translation.y - 2.0).abs() < 1e-5);
+        assert!((t.translation.z - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn scene_plugin_spawns_camera() {
+        let ron = r#"SceneDescriptor(entities: [
+            EntityDescriptor(name: "MainCam", camera: true)
+        ])"#;
+        let path = write_temp_scene("test_camera.ron", ron);
+
+        let mut app = new_app();
+        app.add_plugins(ScenePlugin::from_file(&path));
+        app.update();
+
+        let mut q = app.world_mut().query::<(&Name, &Camera)>();
+        let results: Vec<_> = q.iter(app.world()).collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0 .0, "MainCam");
+    }
+
+    #[test]
+    fn scene_plugin_spawns_directional_light() {
+        let ron = r#"SceneDescriptor(entities: [
+            EntityDescriptor(
+                name: "Sun",
+                directional_light: Some((direction: (0.0, -1.0, 0.0))),
+            )
+        ])"#;
+        let path = write_temp_scene("test_light.ron", ron);
+
+        let mut app = new_app();
+        app.add_plugins(ScenePlugin::from_file(&path));
+        app.update();
+
+        let mut q = app.world_mut().query::<(&Name, &DirectionalLight)>();
+        let results: Vec<_> = q.iter(app.world()).collect();
+        assert_eq!(results.len(), 1);
+        let (name, light) = &results[0];
+        assert_eq!(name.0, "Sun");
+        assert!((light.direction.y - (-1.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn scene_plugin_no_transform_when_not_specified() {
+        let ron = r#"SceneDescriptor(entities: [EntityDescriptor(name: "Ghost")])"#;
+        let path = write_temp_scene("test_no_transform.ron", ron);
+
+        let mut app = new_app();
+        app.add_plugins(ScenePlugin::from_file(&path));
+        app.update();
+
+        let mut q = app.world_mut().query::<(&Name, &Transform)>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            0,
+            "entity without transform field should have no Transform component"
+        );
     }
 }

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -5,10 +5,69 @@ pub struct SceneDescriptor {
     pub entities: Vec<EntityDescriptor>,
 }
 
+/// Describes a single entity in the scene file.
+///
+/// All component fields are optional and default to absent; only `name` is
+/// required.  The legacy `components` field is kept for compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntityDescriptor {
     pub name: String,
+    #[serde(default)]
+    pub transform: Option<TransformDescriptor>,
+    #[serde(default)]
+    pub gltf: Option<String>,
+    #[serde(default)]
+    pub camera: bool,
+    #[serde(default)]
+    pub directional_light: Option<DirectionalLightDescriptor>,
+    #[serde(default)]
     pub components: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransformDescriptor {
+    #[serde(default)]
+    pub translation: [f32; 3],
+    /// Quaternion as [x, y, z, w].  Defaults to identity.
+    #[serde(default = "default_rotation")]
+    pub rotation: [f32; 4],
+    #[serde(default = "default_scale")]
+    pub scale: [f32; 3],
+}
+
+impl Default for TransformDescriptor {
+    fn default() -> Self {
+        Self {
+            translation: [0.0, 0.0, 0.0],
+            rotation: default_rotation(),
+            scale: default_scale(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DirectionalLightDescriptor {
+    pub direction: [f32; 3],
+    #[serde(default = "default_white")]
+    pub color: [f32; 3],
+    #[serde(default = "default_ambient")]
+    pub ambient: [f32; 3],
+}
+
+fn default_rotation() -> [f32; 4] {
+    [0.0, 0.0, 0.0, 1.0]
+}
+
+fn default_scale() -> [f32; 3] {
+    [1.0, 1.0, 1.0]
+}
+
+fn default_white() -> [f32; 3] {
+    [1.0, 1.0, 1.0]
+}
+
+fn default_ambient() -> [f32; 3] {
+    [0.1, 0.1, 0.1]
 }
 
 #[cfg(test)]
@@ -52,5 +111,57 @@ mod tests {
         assert_eq!(entity.name, "Enemy");
         assert_eq!(entity.components.len(), 2);
         assert_eq!(entity.components[0].0, "Transform");
+    }
+
+    #[test]
+    fn entity_descriptor_with_transform_deserializes() {
+        // RON uses tuple syntax () for fixed-size arrays [f32; N]
+        let ron_str = r#"
+            EntityDescriptor(
+                name: "Cube",
+                transform: Some((
+                    translation: (1.0, 2.0, 3.0),
+                    rotation: (0.0, 0.0, 0.0, 1.0),
+                    scale: (1.0, 1.0, 1.0),
+                )),
+                gltf: Some("models/cube.gltf"),
+            )
+        "#;
+        let entity: EntityDescriptor = ron::from_str(ron_str).unwrap();
+        let t = entity.transform.unwrap();
+        assert_eq!(t.translation, [1.0, 2.0, 3.0]);
+        assert_eq!(entity.gltf.as_deref(), Some("models/cube.gltf"));
+    }
+
+    #[test]
+    fn entity_descriptor_with_camera_deserializes() {
+        let ron_str = r#"EntityDescriptor(name: "Cam", camera: true)"#;
+        let entity: EntityDescriptor = ron::from_str(ron_str).unwrap();
+        assert!(entity.camera);
+    }
+
+    #[test]
+    fn entity_descriptor_with_directional_light_deserializes() {
+        let ron_str = r#"
+            EntityDescriptor(
+                name: "Sun",
+                directional_light: Some((
+                    direction: (-0.4, -0.8, -0.4),
+                )),
+            )
+        "#;
+        let entity: EntityDescriptor = ron::from_str(ron_str).unwrap();
+        let dl = entity.directional_light.unwrap();
+        assert_eq!(dl.direction, [-0.4, -0.8, -0.4]);
+        assert_eq!(dl.color, [1.0, 1.0, 1.0]);
+        assert_eq!(dl.ambient, [0.1, 0.1, 0.1]);
+    }
+
+    #[test]
+    fn transform_descriptor_default() {
+        let t = TransformDescriptor::default();
+        assert_eq!(t.translation, [0.0, 0.0, 0.0]);
+        assert_eq!(t.rotation, [0.0, 0.0, 0.0, 1.0]);
+        assert_eq!(t.scale, [1.0, 1.0, 1.0]);
     }
 }


### PR DESCRIPTION
## Summary

- **`TransformDescriptor`** — `translation`, `rotation` (xyzw), `scale` fields; `ScenePlugin` converts to `Transform + GlobalTransform`
- **`gltf` field** — `Some("path/to/model.gltf")` spawns `GltfAsset`; `GltfPlugin` picks it up next frame and registers mesh/texture
- **`camera: true`** — spawns `Camera` component  
- **`directional_light`** — spawns `DirectionalLight` with direction/color/ambient
- All new fields are `#[serde(default)]` — backward compatible with existing `name + components` scenes
- Fixes `bsengine-editor` `EntityDescriptor` construction for new fields

## RON Format

```ron
SceneDescriptor(entities: [
    EntityDescriptor(
        name: "Cube",
        transform: Some((translation: (0.0, 0.0, -3.0))),
        gltf: Some("assets/cube.gltf"),
    ),
    EntityDescriptor(name: "MainCamera", camera: true,
        transform: Some((translation: (0.0, 1.5, 5.0)))),
    EntityDescriptor(name: "Sun",
        directional_light: Some((direction: (-0.4, -0.8, -0.4)))),
])
```

## Test plan

- [ ] CI passes (12 scene tests, all workspace tests green)
- [ ] Scene file with Transform + GLTF + Camera + Light loads and spawns correct components

🤖 Generated with [Claude Code](https://claude.com/claude-code)