### PR TITLE
feat(scripting): add lockRotation API to lock physics rotation axes

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -171,6 +171,14 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn lock_rotations(&mut self, entity: Entity, lock_x: bool, lock_y: bool, lock_z: bool) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.set_enabled_rotations(!lock_x, !lock_y, !lock_z, true);
+            }
+        }
+    }
+
     /// Cast a ray into the physics world. Returns hit info or None.
     pub fn cast_ray(&self, origin: Vec3, dir: Vec3, max_dist: f32) -> Option<RaycastHit> {
         // QueryPipeline<'a> borrows the sets so it is constructed per-call from the broad phase.

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -163,6 +163,12 @@ pub enum ScriptCommand {
         name: String,
         mass: f32,
     },
+    LockRotation {
+        name: String,
+        lock_x: bool,
+        lock_y: bool,
+        lock_z: bool,
+    },
 }
 
 thread_local! {
@@ -551,6 +557,18 @@ pub fn bsengine_set_mass(#[string] name: String, mass: f32) {
 }
 
 #[op2(fast)]
+pub fn bsengine_lock_rotation(#[string] name: String, lock_x: bool, lock_y: bool, lock_z: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::LockRotation {
+            name,
+            lock_x,
+            lock_y,
+            lock_z,
+        });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_set_cursor_visible(visible: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
@@ -788,6 +806,7 @@ deno_core::extension!(
         bsengine_set_angular_damping,
         bsengine_get_mass,
         bsengine_set_mass,
+        bsengine_lock_rotation,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
         bsengine_play_sound,
@@ -852,6 +871,7 @@ const Bsengine = {
     setAngularDamping:    (name, damping)          => Deno.core.ops.bsengine_set_angular_damping(name, damping),
     getMass:              (name)                   => Deno.core.ops.bsengine_get_mass(name),
     setMass:              (name, mass)             => Deno.core.ops.bsengine_set_mass(name, mass),
+    lockRotation:         (name, lockX, lockY, lockZ) => Deno.core.ops.bsengine_lock_rotation(name, lockX, lockY, lockZ),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
     playSound:      (path, opts) => {
@@ -1759,6 +1779,22 @@ JSON.stringify(received)
                     if name == "Rock" && (*mass - 10.0).abs() < 1e-6)
             });
             assert!(found, "SetMass not in buffer");
+        });
+    }
+
+    #[test]
+    fn lock_rotation_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.lockRotation("Player", true, false, true);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::LockRotation { name, lock_x, lock_y, lock_z }
+                    if name == "Player" && *lock_x && !*lock_y && *lock_z)
+            });
+            assert!(found, "LockRotation not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -752,6 +752,21 @@ fn run_scripts(world: &mut World) {
                     pw.set_mass(e, mass);
                 }
             }
+            ScriptCommand::LockRotation {
+                name,
+                lock_x,
+                lock_y,
+                lock_z,
+            } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.lock_rotations(e, lock_x, lock_y, lock_z);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Bsengine.lockRotation(name, lockX, lockY, lockZ)` JS API
- Calls Rapier's `set_enabled_rotations` to prevent rotation on chosen axes at runtime
- Useful for character controllers that must stay upright (lock Y-only or XZ)

## Changes
- `bsengine-physics`: `PhysicsWorld::lock_rotations(entity, lock_x, lock_y, lock_z)`
- `bsengine-scripting/ops.rs`: `LockRotation` command, `bsengine_lock_rotation` op, BOOTSTRAP_JS entry, test
- `bsengine-scripting/plugin.rs`: command handler

## Test plan
- [x] `lock_rotation_enqueues_command` — verifies JS call enqueues correct command with correct bool flags
- [x] All 69 scripting tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)