### PR TITLE
feat(scripting): add getEntitiesByTag API for tag-based entity queries

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -241,6 +241,10 @@ thread_local! {
     // parent_name → [child_names]
     pub(crate) static CHILDREN_SNAPSHOT: RefCell<HashMap<String, Vec<String>>> =
         RefCell::new(HashMap::new());
+
+    // tag label → [entity names]
+    pub(crate) static TAG_SNAPSHOT: RefCell<HashMap<String, Vec<String>>> =
+        RefCell::new(HashMap::new());
 }
 
 /// Full transform returned to scripts: position + rotation quaternion + scale.
@@ -347,6 +351,16 @@ pub fn bsengine_is_key_up(#[string] key: String) -> bool {
 pub fn bsengine_get_entity_names() -> String {
     ENTITY_NAMES_SNAPSHOT
         .with(|s| serde_json::to_string(&*s.borrow()).unwrap_or_else(|_| "[]".to_string()))
+}
+
+#[op2]
+#[string]
+pub fn bsengine_get_entities_by_tag(#[string] tag: String) -> String {
+    TAG_SNAPSHOT.with(|s| {
+        let map = s.borrow();
+        let names = map.get(&tag).cloned().unwrap_or_default();
+        serde_json::to_string(&names).unwrap_or_else(|_| "[]".to_string())
+    })
 }
 
 #[op2(fast)]
@@ -779,6 +793,7 @@ deno_core::extension!(
         bsengine_is_key_down,
         bsengine_is_key_up,
         bsengine_get_entity_names,
+        bsengine_get_entities_by_tag,
         bsengine_set_emissive,
         bsengine_set_color,
         bsengine_spawn,
@@ -841,7 +856,8 @@ const Bsengine = {
     isKeyPressed:   (key)                  => Deno.core.ops.bsengine_is_key_pressed(key),
     isKeyDown:      (key)                  => Deno.core.ops.bsengine_is_key_down(key),
     isKeyUp:        (key)                  => Deno.core.ops.bsengine_is_key_up(key),
-    getEntityNames: ()                     => JSON.parse(Deno.core.ops.bsengine_get_entity_names()),
+    getEntityNames:      ()    => JSON.parse(Deno.core.ops.bsengine_get_entity_names()),
+    getEntitiesByTag:    (tag) => JSON.parse(Deno.core.ops.bsengine_get_entities_by_tag(tag)),
     setEmissive:    (name, r, g, b)        => Deno.core.ops.bsengine_set_emissive(name, r, g, b),
     setColor:       (name, r, g, b)        => Deno.core.ops.bsengine_set_color(name, r, g, b),
     spawn:          (params)               => Deno.core.ops.bsengine_spawn(params),
@@ -1531,6 +1547,34 @@ JSON.stringify(received)
             .unwrap();
         assert!(r.contains("ChildA"), "expected ChildA: {r}");
         assert!(r.contains("ChildB"), "expected ChildB: {r}");
+    }
+
+    #[test]
+    fn get_entities_by_tag_returns_empty_when_no_snapshot() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getEntitiesByTag("enemy"))"#)
+            .unwrap();
+        assert!(r.contains("[]"), "expected empty array: {r}");
+    }
+
+    #[test]
+    fn get_entities_by_tag_returns_list_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::TAG_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "enemy".to_string(),
+                vec!["Goblin".to_string(), "Orc".to_string()],
+            );
+        });
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getEntitiesByTag("enemy"))"#)
+            .unwrap();
+        super::TAG_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("Goblin"), "expected Goblin: {r}");
+        assert!(r.contains("Orc"), "expected Orc: {r}");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -4,8 +4,8 @@ use bevy_app::{App, Plugin, PostStartup, Update};
 use bevy_ecs::prelude::*;
 use bsengine_audio::AudioWorld;
 use bsengine_core::{
-    CursorConfig, GlobalTransform, HudTexts, Material, Parent, ScreenSize, SkyboxPath, Transform,
-    Visible,
+    CursorConfig, GlobalTransform, HudTexts, Material, Parent, ScreenSize, SkyboxPath, Tag,
+    Transform, Visible,
 };
 use bsengine_input::{GamepadButton, GamepadSticks, Input, KeyCode, MouseButton, MouseState};
 use bsengine_physics::CollisionEvent;
@@ -20,7 +20,7 @@ use crate::ops::{
     GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
     KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MASS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
     MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
-    MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT,
+    MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT,
     TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT,
     VISIBLE_SNAPSHOT,
 };
@@ -433,9 +433,22 @@ fn run_scripts(world: &mut World) {
                 .collect()
         })
         .unwrap_or_default();
+    let tag_snapshot: HashMap<String, Vec<String>> = {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        let mut q = world.query::<(&Name, &Tag)>();
+        for (name, tag) in q.iter(world) {
+            for label in tag.iter() {
+                map.entry(label.to_string())
+                    .or_default()
+                    .push(name.0.clone());
+            }
+        }
+        map
+    };
     ENTITY_NAME_MAP.with(|m| *m.borrow_mut() = entity_name_map);
     PARENT_SNAPSHOT.with(|s| *s.borrow_mut() = parent_map);
     CHILDREN_SNAPSHOT.with(|s| *s.borrow_mut() = children_map);
+    TAG_SNAPSHOT.with(|s| *s.borrow_mut() = tag_snapshot);
     VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = velocity_snapshot);
     ANGULAR_VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = angular_velocity_snapshot);
     MASS_SNAPSHOT.with(|s| *s.borrow_mut() = mass_snapshot);


### PR DESCRIPTION
## Summary
- Adds `Bsengine.getEntitiesByTag(tag)` JS API returning an array of entity names
- Reads the existing `Tag` component (from bsengine-core) each frame into a `TAG_SNAPSHOT` thread-local
- Scripts can query all entities with a given label without manually tracking them

## Changes
- `bsengine-scripting/ops.rs`: `TAG_SNAPSHOT` thread-local, `bsengine_get_entities_by_tag` op, BOOTSTRAP_JS entry, 2 tests
- `bsengine-scripting/plugin.rs`: import `Tag`, import `TAG_SNAPSHOT`, build tag→names map each frame

## Test plan
- [x] `get_entities_by_tag_returns_empty_when_no_snapshot` — empty array when no data
- [x] `get_entities_by_tag_returns_list_when_snapshot_set` — returns Goblin, Orc for "enemy" tag
- [x] All 71 scripting tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)