### PR TITLE
feat(scripting): add applyImpulseAtPoint off-center impulse API

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -110,6 +110,18 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn apply_impulse_at_point(&mut self, entity: Entity, impulse: Vec3, point: Vec3) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.apply_impulse_at_point(
+                    Vector::new(impulse.x, impulse.y, impulse.z),
+                    Vector::new(point.x, point.y, point.z),
+                    true,
+                );
+            }
+        }
+    }
+
     pub fn apply_force(&mut self, entity: Entity, force: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -124,6 +124,15 @@ pub enum ScriptCommand {
         fy: f32,
         fz: f32,
     },
+    AddImpulseAtPoint {
+        name: String,
+        fx: f32,
+        fy: f32,
+        fz: f32,
+        px: f32,
+        py: f32,
+        pz: f32,
+    },
     AddForce {
         name: String,
         fx: f32,
@@ -595,6 +604,29 @@ pub fn bsengine_add_impulse(#[string] name: String, fx: f32, fy: f32, fz: f32) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::AddImpulse { name, fx, fy, fz });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_apply_impulse_at_point(
+    #[string] name: String,
+    fx: f32,
+    fy: f32,
+    fz: f32,
+    px: f32,
+    py: f32,
+    pz: f32,
+) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::AddImpulseAtPoint {
+            name,
+            fx,
+            fy,
+            fz,
+            px,
+            py,
+            pz,
+        });
     });
 }
 
@@ -1078,6 +1110,7 @@ deno_core::extension!(
         bsengine_get_children,
         bsengine_get_velocity,
         bsengine_add_impulse,
+        bsengine_apply_impulse_at_point,
         bsengine_add_force,
         bsengine_set_velocity,
         bsengine_get_gravity,
@@ -1171,6 +1204,7 @@ const Bsengine = {
     getChildren:      (name)    => JSON.parse(Deno.core.ops.bsengine_get_children(name)),
     getVelocity:      (name)    => { const v = Deno.core.ops.bsengine_get_velocity(name); return v ? { x: v[0], y: v[1], z: v[2] } : null; },
     addImpulse:       (name, fx, fy, fz) => Deno.core.ops.bsengine_add_impulse(name, fx, fy, fz),
+    applyImpulseAtPoint: (name, fx, fy, fz, px, py, pz) => Deno.core.ops.bsengine_apply_impulse_at_point(name, fx, fy, fz, px, py, pz),
     addForce:         (name, fx, fy, fz) => Deno.core.ops.bsengine_add_force(name, fx, fy, fz),
     setVelocity:      (name, vx, vy, vz) => Deno.core.ops.bsengine_set_velocity(name, vx, vy, vz),
     getGravity:           ()                     => Deno.core.ops.bsengine_get_gravity(),
@@ -2084,6 +2118,22 @@ JSON.stringify(received)
                     if name == "Ball" && (*fy - 10.0).abs() < 1e-6)
             });
             assert!(found, "AddImpulse not in buffer");
+        });
+    }
+
+    #[test]
+    fn apply_impulse_at_point_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.applyImpulseAtPoint("Ball", 0, 10, 0, 1, 0, 0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::AddImpulseAtPoint { name, fy, px, .. }
+                    if name == "Ball" && (*fy - 10.0).abs() < 1e-6 && (*px - 1.0).abs() < 1e-6)
+            });
+            assert!(found, "AddImpulseAtPoint not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -823,6 +823,24 @@ fn run_scripts(world: &mut World) {
                     pw.apply_impulse(e, Vec3::new(fx, fy, fz));
                 }
             }
+            ScriptCommand::AddImpulseAtPoint {
+                name,
+                fx,
+                fy,
+                fz,
+                px,
+                py,
+                pz,
+            } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.apply_impulse_at_point(e, Vec3::new(fx, fy, fz), Vec3::new(px, py, pz));
+                }
+            }
             ScriptCommand::AddForce { name, fx, fy, fz } => {
                 let entity = {
                     let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();


### PR DESCRIPTION
## Summary
- Adds `apply_impulse_at_point` to `PhysicsWorld` (wraps Rapier `apply_impulse_at_point`)
- Adds `ScriptCommand::AddImpulseAtPoint` variant with 6 float params (impulse + point)
- Exposes `Bsengine.applyImpulseAtPoint(name, fx, fy, fz, px, py, pz)` in JS bootstrap
- Generates both linear and angular momentum — useful for hit-scan impacts that spin the target
- Adds test coverage in scripting op tests