### PR TITLE
feat: Visible component — per-entity render visibility toggle

### DIFF
--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod material;
 pub mod parent;
 pub mod time;
 pub mod transform;
+pub mod visible;
 
 pub use camera::Camera;
 pub use global_transform::GlobalTransform;
@@ -15,6 +16,7 @@ pub use material::Material;
 pub use parent::Parent;
 pub use time::Time;
 pub use transform::Transform;
+pub use visible::Visible;
 
 pub fn propagate_global_transforms(world: &mut bevy_ecs::world::World) {
     use bevy_ecs::prelude::Entity;

--- a/crates/bsengine-core/src/visible.rs
+++ b/crates/bsengine-core/src/visible.rs
@@ -1,0 +1,41 @@
+use bevy_ecs::prelude::Component;
+
+/// Controls whether an entity is drawn by the render system.
+/// Entities without this component are treated as visible.
+#[derive(Component, Debug, Clone, PartialEq, Eq)]
+pub struct Visible {
+    pub is_visible: bool,
+}
+
+impl Default for Visible {
+    fn default() -> Self {
+        Self { is_visible: true }
+    }
+}
+
+impl Visible {
+    pub fn hidden() -> Self {
+        Self { is_visible: false }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_visible() {
+        assert!(Visible::default().is_visible);
+    }
+
+    #[test]
+    fn hidden_is_not_visible() {
+        assert!(!Visible::hidden().is_visible);
+    }
+
+    #[test]
+    fn visible_equality() {
+        assert_eq!(Visible::default(), Visible { is_visible: true });
+        assert_ne!(Visible::default(), Visible::hidden());
+    }
+}

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -2,6 +2,7 @@ use bevy_app::{App, Plugin, PostUpdate, Update};
 use bevy_ecs::prelude::{Entity, EventReader, IntoSystemConfigs, ParamSet, Query, Without};
 use bsengine_core::{
     Camera, DirectionalLight, GlobalTransform, Material, Parent, PointLight, SpotLight, Transform,
+    Visible,
 };
 use bsengine_ecs::Res;
 use bsengine_rhi_wgpu::{
@@ -88,6 +89,7 @@ fn render_frame(
         &Transform,
         Option<&GlobalTransform>,
         Option<&Material>,
+        Option<&Visible>,
     )>,
     light_query: Query<&DirectionalLight>,
     point_light_query: Query<(&PointLight, Option<&GlobalTransform>, &Transform)>,
@@ -105,7 +107,10 @@ fn render_frame(
 
     let draw_calls: Vec<(u64, Mat4, Option<u64>, MaterialParams)> = mesh_query
         .iter()
-        .filter_map(|(mr, t, gt, mat)| {
+        .filter_map(|(mr, t, gt, mat, vis)| {
+            if !vis.map(|v| v.is_visible).unwrap_or(true) {
+                return None;
+            }
             let model = gt.map(|g| g.to_matrix()).unwrap_or_else(|| t.to_matrix());
             if let Some((local_center, local_radius)) = registry.get_bounds(mr.mesh_id) {
                 let world_center = (model * local_center.extend(1.0)).truncate();


### PR DESCRIPTION
## Summary

- Adds `Visible { is_visible: bool }` ECS `Component` to `bsengine-core`
- `Visible::default()` → visible; `Visible::hidden()` → not visible
- Entities **without** the component default to visible (no breaking change)
- Render plugin's `mesh_query` includes `Option<&Visible>` and skips invisible entities before frustum culling

## Test plan

- [ ] CI All Green (3 unit tests)
- [ ] Render plugin compile-checks with new query signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)