### PR TITLE
feat(scripting): add gamepad input API (P1.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y mesa-vulkan-drivers libasound2-dev
+        run: sudo apt-get install -y mesa-vulkan-drivers libasound2-dev libudev-dev
 
       - name: Format check
         run: cargo +nightly fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "bsengine-app",
  "bsengine-core",
  "bsengine-ecs",
+ "gilrs",
  "winit",
 ]
 
@@ -1516,6 +1517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1720,40 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902fb00d3f6398e635be22e5c837b303c501835cca7ac11a47bba138f7aafdd8"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
+dependencies = [
+ "inotify",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2191,6 +2232,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2448,16 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.8.1",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2627,6 +2698,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
 ]
 
 [[package]]
@@ -2943,6 +3026,17 @@ dependencies = [
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -4491,6 +4585,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,4 @@ rapier3d          = { version = "0.33", features = ["default"] }
 kira              = { version = "0.12", default-features = false, features = ["cpal", "wav", "ogg", "mp3", "flac"] }
 egui              = "0.29"
 egui-wgpu         = "0.29"
+gilrs             = "0.11"

--- a/crates/bsengine-input/Cargo.toml
+++ b/crates/bsengine-input/Cargo.toml
@@ -10,6 +10,7 @@ bsengine-ecs.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
 winit.workspace = true
+gilrs.workspace = true
 
 [dev-dependencies]
 bsengine-app.workspace = true

--- a/crates/bsengine-input/src/lib.rs
+++ b/crates/bsengine-input/src/lib.rs
@@ -6,5 +6,6 @@ pub mod types;
 pub use plugin::{InputPlugin, MouseState};
 pub use state::Input;
 pub use types::{
-    CursorMoved, ElementState, KeyCode, KeyInput, MouseButton, MouseInput, MouseMotion,
+    CursorMoved, ElementState, GamepadButton, GamepadSticks, KeyCode, KeyInput, MouseButton,
+    MouseInput, MouseMotion,
 };

--- a/crates/bsengine-input/src/plugin.rs
+++ b/crates/bsengine-input/src/plugin.rs
@@ -1,11 +1,16 @@
 use bevy_app::{App, Plugin, PreUpdate};
-use bevy_ecs::prelude::{EventReader, Res, ResMut, Resource};
+use bevy_ecs::prelude::{EventReader, NonSendMut, ResMut, Resource};
 use bsengine_ecs::IntoSystemConfigs;
 
 use crate::{
     state::Input,
-    types::{CursorMoved, ElementState, KeyCode, KeyInput, MouseButton, MouseInput, MouseMotion},
+    types::{
+        CursorMoved, ElementState, GamepadButton, GamepadSticks, KeyCode, KeyInput, MouseButton,
+        MouseInput, MouseMotion,
+    },
 };
+
+pub struct GilrsResource(gilrs::Gilrs);
 
 /// Per-frame mouse position and raw movement delta.
 /// `position` tracks the last cursor position (pixels, top-left origin).
@@ -26,7 +31,9 @@ impl Plugin for InputPlugin {
             .add_event::<MouseMotion>()
             .insert_resource(Input::<KeyCode>::default())
             .insert_resource(Input::<MouseButton>::default())
+            .insert_resource(Input::<GamepadButton>::default())
             .insert_resource(MouseState::default())
+            .insert_resource(GamepadSticks::default())
             .add_systems(
                 PreUpdate,
                 (
@@ -37,12 +44,79 @@ impl Plugin for InputPlugin {
                 )
                     .chain(),
             );
+
+        match gilrs::Gilrs::new() {
+            Ok(g) => {
+                app.insert_non_send_resource(GilrsResource(g));
+                app.add_systems(PreUpdate, poll_gamepad_events.after(clear_input_state));
+            }
+            Err(e) => eprintln!("[input] gamepad not available: {e}"),
+        }
     }
 }
 
-fn clear_input_state(mut keys: ResMut<Input<KeyCode>>, mut buttons: ResMut<Input<MouseButton>>) {
+fn clear_input_state(
+    mut keys: ResMut<Input<KeyCode>>,
+    mut buttons: ResMut<Input<MouseButton>>,
+    mut gamepad: ResMut<Input<GamepadButton>>,
+) {
     keys.clear_transient();
     buttons.clear_transient();
+    gamepad.clear_transient();
+}
+
+fn poll_gamepad_events(
+    gilrs: Option<NonSendMut<GilrsResource>>,
+    mut buttons: ResMut<Input<GamepadButton>>,
+    mut sticks: ResMut<GamepadSticks>,
+) {
+    let Some(mut gilrs) = gilrs else { return };
+    while let Some(event) = gilrs.0.next_event() {
+        match event.event {
+            gilrs::EventType::ButtonPressed(btn, _) => {
+                if let Some(b) = map_gilrs_button(btn) {
+                    buttons.press(b);
+                }
+            }
+            gilrs::EventType::ButtonReleased(btn, _) => {
+                if let Some(b) = map_gilrs_button(btn) {
+                    buttons.release(b);
+                }
+            }
+            gilrs::EventType::AxisChanged(axis, value, _) => match axis {
+                gilrs::Axis::LeftStickX => sticks.left.0 = value,
+                gilrs::Axis::LeftStickY => sticks.left.1 = value,
+                gilrs::Axis::RightStickX => sticks.right.0 = value,
+                gilrs::Axis::RightStickY => sticks.right.1 = value,
+                gilrs::Axis::LeftZ => sticks.left_trigger = value,
+                gilrs::Axis::RightZ => sticks.right_trigger = value,
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+}
+
+fn map_gilrs_button(btn: gilrs::Button) -> Option<GamepadButton> {
+    match btn {
+        gilrs::Button::South => Some(GamepadButton::South),
+        gilrs::Button::East => Some(GamepadButton::East),
+        gilrs::Button::West => Some(GamepadButton::West),
+        gilrs::Button::North => Some(GamepadButton::North),
+        gilrs::Button::LeftTrigger => Some(GamepadButton::LB),
+        gilrs::Button::RightTrigger => Some(GamepadButton::RB),
+        gilrs::Button::LeftTrigger2 => Some(GamepadButton::LT),
+        gilrs::Button::RightTrigger2 => Some(GamepadButton::RT),
+        gilrs::Button::Select => Some(GamepadButton::Select),
+        gilrs::Button::Start => Some(GamepadButton::Start),
+        gilrs::Button::LeftThumb => Some(GamepadButton::LeftStick),
+        gilrs::Button::RightThumb => Some(GamepadButton::RightStick),
+        gilrs::Button::DPadUp => Some(GamepadButton::DPadUp),
+        gilrs::Button::DPadDown => Some(GamepadButton::DPadDown),
+        gilrs::Button::DPadLeft => Some(GamepadButton::DPadLeft),
+        gilrs::Button::DPadRight => Some(GamepadButton::DPadRight),
+        _ => None,
+    }
 }
 
 fn update_keyboard_state(mut keys: ResMut<Input<KeyCode>>, mut events: EventReader<KeyInput>) {
@@ -84,8 +158,8 @@ fn update_mouse_position_state(
 #[cfg(test)]
 mod tests {
     use crate::{
-        state::Input, CursorMoved, ElementState, InputPlugin, KeyCode, KeyInput, MouseButton,
-        MouseInput, MouseMotion, MouseState,
+        state::Input, CursorMoved, ElementState, GamepadButton, GamepadSticks, InputPlugin,
+        KeyCode, KeyInput, MouseButton, MouseInput, MouseMotion, MouseState,
     };
     use bevy_ecs::event::Events;
     use bsengine_app::new_app;
@@ -256,5 +330,19 @@ mod tests {
         let mut app = new_app();
         app.add_plugins(InputPlugin);
         assert!(app.world().get_resource::<MouseState>().is_some());
+    }
+
+    #[test]
+    fn input_plugin_registers_gamepad_button_resource() {
+        let mut app = new_app();
+        app.add_plugins(InputPlugin);
+        assert!(app.world().get_resource::<Input<GamepadButton>>().is_some());
+    }
+
+    #[test]
+    fn input_plugin_registers_gamepad_sticks_resource() {
+        let mut app = new_app();
+        app.add_plugins(InputPlugin);
+        assert!(app.world().get_resource::<GamepadSticks>().is_some());
     }
 }

--- a/crates/bsengine-input/src/types.rs
+++ b/crates/bsengine-input/src/types.rs
@@ -1,3 +1,4 @@
+use bevy_ecs::prelude::Resource;
 use bsengine_ecs::Event;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -89,6 +90,36 @@ pub struct CursorMoved {
 pub struct MouseMotion {
     pub dx: f64,
     pub dy: f64,
+}
+
+/// Gamepad face and shoulder buttons. Bit indices match the scripting API (0=South..15=DPadRight).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GamepadButton {
+    South,      // 0: A / Cross
+    East,       // 1: B / Circle
+    West,       // 2: X / Square
+    North,      // 3: Y / Triangle
+    LB,         // 4: L1 / LeftBumper
+    RB,         // 5: R1 / RightBumper
+    LT,         // 6: L2 / LeftTrigger (digital)
+    RT,         // 7: R2 / RightTrigger (digital)
+    Select,     // 8
+    Start,      // 9
+    LeftStick,  // 10: L3
+    RightStick, // 11: R3
+    DPadUp,     // 12
+    DPadDown,   // 13
+    DPadLeft,   // 14
+    DPadRight,  // 15
+}
+
+/// Analog stick and trigger values from the first connected gamepad.
+#[derive(Resource, Default, Clone)]
+pub struct GamepadSticks {
+    pub left: (f32, f32),
+    pub right: (f32, f32),
+    pub left_trigger: f32,
+    pub right_trigger: f32,
 }
 
 #[cfg(test)]

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -125,6 +125,14 @@ thread_local! {
     // Entity name lookup for raycast results: entity.to_bits() → name
     pub(crate) static ENTITY_NAME_MAP: RefCell<HashMap<u64, String>> =
         RefCell::new(HashMap::new());
+
+    // Gamepad button state (bit 0=South..15=DPadRight)
+    pub(crate) static GAMEPAD_BUTTON_SNAPSHOT: RefCell<u16> = RefCell::new(0);
+    pub(crate) static GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT: RefCell<u16> = RefCell::new(0);
+    pub(crate) static GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT: RefCell<u16> = RefCell::new(0);
+    // (left_x, left_y, right_x, right_y, left_trigger, right_trigger)
+    pub(crate) static GAMEPAD_STICKS_SNAPSHOT: RefCell<(f32, f32, f32, f32, f32, f32)> =
+        RefCell::new((0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
 }
 
 /// Full transform returned to scripts: position + rotation quaternion + scale.
@@ -382,6 +390,60 @@ pub fn bsengine_raycast(
     })
 }
 
+#[op2(fast)]
+pub fn bsengine_is_gamepad_button(button: u32) -> bool {
+    if button > 15 {
+        return false;
+    }
+    GAMEPAD_BUTTON_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
+}
+
+#[op2(fast)]
+pub fn bsengine_is_gamepad_button_down(button: u32) -> bool {
+    if button > 15 {
+        return false;
+    }
+    GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
+}
+
+#[op2(fast)]
+pub fn bsengine_is_gamepad_button_up(button: u32) -> bool {
+    if button > 15 {
+        return false;
+    }
+    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
+}
+
+#[op2]
+#[serde]
+pub fn bsengine_get_left_stick() -> Vec<f32> {
+    GAMEPAD_STICKS_SNAPSHOT.with(|s| {
+        let v = *s.borrow();
+        vec![v.0, v.1]
+    })
+}
+
+#[op2]
+#[serde]
+pub fn bsengine_get_right_stick() -> Vec<f32> {
+    GAMEPAD_STICKS_SNAPSHOT.with(|s| {
+        let v = *s.borrow();
+        vec![v.2, v.3]
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_gamepad_trigger(side: u32) -> f32 {
+    GAMEPAD_STICKS_SNAPSHOT.with(|s| {
+        let v = *s.borrow();
+        if side == 0 {
+            v.4
+        } else {
+            v.5
+        }
+    })
+}
+
 deno_core::extension!(
     bsengine_ops,
     ops = [
@@ -410,6 +472,12 @@ deno_core::extension!(
         bsengine_get_mouse_pos,
         bsengine_get_mouse_delta,
         bsengine_raycast,
+        bsengine_is_gamepad_button,
+        bsengine_is_gamepad_button_down,
+        bsengine_is_gamepad_button_up,
+        bsengine_get_left_stick,
+        bsengine_get_right_stick,
+        bsengine_get_gamepad_trigger,
     ],
 );
 
@@ -449,6 +517,14 @@ const Bsengine = {
     // Raycast: origin/{x,y,z}, dir/{x,y,z}, maxDist → {entityName, point, normal, distance} or null
     raycast:        (origin, dir, maxDist) =>
         Deno.core.ops.bsengine_raycast(origin.x, origin.y, origin.z, dir.x, dir.y, dir.z, maxDist),
+
+    // Gamepad (btn: 0=South/A..15=DPadRight; side: 0=L2, 1=R2)
+    isGamepadButton:     (btn)  => Deno.core.ops.bsengine_is_gamepad_button(btn),
+    isGamepadButtonDown: (btn)  => Deno.core.ops.bsengine_is_gamepad_button_down(btn),
+    isGamepadButtonUp:   (btn)  => Deno.core.ops.bsengine_is_gamepad_button_up(btn),
+    getLeftStick:        ()     => { const v = Deno.core.ops.bsengine_get_left_stick(); return { x: v[0], y: v[1] }; },
+    getRightStick:       ()     => { const v = Deno.core.ops.bsengine_get_right_stick(); return { x: v[0], y: v[1] }; },
+    getGamepadTrigger:   (side) => Deno.core.ops.bsengine_get_gamepad_trigger(side),
 
     // Timers — frame-based (1 frame ≈ 1 tick)
     _timers: [],
@@ -680,6 +756,34 @@ mod tests {
         .unwrap();
         let r = rt.eval("String(received)").unwrap();
         assert!(r.contains("42"), "expected 42: {r}");
+    }
+
+    #[test]
+    fn is_gamepad_button_returns_false_initially() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"Bsengine.isGamepadButton(0) ? "yes" : "no""#)
+            .unwrap();
+        assert!(r.contains("no"), "expected not pressed: {r}");
+    }
+
+    #[test]
+    fn get_left_stick_returns_zeros_initially() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getLeftStick())"#)
+            .unwrap();
+        assert!(r.contains("0"), "expected zeros: {r}");
+    }
+
+    #[test]
+    fn get_gamepad_trigger_returns_zero_initially() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getGamepadTrigger(0))"#).unwrap();
+        assert!(r.contains("0"), "expected 0: {r}");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -4,7 +4,7 @@ use bevy_app::{App, Plugin, PostStartup, Update};
 use bevy_ecs::prelude::*;
 use bsengine_audio::AudioWorld;
 use bsengine_core::{GlobalTransform, HudTexts, Material, Transform};
-use bsengine_input::{Input, KeyCode, MouseButton, MouseState};
+use bsengine_input::{GamepadButton, GamepadSticks, Input, KeyCode, MouseButton, MouseState};
 use bsengine_physics::CollisionEvent;
 use bsengine_physics::PhysicsWorld;
 use bsengine_scene::{Name, PendingSceneLoad, Primitive, PrimitiveMesh, ScriptPath};
@@ -12,9 +12,11 @@ use glam::{Quat, Vec3};
 
 use crate::ops::{
     ScriptCommand, SpawnParams, BOOTSTRAP_JS, COLLISION_SNAPSHOT, COMMAND_BUFFER,
-    ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT,
-    KEY_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
-    MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PHYSICS_WORLD_PTR, TRANSFORM_SNAPSHOT,
+    ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
+    KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
+    MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
+    MOUSE_PRESSED_SNAPSHOT, PHYSICS_WORLD_PTR, TRANSFORM_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -233,6 +235,61 @@ fn run_scripts(world: &mut World) {
         .map(|ms| (ms.position, ms.delta))
         .unwrap_or(((0.0, 0.0), (0.0, 0.0)));
 
+    const GAMEPAD_MAPPINGS: &[(GamepadButton, u32)] = &[
+        (GamepadButton::South, 0),
+        (GamepadButton::East, 1),
+        (GamepadButton::West, 2),
+        (GamepadButton::North, 3),
+        (GamepadButton::LB, 4),
+        (GamepadButton::RB, 5),
+        (GamepadButton::LT, 6),
+        (GamepadButton::RT, 7),
+        (GamepadButton::Select, 8),
+        (GamepadButton::Start, 9),
+        (GamepadButton::LeftStick, 10),
+        (GamepadButton::RightStick, 11),
+        (GamepadButton::DPadUp, 12),
+        (GamepadButton::DPadDown, 13),
+        (GamepadButton::DPadLeft, 14),
+        (GamepadButton::DPadRight, 15),
+    ];
+
+    let (gpad_pressed, gpad_just_pressed, gpad_just_released): (u16, u16, u16) =
+        if let Some(gpad) = world.get_resource::<Input<GamepadButton>>() {
+            let mut p = 0u16;
+            let mut jp = 0u16;
+            let mut jr = 0u16;
+            for &(btn, bit) in GAMEPAD_MAPPINGS {
+                let mask = 1u16 << bit;
+                if gpad.is_pressed(&btn) {
+                    p |= mask;
+                }
+                if gpad.just_pressed(&btn) {
+                    jp |= mask;
+                }
+                if gpad.just_released(&btn) {
+                    jr |= mask;
+                }
+            }
+            (p, jp, jr)
+        } else {
+            (0, 0, 0)
+        };
+
+    let gamepad_sticks = world
+        .get_resource::<GamepadSticks>()
+        .map(|s| {
+            (
+                s.left.0,
+                s.left.1,
+                s.right.0,
+                s.right.1,
+                s.left_trigger,
+                s.right_trigger,
+            )
+        })
+        .unwrap_or((0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+
     let physics_ptr = world
         .get_resource::<PhysicsWorld>()
         .map(|pw| pw as *const PhysicsWorld)
@@ -281,6 +338,10 @@ fn run_scripts(world: &mut World) {
     MOUSE_DELTA_SNAPSHOT.with(|s| *s.borrow_mut() = mouse_delta);
     ENTITY_NAME_MAP.with(|m| *m.borrow_mut() = entity_name_map);
     PHYSICS_WORLD_PTR.with(|p| *p.borrow_mut() = physics_ptr);
+    GAMEPAD_BUTTON_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_pressed);
+    GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_just_pressed);
+    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_just_released);
+    GAMEPAD_STICKS_SNAPSHOT.with(|s| *s.borrow_mut() = gamepad_sticks);
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
 
     if let Some(mut rt) = world.get_non_send_resource_mut::<ScriptRuntimeResource>() {


### PR DESCRIPTION
## Summary

- `gilrs 0.11` integration in `bsengine-input`: `GamepadButton` enum (South/East/West/North, LB/RB, LT/RT, Select/Start, L3/R3, DPad×4), `GamepadSticks` resource (analog sticks + triggers), `GilrsResource` (NonSend), `poll_gamepad_events` system
- 6 new `#[op2]` scripting ops: `isGamepadButton`, `isGamepadButtonDown`, `isGamepadButtonUp`, `getLeftStick`, `getRightStick`, `getGamepadTrigger`
- `Bsengine.*` JS API: button bit indices 0=South…15=DPadRight; stick axes −1..1, triggers 0..1
- Graceful fallback via `eprintln!` when no gamepad hardware is present (gilrs init failure)
- 5 new tests (2 resource registration in input, 3 op-default checks in scripting)

## Test plan

- [x] `cargo test --workspace --exclude bsengine-editor` all green
- [x] `cargo +nightly fmt --all` applied before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)