### PR TITLE
feat(scripting): add hasTag/addTag/removeTag API for runtime tag mutation

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -163,6 +163,14 @@ pub enum ScriptCommand {
         name: String,
         mass: f32,
     },
+    AddTag {
+        name: String,
+        label: String,
+    },
+    RemoveTag {
+        name: String,
+        label: String,
+    },
     LockRotation {
         name: String,
         lock_x: bool,
@@ -244,6 +252,10 @@ thread_local! {
 
     // tag label → [entity names]
     pub(crate) static TAG_SNAPSHOT: RefCell<HashMap<String, Vec<String>>> =
+        RefCell::new(HashMap::new());
+
+    // entity name → [tag labels]
+    pub(crate) static ENTITY_TAGS_SNAPSHOT: RefCell<HashMap<String, Vec<String>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -571,6 +583,31 @@ pub fn bsengine_set_mass(#[string] name: String, mass: f32) {
 }
 
 #[op2(fast)]
+pub fn bsengine_has_tag(#[string] name: String, #[string] label: String) -> bool {
+    ENTITY_TAGS_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|labels| labels.iter().any(|l| l == &label))
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_add_tag(#[string] name: String, #[string] label: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::AddTag { name, label });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_remove_tag(#[string] name: String, #[string] label: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RemoveTag { name, label });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_lock_rotation(#[string] name: String, lock_x: bool, lock_y: bool, lock_z: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut().push(ScriptCommand::LockRotation {
@@ -794,6 +831,9 @@ deno_core::extension!(
         bsengine_is_key_up,
         bsengine_get_entity_names,
         bsengine_get_entities_by_tag,
+        bsengine_has_tag,
+        bsengine_add_tag,
+        bsengine_remove_tag,
         bsengine_set_emissive,
         bsengine_set_color,
         bsengine_spawn,
@@ -858,6 +898,9 @@ const Bsengine = {
     isKeyUp:        (key)                  => Deno.core.ops.bsengine_is_key_up(key),
     getEntityNames:      ()    => JSON.parse(Deno.core.ops.bsengine_get_entity_names()),
     getEntitiesByTag:    (tag) => JSON.parse(Deno.core.ops.bsengine_get_entities_by_tag(tag)),
+    hasTag:              (name, label) => Deno.core.ops.bsengine_has_tag(name, label),
+    addTag:              (name, label) => Deno.core.ops.bsengine_add_tag(name, label),
+    removeTag:           (name, label) => Deno.core.ops.bsengine_remove_tag(name, label),
     setEmissive:    (name, r, g, b)        => Deno.core.ops.bsengine_set_emissive(name, r, g, b),
     setColor:       (name, r, g, b)        => Deno.core.ops.bsengine_set_color(name, r, g, b),
     spawn:          (params)               => Deno.core.ops.bsengine_spawn(params),
@@ -1575,6 +1618,58 @@ JSON.stringify(received)
         super::TAG_SNAPSHOT.with(|s| s.borrow_mut().clear());
         assert!(r.contains("Goblin"), "expected Goblin: {r}");
         assert!(r.contains("Orc"), "expected Orc: {r}");
+    }
+
+    #[test]
+    fn has_tag_returns_false_when_no_snapshot() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.hasTag("Player", "enemy")"#).unwrap();
+        assert!(r.contains("false"), "expected false: {r}");
+    }
+
+    #[test]
+    fn has_tag_returns_true_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::ENTITY_TAGS_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Player".to_string(), vec!["hero".to_string()]);
+        });
+        let r = rt.eval(r#"Bsengine.hasTag("Player", "hero")"#).unwrap();
+        super::ENTITY_TAGS_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("true"), "expected true: {r}");
+    }
+
+    #[test]
+    fn add_tag_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.addTag("Enemy", "stunned");"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::AddTag { name, label }
+                    if name == "Enemy" && label == "stunned")
+            });
+            assert!(found, "AddTag not in buffer");
+        });
+    }
+
+    #[test]
+    fn remove_tag_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.removeTag("Enemy", "stunned");"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::RemoveTag { name, label }
+                    if name == "Enemy" && label == "stunned")
+            });
+            assert!(found, "RemoveTag not in buffer");
+        });
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -16,13 +16,13 @@ use glam::{Quat, Vec3};
 use crate::ops::{
     ScriptCommand, SpawnParams, ANGULAR_VELOCITY_SNAPSHOT, BOOTSTRAP_JS, CHILDREN_SNAPSHOT,
     COLLISION_SNAPSHOT, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
-    GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
-    GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
-    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MASS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
-    MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
-    MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT,
-    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT,
-    VISIBLE_SNAPSHOT,
+    ENTITY_TAGS_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
+    GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT,
+    MASS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
+    MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR,
+    SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
+    TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -433,22 +433,32 @@ fn run_scripts(world: &mut World) {
                 .collect()
         })
         .unwrap_or_default();
-    let tag_snapshot: HashMap<String, Vec<String>> = {
-        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    let (tag_snapshot, entity_tags_snapshot): (
+        HashMap<String, Vec<String>>,
+        HashMap<String, Vec<String>>,
+    ) = {
+        let mut by_label: HashMap<String, Vec<String>> = HashMap::new();
+        let mut by_name: HashMap<String, Vec<String>> = HashMap::new();
         let mut q = world.query::<(&Name, &Tag)>();
         for (name, tag) in q.iter(world) {
             for label in tag.iter() {
-                map.entry(label.to_string())
+                by_label
+                    .entry(label.to_string())
                     .or_default()
                     .push(name.0.clone());
+                by_name
+                    .entry(name.0.clone())
+                    .or_default()
+                    .push(label.to_string());
             }
         }
-        map
+        (by_label, by_name)
     };
     ENTITY_NAME_MAP.with(|m| *m.borrow_mut() = entity_name_map);
     PARENT_SNAPSHOT.with(|s| *s.borrow_mut() = parent_map);
     CHILDREN_SNAPSHOT.with(|s| *s.borrow_mut() = children_map);
     TAG_SNAPSHOT.with(|s| *s.borrow_mut() = tag_snapshot);
+    ENTITY_TAGS_SNAPSHOT.with(|s| *s.borrow_mut() = entity_tags_snapshot);
     VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = velocity_snapshot);
     ANGULAR_VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = angular_velocity_snapshot);
     MASS_SNAPSHOT.with(|s| *s.borrow_mut() = mass_snapshot);
@@ -778,6 +788,28 @@ fn run_scripts(world: &mut World) {
                 if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
                 {
                     pw.lock_rotations(e, lock_x, lock_y, lock_z);
+                }
+            }
+            ScriptCommand::AddTag { name, label } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tag) = world.get_mut::<Tag>(e) {
+                        tag.add(label);
+                    }
+                }
+            }
+            ScriptCommand::RemoveTag { name, label } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tag) = world.get_mut::<Tag>(e) {
+                        tag.remove(&label);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds `Bsengine.hasTag(name, label)` — reads from per-entity tag snapshot
- Adds `Bsengine.addTag(name, label)` / `removeTag(name, label)` — mutates `Tag` component via deferred commands
- Enables runtime status effects, faction changes, dynamic group membership

## Changes
- `ops.rs`: `AddTag`/`RemoveTag` ScriptCommands, `ENTITY_TAGS_SNAPSHOT` thread-local, 3 ops, BOOTSTRAP_JS entries, 4 tests
- `plugin.rs`: builds both `tag_snapshot` (label→names) and `entity_tags_snapshot` (name→labels) in one query pass; handles AddTag/RemoveTag commands

## Test plan
- [x] `has_tag_returns_false_when_no_snapshot`
- [x] `has_tag_returns_true_when_snapshot_set`
- [x] `add_tag_enqueues_command`
- [x] `remove_tag_enqueues_command`
- [x] All 75 scripting tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)