### PR TITLE
feat: Input<T> state resource for keyboard and mouse

### DIFF
--- a/crates/bsengine-input/src/lib.rs
+++ b/crates/bsengine-input/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod convert;
 pub mod plugin;
+pub mod state;
 pub mod types;
 
 pub use plugin::InputPlugin;
+pub use state::Input;
 pub use types::{CursorMoved, ElementState, KeyCode, KeyInput, MouseButton, MouseInput};

--- a/crates/bsengine-input/src/plugin.rs
+++ b/crates/bsengine-input/src/plugin.rs
@@ -1,5 +1,11 @@
-use crate::types::{CursorMoved, KeyInput, MouseInput};
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, PreUpdate};
+use bevy_ecs::prelude::{EventReader, ResMut};
+use bsengine_ecs::IntoSystemConfigs;
+
+use crate::{
+    state::Input,
+    types::{CursorMoved, ElementState, KeyCode, KeyInput, MouseButton, MouseInput},
+};
 
 pub struct InputPlugin;
 
@@ -7,13 +13,48 @@ impl Plugin for InputPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<KeyInput>()
             .add_event::<MouseInput>()
-            .add_event::<CursorMoved>();
+            .add_event::<CursorMoved>()
+            .insert_resource(Input::<KeyCode>::default())
+            .insert_resource(Input::<MouseButton>::default())
+            .add_systems(
+                PreUpdate,
+                (clear_input_state, update_keyboard_state, update_mouse_state).chain(),
+            );
+    }
+}
+
+fn clear_input_state(mut keys: ResMut<Input<KeyCode>>, mut buttons: ResMut<Input<MouseButton>>) {
+    keys.clear_transient();
+    buttons.clear_transient();
+}
+
+fn update_keyboard_state(mut keys: ResMut<Input<KeyCode>>, mut events: EventReader<KeyInput>) {
+    for ev in events.read() {
+        match ev.state {
+            ElementState::Pressed => keys.press(ev.key_code),
+            ElementState::Released => keys.release(ev.key_code),
+        }
+    }
+}
+
+fn update_mouse_state(
+    mut buttons: ResMut<Input<MouseButton>>,
+    mut events: EventReader<MouseInput>,
+) {
+    for ev in events.read() {
+        match ev.state {
+            ElementState::Pressed => buttons.press(ev.button),
+            ElementState::Released => buttons.release(ev.button),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{CursorMoved, InputPlugin, KeyInput, MouseInput};
+    use crate::{
+        state::Input, CursorMoved, ElementState, InputPlugin, KeyCode, KeyInput, MouseButton,
+        MouseInput,
+    };
     use bevy_ecs::event::Events;
     use bsengine_app::new_app;
 
@@ -36,5 +77,88 @@ mod tests {
         let mut app = new_app();
         app.add_plugins(InputPlugin);
         assert!(app.world().get_resource::<Events<CursorMoved>>().is_some());
+    }
+
+    #[test]
+    fn key_input_state_is_pressed_after_event() {
+        let mut app = new_app();
+        app.add_plugins(InputPlugin);
+
+        app.world_mut()
+            .resource_mut::<Events<KeyInput>>()
+            .send(KeyInput {
+                key_code: KeyCode::W,
+                state: ElementState::Pressed,
+            });
+
+        app.update();
+
+        let keys = app.world().resource::<Input<KeyCode>>();
+        assert!(keys.is_pressed(&KeyCode::W));
+        assert!(keys.just_pressed(&KeyCode::W));
+    }
+
+    #[test]
+    fn just_pressed_cleared_next_frame() {
+        let mut app = new_app();
+        app.add_plugins(InputPlugin);
+
+        app.world_mut()
+            .resource_mut::<Events<KeyInput>>()
+            .send(KeyInput {
+                key_code: KeyCode::Space,
+                state: ElementState::Pressed,
+            });
+
+        app.update();
+        app.update();
+
+        let keys = app.world().resource::<Input<KeyCode>>();
+        assert!(keys.is_pressed(&KeyCode::Space));
+        assert!(!keys.just_pressed(&KeyCode::Space));
+    }
+
+    #[test]
+    fn key_released_clears_pressed() {
+        let mut app = new_app();
+        app.add_plugins(InputPlugin);
+
+        app.world_mut()
+            .resource_mut::<Events<KeyInput>>()
+            .send(KeyInput {
+                key_code: KeyCode::A,
+                state: ElementState::Pressed,
+            });
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<Events<KeyInput>>()
+            .send(KeyInput {
+                key_code: KeyCode::A,
+                state: ElementState::Released,
+            });
+        app.update();
+
+        let keys = app.world().resource::<Input<KeyCode>>();
+        assert!(!keys.is_pressed(&KeyCode::A));
+        assert!(keys.just_released(&KeyCode::A));
+    }
+
+    #[test]
+    fn mouse_button_state_tracked() {
+        let mut app = new_app();
+        app.add_plugins(InputPlugin);
+
+        app.world_mut()
+            .resource_mut::<Events<MouseInput>>()
+            .send(MouseInput {
+                button: MouseButton::Left,
+                state: ElementState::Pressed,
+            });
+
+        app.update();
+
+        let buttons = app.world().resource::<Input<MouseButton>>();
+        assert!(buttons.is_pressed(&MouseButton::Left));
     }
 }

--- a/crates/bsengine-input/src/state.rs
+++ b/crates/bsengine-input/src/state.rs
@@ -1,0 +1,104 @@
+use std::collections::HashSet;
+use std::hash::Hash;
+
+use bevy_ecs::prelude::Resource;
+
+/// Persistent per-frame input state for a button-like type (key or mouse button).
+///
+/// Updated once per frame from the corresponding event stream. Use this for
+/// continuous checks (hold-to-move) and for detecting frame-boundary transitions.
+#[derive(Resource)]
+pub struct Input<T: Eq + Hash> {
+    pressed: HashSet<T>,
+    just_pressed: HashSet<T>,
+    just_released: HashSet<T>,
+}
+
+impl<T: Eq + Hash> Default for Input<T> {
+    fn default() -> Self {
+        Self {
+            pressed: HashSet::new(),
+            just_pressed: HashSet::new(),
+            just_released: HashSet::new(),
+        }
+    }
+}
+
+impl<T: Eq + Hash + Clone> Input<T> {
+    pub fn is_pressed(&self, key: &T) -> bool {
+        self.pressed.contains(key)
+    }
+
+    pub fn just_pressed(&self, key: &T) -> bool {
+        self.just_pressed.contains(key)
+    }
+
+    pub fn just_released(&self, key: &T) -> bool {
+        self.just_released.contains(key)
+    }
+
+    pub(crate) fn press(&mut self, key: T) {
+        if !self.pressed.contains(&key) {
+            self.just_pressed.insert(key.clone());
+        }
+        self.pressed.insert(key);
+    }
+
+    pub(crate) fn release(&mut self, key: T) {
+        self.pressed.remove(&key);
+        self.just_released.insert(key);
+    }
+
+    pub(crate) fn clear_transient(&mut self) {
+        self.just_pressed.clear();
+        self.just_released.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    enum TestKey {
+        A,
+        B,
+    }
+
+    #[test]
+    fn press_sets_is_pressed_and_just_pressed() {
+        let mut input = Input::<TestKey>::default();
+        input.press(TestKey::A);
+        assert!(input.is_pressed(&TestKey::A));
+        assert!(input.just_pressed(&TestKey::A));
+        assert!(!input.just_released(&TestKey::A));
+    }
+
+    #[test]
+    fn clear_removes_just_pressed_but_keeps_pressed() {
+        let mut input = Input::<TestKey>::default();
+        input.press(TestKey::A);
+        input.clear_transient();
+        assert!(input.is_pressed(&TestKey::A));
+        assert!(!input.just_pressed(&TestKey::A));
+    }
+
+    #[test]
+    fn release_removes_pressed_and_sets_just_released() {
+        let mut input = Input::<TestKey>::default();
+        input.press(TestKey::A);
+        input.clear_transient();
+        input.release(TestKey::A);
+        assert!(!input.is_pressed(&TestKey::A));
+        assert!(input.just_released(&TestKey::A));
+    }
+
+    #[test]
+    fn double_press_does_not_add_second_just_pressed() {
+        let mut input = Input::<TestKey>::default();
+        input.press(TestKey::A);
+        input.press(TestKey::A);
+        assert!(input.just_pressed(&TestKey::A));
+        assert_eq!(input.just_pressed.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

- **`Input<KeyCode>`** and **`Input<MouseButton>`** resources — updated each frame from the event stream
- **`is_pressed(key)`** — held keys (persists across frames)
- **`just_pressed(key)`** — true only on the exact frame the key went down
- **`just_released(key)`** — true only on the exact frame the key came up
- `InputPlugin` wires up the clear+update systems in `PreUpdate` in order

## Usage

```rust
fn player_move(keys: Res<Input<KeyCode>>, time: Res<Time>, mut query: Query<&mut Transform, With<Player>>) {
    for mut t in query.iter_mut() {
        if keys.is_pressed(&KeyCode::W) { t.translation.z -= 5.0 * time.delta_seconds; }
        if keys.just_pressed(&KeyCode::Space) { /* jump */ }
    }
}
```

## Test plan

- [ ] CI passes (16 input tests including state tests)
- [ ] `just_pressed_cleared_next_frame` verifies transient state clears after one frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)