### PR TITLE
feat: physics collision events via ECS EventWriter

### DIFF
--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -1,6 +1,13 @@
-use bevy_ecs::prelude::Component;
+use bevy_ecs::prelude::{Component, Entity, Event};
 use glam::{Quat, Vec3};
 use rapier3d::prelude::{ColliderHandle, RigidBodyHandle};
+
+#[derive(Event, Debug, Clone, Copy)]
+pub struct CollisionEvent {
+    pub entity_a: Entity,
+    pub entity_b: Entity,
+    pub started: bool,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RigidBodyType {

--- a/crates/bsengine-physics/src/lib.rs
+++ b/crates/bsengine-physics/src/lib.rs
@@ -3,7 +3,8 @@ pub mod plugin;
 pub mod world;
 
 pub use components::{
-    Collider, ColliderShape, PhysicsInput, PhysicsTransform, RigidBody, RigidBodyType,
+    Collider, ColliderShape, CollisionEvent, PhysicsInput, PhysicsTransform, RigidBody,
+    RigidBodyType,
 };
 pub use plugin::PhysicsPlugin;
 pub use world::PhysicsWorld;
@@ -116,6 +117,46 @@ mod tests {
             transform.translation.y > 0.0,
             "ball should rest above floor, got y={}",
             transform.translation.y
+        );
+    }
+
+    #[test]
+    fn collision_event_fires_when_bodies_touch() {
+        use bevy_ecs::event::Events;
+
+        let mut app = new_app();
+
+        app.world_mut().spawn((
+            RigidBody::fixed(),
+            Collider::cuboid(10.0, 0.1, 10.0),
+            PhysicsInput {
+                translation: Vec3::ZERO,
+                rotation: Default::default(),
+            },
+        ));
+
+        app.world_mut().spawn((
+            RigidBody::dynamic(),
+            Collider::ball(0.5),
+            PhysicsInput {
+                translation: Vec3::new(0.0, 1.0, 0.0),
+                rotation: Default::default(),
+            },
+        ));
+
+        let mut received = false;
+        for _ in 0..200 {
+            app.update();
+            let events = app.world().resource::<Events<CollisionEvent>>();
+            let mut reader = events.get_reader();
+            if reader.read(events).next().is_some() {
+                received = true;
+                break;
+            }
+        }
+        assert!(
+            received,
+            "expected collision event when ball lands on floor"
         );
     }
 

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -1,12 +1,16 @@
+use std::sync::Mutex;
+
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use glam::{Quat, Vec3};
+use rapier3d::geometry::{CollisionEvent as RapierCollisionEvent, ContactPair};
+use rapier3d::pipeline::EventHandler;
 use rapier3d::prelude::*;
 
 use crate::{
     components::{
-        Collider, ColliderShape, PhysicsHandles, PhysicsInput, PhysicsTransform, RigidBody,
-        RigidBodyType,
+        Collider, ColliderShape, CollisionEvent, PhysicsHandles, PhysicsInput, PhysicsTransform,
+        RigidBody, RigidBodyType,
     },
     world::PhysicsWorld,
 };
@@ -16,26 +20,49 @@ pub struct PhysicsPlugin;
 impl Plugin for PhysicsPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(PhysicsWorld::default());
+        app.add_event::<CollisionEvent>();
         app.add_systems(Update, (spawn_bodies, step_world, sync_from_rapier).chain());
     }
 }
 
-// Convert project glam 0.29 Vec3 → rapier math Vec3 (glam 0.33) via raw floats
+struct CollisionBuffer {
+    events: Mutex<Vec<RapierCollisionEvent>>,
+}
+
+impl EventHandler for CollisionBuffer {
+    fn handle_collision_event(
+        &self,
+        _bodies: &RigidBodySet,
+        _colliders: &ColliderSet,
+        event: RapierCollisionEvent,
+        _contact_pair: Option<&ContactPair>,
+    ) {
+        self.events.lock().unwrap().push(event);
+    }
+
+    fn handle_contact_force_event(
+        &self,
+        _dt: rapier3d::math::Real,
+        _bodies: &RigidBodySet,
+        _colliders: &ColliderSet,
+        _contact_pair: &ContactPair,
+        _total_force_magnitude: rapier3d::math::Real,
+    ) {
+    }
+}
+
 fn to_rapier_vec(v: Vec3) -> Vector {
     Vector::new(v.x, v.y, v.z)
 }
 
-// Convert project glam 0.29 Quat → rapier Rotation (glam 0.33 Quat) via raw floats
 fn to_rapier_rot(q: Quat) -> Rotation {
     Rotation::from_xyzw(q.x, q.y, q.z, q.w)
 }
 
-// Convert rapier math Vec3 (glam 0.33) → project glam 0.29 Vec3
 fn from_rapier_vec(v: Vector) -> Vec3 {
     Vec3::new(v.x, v.y, v.z)
 }
 
-// Convert rapier Rotation (glam 0.33 Quat) → project glam 0.29 Quat
 fn from_rapier_rot(r: Rotation) -> Quat {
     Quat::from_xyzw(r.x, r.y, r.z, r.w)
 }
@@ -53,13 +80,13 @@ fn spawn_bodies(
 
         let rb = match rigid_body.body_type {
             RigidBodyType::Dynamic => RigidBodyBuilder::dynamic()
-                .position(pose)
+                .pose(pose)
                 .linear_damping(rigid_body.linear_damping)
                 .angular_damping(rigid_body.angular_damping)
                 .build(),
-            RigidBodyType::Static => RigidBodyBuilder::fixed().position(pose).build(),
+            RigidBodyType::Static => RigidBodyBuilder::fixed().pose(pose).build(),
             RigidBodyType::KinematicPosition => RigidBodyBuilder::kinematic_position_based()
-                .position(pose)
+                .pose(pose)
                 .build(),
         };
 
@@ -70,9 +97,11 @@ fn spawn_bodies(
             .restitution(collider.restitution)
             .friction(collider.friction)
             .density(collider.density)
+            .active_events(ActiveEvents::COLLISION_EVENTS)
             .build();
 
         let collider_handle = world.add_collider(coll, body_handle);
+        world.collider_entity_map.insert(collider_handle, entity);
 
         commands.entity(entity).insert((
             PhysicsHandles {
@@ -90,6 +119,7 @@ fn spawn_bodies(
 fn step_world(
     mut world: ResMut<PhysicsWorld>,
     query: Query<(&PhysicsHandles, &PhysicsInput), With<RigidBody>>,
+    mut collision_events: EventWriter<CollisionEvent>,
 ) {
     for (handles, input) in query.iter() {
         if let Some(body) = world.rigid_body_set.get_mut(handles.body_handle) {
@@ -102,7 +132,27 @@ fn step_world(
         }
     }
 
-    world.step();
+    let buffer = CollisionBuffer {
+        events: Mutex::new(Vec::new()),
+    };
+    world.step(&buffer);
+
+    for event in buffer.events.into_inner().unwrap() {
+        let (h1, h2, started) = match event {
+            RapierCollisionEvent::Started(h1, h2, _) => (h1, h2, true),
+            RapierCollisionEvent::Stopped(h1, h2, _) => (h1, h2, false),
+        };
+        if let (Some(&e1), Some(&e2)) = (
+            world.collider_entity_map.get(&h1),
+            world.collider_entity_map.get(&h2),
+        ) {
+            collision_events.send(CollisionEvent {
+                entity_a: e1,
+                entity_b: e2,
+                started,
+            });
+        }
+    }
 }
 
 fn sync_from_rapier(

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -1,10 +1,14 @@
-use bevy_ecs::prelude::Resource;
+use std::collections::HashMap;
+
+use bevy_ecs::prelude::{Entity, Resource};
+use rapier3d::pipeline::EventHandler;
 use rapier3d::prelude::*;
 
 #[derive(Resource)]
 pub struct PhysicsWorld {
     pub(crate) rigid_body_set: RigidBodySet,
     pub(crate) collider_set: ColliderSet,
+    pub(crate) collider_entity_map: HashMap<ColliderHandle, Entity>,
     gravity: Vector,
     integration_parameters: IntegrationParameters,
     physics_pipeline: PhysicsPipeline,
@@ -27,6 +31,7 @@ impl PhysicsWorld {
         Self {
             rigid_body_set: RigidBodySet::new(),
             collider_set: ColliderSet::new(),
+            collider_entity_map: HashMap::new(),
             gravity: Vector::new(0.0, -gravity_magnitude, 0.0),
             integration_parameters: IntegrationParameters::default(),
             physics_pipeline: PhysicsPipeline::new(),
@@ -39,7 +44,7 @@ impl PhysicsWorld {
         }
     }
 
-    pub fn step(&mut self) {
+    pub fn step(&mut self, event_handler: &dyn EventHandler) {
         self.physics_pipeline.step(
             self.gravity,
             &self.integration_parameters,
@@ -52,7 +57,7 @@ impl PhysicsWorld {
             &mut self.multibody_joint_set,
             &mut self.ccd_solver,
             &(),
-            &(),
+            event_handler,
         );
     }
 


### PR DESCRIPTION
## Summary

- **`CollisionEvent { entity_a, entity_b, started }`** — new ECS event emitted every frame contacts start or stop
- **`CollisionBuffer`** — per-step `Mutex<Vec<RapierCollisionEvent>>` implementing rapier's `EventHandler` trait; no crossbeam dep needed
- **`PhysicsWorld::collider_entity_map`** — `HashMap<ColliderHandle, Entity>` populated in `spawn_bodies`, used to map rapier handles back to ECS entities
- All colliders automatically opt-in via `ActiveEvents::COLLISION_EVENTS` — no per-collider configuration needed
- Fixed deprecated `RigidBodyBuilder::position()` → `pose()`

## Usage

```rust
fn on_collision(mut events: EventReader<CollisionEvent>) {
    for ev in events.read() {
        if ev.started {
            println!("{:?} hit {:?}", ev.entity_a, ev.entity_b);
        }
    }
}
```

## Test plan

- [ ] CI passes (6 physics tests including `collision_event_fires_when_bodies_touch`)
- [ ] Existing gravity/floor/kinematic tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)