### PR TITLE
feat(scripting): add setVisible/getVisible API

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -79,6 +79,10 @@ pub enum ScriptCommand {
     Destroy {
         name: String,
     },
+    SetVisible {
+        name: String,
+        visible: bool,
+    },
     PlaySound {
         id: u32,
         path: String,
@@ -144,6 +148,9 @@ thread_local! {
     // (left_x, left_y, right_x, right_y, left_trigger, right_trigger)
     pub(crate) static GAMEPAD_STICKS_SNAPSHOT: RefCell<(f32, f32, f32, f32, f32, f32)> =
         RefCell::new((0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+
+    pub(crate) static VISIBLE_SNAPSHOT: RefCell<HashMap<String, bool>> =
+        RefCell::new(HashMap::new());
 }
 
 /// Full transform returned to scripts: position + rotation quaternion + scale.
@@ -276,6 +283,19 @@ pub fn bsengine_spawn(#[serde] params: SpawnParams) {
 #[op2(fast)]
 pub fn bsengine_destroy(#[string] name: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::Destroy { name }));
+}
+
+#[op2(fast)]
+pub fn bsengine_set_visible(#[string] name: String, visible: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVisible { name, visible });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_visible(#[string] name: String) -> bool {
+    VISIBLE_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(true))
 }
 
 #[op2(fast)]
@@ -477,6 +497,8 @@ deno_core::extension!(
         bsengine_set_color,
         bsengine_spawn,
         bsengine_destroy,
+        bsengine_set_visible,
+        bsengine_get_visible,
         bsengine_play_sound,
         bsengine_stop_sound,
         bsengine_set_hud_text,
@@ -514,6 +536,8 @@ const Bsengine = {
     setColor:       (name, r, g, b)        => Deno.core.ops.bsengine_set_color(name, r, g, b),
     spawn:          (params)               => Deno.core.ops.bsengine_spawn(params),
     destroy:        (name)                 => Deno.core.ops.bsengine_destroy(name),
+    setVisible:     (name, v)              => Deno.core.ops.bsengine_set_visible(name, v),
+    getVisible:     (name)                 => Deno.core.ops.bsengine_get_visible(name),
     playSound:      (path, opts) => {
         const v = (opts && opts.volume !== undefined) ? opts.volume : 1.0;
         const l = (opts && opts.loop) ? true : false;
@@ -843,6 +867,28 @@ mod tests {
         .unwrap();
         let r = rt.eval("hit").unwrap();
         assert!(r.contains("Floor"), "expected Floor: {r}");
+    }
+
+    #[test]
+    fn get_visible_returns_true_for_unknown_entity() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        // Unknown entity defaults to visible=true
+        let r = rt
+            .eval(r#"Bsengine.getVisible("NonExistent") ? "visible" : "hidden""#)
+            .unwrap();
+        assert!(r.contains("visible"), "expected visible by default: {r}");
+    }
+
+    #[test]
+    fn set_visible_queues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        // Should not throw
+        let r = rt
+            .eval(r#"Bsengine.setVisible("Cube", false); "ok""#)
+            .unwrap();
+        assert!(r.contains("ok"), "setVisible threw: {r}");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use bevy_app::{App, Plugin, PostStartup, Update};
 use bevy_ecs::prelude::*;
 use bsengine_audio::AudioWorld;
-use bsengine_core::{GlobalTransform, HudTexts, Material, SkyboxPath, Transform};
+use bsengine_core::{GlobalTransform, HudTexts, Material, SkyboxPath, Transform, Visible};
 use bsengine_input::{GamepadButton, GamepadSticks, Input, KeyCode, MouseButton, MouseState};
 use bsengine_physics::CollisionEvent;
 use bsengine_physics::PhysicsWorld;
@@ -16,7 +16,7 @@ use crate::ops::{
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
     KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
     MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
-    MOUSE_PRESSED_SNAPSHOT, PHYSICS_WORLD_PTR, TRANSFORM_SNAPSHOT,
+    MOUSE_PRESSED_SNAPSHOT, PHYSICS_WORLD_PTR, TRANSFORM_SNAPSHOT, VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -165,6 +165,13 @@ fn run_scripts(world: &mut World) {
         let mut q = world.query::<(&Name, &Transform)>();
         q.iter(world)
             .map(|(n, t)| (n.0.clone(), (t.translation, t.rotation, t.scale)))
+            .collect()
+    };
+
+    let visible_snapshot: HashMap<String, bool> = {
+        let mut q = world.query::<(&Name, &Visible)>();
+        q.iter(world)
+            .map(|(n, v)| (n.0.clone(), v.is_visible))
             .collect()
     };
 
@@ -327,6 +334,7 @@ fn run_scripts(world: &mut World) {
     });
 
     TRANSFORM_SNAPSHOT.with(|s| *s.borrow_mut() = transform_snapshot);
+    VISIBLE_SNAPSHOT.with(|s| *s.borrow_mut() = visible_snapshot);
     KEY_SNAPSHOT.with(|k| *k.borrow_mut() = key_snapshot);
     KEY_JUST_PRESSED_SNAPSHOT.with(|k| *k.borrow_mut() = key_just_pressed);
     KEY_JUST_RELEASED_SNAPSHOT.with(|k| *k.borrow_mut() = key_just_released);
@@ -496,6 +504,15 @@ fn run_scripts(world: &mut World) {
             }
             ScriptCommand::LoadScene { path } => {
                 world.insert_resource(PendingSceneLoad { path });
+            }
+            ScriptCommand::SetVisible { name, visible } => {
+                let mut q = world.query::<(&Name, &mut Visible)>();
+                for (n, mut v) in q.iter_mut(world) {
+                    if n.0 == name {
+                        v.is_visible = visible;
+                        break;
+                    }
+                }
             }
             ScriptCommand::SetSkybox { path } => {
                 let project_dir = world


### PR DESCRIPTION
## Summary

- `Bsengine.setVisible(name, bool)` — show/hide a named entity at runtime
- `Bsengine.getVisible(name)` — query current visibility (defaults `true` for unknown entities)
- `VISIBLE_SNAPSHOT` thread_local captures `Visible.is_visible` from all named entities before V8 runs each frame
- `SetVisible` command updates the ECS `Visible` component via `execute_command`

## Test plan

- [ ] All existing tests pass (17820+ tests, 0 failed)
- [ ] `get_visible_returns_true_for_unknown_entity`: unknown entity defaults to visible
- [ ] `set_visible_queues_command`: `setVisible` call doesn't throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)