### PR TITLE
feat(scripting): add getLinearDamping/getAngularDamping read-backs

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -157,6 +157,18 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn get_linear_damping(&self, entity: Entity) -> Option<f32> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        Some(body.linear_damping())
+    }
+
+    pub fn get_angular_damping(&self, entity: Entity) -> Option<f32> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        Some(body.angular_damping())
+    }
+
     pub fn get_mass(&self, entity: Entity) -> Option<f32> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -267,6 +267,14 @@ thread_local! {
     pub(crate) static COLLIDER_SENSOR_SNAPSHOT: RefCell<HashMap<String, bool>> =
         RefCell::new(HashMap::new());
 
+    // name → linear damping (only for entities with a physics body)
+    pub(crate) static LINEAR_DAMPING_SNAPSHOT: RefCell<HashMap<String, f32>> =
+        RefCell::new(HashMap::new());
+
+    // name → angular damping (only for entities with a physics body)
+    pub(crate) static ANGULAR_DAMPING_SNAPSHOT: RefCell<HashMap<String, f32>> =
+        RefCell::new(HashMap::new());
+
     // child_name → parent_name (only for entities that have a Parent component)
     pub(crate) static PARENT_SNAPSHOT: RefCell<HashMap<String, String>> =
         RefCell::new(HashMap::new());
@@ -615,6 +623,16 @@ pub fn bsengine_is_collider_sensor(#[string] name: String) -> bool {
 }
 
 #[op2(fast)]
+pub fn bsengine_get_linear_damping(#[string] name: String) -> f32 {
+    LINEAR_DAMPING_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
+}
+
+#[op2(fast)]
+pub fn bsengine_get_angular_damping(#[string] name: String) -> f32 {
+    ANGULAR_DAMPING_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
+}
+
+#[op2(fast)]
 pub fn bsengine_set_mass(#[string] name: String, mass: f32) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut().push(ScriptCommand::SetMass { name, mass });
@@ -941,6 +959,8 @@ deno_core::extension!(
         bsengine_get_gravity_scale,
         bsengine_is_kinematic,
         bsengine_is_collider_sensor,
+        bsengine_get_linear_damping,
+        bsengine_get_angular_damping,
         bsengine_lock_rotation,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
@@ -1017,6 +1037,8 @@ const Bsengine = {
     getGravityScale:      (name)                   => Deno.core.ops.bsengine_get_gravity_scale(name),
     isKinematic:          (name)                   => Deno.core.ops.bsengine_is_kinematic(name),
     isColliderSensor:     (name)                   => Deno.core.ops.bsengine_is_collider_sensor(name),
+    getLinearDamping:     (name)                   => Deno.core.ops.bsengine_get_linear_damping(name),
+    getAngularDamping:    (name)                   => Deno.core.ops.bsengine_get_angular_damping(name),
     lockRotation:         (name, lockX, lockY, lockZ) => Deno.core.ops.bsengine_lock_rotation(name, lockX, lockY, lockZ),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
@@ -2113,6 +2135,46 @@ JSON.stringify(received)
             .unwrap();
         super::COLLIDER_SENSOR_SNAPSHOT.with(|s| s.borrow_mut().clear());
         assert_eq!(r, "true");
+    }
+
+    #[test]
+    fn get_linear_damping_returns_zero_by_default() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getLinearDamping("Ball")"#).unwrap();
+        assert!(r.contains('0'), "expected 0: {r}");
+    }
+
+    #[test]
+    fn get_linear_damping_returns_value_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::LINEAR_DAMPING_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Ball".to_string(), 0.3);
+        });
+        let r = rt.eval(r#"Bsengine.getLinearDamping("Ball")"#).unwrap();
+        super::LINEAR_DAMPING_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("0.3"), "expected 0.3: {r}");
+    }
+
+    #[test]
+    fn get_angular_damping_returns_zero_by_default() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getAngularDamping("Ball")"#).unwrap();
+        assert!(r.contains('0'), "expected 0: {r}");
+    }
+
+    #[test]
+    fn get_angular_damping_returns_value_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::ANGULAR_DAMPING_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Ball".to_string(), 0.75);
+        });
+        let r = rt.eval(r#"Bsengine.getAngularDamping("Ball")"#).unwrap();
+        super::ANGULAR_DAMPING_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("0.75"), "expected 0.75: {r}");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -14,12 +14,13 @@ use bsengine_scene::{Name, PendingSceneLoad, Primitive, PrimitiveMesh, ScriptPat
 use glam::{Quat, Vec3};
 
 use crate::ops::{
-    ScriptCommand, SpawnParams, ANGULAR_VELOCITY_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS,
-    CHILDREN_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT, COMMAND_BUFFER,
-    ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, ENTITY_TAGS_SNAPSHOT,
-    GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
-    GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT,
-    KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, MASS_SNAPSHOT,
+    ScriptCommand, SpawnParams, ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT,
+    BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, CHILDREN_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT,
+    COLLISION_SNAPSHOT, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
+    ENTITY_TAGS_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
+    GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
+    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MASS_SNAPSHOT,
     MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
     MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR,
     SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
@@ -470,6 +471,30 @@ fn run_scripts(world: &mut World) {
                 .collect()
         })
         .unwrap_or_default();
+    let linear_damping_snapshot: HashMap<String, f32> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.get_linear_damping(entity).map(|d| (name.clone(), d))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let angular_damping_snapshot: HashMap<String, f32> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.get_angular_damping(entity).map(|d| (name.clone(), d))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let (tag_snapshot, entity_tags_snapshot): (
         HashMap<String, Vec<String>>,
         HashMap<String, Vec<String>>,
@@ -502,6 +527,8 @@ fn run_scripts(world: &mut World) {
     GRAVITY_SCALE_SNAPSHOT.with(|s| *s.borrow_mut() = gravity_scale_snapshot);
     BODY_TYPE_SNAPSHOT.with(|s| *s.borrow_mut() = body_type_snapshot);
     COLLIDER_SENSOR_SNAPSHOT.with(|s| *s.borrow_mut() = collider_sensor_snapshot);
+    LINEAR_DAMPING_SNAPSHOT.with(|s| *s.borrow_mut() = linear_damping_snapshot);
+    ANGULAR_DAMPING_SNAPSHOT.with(|s| *s.borrow_mut() = angular_damping_snapshot);
     let gravity = world
         .get_resource::<PhysicsWorld>()
         .map(|pw| pw.gravity())


### PR DESCRIPTION
## Summary
- Add PhysicsWorld::get_linear_damping and get_angular_damping to bsengine-physics
- Add LINEAR_DAMPING_SNAPSHOT and ANGULAR_DAMPING_SNAPSHOT thread-locals in bsengine-scripting
- Expose Bsengine.getLinearDamping(name) and Bsengine.getAngularDamping(name) in JS API

## Test plan
- [x] Unit tests for both ops (snapshot set/not set)
- [x] cargo test -p bsengine-scripting -p bsengine-physics - 90 tests pass