### PR TITLE
feat: Anchor component — 2D/UI pivot point with presets and pixel offset

### DIFF
--- a/crates/bsengine-core/src/anchor.rs
+++ b/crates/bsengine-core/src/anchor.rs
@@ -1,0 +1,114 @@
+use bevy_ecs::prelude::Component;
+use glam::Vec2;
+
+/// Named anchor presets for common 2-D layout positions.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum AnchorPreset {
+    /// (0.5, 0.5) — dead center.
+    #[default]
+    Center,
+    TopLeft,
+    TopCenter,
+    TopRight,
+    MiddleLeft,
+    MiddleRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+    /// Fully custom normalized position.
+    Custom(Vec2),
+}
+
+impl AnchorPreset {
+    /// Returns the normalized [0,1] position corresponding to this preset.
+    /// Origin is bottom-left; (1,1) is top-right.
+    pub fn normalized(&self) -> Vec2 {
+        match self {
+            Self::Center => Vec2::new(0.5, 0.5),
+            Self::TopLeft => Vec2::new(0.0, 1.0),
+            Self::TopCenter => Vec2::new(0.5, 1.0),
+            Self::TopRight => Vec2::new(1.0, 1.0),
+            Self::MiddleLeft => Vec2::new(0.0, 0.5),
+            Self::MiddleRight => Vec2::new(1.0, 0.5),
+            Self::BottomLeft => Vec2::new(0.0, 0.0),
+            Self::BottomCenter => Vec2::new(0.5, 0.0),
+            Self::BottomRight => Vec2::new(1.0, 0.0),
+            Self::Custom(v) => *v,
+        }
+    }
+}
+
+/// Sets the pivot/anchor point for a 2-D or UI entity.
+/// The layout system positions the entity so that its `anchor` point lands on
+/// the parent's `anchor` normalized coordinate.
+#[derive(Component, Debug, Clone, Copy, PartialEq)]
+pub struct Anchor {
+    pub preset: AnchorPreset,
+    /// Pixel offset applied after the anchor position is resolved.
+    pub offset: Vec2,
+}
+
+impl Anchor {
+    pub fn new(preset: AnchorPreset) -> Self {
+        Self {
+            preset,
+            offset: Vec2::ZERO,
+        }
+    }
+
+    pub fn with_offset(mut self, offset: Vec2) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    /// Normalized [0,1] anchor position (before offset).
+    pub fn normalized(&self) -> Vec2 {
+        self.preset.normalized()
+    }
+}
+
+impl Default for Anchor {
+    fn default() -> Self {
+        Self::new(AnchorPreset::Center)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anchor_center_default() {
+        let a = Anchor::default();
+        let n = a.normalized();
+        assert!((n.x - 0.5).abs() < 0.001);
+        assert!((n.y - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn anchor_top_left() {
+        let a = Anchor::new(AnchorPreset::TopLeft);
+        let n = a.normalized();
+        assert_eq!(n, Vec2::new(0.0, 1.0));
+    }
+
+    #[test]
+    fn anchor_bottom_right() {
+        let a = Anchor::new(AnchorPreset::BottomRight);
+        let n = a.normalized();
+        assert_eq!(n, Vec2::new(1.0, 0.0));
+    }
+
+    #[test]
+    fn custom_anchor() {
+        let pos = Vec2::new(0.25, 0.75);
+        let a = Anchor::new(AnchorPreset::Custom(pos));
+        assert_eq!(a.normalized(), pos);
+    }
+
+    #[test]
+    fn offset_stored() {
+        let a = Anchor::default().with_offset(Vec2::new(10.0, -5.0));
+        assert_eq!(a.offset, Vec2::new(10.0, -5.0));
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod aabb;
 pub mod ambient_occlusion;
+pub mod anchor;
 pub mod angular_velocity;
 pub mod animation_player;
 pub mod attach_point;
@@ -82,6 +83,7 @@ pub mod z_index;
 
 pub use aabb::Aabb;
 pub use ambient_occlusion::AmbientOcclusion;
+pub use anchor::{Anchor, AnchorPreset};
 pub use angular_velocity::AngularVelocity;
 pub use animation_player::AnimationPlayer;
 pub use attach_point::AttachPoint;


### PR DESCRIPTION
## Summary

- `Anchor` `Component` in `bsengine-core` — sets the pivot/anchor for 2D and UI entities
- `AnchorPreset` enum: 9 named positions (Center/TopLeft/…/BottomRight) + `Custom(Vec2)`
- `normalized()` → `[0,1]` position with bottom-left origin
- `offset: Vec2` — pixel nudge applied after anchor resolution
- Default: Center (0.5, 0.5), zero offset

## Test plan

- [ ] CI All Green (5 unit tests)
- [ ] Default anchor → (0.5, 0.5)
- [ ] TopLeft → (0.0, 1.0)
- [ ] BottomRight → (1.0, 0.0)
- [ ] Custom(Vec2) → returns that exact value
- [ ] with_offset stores the offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)