### PR TITLE
feat(scripting): add getParent/getChildren hierarchy query API

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -169,6 +169,13 @@ thread_local! {
     pub(crate) static TIME_DELTA_SNAPSHOT: RefCell<f32> = RefCell::new(0.0);
 
     pub(crate) static SCREEN_SIZE_SNAPSHOT: RefCell<(u32, u32)> = RefCell::new((1280, 720));
+
+    // child_name → parent_name (only for entities that have a Parent component)
+    pub(crate) static PARENT_SNAPSHOT: RefCell<HashMap<String, String>> =
+        RefCell::new(HashMap::new());
+    // parent_name → [child_names]
+    pub(crate) static CHILDREN_SNAPSHOT: RefCell<HashMap<String, Vec<String>>> =
+        RefCell::new(HashMap::new());
 }
 
 /// Full transform returned to scripts: position + rotation quaternion + scale.
@@ -369,6 +376,27 @@ pub fn bsengine_clear_parent(#[string] child: String) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut().push(ScriptCommand::ClearParent { child });
     });
+}
+
+#[op2]
+#[string]
+pub fn bsengine_get_parent(#[string] name: String) -> String {
+    PARENT_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .cloned()
+            .map(|p| format!("\"{p}\""))
+            .unwrap_or_else(|| "null".to_string())
+    })
+}
+
+#[op2]
+#[string]
+pub fn bsengine_get_children(#[string] name: String) -> String {
+    CHILDREN_SNAPSHOT.with(|s| {
+        serde_json::to_string(s.borrow().get(&name).unwrap_or(&Vec::new()))
+            .unwrap_or_else(|_| "[]".to_string())
+    })
 }
 
 #[op2(fast)]
@@ -594,6 +622,8 @@ deno_core::extension!(
         bsengine_get_screen_size,
         bsengine_set_parent,
         bsengine_clear_parent,
+        bsengine_get_parent,
+        bsengine_get_children,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
         bsengine_play_sound,
@@ -643,6 +673,8 @@ const Bsengine = {
     getScreenSize:  ()                     => { const [w, h] = Deno.core.ops.bsengine_get_screen_size(); return { width: w, height: h }; },
     setParent:      (child, parent)        => Deno.core.ops.bsengine_set_parent(child, parent),
     clearParent:      (child)   => Deno.core.ops.bsengine_clear_parent(child),
+    getParent:        (name)    => { const r = Deno.core.ops.bsengine_get_parent(name); return JSON.parse(r); },
+    getChildren:      (name)    => JSON.parse(Deno.core.ops.bsengine_get_children(name)),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
     playSound:      (path, opts) => {
@@ -1210,6 +1242,56 @@ JSON.stringify(received)
             )
             .unwrap();
         assert!(r.contains("not_called"), "expected not_called: {r}");
+    }
+
+    #[test]
+    fn get_parent_returns_null_when_no_snapshot() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getParent("Child"))"#).unwrap();
+        assert!(
+            r.contains("null") || r.contains("undefined"),
+            "expected null: {r}"
+        );
+    }
+
+    #[test]
+    fn get_parent_returns_name_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::PARENT_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Child".to_string(), "Root".to_string());
+        });
+        let r = rt.eval(r#"Bsengine.getParent("Child")"#).unwrap();
+        assert!(r.contains("Root"), "expected Root: {r}");
+    }
+
+    #[test]
+    fn get_children_returns_empty_when_no_snapshot() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getChildren("Root"))"#)
+            .unwrap();
+        assert!(r.contains("[]"), "expected empty array: {r}");
+    }
+
+    #[test]
+    fn get_children_returns_list_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::CHILDREN_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Root".to_string(),
+                vec!["ChildA".to_string(), "ChildB".to_string()],
+            );
+        });
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getChildren("Root"))"#)
+            .unwrap();
+        assert!(r.contains("ChildA"), "expected ChildA: {r}");
+        assert!(r.contains("ChildB"), "expected ChildB: {r}");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -14,13 +14,13 @@ use bsengine_scene::{Name, PendingSceneLoad, Primitive, PrimitiveMesh, ScriptPat
 use glam::{Quat, Vec3};
 
 use crate::ops::{
-    ScriptCommand, SpawnParams, BOOTSTRAP_JS, COLLISION_SNAPSHOT, COMMAND_BUFFER,
-    ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    ScriptCommand, SpawnParams, BOOTSTRAP_JS, CHILDREN_SNAPSHOT, COLLISION_SNAPSHOT,
+    COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
     KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
     MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
-    MOUSE_PRESSED_SNAPSHOT, PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT, TIME_DELTA_SNAPSHOT,
-    TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VISIBLE_SNAPSHOT,
+    MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT,
+    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -324,6 +324,24 @@ fn run_scripts(world: &mut World) {
             .collect()
     };
 
+    let parent_map: HashMap<String, String> = {
+        let mut q = world.query::<(Entity, &Name, &Parent)>();
+        q.iter(world)
+            .filter_map(|(_, n, p)| {
+                entity_name_map
+                    .get(&p.0.to_bits())
+                    .map(|pn| (n.0.clone(), pn.clone()))
+            })
+            .collect()
+    };
+    let children_map: HashMap<String, Vec<String>> = {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for (child, parent) in &parent_map {
+            map.entry(parent.clone()).or_default().push(child.clone());
+        }
+        map
+    };
+
     let scripted: Vec<(String, String)> = {
         let mut q = world.query::<(Entity, &Name, &Script)>();
         q.iter(world)
@@ -376,6 +394,8 @@ fn run_scripts(world: &mut World) {
     MOUSE_POS_SNAPSHOT.with(|s| *s.borrow_mut() = mouse_pos);
     MOUSE_DELTA_SNAPSHOT.with(|s| *s.borrow_mut() = mouse_delta);
     ENTITY_NAME_MAP.with(|m| *m.borrow_mut() = entity_name_map);
+    PARENT_SNAPSHOT.with(|s| *s.borrow_mut() = parent_map);
+    CHILDREN_SNAPSHOT.with(|s| *s.borrow_mut() = children_map);
     PHYSICS_WORLD_PTR.with(|p| *p.borrow_mut() = physics_ptr);
     GAMEPAD_BUTTON_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_pressed);
     GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_just_pressed);


### PR DESCRIPTION
## Summary
- `Bsengine.getParent(name)` → entity name string or null
- `Bsengine.getChildren(name)` → string array (empty if no children)
- Built from `Parent` components each frame into `PARENT_SNAPSHOT` and `CHILDREN_SNAPSHOT` before V8 runs — pure read side, no mutations

## Test plan
- [ ] `get_parent_returns_null_when_no_snapshot`
- [ ] `get_parent_returns_name_when_snapshot_set`
- [ ] `get_children_returns_empty_when_no_snapshot`
- [ ] `get_children_returns_list_when_snapshot_set`
- [ ] All 46 scripting tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)