### PR TITLE
feat(scene): color field + look_at camera helper

### DIFF
--- a/crates/bsengine-core/src/material.rs
+++ b/crates/bsengine-core/src/material.rs
@@ -7,6 +7,7 @@ pub struct Material {
     pub metallic: f32,
     pub roughness: f32,
     pub emissive: Vec3,
+    pub base_color: Vec3,
 }
 
 impl Default for Material {
@@ -16,6 +17,7 @@ impl Default for Material {
             metallic: 0.0,
             roughness: 0.5,
             emissive: Vec3::ZERO,
+            base_color: Vec3::ONE,
         }
     }
 }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -700,6 +700,8 @@ impl Plugin for EditorPlugin {
                                     primitive: None,
                                     script: None,
                                     emissive: None,
+                                    color: None,
+                                    look_at: None,
                                 }
                             })
                         })

--- a/crates/bsengine-mcp/src/game_tools.rs
+++ b/crates/bsengine-mcp/src/game_tools.rs
@@ -15,6 +15,8 @@ SceneDescriptor(entities: [
       rotation:    (0.0, 0.0, 0.0, 1.0), // quaternion xyzw (optional, default identity)
       scale:       (1.0, 1.0, 1.0),      // optional, default 1 1 1
     )),
+    look_at: Some((0.0, 0.0, 0.0)),      // optional: auto-aim camera at this world point
+                                          // overrides rotation when set; useful for top-down/orbital cameras
   ),
   EntityDescriptor(
     name: "Sun",
@@ -28,6 +30,9 @@ SceneDescriptor(entities: [
     name: "Player",
     primitive: Some(Cube),     // available primitives: Cube only
     transform: Some((translation: (0.0, 0.5, 0.0))),
+    color: Some((1.0, 0.2, 0.2)),    // optional: albedo/base color [r, g, b] linear 0–1
+                                      // multiplies vertex color and texture; default white
+    emissive: Some((0.0, 0.0, 0.0)), // optional: self-illumination color; default black (none)
     script: Some("assets/scripts/player.js"),  // relative to game root
   ),
 ])
@@ -35,7 +40,9 @@ SceneDescriptor(entities: [
 Rules:
 - Always include a Camera entity (camera: true) for rendering
 - Always include a Sun entity (directional_light) or scene will be unlit
-- primitive: Some(Cube) renders a white cube; use scale to reshape
+- primitive: Some(Cube) renders a white cube; use color to tint it
+- look_at on a camera entity auto-computes rotation to face the target point
+- color sets the albedo/surface color; emissive makes the entity glow
 - name is the key used by JS Bsengine.getTransform/setTransform"#;
 
 const SCRIPT_API_DOCS: &str = r#"BSEngine JavaScript API (runs in V8 via Deno Core):

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -131,6 +131,7 @@ fn render_frame(
                     metallic: m.metallic,
                     roughness: m.roughness,
                     emissive: m.emissive,
+                    base_color: m.base_color,
                 })
                 .unwrap_or_default();
             Some((mr.mesh_id, model, tex_id, mat_params))

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -24,6 +24,8 @@ struct ModelUniform {
     _pad1: f32,
     emissive: vec3<f32>,
     _pad2: f32,
+    base_color: vec3<f32>,
+    _pad3: f32,
 };
 struct PointLightEntry {
     position: vec3<f32>,
@@ -130,7 +132,7 @@ fn fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
 fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
     let n = normalize(in.world_normal);
     let v = normalize(camera.cam_pos - in.world_pos);
-    let albedo = textureSample(t_diffuse, s_diffuse, in.uv).rgb * in.col;
+    let albedo = textureSample(t_diffuse, s_diffuse, in.uv).rgb * in.col * model_data.base_color;
     let metallic = model_data.metallic;
     let roughness = max(model_data.roughness, 0.04);
     let f0 = mix(vec3<f32>(0.04, 0.04, 0.04), albedo, metallic);
@@ -251,6 +253,7 @@ pub struct MaterialParams {
     pub metallic: f32,
     pub roughness: f32,
     pub emissive: Vec3,
+    pub base_color: Vec3,
 }
 
 impl Default for MaterialParams {
@@ -259,6 +262,7 @@ impl Default for MaterialParams {
             metallic: 0.0,
             roughness: 0.5,
             emissive: Vec3::ZERO,
+            base_color: Vec3::ONE,
         }
     }
 }
@@ -273,6 +277,8 @@ struct ModelUniformData {
     _pad1: f32,
     emissive: [f32; 3],
     _pad2: f32,
+    base_color: [f32; 3],
+    _pad3: f32,
 }
 
 /// A single point light entry for the GPU buffer.
@@ -939,6 +945,8 @@ impl WgpuSurface {
                 _pad1: 0.0,
                 emissive: mat.emissive.to_array(),
                 _pad2: 0.0,
+                base_color: mat.base_color.to_array(),
+                _pad3: 0.0,
             };
             self.queue.write_buffer(
                 &self.model_buffer,

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -33,14 +33,21 @@ impl Plugin for ScenePlugin {
                 let mut builder = commands.spawn(Name(entity.name.clone()));
 
                 if let Some(t) = &entity.transform {
+                    let mut rotation =
+                        Quat::from_xyzw(t.rotation[0], t.rotation[1], t.rotation[2], t.rotation[3]);
+                    // look_at overrides the rotation for camera entities.
+                    if entity.camera {
+                        if let Some(target) = entity.look_at {
+                            let pos = Vec3::from(t.translation);
+                            let dir = Vec3::from(target) - pos;
+                            if dir.length_squared() > 1e-10 {
+                                rotation = Quat::from_rotation_arc(Vec3::NEG_Z, dir.normalize());
+                            }
+                        }
+                    }
                     let transform = Transform {
                         translation: Vec3::from(t.translation),
-                        rotation: Quat::from_xyzw(
-                            t.rotation[0],
-                            t.rotation[1],
-                            t.rotation[2],
-                            t.rotation[3],
-                        ),
+                        rotation,
                         scale: Vec3::from(t.scale),
                     };
                     builder.insert((transform, GlobalTransform::default()));
@@ -70,9 +77,10 @@ impl Plugin for ScenePlugin {
                     builder.insert(ScriptPath(script.clone()));
                 }
 
-                if let Some(emissive) = &entity.emissive {
+                if entity.emissive.is_some() || entity.color.is_some() {
                     builder.insert(Material {
-                        emissive: Vec3::from(*emissive),
+                        emissive: entity.emissive.map(Vec3::from).unwrap_or(Vec3::ZERO),
+                        base_color: entity.color.map(Vec3::from).unwrap_or(Vec3::ONE),
                         ..Default::default()
                     });
                 }

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -42,6 +42,12 @@ pub struct EntityDescriptor {
     pub script: Option<String>,
     #[serde(default)]
     pub emissive: Option<[f32; 3]>,
+    /// Albedo/base color as [r, g, b] in linear 0–1. Multiplies the mesh vertex color and texture.
+    #[serde(default)]
+    pub color: Option<[f32; 3]>,
+    /// Camera-only: point in world space the camera should face. Overrides the transform rotation.
+    #[serde(default)]
+    pub look_at: Option<[f32; 3]>,
     #[serde(default)]
     pub components: Vec<(String, String)>,
 }


### PR DESCRIPTION
## Summary

- `color: Option<[f32; 3]>` added to `EntityDescriptor` — albedo/base color per entity
  - Propagates: `Material.base_color` → `MaterialParams.base_color` → `ModelUniform.base_color` → WGSL shader
  - Shader: `albedo = texture * vertex_color * model_data.base_color` (default white = no tint)
- `look_at: Option<[f32; 3]>` added to `EntityDescriptor` — camera-only shorthand
  - Computes `Quat::from_rotation_arc(NEG_Z, dir)` before spawning; overrides rotation
  - If no `transform` block, look_at is ignored (camera would need a position to look from)
- MCP `SCENE_FORMAT_DOCS` updated with examples for both fields

## Files changed

- `crates/bsengine-rhi-wgpu/src/surface.rs` — WGSL `ModelUniform` + `ModelUniformData` + `MaterialParams`
- `crates/bsengine-core/src/material.rs` — `Material` component
- `crates/bsengine-render/src/plugin.rs` — pass `base_color` in draw call
- `crates/bsengine-scene/src/types.rs` — `EntityDescriptor` fields
- `crates/bsengine-scene/src/plugin.rs` — spawn logic
- `crates/bsengine-editor/src/plugin.rs` — fill new fields in editor struct literal
- `crates/bsengine-mcp/src/game_tools.rs` — docs

## Test plan

- [ ] Workspace tests pass (editor excluded — pre-existing V8 VA conflict)
- [ ] `cargo +nightly fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)