### PR TITLE
fix(rhi-wgpu): correct model bind group entry size 64→96 bytes

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -499,7 +499,7 @@ impl WgpuSurface {
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
                     buffer: &model_buffer,
                     offset: 0,
-                    size: wgpu::BufferSize::new(64),
+                    size: wgpu::BufferSize::new(96),
                 }),
             }],
         });


### PR DESCRIPTION
## Summary
- `ModelUniformData` is 96 bytes: `mat4x4` (64) + metallic/roughness/pad×2 (16) + emissive+pad (16)
- The bind group entry `size` was set to `64`, but `min_binding_size` was correctly `96`
- wgpu validation error at startup: `Binding size 64 of Buffer 'model uniform' is less than minimum 96`
- Fix: change `BufferSize::new(64)` → `BufferSize::new(96)`

## Test plan
- [ ] `cargo run -p bsengine-app` — no wgpu validation panic, window renders
- [ ] `cargo test -p bsengine-rhi-wgpu` — 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)