### PR TITLE
feat(scripting): add getMaterialColor/getMaterialEmissive read-backs

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -250,6 +250,14 @@ thread_local! {
     pub(crate) static VISIBLE_SNAPSHOT: RefCell<HashMap<String, bool>> =
         RefCell::new(HashMap::new());
 
+    // name → base_color [r, g, b] (only for entities with a Material component)
+    pub(crate) static MATERIAL_COLOR_SNAPSHOT: RefCell<HashMap<String, [f32; 3]>> =
+        RefCell::new(HashMap::new());
+
+    // name → emissive [r, g, b] (only for entities with a Material component)
+    pub(crate) static MATERIAL_EMISSIVE_SNAPSHOT: RefCell<HashMap<String, [f32; 3]>> =
+        RefCell::new(HashMap::new());
+
     pub(crate) static TIME_ELAPSED_SNAPSHOT: RefCell<f32> = RefCell::new(0.0);
     pub(crate) static TIME_DELTA_SNAPSHOT: RefCell<f32> = RefCell::new(0.0);
 
@@ -466,6 +474,18 @@ pub fn bsengine_set_visible(#[string] name: String, visible: bool) {
 #[op2(fast)]
 pub fn bsengine_get_visible(#[string] name: String) -> bool {
     VISIBLE_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(true))
+}
+
+#[op2]
+#[serde]
+pub fn bsengine_get_material_color(#[string] name: String) -> Option<Vec<f32>> {
+    MATERIAL_COLOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|c| c.to_vec()))
+}
+
+#[op2]
+#[serde]
+pub fn bsengine_get_material_emissive(#[string] name: String) -> Option<Vec<f32>> {
+    MATERIAL_EMISSIVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|c| c.to_vec()))
 }
 
 #[op2(fast)]
@@ -991,6 +1011,8 @@ deno_core::extension!(
         bsengine_destroy,
         bsengine_set_visible,
         bsengine_get_visible,
+        bsengine_get_material_color,
+        bsengine_get_material_emissive,
         bsengine_look_at,
         bsengine_get_time,
         bsengine_get_delta_time,
@@ -1072,6 +1094,8 @@ const Bsengine = {
     destroy:        (name)                 => Deno.core.ops.bsengine_destroy(name),
     setVisible:     (name, v)              => Deno.core.ops.bsengine_set_visible(name, v),
     getVisible:     (name)                 => Deno.core.ops.bsengine_get_visible(name),
+    getMaterialColor:   (name) => { const v = Deno.core.ops.bsengine_get_material_color(name); return v ? { r: v[0], g: v[1], b: v[2] } : null; },
+    getMaterialEmissive:(name) => { const v = Deno.core.ops.bsengine_get_material_emissive(name); return v ? { r: v[0], g: v[1], b: v[2] } : null; },
     lookAt:         (name, tx, ty, tz)     => Deno.core.ops.bsengine_look_at(name, tx, ty, tz),
 
     // Time
@@ -1663,6 +1687,54 @@ JSON.stringify(received)
             .eval(r#"Bsengine.setVisible("Cube", false); "ok""#)
             .unwrap();
         assert!(r.contains("ok"), "setVisible threw: {r}");
+    }
+
+    #[test]
+    fn get_material_color_returns_null_for_unknown_entity() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"Bsengine.getMaterialColor("Ghost") === null ? "null" : "not-null""#)
+            .unwrap();
+        assert!(r.contains("null"), "expected null: {r}");
+    }
+
+    #[test]
+    fn get_material_color_returns_value_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::MATERIAL_COLOR_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Cube".to_string(), [0.5, 0.25, 1.0]);
+        });
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getMaterialColor("Cube"))"#)
+            .unwrap();
+        super::MATERIAL_COLOR_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("0.5"), "expected r=0.5: {r}");
+    }
+
+    #[test]
+    fn get_material_emissive_returns_null_for_unknown_entity() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"Bsengine.getMaterialEmissive("Ghost") === null ? "null" : "not-null""#)
+            .unwrap();
+        assert!(r.contains("null"), "expected null: {r}");
+    }
+
+    #[test]
+    fn get_material_emissive_returns_value_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::MATERIAL_EMISSIVE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Cube".to_string(), [0.75, 0.0, 0.0]);
+        });
+        let r = rt
+            .eval(r#"JSON.stringify(Bsengine.getMaterialEmissive("Cube"))"#)
+            .unwrap();
+        super::MATERIAL_EMISSIVE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("0.75"), "expected r=0.75: {r}");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -21,10 +21,11 @@ use crate::ops::{
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
     GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
     KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MASS_SNAPSHOT,
-    MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
-    MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR,
-    RESTITUTION_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT,
-    TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
+    MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
+    MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
+    MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, RESTITUTION_SNAPSHOT,
+    SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
+    TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -191,6 +192,20 @@ fn run_scripts(world: &mut World) {
         let mut q = world.query::<(&Name, &Visible)>();
         q.iter(world)
             .map(|(n, v)| (n.0.clone(), v.is_visible))
+            .collect()
+    };
+
+    let material_color_snapshot: HashMap<String, [f32; 3]> = {
+        let mut q = world.query::<(&Name, &Material)>();
+        q.iter(world)
+            .map(|(n, m)| (n.0.clone(), m.base_color.to_array()))
+            .collect()
+    };
+
+    let material_emissive_snapshot: HashMap<String, [f32; 3]> = {
+        let mut q = world.query::<(&Name, &Material)>();
+        q.iter(world)
+            .map(|(n, m)| (n.0.clone(), m.emissive.to_array()))
             .collect()
     };
 
@@ -398,6 +413,8 @@ fn run_scripts(world: &mut World) {
 
     TRANSFORM_SNAPSHOT.with(|s| *s.borrow_mut() = transform_snapshot);
     VISIBLE_SNAPSHOT.with(|s| *s.borrow_mut() = visible_snapshot);
+    MATERIAL_COLOR_SNAPSHOT.with(|s| *s.borrow_mut() = material_color_snapshot);
+    MATERIAL_EMISSIVE_SNAPSHOT.with(|s| *s.borrow_mut() = material_emissive_snapshot);
 
     let (elapsed_secs, delta_secs) =
         if let Some(mut timing) = world.get_resource_mut::<ScriptTimingState>() {


### PR DESCRIPTION
## Summary
- Add MATERIAL_COLOR_SNAPSHOT and MATERIAL_EMISSIVE_SNAPSHOT thread-locals
- Expose Bsengine.getMaterialColor(name) and getMaterialEmissive(name) returning {r,g,b} or null
- Snapshot built from Material component each frame

## Test plan
- [x] 4 new unit tests (null for unknown, value when snapshot set — for each)
- [x] cargo test -p bsengine-scripting -- 101 tests pass