### PR TITLE
fix: increase main-thread stack size to 64MB on Windows MSVC

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,8 @@
 # are on different drives (requires same-drive for symlink without admin rights).
 # CI overrides this via CARGO_TARGET_DIR env var in the workflow.
 target-dir = "C:\\BSEngine-target"
+
+[target.x86_64-pc-windows-msvc]
+# wgpu Vulkan layer enumeration exceeds Windows' default 1MB main-thread stack
+# in debug builds. 64MB gives ample headroom for both debug and release.
+rustflags = ["-C", "link-args=/STACK:67108864"]


### PR DESCRIPTION
## Summary
- wgpu Vulkan layer enumeration exceeds Windows' default 1MB main-thread stack in debug builds
- Results in `STATUS_STACK_OVERFLOW (0xc00000fd)` immediately at startup before any game logic runs
- Fix: add `/STACK:67108864` (64MB) linker flag for `x86_64-pc-windows-msvc` in `.cargo/config.toml`

## Root cause
`WgpuRHIPlugin` calls `pollster::block_on(WgpuRHI::new_headless())` on the main thread, which triggers Vulkan instance creation + layer JSON enumeration. This chain exhausts the default 1MB Windows stack in unoptimized debug builds.

## Test plan
- [ ] `cargo run -p bsengine-app` — window opens without stack overflow
- [ ] `cargo run -p bsengine-demo` — spinning cube visible
- [ ] CI passes (Linux unaffected, flag is Windows-MSVC-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)