### PR TITLE
feat(scripting): setEmissive, setColor, getEntityNames JS API

### DIFF
--- a/crates/bsengine-mcp/src/game_tools.rs
+++ b/crates/bsengine-mcp/src/game_tools.rs
@@ -47,16 +47,30 @@ Rules:
 
 const SCRIPT_API_DOCS: &str = r#"BSEngine JavaScript API (runs in V8 via Deno Core):
 
+Transform:
   Bsengine.getTransform(name: string) → { x, y, z } | null
     Get world position of an entity by name. Returns null if not found.
 
   Bsengine.setTransform(name: string, x: number, y: number, z: number)
     Set world position of an entity by name.
 
+Input:
   Bsengine.isKeyPressed(key: string) → boolean
     Check if a key is held. Available keys:
     "W" "A" "S" "D" "Space" "Enter" "Escape" "Up" "Down" "Left" "Right"
 
+Material:
+  Bsengine.setEmissive(name: string, r: number, g: number, b: number)
+    Set the emissive (glow) color of an entity at runtime. Values 0–1 linear.
+
+  Bsengine.setColor(name: string, r: number, g: number, b: number)
+    Set the albedo/base color of an entity at runtime. Values 0–1 linear.
+
+Scene:
+  Bsengine.getEntityNames() → string[]
+    Returns names of all entities currently in the scene.
+
+Logging:
   Bsengine.log(message: string)
     Print a message to the engine log (tracing INFO).
 
@@ -76,6 +90,14 @@ Example (WASD movement on the entity this script is attached to):
     if (Bsengine.isKeyPressed("A")) x -= SPEED;
     if (Bsengine.isKeyPressed("D")) x += SPEED;
     Bsengine.setTransform(self, x, y, z);
+  }
+
+Example (flash red when near origin):
+  function onUpdate(self) {
+    const t = Bsengine.getTransform(self);
+    if (!t) return;
+    const dist = Math.sqrt(t.x * t.x + t.z * t.z);
+    Bsengine.setEmissive(self, dist < 2.0 ? 1.0 : 0.0, 0.0, 0.0);
   }
 
 Example (controlling another entity by name from this script):

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -13,6 +13,18 @@ pub enum ScriptCommand {
         y: f32,
         z: f32,
     },
+    SetEmissive {
+        name: String,
+        r: f32,
+        g: f32,
+        b: f32,
+    },
+    SetColor {
+        name: String,
+        r: f32,
+        g: f32,
+        b: f32,
+    },
 }
 
 thread_local! {
@@ -20,6 +32,8 @@ thread_local! {
         RefCell::new(HashMap::new());
     pub(crate) static KEY_SNAPSHOT: RefCell<HashSet<String>> =
         RefCell::new(HashSet::new());
+    pub(crate) static ENTITY_NAMES_SNAPSHOT: RefCell<Vec<String>> =
+        RefCell::new(Vec::new());
     pub(crate) static COMMAND_BUFFER: RefCell<Vec<ScriptCommand>> =
         RefCell::new(Vec::new());
 }
@@ -67,6 +81,29 @@ pub fn bsengine_is_key_pressed(#[string] key: String) -> bool {
     KEY_SNAPSHOT.with(|k| k.borrow().contains(&key))
 }
 
+#[op2]
+#[string]
+pub fn bsengine_get_entity_names() -> String {
+    ENTITY_NAMES_SNAPSHOT
+        .with(|s| serde_json::to_string(&*s.borrow()).unwrap_or_else(|_| "[]".to_string()))
+}
+
+#[op2(fast)]
+pub fn bsengine_set_emissive(#[string] name: String, r: f32, g: f32, b: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetEmissive { name, r, g, b });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_color(#[string] name: String, r: f32, g: f32, b: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetColor { name, r, g, b });
+    });
+}
+
 deno_core::extension!(
     bsengine_ops,
     ops = [
@@ -75,17 +112,23 @@ deno_core::extension!(
         bsengine_get_transform,
         bsengine_set_transform,
         bsengine_is_key_pressed,
+        bsengine_get_entity_names,
+        bsengine_set_emissive,
+        bsengine_set_color,
     ],
 );
 
 /// Bootstrap JS loaded before any user script — exposes the `Bsengine` global.
 pub const BOOTSTRAP_JS: &str = r#"
 const Bsengine = {
-    log:          (msg)           => Deno.core.ops.bsengine_log(msg),
-    version:      ()              => Deno.core.ops.bsengine_version(),
-    getTransform: (name)          => Deno.core.ops.bsengine_get_transform(name),
-    setTransform: (name, x, y, z) => Deno.core.ops.bsengine_set_transform(name, x, y, z),
-    isKeyPressed: (key)           => Deno.core.ops.bsengine_is_key_pressed(key),
+    log:            (msg)           => Deno.core.ops.bsengine_log(msg),
+    version:        ()              => Deno.core.ops.bsengine_version(),
+    getTransform:   (name)          => Deno.core.ops.bsengine_get_transform(name),
+    setTransform:   (name, x, y, z) => Deno.core.ops.bsengine_set_transform(name, x, y, z),
+    isKeyPressed:   (key)           => Deno.core.ops.bsengine_is_key_pressed(key),
+    getEntityNames: ()              => JSON.parse(Deno.core.ops.bsengine_get_entity_names()),
+    setEmissive:    (name, r, g, b) => Deno.core.ops.bsengine_set_emissive(name, r, g, b),
+    setColor:       (name, r, g, b) => Deno.core.ops.bsengine_set_color(name, r, g, b),
 
     // Per-entity script registry. Keys are entity bit-IDs (strings).
     _scripts: {},

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -2,12 +2,15 @@ use std::collections::{HashMap, HashSet};
 
 use bevy_app::{App, Plugin, PostStartup, Update};
 use bevy_ecs::prelude::*;
-use bsengine_core::Transform;
+use bsengine_core::{Material, Transform};
 use bsengine_input::{Input, KeyCode};
 use bsengine_scene::{Name, ScriptPath};
 use glam::Vec3;
 
-use crate::ops::{ScriptCommand, BOOTSTRAP_JS, COMMAND_BUFFER, KEY_SNAPSHOT, TRANSFORM_SNAPSHOT};
+use crate::ops::{
+    ScriptCommand, BOOTSTRAP_JS, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, KEY_SNAPSHOT,
+    TRANSFORM_SNAPSHOT,
+};
 use crate::runtime::ScriptRuntime;
 
 /// Root directory of the current project — used to resolve relative script paths.
@@ -151,8 +154,15 @@ fn run_scripts(world: &mut World) {
             .collect()
     };
 
+    // All entity names (not just scripted) for getEntityNames().
+    let all_names: Vec<String> = {
+        let mut q = world.query::<&Name>();
+        q.iter(world).map(|n| n.0.clone()).collect()
+    };
+
     TRANSFORM_SNAPSHOT.with(|s| *s.borrow_mut() = transform_snapshot);
     KEY_SNAPSHOT.with(|k| *k.borrow_mut() = key_snapshot);
+    ENTITY_NAMES_SNAPSHOT.with(|s| *s.borrow_mut() = all_names);
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
 
     if let Some(mut rt) = world.get_non_send_resource_mut::<ScriptRuntimeResource>() {
@@ -172,6 +182,38 @@ fn run_scripts(world: &mut World) {
                     if n.0 == name {
                         t.translation = Vec3::new(x, y, z);
                         break;
+                    }
+                }
+            }
+            ScriptCommand::SetEmissive { name, r, g, b } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut mat) = world.get_mut::<Material>(e) {
+                        mat.emissive = Vec3::new(r, g, b);
+                    } else {
+                        world.entity_mut(e).insert(Material {
+                            emissive: Vec3::new(r, g, b),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            ScriptCommand::SetColor { name, r, g, b } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut mat) = world.get_mut::<Material>(e) {
+                        mat.base_color = Vec3::new(r, g, b);
+                    } else {
+                        world.entity_mut(e).insert(Material {
+                            base_color: Vec3::new(r, g, b),
+                            ..Default::default()
+                        });
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Expands the BSEngine JavaScript API from 5 ops to 8, enabling material manipulation and entity discovery at runtime — zero Rust code required.

**New ops:**
- `Bsengine.setEmissive(name, r, g, b)` — sets `Material.emissive` on any named entity (glow effect)
- `Bsengine.setColor(name, r, g, b)` — sets `Material.base_color` on any named entity (tint)
- `Bsengine.getEntityNames()` → `string[]` — lists all named entities in the scene

**Implementation:**
- `SetEmissive` / `SetColor` variants added to `ScriptCommand` enum; dispatched in same post-JS pass as `SetTransform`
- Inserts default `Material` when entity has none yet
- `ENTITY_NAMES_SNAPSHOT` thread-local populated each frame from all `&Name` entities
- `bsengine_get_entity_names()` returns JSON string, parsed in BOOTSTRAP_JS wrapper
- MCP `SCRIPT_API_DOCS` updated with Material / Scene sections and flash-red example

## Test plan

- [ ] `cargo test --workspace --exclude bsengine-editor` passes
- [ ] `cargo +nightly fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)