### PR TITLE
feat: GLTF animation data — parse AnimationClip from glTF files

### DIFF
--- a/crates/bsengine-gltf/src/animation.rs
+++ b/crates/bsengine-gltf/src/animation.rs
@@ -1,0 +1,80 @@
+/// How keyframe values are interpolated between keyframe times.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interpolation {
+    Linear,
+    Step,
+    CubicSpline,
+}
+
+/// The animated values for a single channel.
+///
+/// Translations and Scales are `[x, y, z]`.
+/// Rotations are `[x, y, z, w]` (quaternion).
+#[derive(Debug, Clone)]
+pub enum KeyframeValues {
+    Translations(Vec<[f32; 3]>),
+    Rotations(Vec<[f32; 4]>),
+    Scales(Vec<[f32; 3]>),
+}
+
+/// One property animated over time, targeting a specific GLTF node by index.
+#[derive(Debug, Clone)]
+pub struct AnimationChannel {
+    /// Index of the target GLTF node (matches the node order in the file).
+    pub node_index: usize,
+    /// Keyframe timestamps in seconds.
+    pub times: Vec<f32>,
+    pub values: KeyframeValues,
+    pub interpolation: Interpolation,
+}
+
+/// A named sequence of animation channels loaded from a GLTF file.
+#[derive(Debug, Clone)]
+pub struct AnimationClip {
+    pub name: String,
+    pub channels: Vec<AnimationChannel>,
+    /// Duration in seconds (= time of the last keyframe across all channels).
+    pub duration: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn animation_clip_stores_duration() {
+        let clip = AnimationClip {
+            name: "Walk".to_string(),
+            channels: vec![],
+            duration: 1.5,
+        };
+        assert!((clip.duration - 1.5).abs() < 1e-6);
+        assert_eq!(clip.name, "Walk");
+    }
+
+    #[test]
+    fn animation_channel_translation_values() {
+        let channel = AnimationChannel {
+            node_index: 0,
+            times: vec![0.0, 0.5, 1.0],
+            values: KeyframeValues::Translations(vec![
+                [0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0],
+            ]),
+            interpolation: Interpolation::Linear,
+        };
+        assert_eq!(channel.times.len(), 3);
+        if let KeyframeValues::Translations(ref t) = channel.values {
+            assert_eq!(t[1], [0.0, 1.0, 0.0]);
+        } else {
+            panic!("expected Translations");
+        }
+    }
+
+    #[test]
+    fn interpolation_variants_are_distinct() {
+        assert_ne!(Interpolation::Linear, Interpolation::Step);
+        assert_ne!(Interpolation::Step, Interpolation::CubicSpline);
+    }
+}

--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod animation;
 pub mod loader;
 pub mod plugin;
 
+pub use animation::{AnimationChannel, AnimationClip, Interpolation, KeyframeValues};
 pub use loader::{GltfImageData, GltfLoader, LoadedGltf, MeshData};
 pub use plugin::{GltfAsset, GltfPlugin};

--- a/crates/bsengine-gltf/src/loader.rs
+++ b/crates/bsengine-gltf/src/loader.rs
@@ -1,6 +1,8 @@
 use bsengine_rhi_wgpu::Vertex;
 use gltf::image::Format as GltfFormat;
 
+use crate::animation::{AnimationChannel, AnimationClip, Interpolation, KeyframeValues};
+
 pub struct MeshData {
     pub name: String,
     pub vertices: Vec<Vertex>,
@@ -17,6 +19,7 @@ pub struct LoadedGltf {
     pub meshes: Vec<MeshData>,
     pub images: Vec<GltfImageData>,
     pub mesh_tex_indices: Vec<Option<usize>>,
+    pub animations: Vec<AnimationClip>,
 }
 
 pub struct GltfLoader;
@@ -103,12 +106,73 @@ impl GltfLoader {
             }
         }
 
+        let animations = parse_animations(&doc, &buffers);
+
         Ok(LoadedGltf {
             meshes,
             images,
             mesh_tex_indices,
+            animations,
         })
     }
+}
+
+fn parse_animations(doc: &gltf::Document, buffers: &[gltf::buffer::Data]) -> Vec<AnimationClip> {
+    let mut clips = Vec::new();
+
+    for anim in doc.animations() {
+        let name = anim.name().unwrap_or("animation").to_string();
+        let mut channels = Vec::new();
+        let mut duration = 0.0f32;
+
+        for channel in anim.channels() {
+            let node_index = channel.target().node().index();
+            let reader = channel.reader(|b| Some(&buffers[b.index()]));
+
+            let times: Vec<f32> = match reader.read_inputs() {
+                Some(inputs) => inputs.collect(),
+                None => continue,
+            };
+
+            if let Some(&last) = times.last() {
+                duration = duration.max(last);
+            }
+
+            let interpolation = match channel.sampler().interpolation() {
+                gltf::animation::Interpolation::Linear => Interpolation::Linear,
+                gltf::animation::Interpolation::Step => Interpolation::Step,
+                gltf::animation::Interpolation::CubicSpline => Interpolation::CubicSpline,
+            };
+
+            let values = match reader.read_outputs() {
+                Some(gltf::animation::util::ReadOutputs::Translations(t)) => {
+                    KeyframeValues::Translations(t.collect())
+                }
+                Some(gltf::animation::util::ReadOutputs::Rotations(r)) => {
+                    KeyframeValues::Rotations(r.into_f32().collect())
+                }
+                Some(gltf::animation::util::ReadOutputs::Scales(s)) => {
+                    KeyframeValues::Scales(s.collect())
+                }
+                _ => continue,
+            };
+
+            channels.push(AnimationChannel {
+                node_index,
+                times,
+                values,
+                interpolation,
+            });
+        }
+
+        clips.push(AnimationClip {
+            name,
+            channels,
+            duration,
+        });
+    }
+
+    clips
 }
 
 fn gltf_pixels_to_rgba(pixels: &[u8], format: GltfFormat, width: u32, height: u32) -> Vec<u8> {
@@ -138,6 +202,20 @@ mod tests {
     #[test]
     fn load_full_nonexistent_returns_error() {
         assert!(GltfLoader::load_full("nonexistent.gltf").is_err());
+    }
+
+    #[test]
+    fn load_full_result_has_animations_field() {
+        let result = GltfLoader::load_full("nonexistent.gltf");
+        assert!(result.is_err());
+        // Verify LoadedGltf struct has the animations field by constructing one
+        let loaded = LoadedGltf {
+            meshes: vec![],
+            images: vec![],
+            mesh_tex_indices: vec![],
+            animations: vec![],
+        };
+        assert_eq!(loaded.animations.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extends `LoadedGltf` with `animations: Vec<AnimationClip>` parsed from `doc.animations()`. Lays the data foundation for a future animation player system.

**New types in `bsengine_gltf::animation`:**
- `AnimationClip { name, channels, duration }` — named clip with total duration
- `AnimationChannel { node_index, times, values, interpolation }` — one animated property on one node
- `KeyframeValues` — `Translations([f32;3])`, `Rotations([f32;4] xyzw)`, `Scales([f32;3])`
- `Interpolation` — `Linear`, `Step`, `CubicSpline`

`node_index` maps back to the GLTF node order; a future node-entity registry will use it to drive `Transform` components.

## Test plan

- [ ] CI passes (11 gltf tests, 3 new animation type tests)
- [ ] `LoadedGltf::animations` is empty for meshes with no animation tracks (no panic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)