### PR TITLE
chore(rhi-wgpu): suppress dead_code warning on WgpuRHI fields

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/rhi.rs
+++ b/crates/bsengine-rhi-wgpu/src/rhi.rs
@@ -1,6 +1,7 @@
 use bsengine_rhi::{RHIMesh, RHIShader, RHITexture, RHI};
 use wgpu::{Device, Queue};
 
+#[allow(dead_code)]
 pub struct WgpuRHI {
     pub(crate) device: Device,
     pub(crate) queue: Queue,


### PR DESCRIPTION
## Summary
- `WgpuRHI.device` and `.queue` are `pub(crate)` and accessed in test helpers (texture.rs, mesh.rs tests)
- Production code uses `WgpuSurface`'s own device/queue; the `WgpuRHI` fields are legitimately only needed for testing
- Add `#[allow(dead_code)]` to suppress the spurious compiler warning

## Test plan
- [ ] `cargo build` — zero warnings
- [ ] `cargo test -p bsengine-rhi-wgpu` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)