### PR TITLE
feat: Tween component system — frame-rate-independent transform animation

### DIFF
--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod app;
 pub mod time;
+pub mod tween;
 
 pub use app::{new_app, App, BsPlugin, Last, PostUpdate, PreUpdate, Startup, Update};
 pub use time::TimePlugin;
+pub use tween::TweenPlugin;
 
 mod tests;

--- a/crates/bsengine-app/src/tween.rs
+++ b/crates/bsengine-app/src/tween.rs
@@ -1,0 +1,247 @@
+use bevy_app::{App, Plugin, Update};
+use bsengine_core::{Time, Transform, Tween, TweenTarget};
+use bsengine_ecs::{Query, Res};
+
+pub struct TweenPlugin;
+
+impl Plugin for TweenPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, tick_tweens);
+    }
+}
+
+fn tick_tweens(mut query: Query<(&mut Tween, &mut Transform)>, time: Res<Time>) {
+    for (mut tween, mut transform) in query.iter_mut() {
+        if tween.finished {
+            continue;
+        }
+
+        tween.elapsed += time.delta_seconds;
+
+        let raw_t = (tween.elapsed / tween.duration).clamp(0.0, 1.0);
+        let done = raw_t >= 1.0;
+
+        let directional_t = if tween.reversed { 1.0 - raw_t } else { raw_t };
+        let eased_t = tween.easing.apply(directional_t);
+
+        match &tween.target {
+            TweenTarget::Translation { from, to } => {
+                transform.translation = from.lerp(*to, eased_t);
+            }
+            TweenTarget::Rotation { from, to } => {
+                transform.rotation = from.slerp(*to, eased_t);
+            }
+            TweenTarget::Scale { from, to } => {
+                transform.scale = from.lerp(*to, eased_t);
+            }
+        }
+
+        if done {
+            match tween.repeat {
+                bsengine_core::RepeatMode::Once => {
+                    tween.finished = true;
+                }
+                bsengine_core::RepeatMode::Loop => {
+                    tween.elapsed -= tween.duration;
+                }
+                bsengine_core::RepeatMode::PingPong => {
+                    tween.elapsed -= tween.duration;
+                    tween.reversed = !tween.reversed;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_core::{EasingFn, RepeatMode, Time, Transform, Tween, TweenTarget};
+    use glam::Vec3;
+
+    fn make_app_with_delta(delta: f32) -> bevy_app::App {
+        let mut app = crate::new_app();
+        app.add_plugins(TweenPlugin);
+        let mut t = Time::default();
+        t.set_delta_for_test(delta);
+        app.insert_resource(t);
+        app
+    }
+
+    #[test]
+    fn tween_plugin_builds() {
+        let mut app = crate::new_app();
+        app.add_plugins(TweenPlugin);
+        app.insert_resource(Time::default());
+    }
+
+    #[test]
+    fn translation_tween_at_half_duration() {
+        let mut app = make_app_with_delta(0.5);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                Tween::new(
+                    TweenTarget::Translation {
+                        from: Vec3::ZERO,
+                        to: Vec3::new(10.0, 0.0, 0.0),
+                    },
+                    1.0,
+                ),
+            ))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert!((transform.translation.x - 5.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn tween_once_finishes_after_full_duration() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                Tween::new(
+                    TweenTarget::Translation {
+                        from: Vec3::ZERO,
+                        to: Vec3::X,
+                    },
+                    0.5,
+                ),
+            ))
+            .id();
+
+        app.update();
+
+        let tween = app.world().get::<Tween>(entity).unwrap();
+        assert!(tween.finished);
+    }
+
+    #[test]
+    fn tween_loop_does_not_finish() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                Tween::new(
+                    TweenTarget::Translation {
+                        from: Vec3::ZERO,
+                        to: Vec3::X,
+                    },
+                    0.5,
+                )
+                .with_repeat(RepeatMode::Loop),
+            ))
+            .id();
+
+        app.update();
+
+        let tween = app.world().get::<Tween>(entity).unwrap();
+        assert!(!tween.finished);
+    }
+
+    #[test]
+    fn tween_pingpong_reverses_direction() {
+        let mut app = make_app_with_delta(0.5);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                Tween::new(
+                    TweenTarget::Translation {
+                        from: Vec3::ZERO,
+                        to: Vec3::X,
+                    },
+                    0.5,
+                )
+                .with_repeat(RepeatMode::PingPong),
+            ))
+            .id();
+
+        app.update();
+
+        let tween = app.world().get::<Tween>(entity).unwrap();
+        assert!(tween.reversed);
+        assert!(!tween.finished);
+    }
+
+    #[test]
+    fn scale_tween_interpolates() {
+        let mut app = make_app_with_delta(0.5);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                Tween::new(
+                    TweenTarget::Scale {
+                        from: Vec3::ONE,
+                        to: Vec3::splat(3.0),
+                    },
+                    1.0,
+                ),
+            ))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert!((transform.scale.x - 2.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn rotation_tween_interpolates() {
+        use glam::Quat;
+        let mut app = make_app_with_delta(0.5);
+        let from_rot = Quat::IDENTITY;
+        let to_rot = Quat::from_rotation_y(std::f32::consts::PI);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                Tween::new(
+                    TweenTarget::Rotation {
+                        from: from_rot,
+                        to: to_rot,
+                    },
+                    1.0,
+                ),
+            ))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        let expected = from_rot.slerp(to_rot, 0.5);
+        assert!(transform.rotation.abs_diff_eq(expected, 1e-4));
+    }
+
+    #[test]
+    fn easing_applied_to_tween() {
+        let mut app = make_app_with_delta(0.5);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                Tween::new(
+                    TweenTarget::Translation {
+                        from: Vec3::ZERO,
+                        to: Vec3::X,
+                    },
+                    1.0,
+                )
+                .with_easing(EasingFn::EaseInQuad),
+            ))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        // EaseInQuad at t=0.5 is 0.25
+        assert!((transform.translation.x - 0.25).abs() < 0.01);
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod material;
 pub mod parent;
 pub mod time;
 pub mod transform;
+pub mod tween;
 
 pub use camera::Camera;
 pub use global_transform::GlobalTransform;
@@ -15,6 +16,7 @@ pub use material::Material;
 pub use parent::Parent;
 pub use time::Time;
 pub use transform::Transform;
+pub use tween::{EasingFn, RepeatMode, Tween, TweenTarget};
 
 pub fn propagate_global_transforms(world: &mut bevy_ecs::world::World) {
     use bevy_ecs::prelude::Entity;

--- a/crates/bsengine-core/src/time.rs
+++ b/crates/bsengine-core/src/time.rs
@@ -29,4 +29,9 @@ impl Time {
         self.elapsed_seconds = now.duration_since(self.startup).as_secs_f32();
         self.last_tick = now;
     }
+
+    /// Override delta_seconds directly — for use in tests only.
+    pub fn set_delta_for_test(&mut self, delta: f32) {
+        self.delta_seconds = delta;
+    }
 }

--- a/crates/bsengine-core/src/tween.rs
+++ b/crates/bsengine-core/src/tween.rs
@@ -1,0 +1,137 @@
+use bevy_ecs::prelude::Component;
+use glam::{Quat, Vec3};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EasingFn {
+    Linear,
+    EaseInQuad,
+    EaseOutQuad,
+    EaseInOutQuad,
+}
+
+impl EasingFn {
+    pub fn apply(self, t: f32) -> f32 {
+        match self {
+            EasingFn::Linear => t,
+            EasingFn::EaseInQuad => t * t,
+            EasingFn::EaseOutQuad => t * (2.0 - t),
+            EasingFn::EaseInOutQuad => {
+                if t < 0.5 {
+                    2.0 * t * t
+                } else {
+                    -1.0 + (4.0 - 2.0 * t) * t
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepeatMode {
+    Once,
+    Loop,
+    PingPong,
+}
+
+#[derive(Debug, Clone)]
+pub enum TweenTarget {
+    Translation { from: Vec3, to: Vec3 },
+    Rotation { from: Quat, to: Quat },
+    Scale { from: Vec3, to: Vec3 },
+}
+
+#[derive(Component, Debug, Clone)]
+pub struct Tween {
+    pub target: TweenTarget,
+    pub duration: f32,
+    pub easing: EasingFn,
+    pub repeat: RepeatMode,
+    pub finished: bool,
+    pub elapsed: f32,
+    pub reversed: bool,
+}
+
+impl Tween {
+    pub fn new(target: TweenTarget, duration: f32) -> Self {
+        Self {
+            target,
+            duration,
+            easing: EasingFn::Linear,
+            repeat: RepeatMode::Once,
+            finished: false,
+            elapsed: 0.0,
+            reversed: false,
+        }
+    }
+
+    pub fn with_easing(mut self, easing: EasingFn) -> Self {
+        self.easing = easing;
+        self
+    }
+
+    pub fn with_repeat(mut self, repeat: RepeatMode) -> Self {
+        self.repeat = repeat;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn easing_linear_identity() {
+        assert!((EasingFn::Linear.apply(0.0) - 0.0).abs() < 1e-6);
+        assert!((EasingFn::Linear.apply(0.5) - 0.5).abs() < 1e-6);
+        assert!((EasingFn::Linear.apply(1.0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn easing_ease_in_quad_starts_slow() {
+        assert!(EasingFn::EaseInQuad.apply(0.5) < 0.5);
+    }
+
+    #[test]
+    fn easing_ease_out_quad_ends_slow() {
+        assert!(EasingFn::EaseOutQuad.apply(0.5) > 0.5);
+    }
+
+    #[test]
+    fn easing_ease_in_out_quad_symmetric() {
+        let t1 = EasingFn::EaseInOutQuad.apply(0.25);
+        let t2 = 1.0 - EasingFn::EaseInOutQuad.apply(0.75);
+        assert!((t1 - t2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn tween_builder_sets_fields() {
+        let tw = Tween::new(
+            TweenTarget::Translation {
+                from: Vec3::ZERO,
+                to: Vec3::X,
+            },
+            1.0,
+        )
+        .with_easing(EasingFn::EaseOutQuad)
+        .with_repeat(RepeatMode::Loop);
+
+        assert_eq!(tw.easing, EasingFn::EaseOutQuad);
+        assert_eq!(tw.repeat, RepeatMode::Loop);
+        assert!(!tw.finished);
+    }
+
+    #[test]
+    fn tween_new_defaults() {
+        let tw = Tween::new(
+            TweenTarget::Scale {
+                from: Vec3::ONE,
+                to: Vec3::splat(2.0),
+            },
+            0.5,
+        );
+        assert_eq!(tw.easing, EasingFn::Linear);
+        assert_eq!(tw.repeat, RepeatMode::Once);
+        assert!(!tw.finished);
+        assert!((tw.elapsed - 0.0).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `Tween` ECS component and `TweenPlugin` that drive `Transform` fields over time using `Res<Time>.delta_seconds`.

**Data types in `bsengine-core`** (same crate as `Transform`, `Time`):
- `Tween { target, duration, easing, repeat, finished, elapsed, reversed }` — ECS `Component`
- `TweenTarget` — `Translation { from: Vec3, to: Vec3 }`, `Rotation { from: Quat, to: Quat }`, `Scale { from: Vec3, to: Vec3 }`
- `EasingFn` — `Linear`, `EaseInQuad`, `EaseOutQuad`, `EaseInOutQuad`
- `RepeatMode` — `Once`, `Loop`, `PingPong`
- `Time::set_delta_for_test(f32)` — override delta for deterministic tests

**`TweenPlugin` in `bsengine-app`**:
- `tick_tweens` system in `Update` reads `Res<Time>` and modifies `Transform` via lerp/slerp
- PingPong flips `reversed` flag on each cycle; Loop wraps `elapsed` back by `duration`

## Test plan

- [ ] CI All Green (6 core unit tests + 8 app integration tests)
- [ ] `translation_tween_at_half_duration` → x=5.0 after 0.5s of a 1.0s tween
- [ ] `easing_applied_to_tween` → EaseInQuad(0.5) = 0.25
- [ ] `tween_pingpong_reverses_direction` → `reversed=true` after first cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)