### PR TITLE
feat(scripting): add addTorque continuous rotational force API

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -141,6 +141,14 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn add_torque(&mut self, entity: Entity, torque: Vec3) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.add_torque(Vector::new(torque.x, torque.y, torque.z), true);
+            }
+        }
+    }
+
     pub fn set_linear_damping(&mut self, entity: Entity, damping: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -151,6 +151,12 @@ pub enum ScriptCommand {
         vy: f32,
         vz: f32,
     },
+    AddTorque {
+        name: String,
+        vx: f32,
+        vy: f32,
+        vz: f32,
+    },
     SetLinearDamping {
         name: String,
         damping: f32,
@@ -603,6 +609,14 @@ pub fn bsengine_add_angular_impulse(#[string] name: String, vx: f32, vy: f32, vz
 }
 
 #[op2(fast)]
+pub fn bsengine_add_torque(#[string] name: String, vx: f32, vy: f32, vz: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AddTorque { name, vx, vy, vz });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_set_linear_damping(#[string] name: String, damping: f32) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
@@ -994,6 +1008,7 @@ deno_core::extension!(
         bsengine_get_angular_velocity,
         bsengine_set_angular_velocity,
         bsengine_add_angular_impulse,
+        bsengine_add_torque,
         bsengine_set_linear_damping,
         bsengine_set_angular_damping,
         bsengine_get_mass,
@@ -1076,6 +1091,7 @@ const Bsengine = {
     getAngularVelocity:   (name)                  => { const v = Deno.core.ops.bsengine_get_angular_velocity(name); return v ? { x: v[0], y: v[1], z: v[2] } : null; },
     setAngularVelocity:   (name, vx, vy, vz)      => Deno.core.ops.bsengine_set_angular_velocity(name, vx, vy, vz),
     addAngularImpulse:    (name, vx, vy, vz)      => Deno.core.ops.bsengine_add_angular_impulse(name, vx, vy, vz),
+    addTorque:            (name, vx, vy, vz)      => Deno.core.ops.bsengine_add_torque(name, vx, vy, vz),
     setLinearDamping:     (name, damping)          => Deno.core.ops.bsengine_set_linear_damping(name, damping),
     setAngularDamping:    (name, damping)          => Deno.core.ops.bsengine_set_angular_damping(name, damping),
     getMass:              (name)                   => Deno.core.ops.bsengine_get_mass(name),
@@ -2068,6 +2084,21 @@ JSON.stringify(received)
                     if name == "Top" && (*vy - 2.0).abs() < 1e-6)
             });
             assert!(found, "AddAngularImpulse not in buffer");
+        });
+    }
+
+    #[test]
+    fn add_torque_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.addTorque("Gyro", 0, 3, 0);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::AddTorque { name, vy, .. }
+                    if name == "Gyro" && (*vy - 3.0).abs() < 1e-6)
+            });
+            assert!(found, "AddTorque not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -838,6 +838,16 @@ fn run_scripts(world: &mut World) {
                     pw.apply_torque_impulse(e, Vec3::new(vx, vy, vz));
                 }
             }
+            ScriptCommand::AddTorque { name, vx, vy, vz } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.add_torque(e, Vec3::new(vx, vy, vz));
+                }
+            }
             ScriptCommand::SetLinearDamping { name, damping } => {
                 let entity = {
                     let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();


### PR DESCRIPTION
## Summary
- Add PhysicsWorld::add_torque to bsengine-physics
- Expose Bsengine.addTorque(name, vx, vy, vz) — continuous per-frame torque, symmetric to addForce

## Test plan
- [x] add_torque_enqueues_command unit test
- [x] cargo test -p bsengine-scripting -p bsengine-physics -- 97 tests pass