### PR TITLE
fix(rhi-wgpu): add FRAGMENT visibility to model bind group layout

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -482,7 +482,7 @@ impl WgpuSurface {
             label: Some("model bgl"),
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
+                visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: true,


### PR DESCRIPTION
## Summary
- PBR fragment shader reads `model_data.metallic`, `.roughness`, `.emissive` (group 1, binding 0)
- The model bind group layout declared `visibility: VERTEX` only
- wgpu validation error at pipeline creation: `Visibility flags don't include the shader stage`
- Fix: `VERTEX → VERTEX | FRAGMENT`

## Test plan
- [ ] `cargo run -p bsengine-app` — mesh pipeline creates successfully, window renders
- [ ] `cargo test -p bsengine-rhi-wgpu` — 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)