### PR TITLE
feat: AngularVelocity component — kinematic rotation integration

### DIFF
--- a/crates/bsengine-app/src/angular_velocity.rs
+++ b/crates/bsengine-app/src/angular_velocity.rs
@@ -1,0 +1,115 @@
+use bevy_app::{App, Plugin, Update};
+use bsengine_core::{AngularVelocity, Time, Transform};
+use bsengine_ecs::{Query, Res};
+use glam::Quat;
+
+pub struct AngularVelocityPlugin;
+
+impl Plugin for AngularVelocityPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, apply_angular_velocity);
+    }
+}
+
+fn apply_angular_velocity(mut query: Query<(&AngularVelocity, &mut Transform)>, time: Res<Time>) {
+    let dt = time.delta_seconds;
+    for (av, mut transform) in query.iter_mut() {
+        let delta = Quat::from_euler(
+            glam::EulerRot::XYZ,
+            av.angular.x * dt,
+            av.angular.y * dt,
+            av.angular.z * dt,
+        );
+        transform.rotation = (transform.rotation * delta).normalize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_core::{AngularVelocity, Time, Transform};
+    use glam::Vec3;
+    use std::f32::consts::PI;
+
+    fn make_app_with_delta(delta: f32) -> bevy_app::App {
+        let mut app = crate::new_app();
+        app.add_plugins(AngularVelocityPlugin);
+        let mut t = Time::default();
+        t.set_delta_for_test(delta);
+        app.insert_resource(t);
+        app
+    }
+
+    #[test]
+    fn angular_velocity_plugin_builds() {
+        let mut app = crate::new_app();
+        app.add_plugins(AngularVelocityPlugin);
+        app.insert_resource(Time::default());
+    }
+
+    #[test]
+    fn zero_angular_velocity_does_not_rotate() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((Transform::default(), AngularVelocity::default()))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert!((transform.rotation.w - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn yaw_rotation_applies() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                AngularVelocity::new(0.0, PI * 0.5, 0.0),
+            ))
+            .id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        let expected = Quat::from_euler(glam::EulerRot::XYZ, 0.0, PI * 0.5, 0.0);
+        assert!((transform.rotation.dot(expected)).abs() > 0.999);
+    }
+
+    #[test]
+    fn rotation_accumulates_over_frames() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Transform::default(),
+                AngularVelocity::new(0.0, PI * 0.5, 0.0),
+            ))
+            .id();
+
+        app.update();
+        app.update();
+
+        // After 2 frames at 1s/frame with 0.5π yaw/s → ~π yaw total
+        // rotation should be close to 180° around Y
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert!(
+            transform.rotation.w.abs() < 0.01,
+            "expected ~180 deg rotation"
+        );
+    }
+
+    #[test]
+    fn entity_without_angular_velocity_not_rotated() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app.world_mut().spawn(Transform::default()).id();
+
+        app.update();
+
+        let transform = app.world().get::<Transform>(entity).unwrap();
+        assert!((transform.rotation.w - 1.0).abs() < 0.001);
+    }
+}

--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod angular_velocity;
 pub mod app;
 pub mod time;
 pub mod tween;
 
+pub use angular_velocity::AngularVelocityPlugin;
 pub use app::{new_app, App, BsPlugin, Last, PostUpdate, PreUpdate, Startup, Update};
 pub use time::TimePlugin;
 pub use tween::TweenPlugin;

--- a/crates/bsengine-core/src/angular_velocity.rs
+++ b/crates/bsengine-core/src/angular_velocity.rs
@@ -1,0 +1,60 @@
+use bevy_ecs::prelude::Component;
+use glam::Vec3;
+
+/// Angular velocity in radians per second (Euler rates: x=pitch, y=yaw, z=roll).
+/// `AngularVelocityPlugin` integrates this into `Transform.rotation` each frame.
+/// For physics-driven rotation use `bsengine-physics` instead.
+#[derive(Component, Debug, Clone, PartialEq)]
+pub struct AngularVelocity {
+    pub angular: Vec3,
+}
+
+impl Default for AngularVelocity {
+    fn default() -> Self {
+        Self {
+            angular: Vec3::ZERO,
+        }
+    }
+}
+
+impl AngularVelocity {
+    pub fn new(pitch: f32, yaw: f32, roll: f32) -> Self {
+        Self {
+            angular: Vec3::new(pitch, yaw, roll),
+        }
+    }
+
+    pub fn from_vec3(angular: Vec3) -> Self {
+        Self { angular }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(AngularVelocity::default().angular, Vec3::ZERO);
+    }
+
+    #[test]
+    fn new_sets_components() {
+        let av = AngularVelocity::new(1.0, 2.0, 3.0);
+        assert_eq!(av.angular, Vec3::new(1.0, 2.0, 3.0));
+    }
+
+    #[test]
+    fn from_vec3_stores_value() {
+        let av = AngularVelocity::from_vec3(Vec3::Y * std::f32::consts::PI);
+        assert_eq!(av.angular, Vec3::Y * std::f32::consts::PI);
+    }
+
+    #[test]
+    fn equality() {
+        assert_eq!(
+            AngularVelocity::new(0.0, 1.0, 0.0),
+            AngularVelocity::from_vec3(Vec3::Y)
+        );
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod angular_velocity;
 pub mod camera;
 pub mod global_transform;
 pub mod light;
@@ -9,6 +10,7 @@ pub mod time;
 pub mod transform;
 pub mod tween;
 
+pub use angular_velocity::AngularVelocity;
 pub use camera::Camera;
 pub use global_transform::GlobalTransform;
 pub use light::{DirectionalLight, PointLight, SpotLight};


### PR DESCRIPTION
## Summary

- `AngularVelocity { angular: Vec3 }` ECS `Component` in `bsengine-core`
- Euler rates: x=pitch, y=yaw, z=roll (radians/second)
- `AngularVelocityPlugin` in `bsengine-app` runs `apply_angular_velocity` in `Update`
  - `rotation *= Quat::from_euler(XYZ, av.x*dt, av.y*dt, av.z*dt).normalize()`
  - Normalizes each frame to prevent floating-point quaternion drift
- Complements `Velocity` (linear) for full kinematic motion

## Test plan

- [ ] CI All Green (4 core unit + 5 app integration = 9 tests)
- [ ] `rotation_accumulates_over_frames` — verifies 2× π/2 ≈ π total rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)