### PR TITLE
feat(scripting): add AnimationPlayer and Lifetime scripting API

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -181,6 +181,31 @@ pub enum ScriptCommand {
         name: String,
         value: f32,
     },
+    PlayAnimation {
+        name: String,
+        clip: String,
+    },
+    PauseAnimation {
+        name: String,
+    },
+    ResumeAnimation {
+        name: String,
+    },
+    ResetAnimation {
+        name: String,
+    },
+    SetAnimationSpeed {
+        name: String,
+        speed: f32,
+    },
+    SetAnimationLooping {
+        name: String,
+        looping: bool,
+    },
+    SetLifetime {
+        name: String,
+        seconds: f32,
+    },
     Spawn(SpawnParams),
     Destroy {
         name: String,
@@ -652,6 +677,14 @@ thread_local! {
 
     // entity name → (current_health, max_health)
     pub(crate) static HEALTH_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
+        RefCell::new(HashMap::new());
+
+    // entity name → (clip, time, speed, looping, playing)
+    pub(crate) static ANIMATION_SNAPSHOT: RefCell<HashMap<String, (String, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+
+    // entity name → remaining lifetime seconds
+    pub(crate) static LIFETIME_SNAPSHOT: RefCell<HashMap<String, f32>> =
         RefCell::new(HashMap::new());
 }
 
@@ -1468,6 +1501,109 @@ pub fn bsengine_set_max_health(#[string] name: String, value: f32) {
         c.borrow_mut()
             .push(ScriptCommand::SetMaxHealth { name, value })
     });
+}
+
+#[op2(fast)]
+pub fn bsengine_play_animation(#[string] name: String, #[string] clip: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::PlayAnimation { name, clip })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_pause_animation(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::PauseAnimation { name }));
+}
+
+#[op2(fast)]
+pub fn bsengine_resume_animation(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResumeAnimation { name }));
+}
+
+#[op2(fast)]
+pub fn bsengine_reset_animation(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResetAnimation { name }));
+}
+
+#[op2(fast)]
+pub fn bsengine_set_animation_speed(#[string] name: String, speed: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAnimationSpeed { name, speed })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_animation_looping(#[string] name: String, looping: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAnimationLooping { name, looping })
+    });
+}
+
+#[op2]
+#[string]
+pub fn bsengine_get_animation_clip(#[string] name: String) -> String {
+    ANIMATION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(clip, _, _, _, _)| clip.clone())
+            .unwrap_or_default()
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_animation_time(#[string] name: String) -> f32 {
+    ANIMATION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, time, _, _, _)| *time)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_animation_speed(#[string] name: String) -> f32 {
+    ANIMATION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, speed, _, _)| *speed)
+            .unwrap_or(1.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_animation_playing(#[string] name: String) -> bool {
+    ANIMATION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, playing)| *playing)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_animation_looping(#[string] name: String) -> bool {
+    ANIMATION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, looping, _)| *looping)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_set_lifetime(#[string] name: String, seconds: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetLifetime { name, seconds })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_lifetime(#[string] name: String) -> f32 {
+    LIFETIME_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
 }
 
 #[op2(fast)]
@@ -2304,6 +2440,19 @@ deno_core::extension!(
         bsengine_heal_entity,
         bsengine_set_health,
         bsengine_set_max_health,
+        bsengine_play_animation,
+        bsengine_pause_animation,
+        bsengine_resume_animation,
+        bsengine_reset_animation,
+        bsengine_set_animation_speed,
+        bsengine_set_animation_looping,
+        bsengine_get_animation_clip,
+        bsengine_get_animation_time,
+        bsengine_get_animation_speed,
+        bsengine_is_animation_playing,
+        bsengine_is_animation_looping,
+        bsengine_set_lifetime,
+        bsengine_get_lifetime,
         bsengine_look_at,
         bsengine_get_time,
         bsengine_get_delta_time,
@@ -2495,7 +2644,20 @@ const Bsengine = {
     damageEntity:       (name, amount)     => Deno.core.ops.bsengine_damage_entity(name, amount),
     healEntity:         (name, amount)     => Deno.core.ops.bsengine_heal_entity(name, amount),
     setHealth:          (name, value)      => Deno.core.ops.bsengine_set_health(name, value),
-    setMaxHealth:       (name, value)      => Deno.core.ops.bsengine_set_max_health(name, value),
+    setMaxHealth:           (name, value)   => Deno.core.ops.bsengine_set_max_health(name, value),
+    playAnimation:          (name, clip)    => Deno.core.ops.bsengine_play_animation(name, clip),
+    pauseAnimation:         (name)          => Deno.core.ops.bsengine_pause_animation(name),
+    resumeAnimation:        (name)          => Deno.core.ops.bsengine_resume_animation(name),
+    resetAnimation:         (name)          => Deno.core.ops.bsengine_reset_animation(name),
+    setAnimationSpeed:      (name, speed)   => Deno.core.ops.bsengine_set_animation_speed(name, speed),
+    setAnimationLooping:    (name, looping) => Deno.core.ops.bsengine_set_animation_looping(name, looping),
+    getAnimationClip:       (name)          => Deno.core.ops.bsengine_get_animation_clip(name),
+    getAnimationTime:       (name)          => Deno.core.ops.bsengine_get_animation_time(name),
+    getAnimationSpeed:      (name)          => Deno.core.ops.bsengine_get_animation_speed(name),
+    isAnimationPlaying:     (name)          => Deno.core.ops.bsengine_is_animation_playing(name),
+    isAnimationLooping:     (name)          => Deno.core.ops.bsengine_is_animation_looping(name),
+    setLifetime:            (name, seconds) => Deno.core.ops.bsengine_set_lifetime(name, seconds),
+    getLifetime:            (name)          => Deno.core.ops.bsengine_get_lifetime(name),
     lookAt:         (name, tx, ty, tz)     => Deno.core.ops.bsengine_look_at(name, tx, ty, tz),
 
     // Time
@@ -6071,5 +6233,177 @@ JSON.stringify(received)
             assert!(found, "SetMaxHealth not in buffer");
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn play_animation_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.playAnimation("Hero", "walk");"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::PlayAnimation { name, clip }
+                    if name == "Hero" && clip == "walk")
+            });
+            assert!(found, "PlayAnimation not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn pause_animation_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.pauseAnimation("Hero");"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::PauseAnimation { name }
+                    if name == "Hero")
+            });
+            assert!(found, "PauseAnimation not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn resume_animation_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.resumeAnimation("Hero");"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::ResumeAnimation { name }
+                    if name == "Hero")
+            });
+            assert!(found, "ResumeAnimation not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn reset_animation_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.resetAnimation("Hero");"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::ResetAnimation { name }
+                    if name == "Hero")
+            });
+            assert!(found, "ResetAnimation not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn set_animation_speed_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setAnimationSpeed("Hero", 2.0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetAnimationSpeed { name, speed }
+                    if name == "Hero" && (*speed - 2.0).abs() < 1e-5)
+            });
+            assert!(found, "SetAnimationSpeed not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn set_animation_looping_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setAnimationLooping("Hero", false);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetAnimationLooping { name, looping }
+                    if name == "Hero" && !*looping)
+            });
+            assert!(found, "SetAnimationLooping not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn get_animation_clip_returns_empty_for_unknown() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getAnimationClip("Unknown");"#).unwrap();
+        assert!(
+            r.trim().is_empty() || r.trim() == "\"\"",
+            "expected empty, got {r}"
+        );
+    }
+
+    #[test]
+    fn get_animation_time_returns_zero_for_unknown() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getAnimationTime("Unknown");"#).unwrap();
+        assert!(r.trim() == "0" || r.trim() == "0.0", "expected 0, got {r}");
+    }
+
+    #[test]
+    fn get_animation_speed_returns_one_for_unknown() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"Bsengine.getAnimationSpeed("Unknown");"#)
+            .unwrap();
+        assert!(r.trim() == "1" || r.trim() == "1.0", "expected 1, got {r}");
+    }
+
+    #[test]
+    fn is_animation_playing_returns_false_for_unknown() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"Bsengine.isAnimationPlaying("Unknown");"#)
+            .unwrap();
+        assert_eq!(r.trim(), "false");
+    }
+
+    #[test]
+    fn is_animation_looping_returns_false_for_unknown() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"Bsengine.isAnimationLooping("Unknown");"#)
+            .unwrap();
+        assert_eq!(r.trim(), "false");
+    }
+
+    #[test]
+    fn set_lifetime_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setLifetime("Bullet", 3.0);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetLifetime { name, seconds }
+                    if name == "Bullet" && (*seconds - 3.0).abs() < 1e-5)
+            });
+            assert!(found, "SetLifetime not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn get_lifetime_returns_zero_for_unknown() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"Bsengine.getLifetime("Unknown");"#).unwrap();
+        assert!(r.trim() == "0" || r.trim() == "0.0", "expected 0, got {r}");
     }
 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -15,13 +15,13 @@ use glam::{EulerRot, Quat, Vec3};
 
 use crate::ops::{
     ScriptCommand, SpawnParams, ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT,
-    BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, CHILDREN_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT,
-    COLLISION_SNAPSHOT, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
-    ENTITY_TAGS_SNAPSHOT, FRICTION_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    ANIMATION_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, CHILDREN_SNAPSHOT,
+    COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT, COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT,
+    ENTITY_NAME_MAP, ENTITY_TAGS_SNAPSHOT, FRICTION_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
     GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, HEALTH_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
-    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MASS_SNAPSHOT,
-    MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MATERIAL_METALLIC_SNAPSHOT,
+    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, LIFETIME_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT,
+    MASS_SNAPSHOT, MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MATERIAL_METALLIC_SNAPSHOT,
     MATERIAL_ROUGHNESS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT,
     MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, PARENT_SNAPSHOT,
     PHYSICS_WORLD_PTR, RESTITUTION_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SLEEP_SNAPSHOT,
@@ -653,6 +653,27 @@ fn run_scripts(world: &mut World) {
         }
         HEALTH_SNAPSHOT.with(|s| *s.borrow_mut() = health_map);
     }
+    {
+        use bsengine_core::AnimationPlayer;
+        let mut anim_map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &AnimationPlayer)>();
+        for (name, ap) in q.iter(world) {
+            anim_map.insert(
+                name.0.clone(),
+                (ap.clip.clone(), ap.time, ap.speed, ap.looping, ap.playing),
+            );
+        }
+        ANIMATION_SNAPSHOT.with(|s| *s.borrow_mut() = anim_map);
+    }
+    {
+        use bsengine_core::Lifetime;
+        let mut lifetime_map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Lifetime)>();
+        for (name, lt) in q.iter(world) {
+            lifetime_map.insert(name.0.clone(), lt.remaining);
+        }
+        LIFETIME_SNAPSHOT.with(|s| *s.borrow_mut() = lifetime_map);
+    }
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
 
     if let Some(mut rt) = world.get_non_send_resource_mut::<ScriptRuntimeResource>() {
@@ -1092,6 +1113,92 @@ fn run_scripts(world: &mut World) {
                     if let Some(mut h) = world.get_mut::<Health>(e) {
                         h.max = value.max(0.0);
                         h.current = h.current.min(h.max);
+                    }
+                }
+            }
+            ScriptCommand::PlayAnimation { name, clip } => {
+                use bsengine_core::AnimationPlayer;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ap) = world.get_mut::<AnimationPlayer>(e) {
+                        ap.clip = clip;
+                        ap.time = 0.0;
+                        ap.playing = true;
+                    }
+                }
+            }
+            ScriptCommand::PauseAnimation { name } => {
+                use bsengine_core::AnimationPlayer;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ap) = world.get_mut::<AnimationPlayer>(e) {
+                        ap.pause();
+                    }
+                }
+            }
+            ScriptCommand::ResumeAnimation { name } => {
+                use bsengine_core::AnimationPlayer;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ap) = world.get_mut::<AnimationPlayer>(e) {
+                        ap.play();
+                    }
+                }
+            }
+            ScriptCommand::ResetAnimation { name } => {
+                use bsengine_core::AnimationPlayer;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ap) = world.get_mut::<AnimationPlayer>(e) {
+                        ap.reset();
+                    }
+                }
+            }
+            ScriptCommand::SetAnimationSpeed { name, speed } => {
+                use bsengine_core::AnimationPlayer;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ap) = world.get_mut::<AnimationPlayer>(e) {
+                        ap.speed = speed;
+                    }
+                }
+            }
+            ScriptCommand::SetAnimationLooping { name, looping } => {
+                use bsengine_core::AnimationPlayer;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ap) = world.get_mut::<AnimationPlayer>(e) {
+                        ap.looping = looping;
+                    }
+                }
+            }
+            ScriptCommand::SetLifetime { name, seconds } => {
+                use bsengine_core::Lifetime;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut lt) = world.get_mut::<Lifetime>(e) {
+                        lt.remaining = seconds.max(0.0);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds `playAnimation`, `pauseAnimation`, `resumeAnimation`, `resetAnimation`, `setAnimationSpeed`, `setAnimationLooping` commands via `ScriptCommand` variants and plugin handlers
- Adds read ops: `getAnimationClip`, `getAnimationTime`, `getAnimationSpeed`, `isAnimationPlaying`, `isAnimationLooping`, `getLifetime` backed by per-frame `ANIMATION_SNAPSHOT` and `LIFETIME_SNAPSHOT` thread-locals
- Adds `setLifetime` command to mutate `Lifetime.remaining` on an entity
- All 13 new JS bindings exposed on the global `Bsengine` object

## Test plan
- [x] 13 new unit tests covering enqueue and read-from-snapshot paths
- [x] `cargo test -p bsengine-scripting` — 232 tests, all pass
- [x] `cargo +nightly fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)