### PR TITLE
feat(scripting): add getVelocity/setVelocity/addImpulse/addForce physics API

### DIFF
--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -103,6 +103,7 @@ fn spawn_bodies(
 
         let collider_handle = world.add_collider(coll, body_handle);
         world.collider_entity_map.insert(collider_handle, entity);
+        world.register_entity_body(entity, body_handle);
 
         commands.entity(entity).insert((
             PhysicsHandles {

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -12,6 +12,7 @@ pub struct PhysicsWorld {
     pub(crate) rigid_body_set: RigidBodySet,
     pub(crate) collider_set: ColliderSet,
     pub(crate) collider_entity_map: HashMap<ColliderHandle, Entity>,
+    pub(crate) entity_body_map: HashMap<Entity, RigidBodyHandle>,
     gravity: Vector,
     integration_parameters: IntegrationParameters,
     physics_pipeline: PhysicsPipeline,
@@ -35,6 +36,7 @@ impl PhysicsWorld {
             rigid_body_set: RigidBodySet::new(),
             collider_set: ColliderSet::new(),
             collider_entity_map: HashMap::new(),
+            entity_body_map: HashMap::new(),
             gravity: Vector::new(0.0, -gravity_magnitude, 0.0),
             integration_parameters: IntegrationParameters::default(),
             physics_pipeline: PhysicsPipeline::new(),
@@ -79,6 +81,41 @@ impl PhysicsWorld {
 
     pub fn set_gravity(&mut self, magnitude: f32) {
         self.gravity = Vector::new(0.0, -magnitude, 0.0);
+    }
+
+    pub(crate) fn register_entity_body(&mut self, entity: Entity, handle: RigidBodyHandle) {
+        self.entity_body_map.insert(entity, handle);
+    }
+
+    pub fn get_linvel(&self, entity: Entity) -> Option<Vec3> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        let v = body.linvel();
+        Some(Vec3::new(v.x, v.y, v.z))
+    }
+
+    pub fn set_linvel(&mut self, entity: Entity, vel: Vec3) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.set_linvel(Vector::new(vel.x, vel.y, vel.z), true);
+            }
+        }
+    }
+
+    pub fn apply_impulse(&mut self, entity: Entity, impulse: Vec3) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.apply_impulse(Vector::new(impulse.x, impulse.y, impulse.z), true);
+            }
+        }
+    }
+
+    pub fn apply_force(&mut self, entity: Entity, force: Vec3) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.add_force(Vector::new(force.x, force.y, force.z), true);
+            }
+        }
     }
 
     /// Cast a ray into the physics world. Returns hit info or None.

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -118,6 +118,24 @@ pub enum ScriptCommand {
     SetCursorLocked {
         locked: bool,
     },
+    AddImpulse {
+        name: String,
+        fx: f32,
+        fy: f32,
+        fz: f32,
+    },
+    AddForce {
+        name: String,
+        fx: f32,
+        fy: f32,
+        fz: f32,
+    },
+    SetVelocity {
+        name: String,
+        vx: f32,
+        vy: f32,
+        vz: f32,
+    },
 }
 
 thread_local! {
@@ -169,6 +187,10 @@ thread_local! {
     pub(crate) static TIME_DELTA_SNAPSHOT: RefCell<f32> = RefCell::new(0.0);
 
     pub(crate) static SCREEN_SIZE_SNAPSHOT: RefCell<(u32, u32)> = RefCell::new((1280, 720));
+
+    // name → linear velocity Vec3 (only for entities with a physics body)
+    pub(crate) static VELOCITY_SNAPSHOT: RefCell<HashMap<String, Vec3>> =
+        RefCell::new(HashMap::new());
 
     // child_name → parent_name (only for entities that have a Parent component)
     pub(crate) static PARENT_SNAPSHOT: RefCell<HashMap<String, String>> =
@@ -399,6 +421,36 @@ pub fn bsengine_get_children(#[string] name: String) -> String {
     })
 }
 
+#[op2]
+#[serde]
+pub fn bsengine_get_velocity(#[string] name: String) -> Option<Vec<f32>> {
+    VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| vec![v.x, v.y, v.z]))
+}
+
+#[op2(fast)]
+pub fn bsengine_add_impulse(#[string] name: String, fx: f32, fy: f32, fz: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AddImpulse { name, fx, fy, fz });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_add_force(#[string] name: String, fx: f32, fy: f32, fz: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AddForce { name, fx, fy, fz });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVelocity { name, vx, vy, vz });
+    });
+}
+
 #[op2(fast)]
 pub fn bsengine_set_cursor_visible(visible: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -624,6 +676,10 @@ deno_core::extension!(
         bsengine_clear_parent,
         bsengine_get_parent,
         bsengine_get_children,
+        bsengine_get_velocity,
+        bsengine_add_impulse,
+        bsengine_add_force,
+        bsengine_set_velocity,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
         bsengine_play_sound,
@@ -675,6 +731,10 @@ const Bsengine = {
     clearParent:      (child)   => Deno.core.ops.bsengine_clear_parent(child),
     getParent:        (name)    => { const r = Deno.core.ops.bsengine_get_parent(name); return JSON.parse(r); },
     getChildren:      (name)    => JSON.parse(Deno.core.ops.bsengine_get_children(name)),
+    getVelocity:      (name)    => { const v = Deno.core.ops.bsengine_get_velocity(name); return v ? { x: v[0], y: v[1], z: v[2] } : null; },
+    addImpulse:       (name, fx, fy, fz) => Deno.core.ops.bsengine_add_impulse(name, fx, fy, fz),
+    addForce:         (name, fx, fy, fz) => Deno.core.ops.bsengine_add_force(name, fx, fy, fz),
+    setVelocity:      (name, vx, vy, vz) => Deno.core.ops.bsengine_set_velocity(name, vx, vy, vz),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
     playSound:      (path, opts) => {
@@ -1292,6 +1352,64 @@ JSON.stringify(received)
             .unwrap();
         assert!(r.contains("ChildA"), "expected ChildA: {r}");
         assert!(r.contains("ChildB"), "expected ChildB: {r}");
+    }
+
+    #[test]
+    fn get_velocity_returns_null_when_no_snapshot() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getVelocity("Ball"))"#).unwrap();
+        assert!(
+            r.contains("null") || r.contains("undefined"),
+            "expected null: {r}"
+        );
+    }
+
+    #[test]
+    fn get_velocity_returns_vec_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::VELOCITY_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Ball".to_string(), glam::Vec3::new(1.0, 2.0, 3.0));
+        });
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getVelocity("Ball"))"#)
+            .unwrap();
+        assert!(r.contains("\"x\":1"), "expected x=1: {r}");
+        assert!(r.contains("\"y\":2"), "expected y=2: {r}");
+    }
+
+    #[test]
+    fn add_impulse_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.addImpulse("Ball", 0, 10, 0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::AddImpulse { name, fy, .. }
+                    if name == "Ball" && (*fy - 10.0).abs() < 1e-6)
+            });
+            assert!(found, "AddImpulse not in buffer");
+        });
+    }
+
+    #[test]
+    fn set_velocity_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setVelocity("Ball", 5, 0, 0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetVelocity { name, vx, .. }
+                    if name == "Ball" && (*vx - 5.0).abs() < 1e-6)
+            });
+            assert!(found, "SetVelocity not in buffer");
+        });
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -20,7 +20,8 @@ use crate::ops::{
     KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
     MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
     MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT,
-    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VISIBLE_SNAPSHOT,
+    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT,
+    VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -324,6 +325,19 @@ fn run_scripts(world: &mut World) {
             .collect()
     };
 
+    let velocity_snapshot: HashMap<String, Vec3> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.get_linvel(entity).map(|v| (name.clone(), v))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     let parent_map: HashMap<String, String> = {
         let mut q = world.query::<(Entity, &Name, &Parent)>();
         q.iter(world)
@@ -396,6 +410,7 @@ fn run_scripts(world: &mut World) {
     ENTITY_NAME_MAP.with(|m| *m.borrow_mut() = entity_name_map);
     PARENT_SNAPSHOT.with(|s| *s.borrow_mut() = parent_map);
     CHILDREN_SNAPSHOT.with(|s| *s.borrow_mut() = children_map);
+    VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = velocity_snapshot);
     PHYSICS_WORLD_PTR.with(|p| *p.borrow_mut() = physics_ptr);
     GAMEPAD_BUTTON_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_pressed);
     GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_just_pressed);
@@ -617,6 +632,36 @@ fn run_scripts(world: &mut World) {
                         visible: true,
                         locked,
                     });
+                }
+            }
+            ScriptCommand::AddImpulse { name, fx, fy, fz } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.apply_impulse(e, Vec3::new(fx, fy, fz));
+                }
+            }
+            ScriptCommand::AddForce { name, fx, fy, fz } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.apply_force(e, Vec3::new(fx, fy, fz));
+                }
+            }
+            ScriptCommand::SetVelocity { name, vx, vy, vz } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_linvel(e, Vec3::new(vx, vy, vz));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add `entity_body_map` to `PhysicsWorld` for entity-keyed rigid body access
- `Bsengine.getVelocity(name)` → `{x,y,z}` or null (read from per-frame snapshot)
- `Bsengine.setVelocity(name, vx, vy, vz)` — set linear velocity directly
- `Bsengine.addImpulse(name, fx, fy, fz)` — instantaneous velocity change
- `Bsengine.addForce(name, fx, fy, fz)` — apply force for current step
- All mutations use deferred ScriptCommand pattern, applied after V8 exits

## Test plan
- [ ] `get_velocity_returns_null_when_no_snapshot`
- [ ] `get_velocity_returns_vec_when_snapshot_set`
- [ ] `add_impulse_enqueues_command`
- [ ] `set_velocity_enqueues_command`
- [ ] 50 total scripting tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)