### PR TITLE
feat(scripting): add physics state read-backs

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -191,6 +191,26 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn get_gravity_scale(&self, entity: Entity) -> Option<f32> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        Some(body.gravity_scale())
+    }
+
+    pub fn is_kinematic(&self, entity: Entity) -> Option<bool> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        Some(body.is_kinematic())
+    }
+
+    pub fn is_collider_sensor(&self, entity: Entity) -> Option<bool> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        let coll_handle = *body.colliders().first()?;
+        let collider = self.collider_set.get(coll_handle)?;
+        Some(collider.is_sensor())
+    }
+
     pub fn set_gravity_scale(&mut self, entity: Entity, scale: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -255,6 +255,18 @@ thread_local! {
     pub(crate) static MASS_SNAPSHOT: RefCell<HashMap<String, f32>> =
         RefCell::new(HashMap::new());
 
+    // name → gravity scale (only for entities with a physics body)
+    pub(crate) static GRAVITY_SCALE_SNAPSHOT: RefCell<HashMap<String, f32>> =
+        RefCell::new(HashMap::new());
+
+    // name → is_kinematic (only for entities with a physics body)
+    pub(crate) static BODY_TYPE_SNAPSHOT: RefCell<HashMap<String, bool>> =
+        RefCell::new(HashMap::new());
+
+    // name → is_sensor (only for entities with at least one collider)
+    pub(crate) static COLLIDER_SENSOR_SNAPSHOT: RefCell<HashMap<String, bool>> =
+        RefCell::new(HashMap::new());
+
     // child_name → parent_name (only for entities that have a Parent component)
     pub(crate) static PARENT_SNAPSHOT: RefCell<HashMap<String, String>> =
         RefCell::new(HashMap::new());
@@ -588,6 +600,21 @@ pub fn bsengine_get_mass(#[string] name: String) -> f32 {
 }
 
 #[op2(fast)]
+pub fn bsengine_get_gravity_scale(#[string] name: String) -> f32 {
+    GRAVITY_SCALE_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(1.0))
+}
+
+#[op2(fast)]
+pub fn bsengine_is_kinematic(#[string] name: String) -> bool {
+    BODY_TYPE_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(false))
+}
+
+#[op2(fast)]
+pub fn bsengine_is_collider_sensor(#[string] name: String) -> bool {
+    COLLIDER_SENSOR_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(false))
+}
+
+#[op2(fast)]
 pub fn bsengine_set_mass(#[string] name: String, mass: f32) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut().push(ScriptCommand::SetMass { name, mass });
@@ -911,6 +938,9 @@ deno_core::extension!(
         bsengine_set_angular_damping,
         bsengine_get_mass,
         bsengine_set_mass,
+        bsengine_get_gravity_scale,
+        bsengine_is_kinematic,
+        bsengine_is_collider_sensor,
         bsengine_lock_rotation,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
@@ -984,6 +1014,9 @@ const Bsengine = {
     setAngularDamping:    (name, damping)          => Deno.core.ops.bsengine_set_angular_damping(name, damping),
     getMass:              (name)                   => Deno.core.ops.bsengine_get_mass(name),
     setMass:              (name, mass)             => Deno.core.ops.bsengine_set_mass(name, mass),
+    getGravityScale:      (name)                   => Deno.core.ops.bsengine_get_gravity_scale(name),
+    isKinematic:          (name)                   => Deno.core.ops.bsengine_is_kinematic(name),
+    isColliderSensor:     (name)                   => Deno.core.ops.bsengine_is_collider_sensor(name),
     lockRotation:         (name, lockX, lockY, lockZ) => Deno.core.ops.bsengine_lock_rotation(name, lockX, lockY, lockZ),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
@@ -2016,6 +2049,70 @@ JSON.stringify(received)
         let r = rt.eval(r#"Bsengine.getMass("Rock")"#).unwrap();
         super::MASS_SNAPSHOT.with(|s| s.borrow_mut().clear());
         assert!(r.contains('5'), "expected 5: {r}");
+    }
+
+    #[test]
+    fn get_gravity_scale_returns_default_when_no_snapshot() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getGravityScale("Cube")"#).unwrap();
+        assert!(r.contains('1'), "expected 1: {r}");
+    }
+
+    #[test]
+    fn get_gravity_scale_returns_value_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::GRAVITY_SCALE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Cube".to_string(), 2.5);
+        });
+        let r = rt.eval(r#"Bsengine.getGravityScale("Cube")"#).unwrap();
+        super::GRAVITY_SCALE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("2.5"), "expected 2.5: {r}");
+    }
+
+    #[test]
+    fn is_kinematic_returns_false_by_default() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.isKinematic("Cube"))"#).unwrap();
+        assert_eq!(r, "false");
+    }
+
+    #[test]
+    fn is_kinematic_returns_true_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::BODY_TYPE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Cube".to_string(), true);
+        });
+        let r = rt.eval(r#"String(Bsengine.isKinematic("Cube"))"#).unwrap();
+        super::BODY_TYPE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert_eq!(r, "true");
+    }
+
+    #[test]
+    fn is_collider_sensor_returns_false_by_default() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.isColliderSensor("Zone"))"#)
+            .unwrap();
+        assert_eq!(r, "false");
+    }
+
+    #[test]
+    fn is_collider_sensor_returns_true_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::COLLIDER_SENSOR_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Zone".to_string(), true);
+        });
+        let r = rt
+            .eval(r#"String(Bsengine.isColliderSensor("Zone"))"#)
+            .unwrap();
+        super::COLLIDER_SENSOR_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert_eq!(r, "true");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -14,12 +14,13 @@ use bsengine_scene::{Name, PendingSceneLoad, Primitive, PrimitiveMesh, ScriptPat
 use glam::{Quat, Vec3};
 
 use crate::ops::{
-    ScriptCommand, SpawnParams, ANGULAR_VELOCITY_SNAPSHOT, BOOTSTRAP_JS, CHILDREN_SNAPSHOT,
-    COLLISION_SNAPSHOT, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
-    ENTITY_TAGS_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
-    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
-    GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT,
-    MASS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
+    ScriptCommand, SpawnParams, ANGULAR_VELOCITY_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS,
+    CHILDREN_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT, COMMAND_BUFFER,
+    ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, ENTITY_TAGS_SNAPSHOT,
+    GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
+    GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT,
+    KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MASS_SNAPSHOT,
+    MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
     MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR,
     SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
     TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
@@ -433,6 +434,42 @@ fn run_scripts(world: &mut World) {
                 .collect()
         })
         .unwrap_or_default();
+    let gravity_scale_snapshot: HashMap<String, f32> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.get_gravity_scale(entity).map(|s| (name.clone(), s))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let body_type_snapshot: HashMap<String, bool> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.is_kinematic(entity).map(|k| (name.clone(), k))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let collider_sensor_snapshot: HashMap<String, bool> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.is_collider_sensor(entity).map(|s| (name.clone(), s))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let (tag_snapshot, entity_tags_snapshot): (
         HashMap<String, Vec<String>>,
         HashMap<String, Vec<String>>,
@@ -462,6 +499,9 @@ fn run_scripts(world: &mut World) {
     VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = velocity_snapshot);
     ANGULAR_VELOCITY_SNAPSHOT.with(|s| *s.borrow_mut() = angular_velocity_snapshot);
     MASS_SNAPSHOT.with(|s| *s.borrow_mut() = mass_snapshot);
+    GRAVITY_SCALE_SNAPSHOT.with(|s| *s.borrow_mut() = gravity_scale_snapshot);
+    BODY_TYPE_SNAPSHOT.with(|s| *s.borrow_mut() = body_type_snapshot);
+    COLLIDER_SENSOR_SNAPSHOT.with(|s| *s.borrow_mut() = collider_sensor_snapshot);
     let gravity = world
         .get_resource::<PhysicsWorld>()
         .map(|pw| pw.gravity())


### PR DESCRIPTION
## Summary
- Adds `PhysicsWorld::get_gravity_scale`, `is_kinematic`, `is_collider_sensor` read methods
- Adds `GRAVITY_SCALE_SNAPSHOT`, `BODY_TYPE_SNAPSHOT`, `COLLIDER_SENSOR_SNAPSHOT` thread-locals
- Exposes `Bsengine.getGravityScale(name)`, `isKinematic(name)`, `isColliderSensor(name)` to JS
- Snapshots built each frame alongside existing mass/velocity snapshots
- 6 new unit tests (default+value for each)

## Test plan
- [ ] `cargo test -p bsengine-scripting -p bsengine-physics` → 86 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)