### PR TITLE
feat: Time resource with delta_seconds and elapsed_seconds

### DIFF
--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod app;
+pub mod time;
 
 pub use app::{new_app, App, BsPlugin, Last, PostUpdate, PreUpdate, Startup, Update};
+pub use time::TimePlugin;
 
 mod tests;

--- a/crates/bsengine-app/src/tests.rs
+++ b/crates/bsengine-app/src/tests.rs
@@ -20,4 +20,33 @@ mod tests {
         let mut app = new_app();
         app.add_plugins(MyPlugin);
     }
+
+    #[test]
+    fn time_plugin_inserts_time_resource() {
+        use crate::TimePlugin;
+        use bsengine_core::Time;
+
+        let mut app = new_app();
+        app.add_plugins(TimePlugin);
+        app.update();
+
+        let time = app.world().resource::<Time>();
+        assert!(time.elapsed_seconds >= 0.0);
+    }
+
+    #[test]
+    fn time_advances_each_frame() {
+        use crate::TimePlugin;
+        use bsengine_core::Time;
+
+        let mut app = new_app();
+        app.add_plugins(TimePlugin);
+
+        app.update();
+        let e1 = app.world().resource::<Time>().elapsed_seconds;
+        app.update();
+        let e2 = app.world().resource::<Time>().elapsed_seconds;
+
+        assert!(e2 > e1, "elapsed_seconds should increase each frame");
+    }
 }

--- a/crates/bsengine-app/src/time.rs
+++ b/crates/bsengine-app/src/time.rs
@@ -1,0 +1,16 @@
+use bevy_app::prelude::*;
+use bsengine_core::Time;
+use bsengine_ecs::ResMut;
+
+pub struct TimePlugin;
+
+impl Plugin for TimePlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(Time::default());
+        app.add_systems(PreUpdate, tick_time);
+    }
+}
+
+fn tick_time(mut time: ResMut<Time>) {
+    time.tick();
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod light;
 pub mod logging;
 pub mod material;
 pub mod parent;
+pub mod time;
 pub mod transform;
 
 pub use camera::Camera;
@@ -12,6 +13,7 @@ pub use light::{DirectionalLight, PointLight, SpotLight};
 pub use logging::init_logging;
 pub use material::Material;
 pub use parent::Parent;
+pub use time::Time;
 pub use transform::Transform;
 
 pub fn propagate_global_transforms(world: &mut bevy_ecs::world::World) {

--- a/crates/bsengine-core/src/time.rs
+++ b/crates/bsengine-core/src/time.rs
@@ -1,0 +1,32 @@
+use std::time::Instant;
+
+use bevy_ecs::prelude::Resource;
+
+#[derive(Resource)]
+pub struct Time {
+    pub delta_seconds: f32,
+    pub elapsed_seconds: f32,
+    startup: Instant,
+    last_tick: Instant,
+}
+
+impl Default for Time {
+    fn default() -> Self {
+        let now = Instant::now();
+        Self {
+            delta_seconds: 0.0,
+            elapsed_seconds: 0.0,
+            startup: now,
+            last_tick: now,
+        }
+    }
+}
+
+impl Time {
+    pub fn tick(&mut self) {
+        let now = Instant::now();
+        self.delta_seconds = now.duration_since(self.last_tick).as_secs_f32();
+        self.elapsed_seconds = now.duration_since(self.startup).as_secs_f32();
+        self.last_tick = now;
+    }
+}


### PR DESCRIPTION
## Summary

- **`bsengine_core::Time`** — resource with `delta_seconds` and `elapsed_seconds` tracked via `std::time::Instant`
- **`bsengine_app::TimePlugin`** — inserts `Time` and ticks it in `PreUpdate` each frame
- No new dependencies — uses `std::time::Instant` directly

## Usage

```rust
fn move_player(time: Res<Time>, mut query: Query<&mut Transform, With<Player>>) {
    for mut t in query.iter_mut() {
        t.translation.x += 5.0 * time.delta_seconds;
    }
}
```

## Test plan

- [ ] CI passes (4 bsengine-app tests + 17 bsengine-core tests)
- [ ] `time_advances_each_frame` verifies elapsed_seconds increases monotonically

🤖 Generated with [Claude Code](https://claude.com/claude-code)