### PR TITLE
feat(scripting): add isSleeping/wakeUp/sleep body state APIs

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -215,6 +215,28 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn is_sleeping(&self, entity: Entity) -> Option<bool> {
+        let handle = self.entity_body_map.get(&entity)?;
+        let body = self.rigid_body_set.get(*handle)?;
+        Some(body.is_sleeping())
+    }
+
+    pub fn wake_up(&mut self, entity: Entity) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.wake_up(true);
+            }
+        }
+    }
+
+    pub fn put_to_sleep(&mut self, entity: Entity) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.sleep();
+            }
+        }
+    }
+
     pub fn get_restitution(&self, entity: Entity) -> Option<f32> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -213,6 +213,12 @@ pub enum ScriptCommand {
         lock_y: bool,
         lock_z: bool,
     },
+    WakeUp {
+        name: String,
+    },
+    PutToSleep {
+        name: String,
+    },
 }
 
 thread_local! {
@@ -297,6 +303,10 @@ thread_local! {
 
     // name → is_sensor (only for entities with at least one collider)
     pub(crate) static COLLIDER_SENSOR_SNAPSHOT: RefCell<HashMap<String, bool>> =
+        RefCell::new(HashMap::new());
+
+    // name → is_sleeping (only for entities with a physics body)
+    pub(crate) static SLEEP_SNAPSHOT: RefCell<HashMap<String, bool>> =
         RefCell::new(HashMap::new());
 
     // name → linear damping (only for entities with a physics body)
@@ -686,6 +696,21 @@ pub fn bsengine_is_kinematic(#[string] name: String) -> bool {
 }
 
 #[op2(fast)]
+pub fn bsengine_is_sleeping(#[string] name: String) -> bool {
+    SLEEP_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(false))
+}
+
+#[op2(fast)]
+pub fn bsengine_wake_up(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::WakeUp { name }));
+}
+
+#[op2(fast)]
+pub fn bsengine_sleep(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::PutToSleep { name }));
+}
+
+#[op2(fast)]
 pub fn bsengine_is_collider_sensor(#[string] name: String) -> bool {
     COLLIDER_SENSOR_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(false))
 }
@@ -1068,6 +1093,9 @@ deno_core::extension!(
         bsengine_set_mass,
         bsengine_get_gravity_scale,
         bsengine_is_kinematic,
+        bsengine_is_sleeping,
+        bsengine_wake_up,
+        bsengine_sleep,
         bsengine_is_collider_sensor,
         bsengine_get_linear_damping,
         bsengine_get_angular_damping,
@@ -1158,6 +1186,9 @@ const Bsengine = {
     setMass:              (name, mass)             => Deno.core.ops.bsengine_set_mass(name, mass),
     getGravityScale:      (name)                   => Deno.core.ops.bsengine_get_gravity_scale(name),
     isKinematic:          (name)                   => Deno.core.ops.bsengine_is_kinematic(name),
+    isSleeping:           (name)                   => Deno.core.ops.bsengine_is_sleeping(name),
+    wakeUp:               (name)                   => Deno.core.ops.bsengine_wake_up(name),
+    sleep:                (name)                   => Deno.core.ops.bsengine_sleep(name),
     isColliderSensor:     (name)                   => Deno.core.ops.bsengine_is_collider_sensor(name),
     getLinearDamping:     (name)                   => Deno.core.ops.bsengine_get_linear_damping(name),
     getAngularDamping:    (name)                   => Deno.core.ops.bsengine_get_angular_damping(name),
@@ -2498,6 +2529,54 @@ JSON.stringify(received)
             });
             assert!(found, "LockTranslation not in buffer");
         });
+    }
+
+    #[test]
+    fn wake_up_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.wakeUp("Rock");"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf
+                .iter()
+                .any(|cmd| matches!(cmd, super::ScriptCommand::WakeUp { name } if name == "Rock"));
+            assert!(found, "WakeUp not in buffer");
+        });
+    }
+
+    #[test]
+    fn sleep_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.sleep("Rock");"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(
+                |cmd| matches!(cmd, super::ScriptCommand::PutToSleep { name } if name == "Rock"),
+            );
+            assert!(found, "PutToSleep not in buffer");
+        });
+    }
+
+    #[test]
+    fn is_sleeping_returns_false_by_default() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let v = rt.eval(r#"String(Bsengine.isSleeping("Rock"))"#).unwrap();
+        assert_eq!(v, "false");
+    }
+
+    #[test]
+    fn is_sleeping_returns_true_when_snapshot_set() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::SLEEP_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Rock".to_string(), true);
+        });
+        let v = rt.eval(r#"String(Bsengine.isSleeping("Rock"))"#).unwrap();
+        super::SLEEP_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert_eq!(v, "true");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -24,7 +24,7 @@ use crate::ops::{
     MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
     MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
     MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, RESTITUTION_SNAPSHOT,
-    SCREEN_SIZE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
+    SCREEN_SIZE_SNAPSHOT, SLEEP_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
     TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
@@ -536,6 +536,18 @@ fn run_scripts(world: &mut World) {
                 .collect()
         })
         .unwrap_or_default();
+    let sleep_snapshot: HashMap<String, bool> = world
+        .get_resource::<PhysicsWorld>()
+        .map(|pw| {
+            entity_name_map
+                .iter()
+                .filter_map(|(&bits, name)| {
+                    let entity = bevy_ecs::prelude::Entity::from_bits(bits);
+                    pw.is_sleeping(entity).map(|v| (name.clone(), v))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let (tag_snapshot, entity_tags_snapshot): (
         HashMap<String, Vec<String>>,
         HashMap<String, Vec<String>>,
@@ -572,6 +584,7 @@ fn run_scripts(world: &mut World) {
     ANGULAR_DAMPING_SNAPSHOT.with(|s| *s.borrow_mut() = angular_damping_snapshot);
     RESTITUTION_SNAPSHOT.with(|s| *s.borrow_mut() = restitution_snapshot);
     FRICTION_SNAPSHOT.with(|s| *s.borrow_mut() = friction_snapshot);
+    SLEEP_SNAPSHOT.with(|s| *s.borrow_mut() = sleep_snapshot);
     let gravity = world
         .get_resource::<PhysicsWorld>()
         .map(|pw| pw.gravity())
@@ -933,6 +946,26 @@ fn run_scripts(world: &mut World) {
                 if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
                 {
                     pw.lock_translations(e, lock_x, lock_y, lock_z);
+                }
+            }
+            ScriptCommand::WakeUp { name } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.wake_up(e);
+                }
+            }
+            ScriptCommand::PutToSleep { name } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.put_to_sleep(e);
                 }
             }
             ScriptCommand::AddTag { name, label } => {


### PR DESCRIPTION
## Summary
- Adds `is_sleeping`, `wake_up`, `put_to_sleep` to `PhysicsWorld` (wraps Rapier `is_sleeping()`, `wake_up()`, `sleep()`)
- Adds `SLEEP_SNAPSHOT` thread-local populated each frame from physics bodies
- Adds `ScriptCommand::WakeUp` and `ScriptCommand::PutToSleep` variants
- Exposes `Bsengine.isSleeping(name)`, `Bsengine.wakeUp(name)`, `Bsengine.sleep(name)` in JS bootstrap
- Adds 4 tests: command enqueue and snapshot readback for both sleep directions