### PR TITLE
feat: MouseMotion event — raw device delta for FPS camera input

### DIFF
--- a/crates/bsengine-input/src/lib.rs
+++ b/crates/bsengine-input/src/lib.rs
@@ -3,4 +3,6 @@ pub mod plugin;
 pub mod types;
 
 pub use plugin::InputPlugin;
-pub use types::{CursorMoved, ElementState, KeyCode, KeyInput, MouseButton, MouseInput};
+pub use types::{
+    CursorMoved, ElementState, KeyCode, KeyInput, MouseButton, MouseInput, MouseMotion,
+};

--- a/crates/bsengine-input/src/plugin.rs
+++ b/crates/bsengine-input/src/plugin.rs
@@ -1,4 +1,4 @@
-use crate::types::{CursorMoved, KeyInput, MouseInput};
+use crate::types::{CursorMoved, KeyInput, MouseInput, MouseMotion};
 use bevy_app::{App, Plugin};
 
 pub struct InputPlugin;
@@ -7,13 +7,14 @@ impl Plugin for InputPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<KeyInput>()
             .add_event::<MouseInput>()
-            .add_event::<CursorMoved>();
+            .add_event::<CursorMoved>()
+            .add_event::<MouseMotion>();
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{CursorMoved, InputPlugin, KeyInput, MouseInput};
+    use crate::{CursorMoved, InputPlugin, KeyInput, MouseInput, MouseMotion};
     use bevy_ecs::event::Events;
     use bsengine_app::new_app;
 
@@ -36,5 +37,12 @@ mod tests {
         let mut app = new_app();
         app.add_plugins(InputPlugin);
         assert!(app.world().get_resource::<Events<CursorMoved>>().is_some());
+    }
+
+    #[test]
+    fn input_plugin_registers_mouse_motion_events() {
+        let mut app = new_app();
+        app.add_plugins(InputPlugin);
+        assert!(app.world().get_resource::<Events<MouseMotion>>().is_some());
     }
 }

--- a/crates/bsengine-input/src/types.rs
+++ b/crates/bsengine-input/src/types.rs
@@ -82,6 +82,15 @@ pub struct CursorMoved {
     pub y: f64,
 }
 
+/// Raw mouse movement delta from the OS device event stream.
+/// Unlike CursorMoved, this is not affected by cursor acceleration or screen bounds.
+/// Use this for FPS-style camera rotation.
+#[derive(Event, Debug, Clone)]
+pub struct MouseMotion {
+    pub dx: f64,
+    pub dy: f64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bsengine-window/src/runner.rs
+++ b/crates/bsengine-window/src/runner.rs
@@ -2,7 +2,7 @@ use bevy_app::{App, AppExit};
 use bevy_ecs::event::Events;
 use std::sync::Arc;
 use winit::application::ApplicationHandler;
-use winit::event::WindowEvent;
+use winit::event::{DeviceEvent, DeviceId, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::{Window, WindowId};
 
@@ -128,6 +128,24 @@ impl ApplicationHandler for BsWinitApp {
                 }
             }
             _ => {}
+        }
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _device_id: DeviceId,
+        event: DeviceEvent,
+    ) {
+        if let DeviceEvent::MouseMotion { delta: (dx, dy) } = event {
+            use bsengine_input::MouseMotion;
+            if let Some(mut events) = self
+                .ecs_app
+                .world_mut()
+                .get_resource_mut::<Events<MouseMotion>>()
+            {
+                events.send(MouseMotion { dx, dy });
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `MouseMotion { dx: f64, dy: f64 }` event to `bsengine-input`
- Wires `winit::DeviceEvent::MouseMotion` in `BsWinitApp::device_event()` in `bsengine-window`
- `InputPlugin` registers `MouseMotion` alongside `KeyInput`, `MouseInput`, `CursorMoved`

Unlike `CursorMoved` (absolute screen position), `MouseMotion` gives raw OS pointer delta — unaffected by cursor bounds or acceleration. Required for FPS-style camera rotation.

## Test plan

- [ ] CI green (9 input tests, including `input_plugin_registers_mouse_motion_events`)
- [ ] `MouseMotion` is not fired when cursor is locked to screen edge (distinguishes it from CursorMoved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)