### PR TITLE
feat(scripting): add setRestitution/setFriction/getRestitution/getFriction runtime API

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -191,6 +191,46 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn get_restitution(&self, entity: Entity) -> Option<f32> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        let coll_handle = *body.colliders().first()?;
+        let collider = self.collider_set.get(coll_handle)?;
+        Some(collider.restitution())
+    }
+
+    pub fn set_restitution(&mut self, entity: Entity, restitution: f32) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get(handle) {
+                for &coll_handle in body.colliders() {
+                    if let Some(collider) = self.collider_set.get_mut(coll_handle) {
+                        collider.set_restitution(restitution);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn get_friction(&self, entity: Entity) -> Option<f32> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        let coll_handle = *body.colliders().first()?;
+        let collider = self.collider_set.get(coll_handle)?;
+        Some(collider.friction())
+    }
+
+    pub fn set_friction(&mut self, entity: Entity, friction: f32) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get(handle) {
+                for &coll_handle in body.colliders() {
+                    if let Some(collider) = self.collider_set.get_mut(coll_handle) {
+                        collider.set_friction(friction);
+                    }
+                }
+            }
+        }
+    }
+
     pub fn set_collider_sensor(&mut self, entity: Entity, sensor: bool) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get(handle) {

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -183,6 +183,14 @@ pub enum ScriptCommand {
         name: String,
         sensor: bool,
     },
+    SetRestitution {
+        name: String,
+        restitution: f32,
+    },
+    SetFriction {
+        name: String,
+        friction: f32,
+    },
     LockRotation {
         name: String,
         lock_x: bool,
@@ -273,6 +281,14 @@ thread_local! {
 
     // name → angular damping (only for entities with a physics body)
     pub(crate) static ANGULAR_DAMPING_SNAPSHOT: RefCell<HashMap<String, f32>> =
+        RefCell::new(HashMap::new());
+
+    // name → restitution (only for entities with at least one collider)
+    pub(crate) static RESTITUTION_SNAPSHOT: RefCell<HashMap<String, f32>> =
+        RefCell::new(HashMap::new());
+
+    // name → friction (only for entities with at least one collider)
+    pub(crate) static FRICTION_SNAPSHOT: RefCell<HashMap<String, f32>> =
         RefCell::new(HashMap::new());
 
     // child_name → parent_name (only for entities that have a Parent component)
@@ -633,6 +649,32 @@ pub fn bsengine_get_angular_damping(#[string] name: String) -> f32 {
 }
 
 #[op2(fast)]
+pub fn bsengine_get_restitution(#[string] name: String) -> f32 {
+    RESTITUTION_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
+}
+
+#[op2(fast)]
+pub fn bsengine_set_restitution(#[string] name: String, restitution: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetRestitution { name, restitution });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_friction(#[string] name: String) -> f32 {
+    FRICTION_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
+}
+
+#[op2(fast)]
+pub fn bsengine_set_friction(#[string] name: String, friction: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetFriction { name, friction });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_set_mass(#[string] name: String, mass: f32) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut().push(ScriptCommand::SetMass { name, mass });
@@ -961,6 +1003,10 @@ deno_core::extension!(
         bsengine_is_collider_sensor,
         bsengine_get_linear_damping,
         bsengine_get_angular_damping,
+        bsengine_get_restitution,
+        bsengine_set_restitution,
+        bsengine_get_friction,
+        bsengine_set_friction,
         bsengine_lock_rotation,
         bsengine_set_cursor_visible,
         bsengine_set_cursor_locked,
@@ -1039,6 +1085,10 @@ const Bsengine = {
     isColliderSensor:     (name)                   => Deno.core.ops.bsengine_is_collider_sensor(name),
     getLinearDamping:     (name)                   => Deno.core.ops.bsengine_get_linear_damping(name),
     getAngularDamping:    (name)                   => Deno.core.ops.bsengine_get_angular_damping(name),
+    getRestitution:       (name)                   => Deno.core.ops.bsengine_get_restitution(name),
+    setRestitution:       (name, v)                => Deno.core.ops.bsengine_set_restitution(name, v),
+    getFriction:          (name)                   => Deno.core.ops.bsengine_get_friction(name),
+    setFriction:          (name, v)                => Deno.core.ops.bsengine_set_friction(name, v),
     lockRotation:         (name, lockX, lockY, lockZ) => Deno.core.ops.bsengine_lock_rotation(name, lockX, lockY, lockZ),
     setCursorVisible: (visible) => Deno.core.ops.bsengine_set_cursor_visible(visible),
     setCursorLocked:  (locked)  => Deno.core.ops.bsengine_set_cursor_locked(locked),
@@ -2175,6 +2225,76 @@ JSON.stringify(received)
         let r = rt.eval(r#"Bsengine.getAngularDamping("Ball")"#).unwrap();
         super::ANGULAR_DAMPING_SNAPSHOT.with(|s| s.borrow_mut().clear());
         assert!(r.contains("0.75"), "expected 0.75: {r}");
+    }
+
+    #[test]
+    fn get_restitution_returns_zero_by_default() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getRestitution("Ball")"#).unwrap();
+        assert!(r.contains('0'), "expected 0: {r}");
+    }
+
+    #[test]
+    fn get_restitution_returns_value_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::RESTITUTION_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Ball".to_string(), 0.75);
+        });
+        let r = rt.eval(r#"Bsengine.getRestitution("Ball")"#).unwrap();
+        super::RESTITUTION_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("0.75"), "expected 0.75: {r}");
+    }
+
+    #[test]
+    fn set_restitution_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setRestitution("Ball", 0.5);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetRestitution { name, restitution }
+                    if name == "Ball" && (*restitution - 0.5).abs() < 1e-6)
+            });
+            assert!(found, "SetRestitution not in buffer");
+        });
+    }
+
+    #[test]
+    fn get_friction_returns_zero_by_default() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getFriction("Ball")"#).unwrap();
+        assert!(r.contains('0'), "expected 0: {r}");
+    }
+
+    #[test]
+    fn get_friction_returns_value_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::FRICTION_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Ball".to_string(), 0.5);
+        });
+        let r = rt.eval(r#"Bsengine.getFriction("Ball")"#).unwrap();
+        super::FRICTION_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("0.5"), "expected 0.5: {r}");
+    }
+
+    #[test]
+    fn set_friction_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setFriction("Ball", 0.25);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetFriction { name, friction }
+                    if name == "Ball" && (*friction - 0.25).abs() < 1e-6)
+            });
+            assert!(found, "SetFriction not in buffer");
+        });
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -17,14 +17,14 @@ use crate::ops::{
     ScriptCommand, SpawnParams, ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT,
     BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, CHILDREN_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT,
     COLLISION_SNAPSHOT, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
-    ENTITY_TAGS_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    ENTITY_TAGS_SNAPSHOT, FRICTION_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
     GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
     KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MASS_SNAPSHOT,
     MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
     MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR,
-    SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
-    TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
+    RESTITUTION_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT,
+    TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -495,6 +495,30 @@ fn run_scripts(world: &mut World) {
                 .collect()
         })
         .unwrap_or_default();
+    let restitution_snapshot: HashMap<String, f32> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.get_restitution(entity).map(|v| (name.clone(), v))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let friction_snapshot: HashMap<String, f32> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.get_friction(entity).map(|v| (name.clone(), v))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let (tag_snapshot, entity_tags_snapshot): (
         HashMap<String, Vec<String>>,
         HashMap<String, Vec<String>>,
@@ -529,6 +553,8 @@ fn run_scripts(world: &mut World) {
     COLLIDER_SENSOR_SNAPSHOT.with(|s| *s.borrow_mut() = collider_sensor_snapshot);
     LINEAR_DAMPING_SNAPSHOT.with(|s| *s.borrow_mut() = linear_damping_snapshot);
     ANGULAR_DAMPING_SNAPSHOT.with(|s| *s.borrow_mut() = angular_damping_snapshot);
+    RESTITUTION_SNAPSHOT.with(|s| *s.borrow_mut() = restitution_snapshot);
+    FRICTION_SNAPSHOT.with(|s| *s.borrow_mut() = friction_snapshot);
     let gravity = world
         .get_resource::<PhysicsWorld>()
         .map(|pw| pw.gravity())
@@ -907,6 +933,26 @@ fn run_scripts(world: &mut World) {
                 if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
                 {
                     pw.set_collider_sensor(e, sensor);
+                }
+            }
+            ScriptCommand::SetRestitution { name, restitution } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_restitution(e, restitution);
+                }
+            }
+            ScriptCommand::SetFriction { name, friction } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.set_friction(e, friction);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add PhysicsWorld::get_restitution/set_restitution/get_friction/set_friction to bsengine-physics
- Add RESTITUTION_SNAPSHOT and FRICTION_SNAPSHOT thread-locals in bsengine-scripting
- Expose Bsengine.getRestitution/setRestitution/getFriction/setFriction in JS API

## Test plan
- [x] 6 new unit tests (get default, get with snapshot, set enqueues command for each)
- [x] cargo test -p bsengine-scripting -p bsengine-physics -- 96 tests pass