### PR TITLE
feat(scripting): add setMetallic/getMetallic/setRoughness/getRoughness ops

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -87,6 +87,14 @@ pub enum ScriptCommand {
         g: f32,
         b: f32,
     },
+    SetMetallic {
+        name: String,
+        value: f32,
+    },
+    SetRoughness {
+        name: String,
+        value: f32,
+    },
     Spawn(SpawnParams),
     Destroy {
         name: String,
@@ -402,6 +410,14 @@ thread_local! {
 
     // name → emissive [r, g, b] (only for entities with a Material component)
     pub(crate) static MATERIAL_EMISSIVE_SNAPSHOT: RefCell<HashMap<String, [f32; 3]>> =
+        RefCell::new(HashMap::new());
+
+    // name → metallic (only for entities with a Material component)
+    pub(crate) static MATERIAL_METALLIC_SNAPSHOT: RefCell<HashMap<String, f32>> =
+        RefCell::new(HashMap::new());
+
+    // name → roughness (only for entities with a Material component)
+    pub(crate) static MATERIAL_ROUGHNESS_SNAPSHOT: RefCell<HashMap<String, f32>> =
         RefCell::new(HashMap::new());
 
     pub(crate) static TIME_ELAPSED_SNAPSHOT: RefCell<f32> = RefCell::new(0.0);
@@ -1036,6 +1052,32 @@ pub fn bsengine_get_material_color(#[string] name: String) -> Option<Vec<f32>> {
 #[serde]
 pub fn bsengine_get_material_emissive(#[string] name: String) -> Option<Vec<f32>> {
     MATERIAL_EMISSIVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|c| c.to_vec()))
+}
+
+#[op2(fast)]
+pub fn bsengine_set_metallic(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetMetallic { name, value });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_metallic(#[string] name: String) -> f32 {
+    MATERIAL_METALLIC_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(f32::NAN))
+}
+
+#[op2(fast)]
+pub fn bsengine_set_roughness(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetRoughness { name, value });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_roughness(#[string] name: String) -> f32 {
+    MATERIAL_ROUGHNESS_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(f32::NAN))
 }
 
 #[op2(fast)]
@@ -1721,6 +1763,10 @@ deno_core::extension!(
         bsengine_get_visible,
         bsengine_get_material_color,
         bsengine_get_material_emissive,
+        bsengine_set_metallic,
+        bsengine_get_metallic,
+        bsengine_set_roughness,
+        bsengine_get_roughness,
         bsengine_look_at,
         bsengine_get_time,
         bsengine_get_delta_time,
@@ -1865,6 +1911,10 @@ const Bsengine = {
     getVisible:     (name)                 => Deno.core.ops.bsengine_get_visible(name),
     getMaterialColor:   (name) => { const v = Deno.core.ops.bsengine_get_material_color(name); return v ? { r: v[0], g: v[1], b: v[2] } : null; },
     getMaterialEmissive:(name) => { const v = Deno.core.ops.bsengine_get_material_emissive(name); return v ? { r: v[0], g: v[1], b: v[2] } : null; },
+    setMetallic:    (name, value)          => Deno.core.ops.bsengine_set_metallic(name, value),
+    getMetallic:    (name)                 => Deno.core.ops.bsengine_get_metallic(name),
+    setRoughness:   (name, value)          => Deno.core.ops.bsengine_set_roughness(name, value),
+    getRoughness:   (name)                 => Deno.core.ops.bsengine_get_roughness(name),
     lookAt:         (name, tx, ty, tz)     => Deno.core.ops.bsengine_look_at(name, tx, ty, tz),
 
     // Time
@@ -4653,5 +4703,69 @@ JSON.stringify(received)
             }
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn set_metallic_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setMetallic("Sphere", 0.8);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert_eq!(buf.len(), 1);
+            match &buf[0] {
+                super::ScriptCommand::SetMetallic { name, value } => {
+                    assert_eq!(name, "Sphere");
+                    assert!((value - 0.8).abs() < 1e-4);
+                }
+                _ => panic!("expected SetMetallic command"),
+            }
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn get_metallic_returns_value() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::MATERIAL_METALLIC_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Sphere".to_string(), 0.75);
+        });
+        let r = rt.eval(r#"Bsengine.getMetallic("Sphere")"#).unwrap();
+        super::MATERIAL_METALLIC_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        let v: f32 = r.trim().parse().expect("expected a number");
+        assert!((v - 0.75).abs() < 1e-4, "expected 0.75, got {v}");
+    }
+
+    #[test]
+    fn set_roughness_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setRoughness("Sphere", 0.3);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert_eq!(buf.len(), 1);
+            match &buf[0] {
+                super::ScriptCommand::SetRoughness { name, value } => {
+                    assert_eq!(name, "Sphere");
+                    assert!((value - 0.3).abs() < 1e-4);
+                }
+                _ => panic!("expected SetRoughness command"),
+            }
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn get_roughness_returns_value() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::MATERIAL_ROUGHNESS_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Sphere".to_string(), 0.4);
+        });
+        let r = rt.eval(r#"Bsengine.getRoughness("Sphere")"#).unwrap();
+        super::MATERIAL_ROUGHNESS_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        let v: f32 = r.trim().parse().expect("expected a number");
+        assert!((v - 0.4).abs() < 1e-4, "expected 0.4, got {v}");
     }
 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -21,11 +21,12 @@ use crate::ops::{
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
     GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
     KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MASS_SNAPSHOT,
-    MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
-    MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
-    MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, RESTITUTION_SNAPSHOT,
-    SCREEN_SIZE_SNAPSHOT, SLEEP_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
-    TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
+    MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MATERIAL_METALLIC_SNAPSHOT,
+    MATERIAL_ROUGHNESS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT,
+    MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT,
+    PHYSICS_WORLD_PTR, RESTITUTION_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SLEEP_SNAPSHOT, TAG_SNAPSHOT,
+    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT,
+    VISIBLE_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -216,6 +217,20 @@ fn run_scripts(world: &mut World) {
         let mut q = world.query::<(&Name, &Material)>();
         q.iter(world)
             .map(|(n, m)| (n.0.clone(), m.emissive.to_array()))
+            .collect()
+    };
+
+    let material_metallic_snapshot: HashMap<String, f32> = {
+        let mut q = world.query::<(&Name, &Material)>();
+        q.iter(world)
+            .map(|(n, m)| (n.0.clone(), m.metallic))
+            .collect()
+    };
+
+    let material_roughness_snapshot: HashMap<String, f32> = {
+        let mut q = world.query::<(&Name, &Material)>();
+        q.iter(world)
+            .map(|(n, m)| (n.0.clone(), m.roughness))
             .collect()
     };
 
@@ -426,6 +441,8 @@ fn run_scripts(world: &mut World) {
     VISIBLE_SNAPSHOT.with(|s| *s.borrow_mut() = visible_snapshot);
     MATERIAL_COLOR_SNAPSHOT.with(|s| *s.borrow_mut() = material_color_snapshot);
     MATERIAL_EMISSIVE_SNAPSHOT.with(|s| *s.borrow_mut() = material_emissive_snapshot);
+    MATERIAL_METALLIC_SNAPSHOT.with(|s| *s.borrow_mut() = material_metallic_snapshot);
+    MATERIAL_ROUGHNESS_SNAPSHOT.with(|s| *s.borrow_mut() = material_roughness_snapshot);
 
     let (elapsed_secs, delta_secs) =
         if let Some(mut timing) = world.get_resource_mut::<ScriptTimingState>() {
@@ -782,6 +799,38 @@ fn run_scripts(world: &mut World) {
                     } else {
                         world.entity_mut(e).insert(Material {
                             base_color: Vec3::new(r, g, b),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            ScriptCommand::SetMetallic { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut mat) = world.get_mut::<Material>(e) {
+                        mat.metallic = value;
+                    } else {
+                        world.entity_mut(e).insert(Material {
+                            metallic: value,
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            ScriptCommand::SetRoughness { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut mat) = world.get_mut::<Material>(e) {
+                        mat.roughness = value;
+                    } else {
+                        world.entity_mut(e).insert(Material {
+                            roughness: value,
                             ..Default::default()
                         });
                     }


### PR DESCRIPTION
## Summary
- Add `MATERIAL_METALLIC_SNAPSHOT` and `MATERIAL_ROUGHNESS_SNAPSHOT` thread-locals in ops.rs
- Add `SetMetallic` and `SetRoughness` ScriptCommand variants with op functions and BOOTSTRAP_JS entries
- Populate metallic/roughness snapshots each frame in plugin.rs
- Handle `SetMetallic`/`SetRoughness` commands in plugin.rs match arm
- 4 new tests covering setter/getter round-trips

## Test plan
- [x] `cargo test -p bsengine-scripting` — 174 passed, 0 failed