### PR TITLE
feat: Velocity component — kinematic linear motion

### DIFF
--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod app;
 pub mod time;
 pub mod tween;
+pub mod velocity;
 
 pub use app::{new_app, App, BsPlugin, Last, PostUpdate, PreUpdate, Startup, Update};
 pub use time::TimePlugin;
 pub use tween::TweenPlugin;
+pub use velocity::VelocityPlugin;
 
 mod tests;

--- a/crates/bsengine-app/src/velocity.rs
+++ b/crates/bsengine-app/src/velocity.rs
@@ -1,0 +1,112 @@
+use bevy_app::{App, Plugin, Update};
+use bsengine_core::{Time, Transform, Velocity};
+use bsengine_ecs::{Query, Res};
+
+pub struct VelocityPlugin;
+
+impl Plugin for VelocityPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, apply_velocity);
+    }
+}
+
+fn apply_velocity(mut query: Query<(&Velocity, &mut Transform)>, time: Res<Time>) {
+    for (vel, mut transform) in query.iter_mut() {
+        transform.translation += vel.linear * time.delta_seconds;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_core::{Time, Transform, Velocity};
+    use glam::Vec3;
+
+    fn make_app_with_delta(delta: f32) -> bevy_app::App {
+        let mut app = crate::new_app();
+        app.add_plugins(VelocityPlugin);
+        let mut t = Time::default();
+        t.set_delta_for_test(delta);
+        app.insert_resource(t);
+        app
+    }
+
+    #[test]
+    fn velocity_plugin_builds() {
+        let mut app = crate::new_app();
+        app.add_plugins(VelocityPlugin);
+        app.insert_resource(Time::default());
+    }
+
+    #[test]
+    fn entity_moves_by_velocity_times_delta() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((Transform::default(), Velocity::new(3.0, 0.0, 0.0)))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert!((transform.translation.x - 3.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn velocity_scales_with_delta() {
+        let mut app = make_app_with_delta(0.5);
+        let entity = app
+            .world_mut()
+            .spawn((Transform::default(), Velocity::new(0.0, 4.0, 0.0)))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert!((transform.translation.y - 2.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn zero_velocity_does_not_move() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((Transform::default(), Velocity::default()))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert_eq!(transform.translation, Vec3::ZERO);
+    }
+
+    #[test]
+    fn entity_without_velocity_not_moved() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn(Transform::from_translation(Vec3::new(5.0, 0.0, 0.0)))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert_eq!(transform.translation, Vec3::new(5.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn velocity_accumulates_over_frames() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((Transform::default(), Velocity::new(1.0, 0.0, 0.0)))
+            .id();
+
+        app.update();
+        app.update();
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert!((transform.translation.x - 3.0).abs() < 0.001);
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod parent;
 pub mod time;
 pub mod transform;
 pub mod tween;
+pub mod velocity;
 
 pub use camera::Camera;
 pub use global_transform::GlobalTransform;
@@ -17,6 +18,7 @@ pub use parent::Parent;
 pub use time::Time;
 pub use transform::Transform;
 pub use tween::{EasingFn, RepeatMode, Tween, TweenTarget};
+pub use velocity::Velocity;
 
 pub fn propagate_global_transforms(world: &mut bevy_ecs::world::World) {
     use bevy_ecs::prelude::Entity;

--- a/crates/bsengine-core/src/velocity.rs
+++ b/crates/bsengine-core/src/velocity.rs
@@ -1,0 +1,55 @@
+use bevy_ecs::prelude::Component;
+use glam::Vec3;
+
+/// Kinematic linear velocity in world units per second.
+/// `VelocityPlugin` integrates this into `Transform.translation` each frame.
+/// For physics-driven motion use `bsengine-physics` instead.
+#[derive(Component, Debug, Clone, PartialEq)]
+pub struct Velocity {
+    pub linear: Vec3,
+}
+
+impl Default for Velocity {
+    fn default() -> Self {
+        Self { linear: Vec3::ZERO }
+    }
+}
+
+impl Velocity {
+    pub fn new(x: f32, y: f32, z: f32) -> Self {
+        Self {
+            linear: Vec3::new(x, y, z),
+        }
+    }
+
+    pub fn from_vec3(linear: Vec3) -> Self {
+        Self { linear }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(Velocity::default().linear, Vec3::ZERO);
+    }
+
+    #[test]
+    fn new_sets_components() {
+        let v = Velocity::new(1.0, 2.0, 3.0);
+        assert_eq!(v.linear, Vec3::new(1.0, 2.0, 3.0));
+    }
+
+    #[test]
+    fn from_vec3_stores_value() {
+        let v = Velocity::from_vec3(Vec3::X * 5.0);
+        assert_eq!(v.linear, Vec3::X * 5.0);
+    }
+
+    #[test]
+    fn equality() {
+        assert_eq!(Velocity::new(1.0, 0.0, 0.0), Velocity::from_vec3(Vec3::X));
+    }
+}


### PR DESCRIPTION
## Summary

- `Velocity { linear: Vec3 }` ECS `Component` in `bsengine-core`
- `VelocityPlugin` in `bsengine-app` runs `apply_velocity` in `Update`
  - `transform.translation += velocity.linear * time.delta_seconds`
- Entities without `Velocity` are not affected
- Use `bsengine-physics` for full collision/rigidbody; this is for simple kinematic motion

## Test plan

- [ ] CI All Green (10 tests: 4 core unit + 6 app integration)
- [ ] `velocity_accumulates_over_frames` — 3× frame accumulation check

🤖 Generated with [Claude Code](https://claude.com/claude-code)