### PR TITLE
feat(scripting): add getSoundState and getSoundPosition ops

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -551,6 +551,14 @@ thread_local! {
     // entity name → [tag labels]
     pub(crate) static ENTITY_TAGS_SNAPSHOT: RefCell<HashMap<String, Vec<String>>> =
         RefCell::new(HashMap::new());
+
+    // sound id → playback state string ("playing", "pausing", "paused", etc.)
+    pub(crate) static SOUND_STATE_SNAPSHOT: RefCell<HashMap<u32, String>> =
+        RefCell::new(HashMap::new());
+
+    // sound id → playback position in seconds
+    pub(crate) static SOUND_POSITION_SNAPSHOT: RefCell<HashMap<u32, f64>> =
+        RefCell::new(HashMap::new());
 }
 
 /// Full transform returned to scripts: position + rotation quaternion + scale.
@@ -1722,6 +1730,19 @@ pub fn bsengine_set_sound_playback_rate(id: u32, rate: f32) {
     });
 }
 
+#[op2]
+#[string]
+pub fn bsengine_get_sound_state(id: u32) -> String {
+    SOUND_STATE_SNAPSHOT
+        .with(|s| s.borrow().get(&id).cloned())
+        .unwrap_or_default()
+}
+
+#[op2(fast)]
+pub fn bsengine_get_sound_position(id: u32) -> f64 {
+    SOUND_POSITION_SNAPSHOT.with(|s| s.borrow().get(&id).copied().unwrap_or(0.0))
+}
+
 #[op2(fast)]
 pub fn bsengine_set_hud_text(#[string] id: String, #[string] text: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SetHudText { id, text }));
@@ -2021,6 +2042,8 @@ deno_core::extension!(
         bsengine_set_sound_volume,
         bsengine_set_sound_panning,
         bsengine_set_sound_playback_rate,
+        bsengine_get_sound_state,
+        bsengine_get_sound_position,
         bsengine_set_hud_text,
         bsengine_clear_hud_text,
         bsengine_load_scene,
@@ -2193,6 +2216,8 @@ const Bsengine = {
     setSoundVolume:       (id, db)      => Deno.core.ops.bsengine_set_sound_volume(id, db),
     setSoundPanning:      (id, panning) => Deno.core.ops.bsengine_set_sound_panning(id, panning),
     setSoundPlaybackRate: (id, rate)    => Deno.core.ops.bsengine_set_sound_playback_rate(id, rate),
+    getSoundState:        (id)          => Deno.core.ops.bsengine_get_sound_state(id),
+    getSoundPosition:     (id)          => Deno.core.ops.bsengine_get_sound_position(id),
     setHudText:     (id, text)             => Deno.core.ops.bsengine_set_hud_text(id, String(text)),
     clearHudText:   (id)                   => Deno.core.ops.bsengine_clear_hud_text(id),
     loadScene:      (path)                 => Deno.core.ops.bsengine_load_scene(path),
@@ -4672,6 +4697,41 @@ JSON.stringify(received)
             assert!(found, "SetSoundPlaybackRate not in buffer");
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn get_sound_state_reads_snapshot() {
+        super::SOUND_STATE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(99, "playing".to_string());
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getSoundState(99);"#).unwrap();
+        super::SOUND_STATE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("playing"), "expected playing: {r}");
+    }
+
+    #[test]
+    fn get_sound_state_returns_empty_for_unknown_id() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getSoundState(9999);"#).unwrap();
+        assert!(
+            r.trim().is_empty() || r.trim() == "\"\"",
+            "expected empty string: {r}"
+        );
+    }
+
+    #[test]
+    fn get_sound_position_reads_snapshot() {
+        super::SOUND_POSITION_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(42, 3.5);
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getSoundPosition(42);"#).unwrap();
+        super::SOUND_POSITION_SNAPSHOT.with(|s| s.borrow_mut().clear());
+        assert!(r.contains("3.5"), "expected 3.5: {r}");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -24,9 +24,10 @@ use crate::ops::{
     MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MATERIAL_METALLIC_SNAPSHOT,
     MATERIAL_ROUGHNESS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT,
     MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT,
-    PHYSICS_WORLD_PTR, RESTITUTION_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SLEEP_SNAPSHOT, TAG_SNAPSHOT,
-    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT,
-    VISIBLE_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
+    PHYSICS_WORLD_PTR, RESTITUTION_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SLEEP_SNAPSHOT,
+    SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT, TAG_SNAPSHOT, TIME_DELTA_SNAPSHOT,
+    TIME_ELAPSED_SNAPSHOT, TRANSFORM_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
+    WORLD_TRANSFORM_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -623,6 +624,26 @@ fn run_scripts(world: &mut World) {
     GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_just_pressed);
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_just_released);
     GAMEPAD_STICKS_SNAPSHOT.with(|s| *s.borrow_mut() = gamepad_sticks);
+    if let Some(handles) = world.get_resource::<SoundHandles>() {
+        use kira::sound::PlaybackState;
+        let mut states = std::collections::HashMap::new();
+        let mut positions = std::collections::HashMap::new();
+        for (id, handle) in &handles.0 {
+            let state = match handle.state() {
+                PlaybackState::Playing => "playing",
+                PlaybackState::Pausing => "pausing",
+                PlaybackState::Paused => "paused",
+                PlaybackState::WaitingToResume => "waiting_to_resume",
+                PlaybackState::Resuming => "resuming",
+                PlaybackState::Stopping => "stopping",
+                PlaybackState::Stopped => "stopped",
+            };
+            states.insert(*id, state.to_string());
+            positions.insert(*id, handle.position());
+        }
+        SOUND_STATE_SNAPSHOT.with(|s| *s.borrow_mut() = states);
+        SOUND_POSITION_SNAPSHOT.with(|s| *s.borrow_mut() = positions);
+    }
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
 
     if let Some(mut rt) = world.get_non_send_resource_mut::<ScriptRuntimeResource>() {


### PR DESCRIPTION
## Summary
- Add `Bsengine.getSoundState(id)` — returns playback state string ("playing", "pausing", "paused", "waiting_to_resume", "resuming", "stopping", "stopped", or "" if id unknown)
- Add `Bsengine.getSoundPosition(id)` — returns current playback position in seconds (0.0 if unknown)
- Both read from per-frame thread_local snapshots populated from `SoundHandles` in `run_scripts`

## Test plan
- [x] `get_sound_state_reads_snapshot` - pre-populates snapshot, verifies correct state returned
- [x] `get_sound_state_returns_empty_for_unknown_id` - verifies "" returned for missing id
- [x] `get_sound_position_reads_snapshot` - pre-populates snapshot, verifies position returned
- [x] All 193 scripting tests pass

Generated with Claude Code