### PR TITLE
feat(scripting): add setKinematic API to switch physics body type at runtime

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -179,6 +179,19 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn set_body_type(&mut self, entity: Entity, kinematic: bool) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                let body_type = if kinematic {
+                    RigidBodyType::KinematicPositionBased
+                } else {
+                    RigidBodyType::Dynamic
+                };
+                body.set_body_type(body_type, true);
+            }
+        }
+    }
+
     /// Cast a ray into the physics world. Returns hit info or None.
     pub fn cast_ray(&self, origin: Vec3, dir: Vec3, max_dist: f32) -> Option<RaycastHit> {
         // QueryPipeline<'a> borrows the sets so it is constructed per-call from the broad phase.

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -171,6 +171,10 @@ pub enum ScriptCommand {
         name: String,
         label: String,
     },
+    SetKinematic {
+        name: String,
+        kinematic: bool,
+    },
     LockRotation {
         name: String,
         lock_x: bool,
@@ -608,6 +612,14 @@ pub fn bsengine_remove_tag(#[string] name: String, #[string] label: String) {
 }
 
 #[op2(fast)]
+pub fn bsengine_set_kinematic(#[string] name: String, kinematic: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetKinematic { name, kinematic });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_lock_rotation(#[string] name: String, lock_x: bool, lock_y: bool, lock_z: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut().push(ScriptCommand::LockRotation {
@@ -834,6 +846,7 @@ deno_core::extension!(
         bsengine_has_tag,
         bsengine_add_tag,
         bsengine_remove_tag,
+        bsengine_set_kinematic,
         bsengine_set_emissive,
         bsengine_set_color,
         bsengine_spawn,
@@ -901,6 +914,7 @@ const Bsengine = {
     hasTag:              (name, label) => Deno.core.ops.bsengine_has_tag(name, label),
     addTag:              (name, label) => Deno.core.ops.bsengine_add_tag(name, label),
     removeTag:           (name, label) => Deno.core.ops.bsengine_remove_tag(name, label),
+    setKinematic:        (name, kinematic) => Deno.core.ops.bsengine_set_kinematic(name, kinematic),
     setEmissive:    (name, r, g, b)        => Deno.core.ops.bsengine_set_emissive(name, r, g, b),
     setColor:       (name, r, g, b)        => Deno.core.ops.bsengine_set_color(name, r, g, b),
     spawn:          (params)               => Deno.core.ops.bsengine_spawn(params),
@@ -1669,6 +1683,21 @@ JSON.stringify(received)
                     if name == "Enemy" && label == "stunned")
             });
             assert!(found, "RemoveTag not in buffer");
+        });
+    }
+
+    #[test]
+    fn set_kinematic_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setKinematic("Box", true);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetKinematic { name, kinematic }
+                    if name == "Box" && *kinematic)
+            });
+            assert!(found, "SetKinematic not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -812,6 +812,16 @@ fn run_scripts(world: &mut World) {
                     }
                 }
             }
+            ScriptCommand::SetKinematic { name, kinematic } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_body_type(e, kinematic);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds \`Bsengine.setKinematic(name, bool)\` JS API
- Switches body between \`Dynamic\` and \`KinematicPositionBased\` via Rapier's \`set_body_type\`
- Enables grab/release mechanics, platform activation, runtime physics mode changes

## Changes
- \`bsengine-physics/world.rs\`: \`PhysicsWorld::set_body_type(entity, kinematic)\`
- \`bsengine-scripting/ops.rs\`: \`SetKinematic\` command, \`bsengine_set_kinematic\` op, BOOTSTRAP_JS entry, test
- \`bsengine-scripting/plugin.rs\`: command handler

## Test plan
- [x] \`set_kinematic_enqueues_command\` — verifies JS call enqueues correct command
- [x] All 76 scripting + 6 physics tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)