### PR TITLE
feat: Billboard component — camera-facing marker for sprites and VFX

### DIFF
--- a/crates/bsengine-core/src/billboard.rs
+++ b/crates/bsengine-core/src/billboard.rs
@@ -1,0 +1,70 @@
+use bevy_ecs::prelude::Component;
+
+/// How an entity should be oriented to face the camera.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BillboardMode {
+    /// Rotates around both X and Y axes — always faces the camera directly.
+    #[default]
+    Full,
+    /// Rotates only around the Y axis — stays upright (e.g. trees, characters).
+    Vertical,
+}
+
+/// Marker that tells the render system to orient this entity toward the active camera.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Billboard {
+    pub mode: BillboardMode,
+}
+
+impl Billboard {
+    pub fn full() -> Self {
+        Self {
+            mode: BillboardMode::Full,
+        }
+    }
+
+    pub fn vertical() -> Self {
+        Self {
+            mode: BillboardMode::Vertical,
+        }
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.mode == BillboardMode::Full
+    }
+
+    pub fn is_vertical(&self) -> bool {
+        self.mode == BillboardMode::Vertical
+    }
+}
+
+impl Default for Billboard {
+    fn default() -> Self {
+        Self::full()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_billboard_default() {
+        let b = Billboard::default();
+        assert!(b.is_full());
+        assert!(!b.is_vertical());
+    }
+
+    #[test]
+    fn vertical_billboard() {
+        let b = Billboard::vertical();
+        assert!(b.is_vertical());
+        assert!(!b.is_full());
+    }
+
+    #[test]
+    fn mode_equality() {
+        assert_eq!(Billboard::full().mode, BillboardMode::Full);
+        assert_eq!(Billboard::vertical().mode, BillboardMode::Vertical);
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod aabb;
 pub mod angular_velocity;
 pub mod audio_emitter;
+pub mod billboard;
 pub mod camera;
 pub mod capsule;
 pub mod color;
@@ -34,6 +35,7 @@ pub mod z_index;
 pub use aabb::Aabb;
 pub use angular_velocity::AngularVelocity;
 pub use audio_emitter::{AudioEmitter, AudioListener};
+pub use billboard::{Billboard, BillboardMode};
 pub use camera::Camera;
 pub use capsule::Capsule;
 pub use color::Color;


### PR DESCRIPTION
## Summary

- `Billboard` `Component` in `bsengine-core` — marks an entity to face the camera
- `BillboardMode::Full` — rotates on all axes
- `BillboardMode::Vertical` — Y-axis only (stays upright)
- Builder: `Billboard::full()` / `Billboard::vertical()`
- Pure data; render system queries it to override rotation each frame

## Test plan

- [ ] CI All Green (3 unit tests)
- [ ] Default mode is `Full`
- [ ] `vertical()` sets `Vertical` mode
- [ ] `is_full()` / `is_vertical()` helpers correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)