### PR TITLE
feat: Damping component — linear velocity damping

### DIFF
--- a/crates/bsengine-app/src/damping.rs
+++ b/crates/bsengine-app/src/damping.rs
@@ -1,0 +1,108 @@
+use bevy_app::{App, Plugin, Update};
+use bsengine_core::{Damping, Time, Velocity};
+use bsengine_ecs::{Query, Res};
+
+pub struct DampingPlugin;
+
+impl Plugin for DampingPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, apply_damping);
+    }
+}
+
+fn apply_damping(mut query: Query<(&Damping, &mut Velocity)>, time: Res<Time>) {
+    let dt = time.delta_seconds;
+    for (damping, mut vel) in query.iter_mut() {
+        let factor = (1.0 - damping.linear * dt).max(0.0);
+        vel.linear *= factor;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_core::{Damping, Time, Velocity};
+    use glam::Vec3;
+
+    fn make_app_with_delta(delta: f32) -> bevy_app::App {
+        let mut app = crate::new_app();
+        app.add_plugins(DampingPlugin);
+        let mut t = Time::default();
+        t.set_delta_for_test(delta);
+        app.insert_resource(t);
+        app
+    }
+
+    #[test]
+    fn damping_plugin_builds() {
+        let mut app = crate::new_app();
+        app.add_plugins(DampingPlugin);
+        app.insert_resource(Time::default());
+    }
+
+    #[test]
+    fn zero_damping_does_not_change_velocity() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((Velocity::new(10.0, 0.0, 0.0), Damping::new(0.0)))
+            .id();
+
+        app.update();
+
+        let vel = app.world().get::<Velocity>(entity).unwrap();
+        assert!((vel.linear.x - 10.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn damping_reduces_velocity() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((Velocity::new(10.0, 0.0, 0.0), Damping::new(0.5)))
+            .id();
+
+        app.update();
+
+        let vel = app.world().get::<Velocity>(entity).unwrap();
+        // factor = (1.0 - 0.5 * 1.0).max(0.0) = 0.5 → 10.0 * 0.5 = 5.0
+        assert!((vel.linear.x - 5.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn full_damping_stops_velocity() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((Velocity::new(10.0, 5.0, 3.0), Damping::new(1.0)))
+            .id();
+
+        app.update();
+
+        let vel = app.world().get::<Velocity>(entity).unwrap();
+        // factor = (1.0 - 1.0 * 1.0).max(0.0) = 0.0
+        assert_eq!(vel.linear, Vec3::ZERO);
+    }
+
+    #[test]
+    fn overdamping_clamps_to_zero() {
+        let mut app = make_app_with_delta(1.0);
+        let entity = app
+            .world_mut()
+            .spawn((Velocity::new(10.0, 0.0, 0.0), Damping::new(2.0)))
+            .id();
+
+        app.update();
+
+        let vel = app.world().get::<Velocity>(entity).unwrap();
+        // factor = (1.0 - 2.0 * 1.0).max(0.0) = 0.0 — no sign reversal
+        assert_eq!(vel.linear, Vec3::ZERO);
+    }
+
+    #[test]
+    fn entity_without_velocity_not_affected() {
+        let mut app = make_app_with_delta(1.0);
+        app.world_mut().spawn(Damping::new(1.0));
+        app.update();
+    }
+}

--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod app;
+pub mod damping;
 pub mod lifetime;
 pub mod time;
 pub mod tween;
 pub mod velocity;
 
 pub use app::{new_app, App, BsPlugin, Last, PostUpdate, PreUpdate, Startup, Update};
+pub use damping::DampingPlugin;
 pub use lifetime::LifetimePlugin;
 pub use time::TimePlugin;
 pub use tween::TweenPlugin;

--- a/crates/bsengine-core/src/damping.rs
+++ b/crates/bsengine-core/src/damping.rs
@@ -1,0 +1,42 @@
+use bevy_ecs::prelude::Component;
+
+/// Linear damping applied to `Velocity.linear` each frame.
+/// Formula: `velocity *= (1.0 - linear * dt).max(0.0)`.
+/// `linear = 0.0` → no damping. `linear = 2.0` → ~50% speed loss per second.
+#[derive(Component, Debug, Clone, Copy, PartialEq)]
+pub struct Damping {
+    pub linear: f32,
+}
+
+impl Default for Damping {
+    fn default() -> Self {
+        Self { linear: 0.0 }
+    }
+}
+
+impl Damping {
+    pub fn new(linear: f32) -> Self {
+        Self { linear }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(Damping::default().linear, 0.0);
+    }
+
+    #[test]
+    fn new_stores_value() {
+        assert_eq!(Damping::new(2.5).linear, 2.5);
+    }
+
+    #[test]
+    fn negative_damping_allowed() {
+        // Negative damping = acceleration; users may want this.
+        assert_eq!(Damping::new(-1.0).linear, -1.0);
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod camera;
+pub mod damping;
 pub mod global_transform;
 pub mod lifetime;
 pub mod light;
@@ -13,6 +14,7 @@ pub mod tween;
 pub mod velocity;
 
 pub use camera::Camera;
+pub use damping::Damping;
 pub use global_transform::GlobalTransform;
 pub use lifetime::Lifetime;
 pub use light::{DirectionalLight, PointLight, SpotLight};


### PR DESCRIPTION
## Summary

- `Damping { linear: f32 }` ECS `Component` in `bsengine-core`
- `DampingPlugin` in `bsengine-app` runs `apply_damping` in `Update`
  - `velocity.linear *= (1.0 - linear * dt).max(0.0)`
  - Clamped to 0 — overdamping never reverses velocity direction
- `linear = 0.0` → no change, `linear = 1.0` → ~stops in 1s, `linear = 2.0` → ~stops in 0.5s
- Pairs with `GravityPlugin` to give entities terminal velocity

## Test plan

- [ ] CI All Green (3 core unit + 6 app integration = 9 tests)
- [ ] `overdamping_clamps_to_zero` — damping > 1/dt never creates negative speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)