### PR TITLE
feat(scripting): add getAngularVelocity/setAngularVelocity/addAngularImpulse

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -118,6 +118,29 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn get_angvel(&self, entity: Entity) -> Option<Vec3> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        let v = body.angvel();
+        Some(Vec3::new(v.x, v.y, v.z))
+    }
+
+    pub fn set_angvel(&mut self, entity: Entity, vel: Vec3) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.set_angvel(Vector::new(vel.x, vel.y, vel.z), true);
+            }
+        }
+    }
+
+    pub fn apply_torque_impulse(&mut self, entity: Entity, impulse: Vec3) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.apply_torque_impulse(Vector::new(impulse.x, impulse.y, impulse.z), true);
+            }
+        }
+    }
+
     /// Cast a ray into the physics world. Returns hit info or None.
     pub fn cast_ray(&self, origin: Vec3, dir: Vec3, max_dist: f32) -> Option<RaycastHit> {
         // QueryPipeline<'a> borrows the sets so it is constructed per-call from the broad phase.

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -139,6 +139,18 @@ pub enum ScriptCommand {
     SetGravity {
         magnitude: f32,
     },
+    SetAngularVelocity {
+        name: String,
+        vx: f32,
+        vy: f32,
+        vz: f32,
+    },
+    AddAngularImpulse {
+        name: String,
+        vx: f32,
+        vy: f32,
+        vz: f32,
+    },
 }
 
 thread_local! {
@@ -196,6 +208,10 @@ thread_local! {
         RefCell::new(HashMap::new());
 
     pub(crate) static GRAVITY_SNAPSHOT: RefCell<f32> = RefCell::new(9.81);
+
+    // name → angular velocity Vec3 (only for entities with a physics body)
+    pub(crate) static ANGULAR_VELOCITY_SNAPSHOT: RefCell<HashMap<String, Vec3>> =
+        RefCell::new(HashMap::new());
 
     // child_name → parent_name (only for entities that have a Parent component)
     pub(crate) static PARENT_SNAPSHOT: RefCell<HashMap<String, String>> =
@@ -468,6 +484,28 @@ pub fn bsengine_set_gravity(magnitude: f32) {
     });
 }
 
+#[op2]
+#[serde]
+pub fn bsengine_get_angular_velocity(#[string] name: String) -> Option<Vec<f32>> {
+    ANGULAR_VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| vec![v.x, v.y, v.z]))
+}
+
+#[op2(fast)]
+pub fn bsengine_set_angular_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAngularVelocity { name, vx, vy, vz });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_add_angular_impulse(#[string] name: String, vx: f32, vy: f32, vz: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AddAngularImpulse { name, vx, vy, vz });
+    });
+}
+
 #[op2(fast)]
 pub fn bsengine_set_cursor_visible(visible: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -699,6 +737,9 @@ deno_core::extension!(
         bsengine_set_velocity,
         bsengine_get_gravity,
         bsengine_set_gravity,
+        bsengine_get_angular_velocity,
+        bsengine_set_angular_velocity,
+        bsengine_add_angular_impulse,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
         bsengine_play_sound,
@@ -754,8 +795,11 @@ const Bsengine = {
     addImpulse:       (name, fx, fy, fz) => Deno.core.ops.bsengine_add_impulse(name, fx, fy, fz),
     addForce:         (name, fx, fy, fz) => Deno.core.ops.bsengine_add_force(name, fx, fy, fz),
     setVelocity:      (name, vx, vy, vz) => Deno.core.ops.bsengine_set_velocity(name, vx, vy, vz),
-    getGravity:       ()         => Deno.core.ops.bsengine_get_gravity(),
-    setGravity:       (magnitude) => Deno.core.ops.bsengine_set_gravity(magnitude),
+    getGravity:           ()                     => Deno.core.ops.bsengine_get_gravity(),
+    setGravity:           (magnitude)             => Deno.core.ops.bsengine_set_gravity(magnitude),
+    getAngularVelocity:   (name)                  => { const v = Deno.core.ops.bsengine_get_angular_velocity(name); return v ? { x: v[0], y: v[1], z: v[2] } : null; },
+    setAngularVelocity:   (name, vx, vy, vz)      => Deno.core.ops.bsengine_set_angular_velocity(name, vx, vy, vz),
+    addAngularImpulse:    (name, vx, vy, vz)      => Deno.core.ops.bsengine_add_angular_impulse(name, vx, vy, vz),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
     playSound:      (path, opts) => {
@@ -1536,6 +1580,69 @@ JSON.stringify(received)
                     if (*magnitude).abs() < 1e-6)
             });
             assert!(found, "SetGravity not in buffer");
+        });
+    }
+
+    #[test]
+    fn get_angular_velocity_returns_null_when_no_snapshot() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getAngularVelocity("Spinner"))"#)
+            .unwrap();
+        assert!(
+            r.contains("null") || r.contains("undefined"),
+            "expected null: {r}"
+        );
+    }
+
+    #[test]
+    fn get_angular_velocity_returns_vec_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::ANGULAR_VELOCITY_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Spinner".to_string(), glam::Vec3::new(0.0, 3.14, 0.0));
+        });
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getAngularVelocity("Spinner"))"#)
+            .unwrap();
+        super::ANGULAR_VELOCITY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(
+            r.contains("\"y\":3.14") || r.contains("\"y\":3.1"),
+            "expected y≈3.14: {r}"
+        );
+    }
+
+    #[test]
+    fn set_angular_velocity_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setAngularVelocity("Top", 0, 5, 0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetAngularVelocity { name, vy, .. }
+                    if name == "Top" && (*vy - 5.0).abs() < 1e-6)
+            });
+            assert!(found, "SetAngularVelocity not in buffer");
+        });
+    }
+
+    #[test]
+    fn add_angular_impulse_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.addAngularImpulse("Top", 0, 2, 0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::AddAngularImpulse { name, vy, .. }
+                    if name == "Top" && (*vy - 2.0).abs() < 1e-6)
+            });
+            assert!(found, "AddAngularImpulse not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -1602,16 +1602,13 @@ JSON.stringify(received)
         rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
         super::ANGULAR_VELOCITY_SNAPSHOT.with(|s| {
             s.borrow_mut()
-                .insert("Spinner".to_string(), glam::Vec3::new(0.0, 3.14, 0.0));
+                .insert("Spinner".to_string(), glam::Vec3::new(0.0, 2.5, 0.0));
         });
         let r = rt
             .eval(r#"JSON.stringify(Bsengine.getAngularVelocity("Spinner"))"#)
             .unwrap();
         super::ANGULAR_VELOCITY_SNAPSHOT.with(|s| s.borrow_mut().clear());
-        assert!(
-            r.contains("\"y\":3.14") || r.contains("\"y\":3.1"),
-            "expected y≈3.14: {r}"
-        );
+        assert!(r.contains("\"y\":2.5"), "expected y=2.5: {r}");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -14,14 +14,14 @@ use bsengine_scene::{Name, PendingSceneLoad, Primitive, PrimitiveMesh, ScriptPat
 use glam::{Quat, Vec3};
 
 use crate::ops::{
-    ScriptCommand, SpawnParams, BOOTSTRAP_JS, CHILDREN_SNAPSHOT, COLLISION_SNAPSHOT,
-    COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
-    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
-    GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT,
-    MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
-    MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR,
-    SCREEN_SIZE_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT,
-    VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
+    ScriptCommand, SpawnParams, ANGULAR_VELOCITY_SNAPSHOT, BOOTSTRAP_JS, CHILDREN_SNAPSHOT,
+    COLLISION_SNAPSHOT, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
+    GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
+    GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
+    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT,
+    MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT,
+    PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
+    TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -338,6 +338,19 @@ fn run_scripts(world: &mut World) {
         })
         .unwrap_or_default();
 
+    let angular_velocity_snapshot: HashMap<String, Vec3> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.get_angvel(entity).map(|v| (name.clone(), v))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     let parent_map: HashMap<String, String> = {
         let mut q = world.query::<(Entity, &Name, &Parent)>();
         q.iter(world)
@@ -411,6 +424,7 @@ fn run_scripts(world: &mut World) {
     PARENT_SNAPSHOT.with(|s| *s.borrow_mut() = parent_map);
     CHILDREN_SNAPSHOT.with(|s| *s.borrow_mut() = children_map);
     VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = velocity_snapshot);
+    ANGULAR_VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = angular_velocity_snapshot);
     let gravity = world
         .get_resource::<PhysicsWorld>()
         .map(|pw| pw.gravity())
@@ -672,6 +686,26 @@ fn run_scripts(world: &mut World) {
             ScriptCommand::SetGravity { magnitude } => {
                 if let Some(mut pw) = world.get_resource_mut::<PhysicsWorld>() {
                     pw.set_gravity(magnitude);
+                }
+            }
+            ScriptCommand::SetAngularVelocity { name, vx, vy, vz } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_angvel(e, Vec3::new(vx, vy, vz));
+                }
+            }
+            ScriptCommand::AddAngularImpulse { name, vx, vy, vz } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.apply_torque_impulse(e, Vec3::new(vx, vy, vz));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds `get_angvel` / `set_angvel` / `apply_torque_impulse` to `PhysicsWorld` in bsengine-physics
- Adds `ANGULAR_VELOCITY_SNAPSHOT` thread-local populated each frame from `PhysicsWorld`
- Exposes `Bsengine.getAngularVelocity(name)` → `{x,y,z}|null`, `setAngularVelocity(name,vx,vy,vz)`, `addAngularImpulse(name,vx,vy,vz)` to JS
- 4 new tests; all 63 scripting tests pass

## Test plan
- [ ] `get_angular_velocity_returns_null_when_no_snapshot`
- [ ] `get_angular_velocity_returns_vec_when_snapshot_set`
- [ ] `set_angular_velocity_enqueues_command`
- [ ] `add_angular_impulse_enqueues_command`

🤖 Generated with [Claude Code](https://claude.com/claude-code)