### PR TITLE
feat(runtime): add bsengine-runtime binary and project-based loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bsengine-runtime"
+version = "0.1.0"
+dependencies = [
+ "bevy_app",
+ "bsengine-app",
+ "bsengine-core",
+ "bsengine-ecs",
+ "bsengine-input",
+ "bsengine-render",
+ "bsengine-rhi-wgpu",
+ "bsengine-scene",
+ "bsengine-window",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "bsengine-scene"
 version = "0.1.0"
 dependencies = [
@@ -1045,6 +1062,21 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "cube-roller"
+version = "0.1.0"
+dependencies = [
+ "bevy_ecs",
+ "bsengine-app",
+ "bsengine-core",
+ "bsengine-ecs",
+ "bsengine-input",
+ "bsengine-render",
+ "bsengine-rhi-wgpu",
+ "bsengine-window",
+ "glam 0.29.3",
+]
 
 [[package]]
 name = "cursor-icon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/bsengine-gltf",
     "crates/bsengine-demo",
     "crates/bsengine-editor",
+    "crates/bsengine-runtime",
     "games/cube-roller",
 ]
 
@@ -59,6 +60,7 @@ glam              = "0.29"
 gltf              = "1"
 image             = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 bsengine-gltf     = { path = "crates/bsengine-gltf" }
+bsengine-runtime  = { path = "crates/bsengine-runtime" }
 bsengine-editor   = { path = "crates/bsengine-editor" }
 bsengine-physics  = { path = "crates/bsengine-physics" }
 bsengine-audio    = { path = "crates/bsengine-audio" }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -697,6 +697,8 @@ impl Plugin for EditorPlugin {
                                     gltf: None,
                                     camera: false,
                                     directional_light: None,
+                                    primitive: None,
+                                    script: None,
                                 }
                             })
                         })

--- a/crates/bsengine-runtime/Cargo.toml
+++ b/crates/bsengine-runtime/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bsengine-runtime"
+description = "BSEngine project runner — loads project.toml and entry scene, no game-specific Rust required"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "bsengine-runtime"
+path = "src/main.rs"
+
+[dependencies]
+bevy_app        = { workspace = true }
+bsengine-app    = { workspace = true }
+bsengine-core   = { workspace = true }
+bsengine-ecs    = { workspace = true }
+bsengine-input  = { workspace = true }
+bsengine-render = { workspace = true }
+bsengine-rhi-wgpu = { workspace = true }
+bsengine-scene  = { workspace = true }
+bsengine-window = { workspace = true }
+serde           = { workspace = true }
+toml            = { workspace = true }

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -1,0 +1,100 @@
+use std::env;
+
+use bevy_app::PostStartup;
+use bsengine_app::new_app;
+use bsengine_ecs::{Commands, Entity, Query, ResMut};
+use bsengine_input::InputPlugin;
+use bsengine_render::{MeshRenderer, RenderPlugin};
+use bsengine_rhi_wgpu::{cube_vertices, GpuMeshRegistry, WgpuRHIPlugin};
+use bsengine_scene::{Primitive, PrimitiveMesh, ScenePlugin};
+use bsengine_window::{WindowDescriptor, WindowPlugin};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct ProjectManifest {
+    project: ProjectSection,
+    #[serde(default)]
+    window: WindowSection,
+}
+
+#[derive(Deserialize)]
+struct ProjectSection {
+    name: String,
+    entry_scene: String,
+}
+
+#[derive(Deserialize, Default)]
+struct WindowSection {
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default = "default_width")]
+    width: u32,
+    #[serde(default = "default_height")]
+    height: u32,
+    #[serde(default = "default_true")]
+    resizable: bool,
+}
+
+fn default_width() -> u32 {
+    1280
+}
+fn default_height() -> u32 {
+    720
+}
+fn default_true() -> bool {
+    true
+}
+
+fn main() {
+    let project_dir = env::args().nth(1).unwrap_or_else(|| ".".to_string());
+    let manifest_path = format!("{}/project.toml", project_dir);
+
+    let manifest_str = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|e| panic!("Cannot read {manifest_path}: {e}"));
+    let manifest: ProjectManifest = toml::from_str(&manifest_str)
+        .unwrap_or_else(|e| panic!("Cannot parse {manifest_path}: {e}"));
+
+    let scene_path = format!("{}/{}", project_dir, manifest.project.entry_scene);
+    let title = manifest
+        .window
+        .title
+        .unwrap_or_else(|| manifest.project.name.clone());
+
+    new_app()
+        .add_plugins(WgpuRHIPlugin)
+        .add_plugins(WindowPlugin {
+            descriptor: WindowDescriptor {
+                title,
+                width: manifest.window.width,
+                height: manifest.window.height,
+                resizable: manifest.window.resizable,
+            },
+        })
+        .add_plugins(InputPlugin)
+        .add_plugins(RenderPlugin)
+        .add_plugins(ScenePlugin::from_file(&scene_path))
+        .add_systems(PostStartup, resolve_primitives)
+        .run();
+}
+
+fn resolve_primitives(
+    query: Query<(Entity, &PrimitiveMesh)>,
+    mut commands: Commands,
+    registry: Option<ResMut<GpuMeshRegistry>>,
+) {
+    let Some(mut registry) = registry else { return };
+
+    let mut cube_id: Option<u64> = None;
+
+    for (entity, prim) in query.iter() {
+        match &prim.0 {
+            Primitive::Cube => {
+                let id = *cube_id.get_or_insert_with(|| {
+                    let (verts, indices) = cube_vertices();
+                    registry.register(&verts, &indices)
+                });
+                commands.entity(entity).insert(MeshRenderer { mesh_id: id });
+            }
+        }
+    }
+}

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -3,5 +3,6 @@ pub mod types;
 
 pub use plugin::{Name, ScenePlugin};
 pub use types::{
-    DirectionalLightDescriptor, EntityDescriptor, SceneDescriptor, TransformDescriptor,
+    DirectionalLightDescriptor, EntityDescriptor, Primitive, PrimitiveMesh, SceneDescriptor,
+    TransformDescriptor,
 };

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -1,4 +1,4 @@
-use crate::types::SceneDescriptor;
+use crate::types::{PrimitiveMesh, SceneDescriptor};
 use bevy_app::{App, Plugin, Startup};
 use bevy_ecs::prelude::{Commands, Component};
 use bsengine_core::{Camera, DirectionalLight, GlobalTransform, Transform};
@@ -60,6 +60,10 @@ impl Plugin for ScenePlugin {
                         color: Vec3::from(dl.color),
                         ambient: Vec3::from(dl.ambient),
                     });
+                }
+
+                if let Some(prim) = &entity.primitive {
+                    builder.insert(PrimitiveMesh(prim.clone()));
                 }
             }
         });

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -1,9 +1,21 @@
+use bevy_ecs::prelude::Component;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SceneDescriptor {
     pub entities: Vec<EntityDescriptor>,
 }
+
+/// Built-in primitive mesh shapes that the runtime can spawn without an asset file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Primitive {
+    Cube,
+}
+
+/// Marker component inserted by `ScenePlugin` for entities with `primitive: Some(...)`.
+/// The runtime converts this into a `MeshRenderer` with registered GPU geometry.
+#[derive(Component, Debug, Clone)]
+pub struct PrimitiveMesh(pub Primitive);
 
 /// Describes a single entity in the scene file.
 ///
@@ -20,6 +32,10 @@ pub struct EntityDescriptor {
     pub camera: bool,
     #[serde(default)]
     pub directional_light: Option<DirectionalLightDescriptor>,
+    #[serde(default)]
+    pub primitive: Option<Primitive>,
+    #[serde(default)]
+    pub script: Option<String>,
     #[serde(default)]
     pub components: Vec<(String, String)>,
 }

--- a/games/cube-roller/assets/scenes/main.ron
+++ b/games/cube-roller/assets/scenes/main.ron
@@ -1,0 +1,70 @@
+SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Camera",
+        camera: true,
+        transform: Some((
+            translation: (0.0, 8.0, 12.0),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Sun",
+        directional_light: Some((
+            direction: (-0.4, -0.8, -0.4),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Floor",
+        primitive: Some(Cube),
+        transform: Some((
+            translation: (0.0, -0.5, 0.0),
+            scale: (20.0, 0.2, 20.0),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Player",
+        primitive: Some(Cube),
+        transform: Some((
+            translation: (0.0, 0.5, 0.0),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Item1",
+        primitive: Some(Cube),
+        transform: Some((
+            translation: (3.0, 0.5, 0.0),
+            scale: (0.4, 0.4, 0.4),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Item2",
+        primitive: Some(Cube),
+        transform: Some((
+            translation: (-3.0, 0.5, 2.0),
+            scale: (0.4, 0.4, 0.4),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Item3",
+        primitive: Some(Cube),
+        transform: Some((
+            translation: (0.0, 0.5, -4.0),
+            scale: (0.4, 0.4, 0.4),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Item4",
+        primitive: Some(Cube),
+        transform: Some((
+            translation: (5.0, 0.5, -3.0),
+            scale: (0.4, 0.4, 0.4),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Item5",
+        primitive: Some(Cube),
+        transform: Some((
+            translation: (-5.0, 0.5, -2.0),
+            scale: (0.4, 0.4, 0.4),
+        )),
+    ),
+])

--- a/games/cube-roller/project.toml
+++ b/games/cube-roller/project.toml
@@ -1,0 +1,8 @@
+[project]
+name = "Cube Roller"
+entry_scene = "assets/scenes/main.ron"
+
+[window]
+title = "Cube Roller"
+width = 1280
+height = 720


### PR DESCRIPTION
## Summary
- Adds `crates/bsengine-runtime` — a fixed engine binary that runs any BSEngine project without game-specific Rust code
- Extends `EntityDescriptor` with `primitive: Option<Primitive>` (currently `Cube`) and `script: Option<String>` (path to JS file, wired up in next PR)
- `PrimitiveMesh` marker component bridges the scene loader and the GPU mesh registry in the runtime
- `games/cube-roller` now has `project.toml` + `assets/scenes/main.ron`

## Usage
```
cargo run -p bsengine-runtime -- ./games/cube-roller
```

## Scene format
```ron
EntityDescriptor(
    name: "Player",
    primitive: Some(Cube),
    transform: Some((translation: (0.0, 0.5, 0.0))),
)
```

## Test plan
- [ ] `cargo build -p bsengine-runtime` ✅
- [ ] `cargo test -p bsengine-scene -p bsengine-editor` — all pass ✅
- [ ] `cargo run -p bsengine-runtime -- ./games/cube-roller` opens window with floor + player + items rendered

## What's next
- Script field wired to Deno runtime (ECS bridge ops)
- `onUpdate` / `onCollision` callbacks in JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)