### PR TITLE
feat: Ray struct — raycasting against AABB and spheres

### DIFF
--- a/crates/bsengine-core/src/aabb.rs
+++ b/crates/bsengine-core/src/aabb.rs
@@ -1,0 +1,178 @@
+use bevy_ecs::prelude::Component;
+use glam::Vec3;
+
+/// Axis-aligned bounding box in local space.
+/// Used for broad-phase collision detection and frustum culling.
+/// Combine with `GlobalTransform` to get world-space bounds.
+#[derive(Component, Debug, Clone, Copy, PartialEq)]
+pub struct Aabb {
+    pub min: Vec3,
+    pub max: Vec3,
+}
+
+impl Aabb {
+    pub fn new(min: Vec3, max: Vec3) -> Self {
+        Self { min, max }
+    }
+
+    /// Create from center and half-extents (positive values for each axis).
+    pub fn from_center_half_extents(center: Vec3, half: Vec3) -> Self {
+        Self {
+            min: center - half,
+            max: center + half,
+        }
+    }
+
+    /// Create a unit cube centered at origin.
+    pub fn unit() -> Self {
+        Self::from_center_half_extents(Vec3::ZERO, Vec3::ONE * 0.5)
+    }
+
+    pub fn center(self) -> Vec3 {
+        (self.min + self.max) * 0.5
+    }
+
+    pub fn size(self) -> Vec3 {
+        self.max - self.min
+    }
+
+    pub fn half_extents(self) -> Vec3 {
+        self.size() * 0.5
+    }
+
+    pub fn contains_point(self, point: Vec3) -> bool {
+        point.cmpge(self.min).all() && point.cmple(self.max).all()
+    }
+
+    /// Returns true if this AABB overlaps with `other` (inclusive on boundary).
+    pub fn intersects(self, other: Self) -> bool {
+        self.min.cmple(other.max).all() && self.max.cmpge(other.min).all()
+    }
+
+    /// Expand to include the given point.
+    pub fn expanded_to_include(self, point: Vec3) -> Self {
+        Self {
+            min: self.min.min(point),
+            max: self.max.max(point),
+        }
+    }
+
+    /// Union of two AABBs.
+    pub fn union(self, other: Self) -> Self {
+        Self {
+            min: self.min.min(other.min),
+            max: self.max.max(other.max),
+        }
+    }
+
+    /// Intersection of two AABBs. Returns None if they do not overlap.
+    pub fn intersection(self, other: Self) -> Option<Self> {
+        let min = self.min.max(other.min);
+        let max = self.max.min(other.max);
+        if min.cmple(max).all() {
+            Some(Self { min, max })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unit() -> Aabb {
+        Aabb::new(Vec3::NEG_ONE, Vec3::ONE)
+    }
+
+    #[test]
+    fn center_of_unit_cube() {
+        assert_eq!(unit().center(), Vec3::ZERO);
+    }
+
+    #[test]
+    fn size_of_unit_cube() {
+        assert_eq!(unit().size(), Vec3::ONE * 2.0);
+    }
+
+    #[test]
+    fn half_extents() {
+        assert_eq!(unit().half_extents(), Vec3::ONE);
+    }
+
+    #[test]
+    fn from_center_half_extents() {
+        let a = Aabb::from_center_half_extents(Vec3::ZERO, Vec3::ONE);
+        assert_eq!(a.min, Vec3::NEG_ONE);
+        assert_eq!(a.max, Vec3::ONE);
+    }
+
+    #[test]
+    fn contains_interior_point() {
+        assert!(unit().contains_point(Vec3::ZERO));
+    }
+
+    #[test]
+    fn contains_boundary_point() {
+        assert!(unit().contains_point(Vec3::ONE));
+    }
+
+    #[test]
+    fn does_not_contain_exterior() {
+        assert!(!unit().contains_point(Vec3::new(2.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn overlapping_aabbs_intersect() {
+        let a = Aabb::new(Vec3::ZERO, Vec3::ONE * 2.0);
+        let b = Aabb::new(Vec3::ONE, Vec3::ONE * 3.0);
+        assert!(a.intersects(b));
+        assert!(b.intersects(a));
+    }
+
+    #[test]
+    fn non_overlapping_aabbs_do_not_intersect() {
+        let a = Aabb::new(Vec3::ZERO, Vec3::ONE);
+        let b = Aabb::new(Vec3::new(2.0, 0.0, 0.0), Vec3::new(3.0, 1.0, 1.0));
+        assert!(!a.intersects(b));
+    }
+
+    #[test]
+    fn touching_aabbs_intersect() {
+        let a = Aabb::new(Vec3::ZERO, Vec3::ONE);
+        let b = Aabb::new(Vec3::ONE, Vec3::ONE * 2.0);
+        assert!(a.intersects(b));
+    }
+
+    #[test]
+    fn union_enclosing_box() {
+        let a = Aabb::new(Vec3::NEG_ONE, Vec3::ZERO);
+        let b = Aabb::new(Vec3::ZERO, Vec3::ONE);
+        let u = a.union(b);
+        assert_eq!(u.min, Vec3::NEG_ONE);
+        assert_eq!(u.max, Vec3::ONE);
+    }
+
+    #[test]
+    fn intersection_returns_overlap() {
+        let a = Aabb::new(Vec3::ZERO, Vec3::ONE * 2.0);
+        let b = Aabb::new(Vec3::ONE, Vec3::ONE * 3.0);
+        let i = a.intersection(b).unwrap();
+        assert_eq!(i.min, Vec3::ONE);
+        assert_eq!(i.max, Vec3::ONE * 2.0);
+    }
+
+    #[test]
+    fn intersection_none_when_no_overlap() {
+        let a = Aabb::new(Vec3::ZERO, Vec3::ONE);
+        let b = Aabb::new(Vec3::new(2.0, 0.0, 0.0), Vec3::new(3.0, 1.0, 1.0));
+        assert!(a.intersection(b).is_none());
+    }
+
+    #[test]
+    fn expand_to_include_point() {
+        let a = Aabb::new(Vec3::ZERO, Vec3::ONE);
+        let expanded = a.expanded_to_include(Vec3::new(2.0, 0.0, 0.0));
+        assert_eq!(expanded.max.x, 2.0);
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod aabb;
 pub mod angular_velocity;
 pub mod camera;
 pub mod color;
@@ -9,12 +10,14 @@ pub mod logging;
 pub mod material;
 pub mod name;
 pub mod parent;
+pub mod ray;
 pub mod tag;
 pub mod time;
 pub mod transform;
 pub mod tween;
 pub mod velocity;
 
+pub use aabb::Aabb;
 pub use angular_velocity::AngularVelocity;
 pub use camera::Camera;
 pub use color::Color;
@@ -26,6 +29,7 @@ pub use logging::init_logging;
 pub use material::Material;
 pub use name::Name;
 pub use parent::Parent;
+pub use ray::Ray;
 pub use tag::Tag;
 pub use time::Time;
 pub use transform::Transform;

--- a/crates/bsengine-core/src/ray.rs
+++ b/crates/bsengine-core/src/ray.rs
@@ -1,0 +1,167 @@
+use glam::Vec3;
+
+use crate::Aabb;
+
+/// A ray in 3D space — used for raycasting, picking, and line-of-sight tests.
+/// Direction is always normalized on construction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Ray {
+    pub origin: Vec3,
+    /// Unit vector. Use `Ray::new()` to construct with auto-normalization.
+    pub direction: Vec3,
+}
+
+impl Ray {
+    /// Construct a ray. `direction` is normalized automatically.
+    pub fn new(origin: Vec3, direction: Vec3) -> Self {
+        Self {
+            origin,
+            direction: direction.normalize(),
+        }
+    }
+
+    /// Point along the ray at parameter `t`. Negative `t` goes behind the origin.
+    pub fn at(&self, t: f32) -> Vec3 {
+        self.origin + self.direction * t
+    }
+
+    /// Slab-method AABB intersection. Returns `Some(t)` at the entry point,
+    /// where `t >= 0` means the intersection is in front of the origin.
+    /// Returns `None` if the ray misses or the box is fully behind the origin.
+    pub fn intersect_aabb(&self, aabb: &Aabb) -> Option<f32> {
+        let inv_dir = Vec3::new(
+            if self.direction.x != 0.0 {
+                1.0 / self.direction.x
+            } else {
+                f32::INFINITY
+            },
+            if self.direction.y != 0.0 {
+                1.0 / self.direction.y
+            } else {
+                f32::INFINITY
+            },
+            if self.direction.z != 0.0 {
+                1.0 / self.direction.z
+            } else {
+                f32::INFINITY
+            },
+        );
+
+        let t1 = (aabb.min - self.origin) * inv_dir;
+        let t2 = (aabb.max - self.origin) * inv_dir;
+
+        let t_min = t1.min(t2);
+        let t_max = t1.max(t2);
+
+        let entry = t_min.x.max(t_min.y).max(t_min.z);
+        let exit = t_max.x.min(t_max.y).min(t_max.z);
+
+        if entry > exit || exit < 0.0 {
+            return None;
+        }
+
+        let t = if entry >= 0.0 { entry } else { exit };
+        Some(t)
+    }
+
+    /// Sphere intersection. Returns `Some(t)` at the nearest surface hit
+    /// in front of the origin, or `None` if the ray misses.
+    pub fn intersect_sphere(&self, center: Vec3, radius: f32) -> Option<f32> {
+        let l = center - self.origin;
+        let tca = l.dot(self.direction);
+        let d2 = l.dot(l) - tca * tca;
+        let r2 = radius * radius;
+
+        if d2 > r2 {
+            return None;
+        }
+
+        let thc = (r2 - d2).sqrt();
+        let t0 = tca - thc;
+        let t1 = tca + thc;
+
+        if t1 < 0.0 {
+            return None; // both intersections behind origin
+        }
+
+        Some(if t0 >= 0.0 { t0 } else { t1 })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    fn unit_aabb() -> Aabb {
+        Aabb::new(Vec3::NEG_ONE, Vec3::ONE)
+    }
+
+    #[test]
+    fn direction_is_normalized() {
+        let r = Ray::new(Vec3::ZERO, Vec3::new(0.0, 0.0, 2.0));
+        assert!((r.direction.length() - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn at_returns_point_along_ray() {
+        let r = Ray::new(Vec3::ZERO, Vec3::Z);
+        assert_eq!(r.at(3.0), Vec3::new(0.0, 0.0, 3.0));
+    }
+
+    #[test]
+    fn ray_hits_aabb_head_on() {
+        let r = Ray::new(Vec3::new(0.0, 0.0, -5.0), Vec3::Z);
+        let t = r.intersect_aabb(&unit_aabb());
+        assert!(t.is_some());
+        assert!((t.unwrap() - 4.0).abs() < 0.001); // hits at z = -1, so t = 4
+    }
+
+    #[test]
+    fn ray_misses_aabb() {
+        let r = Ray::new(Vec3::new(5.0, 0.0, -5.0), Vec3::Z);
+        assert!(r.intersect_aabb(&unit_aabb()).is_none());
+    }
+
+    #[test]
+    fn ray_behind_aabb_returns_none() {
+        let r = Ray::new(Vec3::new(0.0, 0.0, 5.0), Vec3::Z); // pointing away
+        assert!(r.intersect_aabb(&unit_aabb()).is_none());
+    }
+
+    #[test]
+    fn ray_inside_aabb_hits_exit() {
+        let r = Ray::new(Vec3::ZERO, Vec3::Z); // inside unit_aabb
+        let t = r.intersect_aabb(&unit_aabb());
+        assert!(t.is_some());
+        assert!(t.unwrap() >= 0.0);
+    }
+
+    #[test]
+    fn ray_hits_sphere() {
+        let r = Ray::new(Vec3::new(0.0, 0.0, -5.0), Vec3::Z);
+        let t = r.intersect_sphere(Vec3::ZERO, 1.0);
+        assert!(t.is_some());
+        assert!((t.unwrap() - 4.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn ray_misses_sphere() {
+        let r = Ray::new(Vec3::new(5.0, 0.0, -5.0), Vec3::Z);
+        assert!(r.intersect_sphere(Vec3::ZERO, 1.0).is_none());
+    }
+
+    #[test]
+    fn ray_behind_sphere_returns_none() {
+        let r = Ray::new(Vec3::new(0.0, 0.0, 5.0), Vec3::Z);
+        assert!(r.intersect_sphere(Vec3::ZERO, 1.0).is_none());
+    }
+
+    #[test]
+    fn ray_inside_sphere_returns_exit_point() {
+        let r = Ray::new(Vec3::ZERO, Vec3::Z); // inside sphere of radius 2
+        let t = r.intersect_sphere(Vec3::ZERO, 2.0);
+        assert!(t.is_some());
+        assert!((t.unwrap() - 2.0).abs() < 0.001);
+    }
+}


### PR DESCRIPTION
## Summary

- `Ray { origin: Vec3, direction: Vec3 }` utility struct in `bsengine-core` — not a Component
- Direction is always normalized via `Ray::new(origin, direction)`
- `at(t) -> Vec3` — evaluate point along ray
- `intersect_aabb(&Aabb) -> Option<f32>` — slab method; returns t at entry, or `None` if miss or behind
- `intersect_sphere(center, radius) -> Option<f32>` — geometric intersection; handles inside-sphere case
- `Aabb` component also included (same as PR #670 — no-op conflict when that merges)

## Test plan

- [ ] CI All Green (11 core unit tests — 10 ray + aabb)
- [ ] `ray_inside_aabb_hits_exit` — ray starting inside box returns exit t
- [ ] `ray_inside_sphere_returns_exit_point` — inside sphere returns far intersection

🤖 Generated with [Claude Code](https://claude.com/claude-code)