### PR TITLE
feat: Lifetime component — timer-based automatic entity despawn

### DIFF
--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod app;
+pub mod lifetime;
 pub mod time;
 
 pub use app::{new_app, App, BsPlugin, Last, PostUpdate, PreUpdate, Startup, Update};
+pub use lifetime::LifetimePlugin;
 pub use time::TimePlugin;
 
 mod tests;

--- a/crates/bsengine-app/src/lifetime.rs
+++ b/crates/bsengine-app/src/lifetime.rs
@@ -1,0 +1,95 @@
+use bevy_app::{App, Plugin, Update};
+use bsengine_core::{Lifetime, Time};
+use bsengine_ecs::{Commands, Entity, Query, Res};
+
+pub struct LifetimePlugin;
+
+impl Plugin for LifetimePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, tick_lifetimes);
+    }
+}
+
+fn tick_lifetimes(
+    mut commands: Commands,
+    mut query: Query<(Entity, &mut Lifetime)>,
+    time: Res<Time>,
+) {
+    for (entity, mut lifetime) in query.iter_mut() {
+        lifetime.remaining -= time.delta_seconds;
+        if lifetime.remaining <= 0.0 {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_core::{Lifetime, Time};
+
+    fn make_app_with_delta(delta: f32) -> bevy_app::App {
+        let mut app = crate::new_app();
+        app.add_plugins(LifetimePlugin);
+        let mut t = Time::default();
+        t.set_delta_for_test(delta);
+        app.insert_resource(t);
+        app
+    }
+
+    #[test]
+    fn lifetime_plugin_builds() {
+        let mut app = crate::new_app();
+        app.add_plugins(LifetimePlugin);
+        app.insert_resource(Time::default());
+    }
+
+    #[test]
+    fn entity_despawns_when_lifetime_expires() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app.world_mut().spawn(Lifetime::from_seconds(0.5)).id();
+
+        app.update();
+
+        assert!(app.world().get_entity(entity).is_none());
+    }
+
+    #[test]
+    fn entity_survives_when_lifetime_not_expired() {
+        let mut app = make_app_with_delta(0.1);
+        let entity = app.world_mut().spawn(Lifetime::from_seconds(1.0)).id();
+
+        app.update();
+
+        assert!(app.world().get_entity(entity).is_some());
+    }
+
+    #[test]
+    fn lifetime_decrements_each_frame() {
+        let mut app = make_app_with_delta(0.3);
+        let entity = app.world_mut().spawn(Lifetime::from_seconds(1.0)).id();
+
+        app.update();
+
+        let lifetime = app.world().get::<Lifetime>(entity).unwrap();
+        assert!((lifetime.remaining - 0.7).abs() < 0.01);
+    }
+
+    #[test]
+    fn entity_despawns_after_multiple_frames() {
+        let mut app = make_app_with_delta(0.4);
+        let entity = app.world_mut().spawn(Lifetime::from_seconds(1.0)).id();
+
+        // Frame 1: remaining = 0.6
+        app.update();
+        assert!(app.world().get_entity(entity).is_some());
+
+        // Frame 2: remaining = 0.2
+        app.update();
+        assert!(app.world().get_entity(entity).is_some());
+
+        // Frame 3: remaining = -0.2 → despawn
+        app.update();
+        assert!(app.world().get_entity(entity).is_none());
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod camera;
 pub mod global_transform;
+pub mod lifetime;
 pub mod light;
 pub mod logging;
 pub mod material;
@@ -9,6 +10,7 @@ pub mod transform;
 
 pub use camera::Camera;
 pub use global_transform::GlobalTransform;
+pub use lifetime::Lifetime;
 pub use light::{DirectionalLight, PointLight, SpotLight};
 pub use logging::init_logging;
 pub use material::Material;

--- a/crates/bsengine-core/src/lifetime.rs
+++ b/crates/bsengine-core/src/lifetime.rs
@@ -1,0 +1,49 @@
+use bevy_ecs::prelude::Component;
+
+/// Automatically despawns an entity when `remaining` reaches zero.
+/// Decrement is driven by `LifetimePlugin` using `Res<Time>.delta_seconds`.
+#[derive(Component, Debug, Clone)]
+pub struct Lifetime {
+    pub remaining: f32,
+}
+
+impl Lifetime {
+    pub fn from_seconds(seconds: f32) -> Self {
+        Self {
+            remaining: seconds.max(0.0),
+        }
+    }
+
+    pub fn is_expired(&self) -> bool {
+        self.remaining <= 0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_seconds_stores_value() {
+        let l = Lifetime::from_seconds(2.5);
+        assert!((l.remaining - 2.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn from_seconds_clamps_negative_to_zero() {
+        let l = Lifetime::from_seconds(-1.0);
+        assert!((l.remaining - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn is_expired_when_zero() {
+        let l = Lifetime { remaining: 0.0 };
+        assert!(l.is_expired());
+    }
+
+    #[test]
+    fn is_not_expired_when_positive() {
+        let l = Lifetime::from_seconds(0.1);
+        assert!(!l.is_expired());
+    }
+}

--- a/crates/bsengine-core/src/time.rs
+++ b/crates/bsengine-core/src/time.rs
@@ -29,4 +29,9 @@ impl Time {
         self.elapsed_seconds = now.duration_since(self.startup).as_secs_f32();
         self.last_tick = now;
     }
+
+    /// Override delta_seconds directly — for use in tests only.
+    pub fn set_delta_for_test(&mut self, delta: f32) {
+        self.delta_seconds = delta;
+    }
 }


### PR DESCRIPTION
## Summary

- `Lifetime { remaining: f32 }` ECS `Component` in `bsengine-core`
- `Lifetime::from_seconds(f32)` — clamps negative to 0
- `LifetimePlugin` in `bsengine-app` runs `tick_lifetimes` in `Update`
  - Decrements `remaining` by `Time.delta_seconds`
  - Despawns entity when `remaining <= 0`
- Entities without `Lifetime` are unaffected

Common use cases: bullets, particles, VFX, projectiles, any entity with a TTL.

## Test plan

- [ ] CI All Green (9 tests: 4 core unit + 5 app integration)
- [ ] `entity_despawns_after_multiple_frames` — multi-frame accumulation check

🤖 Generated with [Claude Code](https://claude.com/claude-code)