### PR TITLE
feat(scripting): add setColliderSensor API

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -179,6 +179,18 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn set_collider_sensor(&mut self, entity: Entity, sensor: bool) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get(handle) {
+                for &coll_handle in body.colliders() {
+                    if let Some(collider) = self.collider_set.get_mut(coll_handle) {
+                        collider.set_sensor(sensor);
+                    }
+                }
+            }
+        }
+    }
+
     pub fn set_gravity_scale(&mut self, entity: Entity, scale: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -179,6 +179,10 @@ pub enum ScriptCommand {
         name: String,
         scale: f32,
     },
+    SetColliderSensor {
+        name: String,
+        sensor: bool,
+    },
     LockRotation {
         name: String,
         lock_x: bool,
@@ -642,6 +646,14 @@ pub fn bsengine_set_gravity_scale(#[string] name: String, scale: f32) {
 }
 
 #[op2(fast)]
+pub fn bsengine_set_collider_sensor(#[string] name: String, sensor: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetColliderSensor { name, sensor });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_lock_rotation(#[string] name: String, lock_x: bool, lock_y: bool, lock_z: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut().push(ScriptCommand::LockRotation {
@@ -871,6 +883,7 @@ deno_core::extension!(
         bsengine_set_kinematic,
         bsengine_get_tags,
         bsengine_set_gravity_scale,
+        bsengine_set_collider_sensor,
         bsengine_set_emissive,
         bsengine_set_color,
         bsengine_spawn,
@@ -941,6 +954,7 @@ const Bsengine = {
     setKinematic:        (name, kinematic) => Deno.core.ops.bsengine_set_kinematic(name, kinematic),
     getTags:             (name)            => JSON.parse(Deno.core.ops.bsengine_get_tags(name)),
     setGravityScale:     (name, scale)     => Deno.core.ops.bsengine_set_gravity_scale(name, scale),
+    setColliderSensor:   (name, sensor)    => Deno.core.ops.bsengine_set_collider_sensor(name, sensor),
     setEmissive:    (name, r, g, b)        => Deno.core.ops.bsengine_set_emissive(name, r, g, b),
     setColor:       (name, r, g, b)        => Deno.core.ops.bsengine_set_color(name, r, g, b),
     spawn:          (params)               => Deno.core.ops.bsengine_spawn(params),
@@ -1751,6 +1765,22 @@ JSON.stringify(received)
                     if name == "Ball" && (*scale - 0.5).abs() < 1e-6)
             });
             assert!(found, "SetGravityScale not in buffer");
+        });
+    }
+
+    #[test]
+    fn set_collider_sensor_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setColliderSensor("Zone", true);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetColliderSensor { name, sensor }
+                    if name == "Zone" && *sensor)
+            });
+            assert!(found, "SetColliderSensor not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -832,6 +832,16 @@ fn run_scripts(world: &mut World) {
                     pw.set_gravity_scale(e, scale);
                 }
             }
+            ScriptCommand::SetColliderSensor { name, sensor } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_collider_sensor(e, sensor);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Bsengine.setColliderSensor(name, sensor)` JS scripting API
- Adds `PhysicsWorld::set_collider_sensor` toggling sensor mode on all body colliders via Rapier
- Adds `SetColliderSensor` ScriptCommand variant with handler in scripting plugin
- Adds unit test `set_collider_sensor_enqueues_command`

## Test plan
- [ ] `cargo test -p bsengine-scripting -p bsengine-physics` → 80 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)