### PR TITLE
feat: Vignette component — screen-edge darkening post-process

### DIFF
--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod transform;
 pub mod tween;
 pub mod velocity;
 pub mod viewport;
+pub mod vignette;
 pub mod visible;
 pub mod z_index;
 
@@ -93,6 +94,7 @@ pub use transform::Transform;
 pub use tween::{EasingFn, RepeatMode, Tween, TweenTarget};
 pub use velocity::Velocity;
 pub use viewport::Viewport;
+pub use vignette::Vignette;
 pub use visible::Visible;
 pub use z_index::ZIndex;
 

--- a/crates/bsengine-core/src/vignette.rs
+++ b/crates/bsengine-core/src/vignette.rs
@@ -1,0 +1,85 @@
+use bevy_ecs::prelude::Component;
+
+/// Screen-space vignette post-processing applied by a camera.
+/// Darkens the edges of the screen, drawing the eye to the centre.
+#[derive(Component, Debug, Clone, Copy, PartialEq)]
+pub struct Vignette {
+    /// Strength of the vignette. 0 = invisible, 1 = fully black at the furthest edges.
+    pub intensity: f32,
+    /// How quickly the darkening falls off from the edges inward.
+    /// Higher values produce a sharper, smaller vignette ring.
+    pub smoothness: f32,
+    /// Color of the vignette overlay (usually black but can be tinted).
+    pub color: [f32; 3],
+    pub enabled: bool,
+}
+
+impl Vignette {
+    pub fn new(intensity: f32) -> Self {
+        Self {
+            intensity: intensity.clamp(0.0, 1.0),
+            smoothness: 0.5,
+            color: [0.0, 0.0, 0.0],
+            enabled: true,
+        }
+    }
+
+    pub fn with_smoothness(mut self, smoothness: f32) -> Self {
+        self.smoothness = smoothness.max(0.0);
+        self
+    }
+
+    pub fn with_color(mut self, r: f32, g: f32, b: f32) -> Self {
+        self.color = [r.clamp(0.0, 1.0), g.clamp(0.0, 1.0), b.clamp(0.0, 1.0)];
+        self
+    }
+
+    pub fn disabled(mut self) -> Self {
+        self.enabled = false;
+        self
+    }
+}
+
+impl Default for Vignette {
+    fn default() -> Self {
+        Self::new(0.5)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vignette_defaults() {
+        let v = Vignette::default();
+        assert!((v.intensity - 0.5).abs() < 0.001);
+        assert!((v.smoothness - 0.5).abs() < 0.001);
+        assert_eq!(v.color, [0.0, 0.0, 0.0]);
+        assert!(v.enabled);
+    }
+
+    #[test]
+    fn intensity_clamped() {
+        let v = Vignette::new(3.0);
+        assert!((v.intensity - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn smoothness_clamped() {
+        let v = Vignette::default().with_smoothness(-1.0);
+        assert_eq!(v.smoothness, 0.0);
+    }
+
+    #[test]
+    fn color_channels_clamped() {
+        let v = Vignette::default().with_color(-1.0, 2.0, 0.5);
+        assert_eq!(v.color, [0.0, 1.0, 0.5]);
+    }
+
+    #[test]
+    fn disabled_flag() {
+        let v = Vignette::new(0.5).disabled();
+        assert!(!v.enabled);
+    }
+}


### PR DESCRIPTION
## Summary

- `Vignette` `Component` in `bsengine-core` — attaches to a camera for vignette darkening
- Fields: `intensity` [0,1], `smoothness` (>= 0), `color` ([f32;3], RGB), `enabled`
- Default: 0.5 intensity, 0.5 smoothness, black `[0, 0, 0]`
- Color channels clamped to [0, 1]

## Test plan

- [ ] CI All Green (5 unit tests)
- [ ] Defaults: intensity=0.5, smoothness=0.5, black, enabled
- [ ] intensity clamped to [0, 1]
- [ ] smoothness clamped to >= 0
- [ ] color channels individually clamped to [0, 1]
- [ ] disabled() sets enabled = false

🤖 Generated with [Claude Code](https://claude.com/claude-code)