### PR TITLE
feat(scripting): add setLinearDamping/setAngularDamping physics body control

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -141,6 +141,22 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn set_linear_damping(&mut self, entity: Entity, damping: f32) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.set_linear_damping(damping);
+            }
+        }
+    }
+
+    pub fn set_angular_damping(&mut self, entity: Entity, damping: f32) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.set_angular_damping(damping);
+            }
+        }
+    }
+
     /// Cast a ray into the physics world. Returns hit info or None.
     pub fn cast_ray(&self, origin: Vec3, dir: Vec3, max_dist: f32) -> Option<RaycastHit> {
         // QueryPipeline<'a> borrows the sets so it is constructed per-call from the broad phase.

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -151,6 +151,14 @@ pub enum ScriptCommand {
         vy: f32,
         vz: f32,
     },
+    SetLinearDamping {
+        name: String,
+        damping: f32,
+    },
+    SetAngularDamping {
+        name: String,
+        damping: f32,
+    },
 }
 
 thread_local! {
@@ -507,6 +515,22 @@ pub fn bsengine_add_angular_impulse(#[string] name: String, vx: f32, vy: f32, vz
 }
 
 #[op2(fast)]
+pub fn bsengine_set_linear_damping(#[string] name: String, damping: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetLinearDamping { name, damping });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_angular_damping(#[string] name: String, damping: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAngularDamping { name, damping });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_set_cursor_visible(visible: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
@@ -740,6 +764,8 @@ deno_core::extension!(
         bsengine_get_angular_velocity,
         bsengine_set_angular_velocity,
         bsengine_add_angular_impulse,
+        bsengine_set_linear_damping,
+        bsengine_set_angular_damping,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
         bsengine_play_sound,
@@ -800,6 +826,8 @@ const Bsengine = {
     getAngularVelocity:   (name)                  => { const v = Deno.core.ops.bsengine_get_angular_velocity(name); return v ? { x: v[0], y: v[1], z: v[2] } : null; },
     setAngularVelocity:   (name, vx, vy, vz)      => Deno.core.ops.bsengine_set_angular_velocity(name, vx, vy, vz),
     addAngularImpulse:    (name, vx, vy, vz)      => Deno.core.ops.bsengine_add_angular_impulse(name, vx, vy, vz),
+    setLinearDamping:     (name, damping)          => Deno.core.ops.bsengine_set_linear_damping(name, damping),
+    setAngularDamping:    (name, damping)          => Deno.core.ops.bsengine_set_angular_damping(name, damping),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
     playSound:      (path, opts) => {
@@ -1640,6 +1668,38 @@ JSON.stringify(received)
                     if name == "Top" && (*vy - 2.0).abs() < 1e-6)
             });
             assert!(found, "AddAngularImpulse not in buffer");
+        });
+    }
+
+    #[test]
+    fn set_linear_damping_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setLinearDamping("Ball", 0.5);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetLinearDamping { name, damping }
+                    if name == "Ball" && (*damping - 0.5).abs() < 1e-6)
+            });
+            assert!(found, "SetLinearDamping not in buffer");
+        });
+    }
+
+    #[test]
+    fn set_angular_damping_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setAngularDamping("Ball", 0.8);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetAngularDamping { name, damping }
+                    if name == "Ball" && (*damping - 0.8).abs() < 1e-6)
+            });
+            assert!(found, "SetAngularDamping not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -708,6 +708,26 @@ fn run_scripts(world: &mut World) {
                     pw.apply_torque_impulse(e, Vec3::new(vx, vy, vz));
                 }
             }
+            ScriptCommand::SetLinearDamping { name, damping } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_linear_damping(e, damping);
+                }
+            }
+            ScriptCommand::SetAngularDamping { name, damping } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_angular_damping(e, damping);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `set_linear_damping` / `set_angular_damping` to `PhysicsWorld` in bsengine-physics
- Exposes `Bsengine.setLinearDamping(name, damping)` and `Bsengine.setAngularDamping(name, damping)` to JS
- Queues `SetLinearDamping` / `SetAngularDamping` commands dispatched each frame via `run_scripts`
- 2 new tests; all 65 scripting tests pass

## Test plan
- [ ] `set_linear_damping_enqueues_command` — SetLinearDamping pushed to COMMAND_BUFFER with correct value
- [ ] `set_angular_damping_enqueues_command` — SetAngularDamping pushed to COMMAND_BUFFER with correct value

🤖 Generated with [Claude Code](https://claude.com/claude-code)