### PR TITLE
feat(scripting): add getMass/setMass physics body mass control

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -157,6 +157,20 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn get_mass(&self, entity: Entity) -> Option<f32> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        Some(body.mass())
+    }
+
+    pub fn set_mass(&mut self, entity: Entity, mass: f32) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.set_additional_mass(mass, true);
+            }
+        }
+    }
+
     /// Cast a ray into the physics world. Returns hit info or None.
     pub fn cast_ray(&self, origin: Vec3, dir: Vec3, max_dist: f32) -> Option<RaycastHit> {
         // QueryPipeline<'a> borrows the sets so it is constructed per-call from the broad phase.

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -159,6 +159,10 @@ pub enum ScriptCommand {
         name: String,
         damping: f32,
     },
+    SetMass {
+        name: String,
+        mass: f32,
+    },
 }
 
 thread_local! {
@@ -219,6 +223,10 @@ thread_local! {
 
     // name → angular velocity Vec3 (only for entities with a physics body)
     pub(crate) static ANGULAR_VELOCITY_SNAPSHOT: RefCell<HashMap<String, Vec3>> =
+        RefCell::new(HashMap::new());
+
+    // name → mass (only for entities with a physics body)
+    pub(crate) static MASS_SNAPSHOT: RefCell<HashMap<String, f32>> =
         RefCell::new(HashMap::new());
 
     // child_name → parent_name (only for entities that have a Parent component)
@@ -531,6 +539,18 @@ pub fn bsengine_set_angular_damping(#[string] name: String, damping: f32) {
 }
 
 #[op2(fast)]
+pub fn bsengine_get_mass(#[string] name: String) -> f32 {
+    MASS_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
+}
+
+#[op2(fast)]
+pub fn bsengine_set_mass(#[string] name: String, mass: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::SetMass { name, mass });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_set_cursor_visible(visible: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
@@ -766,6 +786,8 @@ deno_core::extension!(
         bsengine_add_angular_impulse,
         bsengine_set_linear_damping,
         bsengine_set_angular_damping,
+        bsengine_get_mass,
+        bsengine_set_mass,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
         bsengine_play_sound,
@@ -828,6 +850,8 @@ const Bsengine = {
     addAngularImpulse:    (name, vx, vy, vz)      => Deno.core.ops.bsengine_add_angular_impulse(name, vx, vy, vz),
     setLinearDamping:     (name, damping)          => Deno.core.ops.bsengine_set_linear_damping(name, damping),
     setAngularDamping:    (name, damping)          => Deno.core.ops.bsengine_set_angular_damping(name, damping),
+    getMass:              (name)                   => Deno.core.ops.bsengine_get_mass(name),
+    setMass:              (name, mass)             => Deno.core.ops.bsengine_set_mass(name, mass),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
     playSound:      (path, opts) => {
@@ -1700,6 +1724,41 @@ JSON.stringify(received)
                     if name == "Ball" && (*damping - 0.8).abs() < 1e-6)
             });
             assert!(found, "SetAngularDamping not in buffer");
+        });
+    }
+
+    #[test]
+    fn get_mass_returns_zero_when_no_snapshot() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getMass("Rock")"#).unwrap();
+        assert!(r.contains('0'), "expected 0: {r}");
+    }
+
+    #[test]
+    fn get_mass_returns_value_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::MASS_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Rock".to_string(), 5.0);
+        });
+        let r = rt.eval(r#"Bsengine.getMass("Rock")"#).unwrap();
+        super::MASS_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains('5'), "expected 5: {r}");
+    }
+
+    #[test]
+    fn set_mass_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setMass("Rock", 10.0);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetMass { name, mass }
+                    if name == "Rock" && (*mass - 10.0).abs() < 1e-6)
+            });
+            assert!(found, "SetMass not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -18,10 +18,11 @@ use crate::ops::{
     COLLISION_SNAPSHOT, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
     GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
     GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
-    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT,
-    MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT,
-    PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
-    TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
+    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MASS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
+    MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
+    MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT,
+    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT,
+    VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -420,11 +421,24 @@ fn run_scripts(world: &mut World) {
     MOUSE_JUST_RELEASED_SNAPSHOT.with(|s| *s.borrow_mut() = mb_just_released);
     MOUSE_POS_SNAPSHOT.with(|s| *s.borrow_mut() = mouse_pos);
     MOUSE_DELTA_SNAPSHOT.with(|s| *s.borrow_mut() = mouse_delta);
+    let mass_snapshot: HashMap<String, f32> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.get_mass(entity).map(|m| (name.clone(), m))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     ENTITY_NAME_MAP.with(|m| *m.borrow_mut() = entity_name_map);
     PARENT_SNAPSHOT.with(|s| *s.borrow_mut() = parent_map);
     CHILDREN_SNAPSHOT.with(|s| *s.borrow_mut() = children_map);
     VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = velocity_snapshot);
     ANGULAR_VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = angular_velocity_snapshot);
+    MASS_SNAPSHOT.with(|s| *s.borrow_mut() = mass_snapshot);
     let gravity = world
         .get_resource::<PhysicsWorld>()
         .map(|pw| pw.gravity())
@@ -726,6 +740,16 @@ fn run_scripts(world: &mut World) {
                 if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
                 {
                     pw.set_angular_damping(e, damping);
+                }
+            }
+            ScriptCommand::SetMass { name, mass } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_mass(e, mass);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds `get_mass` / `set_mass` to `PhysicsWorld` using Rapier's `body.mass()` / `body.set_additional_mass()`
- Adds `MASS_SNAPSHOT` thread-local (name → mass) populated each frame from `PhysicsWorld`
- Exposes `Bsengine.getMass(name)` → `f32` (0 if no physics body) and `Bsengine.setMass(name, mass)` to JS
- Fix: mass snapshot is built before `entity_name_map` is moved into `ENTITY_NAME_MAP.with()`
- 3 new tests; all 68 scripting tests pass

## Test plan
- [ ] `get_mass_returns_zero_when_no_snapshot` — returns 0 with empty snapshot
- [ ] `get_mass_returns_value_when_snapshot_set` — returns value when MASS_SNAPSHOT overridden
- [ ] `set_mass_enqueues_command` — SetMass pushed to COMMAND_BUFFER with correct value

🤖 Generated with [Claude Code](https://claude.com/claude-code)