### PR TITLE
feat(scripting): add addForceAtPoint continuous off-center force API

### DIFF
--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -130,6 +130,18 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn apply_force_at_point(&mut self, entity: Entity, force: Vec3, point: Vec3) {
+        if let Some(&handle) = self.entity_body_map.get(&entity) {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                body.add_force_at_point(
+                    Vector::new(force.x, force.y, force.z),
+                    Vector::new(point.x, point.y, point.z),
+                    true,
+                );
+            }
+        }
+    }
+
     pub fn get_angvel(&self, entity: Entity) -> Option<Vec3> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -139,6 +139,15 @@ pub enum ScriptCommand {
         fy: f32,
         fz: f32,
     },
+    AddForceAtPoint {
+        name: String,
+        fx: f32,
+        fy: f32,
+        fz: f32,
+        px: f32,
+        py: f32,
+        pz: f32,
+    },
     SetVelocity {
         name: String,
         vx: f32,
@@ -688,6 +697,29 @@ pub fn bsengine_add_force(#[string] name: String, fx: f32, fy: f32, fz: f32) {
 }
 
 #[op2(fast)]
+pub fn bsengine_add_force_at_point(
+    #[string] name: String,
+    fx: f32,
+    fy: f32,
+    fz: f32,
+    px: f32,
+    py: f32,
+    pz: f32,
+) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::AddForceAtPoint {
+            name,
+            fx,
+            fy,
+            fz,
+            px,
+            py,
+            pz,
+        });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_set_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
@@ -1165,6 +1197,7 @@ deno_core::extension!(
         bsengine_add_impulse,
         bsengine_apply_impulse_at_point,
         bsengine_add_force,
+        bsengine_add_force_at_point,
         bsengine_set_velocity,
         bsengine_get_gravity,
         bsengine_set_gravity,
@@ -1263,6 +1296,7 @@ const Bsengine = {
     addImpulse:       (name, fx, fy, fz) => Deno.core.ops.bsengine_add_impulse(name, fx, fy, fz),
     applyImpulseAtPoint: (name, fx, fy, fz, px, py, pz) => Deno.core.ops.bsengine_apply_impulse_at_point(name, fx, fy, fz, px, py, pz),
     addForce:         (name, fx, fy, fz) => Deno.core.ops.bsengine_add_force(name, fx, fy, fz),
+    addForceAtPoint:  (name, fx, fy, fz, px, py, pz) => Deno.core.ops.bsengine_add_force_at_point(name, fx, fy, fz, px, py, pz),
     setVelocity:      (name, vx, vy, vz) => Deno.core.ops.bsengine_set_velocity(name, vx, vy, vz),
     getGravity:           ()                     => Deno.core.ops.bsengine_get_gravity(),
     setGravity:           (magnitude)             => Deno.core.ops.bsengine_set_gravity(magnitude),
@@ -2360,6 +2394,22 @@ JSON.stringify(received)
                     if name == "Ball" && (*fy - 10.0).abs() < 1e-6 && (*px - 1.0).abs() < 1e-6)
             });
             assert!(found, "AddImpulseAtPoint not in buffer");
+        });
+    }
+
+    #[test]
+    fn add_force_at_point_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.addForceAtPoint("Ball", 0, 5, 0, 1, 0, 0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::AddForceAtPoint { name, fy, px, .. }
+                    if name == "Ball" && (*fy - 5.0).abs() < 1e-6 && (*px - 1.0).abs() < 1e-6)
+            });
+            assert!(found, "AddForceAtPoint not in buffer");
         });
     }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -851,6 +851,24 @@ fn run_scripts(world: &mut World) {
                     pw.apply_force(e, Vec3::new(fx, fy, fz));
                 }
             }
+            ScriptCommand::AddForceAtPoint {
+                name,
+                fx,
+                fy,
+                fz,
+                px,
+                py,
+                pz,
+            } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let (Some(e), Some(mut pw)) = (entity, world.get_resource_mut::<PhysicsWorld>())
+                {
+                    pw.apply_force_at_point(e, Vec3::new(fx, fy, fz), Vec3::new(px, py, pz));
+                }
+            }
             ScriptCommand::SetVelocity { name, vx, vy, vz } => {
                 let entity = {
                     let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();


### PR DESCRIPTION
## Summary
- Adds `Bsengine.addForceAtPoint(name, fx, fy, fz, px, py, pz)` JS API
- Applies sustained force at a world-space point each frame, generating torque
- Mirrors `applyImpulseAtPoint` but for continuous per-frame force accumulation

## Implementation
- `PhysicsWorld::apply_force_at_point` via `body.add_force_at_point(Vector, Vector, true)`
- `AddForceAtPoint` ScriptCommand variant → handled in plugin.rs
- `bsengine_add_force_at_point` op registered and exposed in BOOTSTRAP_JS

## Test plan
- [x] `add_force_at_point_enqueues_command` — verifies fy==5.0, px==1.0
- [x] 102 tests pass (`cargo test -p bsengine-scripting -p bsengine-physics`)