### PR TITLE
feat(scripting): add ChromaticAberration scripting API

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -741,6 +741,14 @@ pub enum ScriptCommand {
     ClearTint {
         name: String,
     },
+    SetChromAbIntensity {
+        name: String,
+        intensity: f32,
+    },
+    SetChromAbEnabled {
+        name: String,
+        enabled: bool,
+    },
     PlayAnimation {
         name: String,
         clip: String,
@@ -1373,6 +1381,10 @@ thread_local! {
 
     // entity name → (color_r, color_g, color_b, intensity, mode_u32, fade_rate, pulse_speed, pulse_phase, peak_intensity, enabled)
     pub(crate) static TINT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, u32, f32, f32, f32, f32, bool)>> =
+        RefCell::new(HashMap::new());
+
+    // entity name → (intensity, enabled)
+    pub(crate) static CHROM_AB_SNAPSHOT: RefCell<HashMap<String, (f32, bool)>> =
         RefCell::new(HashMap::new());
 }
 
@@ -5360,6 +5372,37 @@ pub fn bsengine_is_tint_active(#[string] name: String) -> bool {
 }
 
 #[op2(fast)]
+pub fn bsengine_set_chrom_ab_intensity(#[string] name: String, intensity: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetChromAbIntensity { name, intensity })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_chrom_ab_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetChromAbEnabled { name, enabled })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_chrom_ab_intensity(#[string] name: String) -> f32 {
+    CHROM_AB_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(intensity, _)| *intensity)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_chrom_ab_enabled(#[string] name: String) -> bool {
+    CHROM_AB_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(_, en)| *en).unwrap_or(true))
+}
+
+#[op2(fast)]
 pub fn bsengine_look_at(#[string] name: String, tx: f32, ty: f32, tz: f32) {
     let origin = TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(pos, _, _)| *pos));
     if let Some(pos) = origin {
@@ -6630,6 +6673,10 @@ deno_core::extension!(
         bsengine_get_tint_peak_intensity,
         bsengine_is_tint_enabled,
         bsengine_is_tint_active,
+        bsengine_set_chrom_ab_intensity,
+        bsengine_set_chrom_ab_enabled,
+        bsengine_get_chrom_ab_intensity,
+        bsengine_is_chrom_ab_enabled,
     ],
 );
 
@@ -7095,6 +7142,10 @@ const Bsengine = {
     getTintPeakIntensity:(name)            => Deno.core.ops.bsengine_get_tint_peak_intensity(name),
     isTintEnabled:      (name)             => Deno.core.ops.bsengine_is_tint_enabled(name),
     isTintActive:       (name)             => Deno.core.ops.bsengine_is_tint_active(name),
+    setChromAbIntensity:(name, v)          => Deno.core.ops.bsengine_set_chrom_ab_intensity(name, v),
+    setChromAbEnabled:  (name, v)          => Deno.core.ops.bsengine_set_chrom_ab_enabled(name, v),
+    getChromAbIntensity:(name)             => Deno.core.ops.bsengine_get_chrom_ab_intensity(name),
+    isChromAbEnabled:   (name)             => Deno.core.ops.bsengine_is_chrom_ab_enabled(name),
     lookAt:         (name, tx, ty, tz)     => Deno.core.ops.bsengine_look_at(name, tx, ty, tz),
 
     // Time
@@ -13466,6 +13517,45 @@ JSON.stringify(received)
             assert!(buf
                 .iter()
                 .any(|cmd| matches!(cmd, super::ScriptCommand::ClearTint { name } if name == "Hero")));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn chrom_ab_snapshot_read_ops() {
+        super::CHROM_AB_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Cam".to_string(), (0.03, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let intensity = rt.eval(r#"Bsengine.getChromAbIntensity("Cam");"#).unwrap();
+        assert!((intensity.trim().parse::<f32>().unwrap() - 0.03).abs() < 0.001);
+        let en = rt.eval(r#"Bsengine.isChromAbEnabled("Cam");"#).unwrap();
+        assert_eq!(en.trim(), "true");
+        super::CHROM_AB_SNAPSHOT.with(|s| s.borrow_mut().remove("Cam"));
+    }
+
+    #[test]
+    fn chrom_ab_write_ops_queue_commands() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setChromAbIntensity("Cam", 0.05);"#)
+            .unwrap();
+        rt.eval(r#"Bsengine.setChromAbEnabled("Cam", false);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetChromAbIntensity { name, intensity }
+                if name == "Cam" && (*intensity - 0.05).abs() < 0.001
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetChromAbEnabled { name, enabled }
+                if name == "Cam" && !*enabled
+            )));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -16,15 +16,16 @@ use glam::{EulerRot, Quat, Vec3};
 use crate::ops::{
     ScriptCommand, SpawnParams, AMMO_SNAPSHOT, ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT,
     ANIMATION_SNAPSHOT, ARMOR_SNAPSHOT, BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS,
-    CHARGE_SNAPSHOT, CHILDREN_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT,
-    COMMAND_BUFFER, COOLDOWN_SNAPSHOT, CROSSHAIR_SNAPSHOT, DASH_SNAPSHOT, DIALOGUE_SNAPSHOT,
-    DISSOLVE_SNAPSHOT, EMISSIVE_SNAPSHOT, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
-    ENTITY_TAGS_SNAPSHOT, EXPERIENCE_SNAPSHOT, FOOTSTEP_SNAPSHOT, FRICTION_SNAPSHOT, FUEL_SNAPSHOT,
-    GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
-    GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAPPLE_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT,
-    GRAVITY_SNAPSHOT, GRID_SNAP_SNAPSHOT, HEALTH_SNAPSHOT, INTERACTABLE_SNAPSHOT, JUMP_SNAPSHOT,
-    KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, KNOCKBACK_SNAPSHOT,
-    LEVEL_SNAPSHOT, LIFETIME_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MANA_SNAPSHOT, MASS_SNAPSHOT,
+    CHARGE_SNAPSHOT, CHILDREN_SNAPSHOT, CHROM_AB_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT,
+    COLLISION_SNAPSHOT, COMMAND_BUFFER, COOLDOWN_SNAPSHOT, CROSSHAIR_SNAPSHOT, DASH_SNAPSHOT,
+    DIALOGUE_SNAPSHOT, DISSOLVE_SNAPSHOT, EMISSIVE_SNAPSHOT, ENTITY_NAMES_SNAPSHOT,
+    ENTITY_NAME_MAP, ENTITY_TAGS_SNAPSHOT, EXPERIENCE_SNAPSHOT, FOOTSTEP_SNAPSHOT,
+    FRICTION_SNAPSHOT, FUEL_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
+    GRAPPLE_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, GRID_SNAP_SNAPSHOT,
+    HEALTH_SNAPSHOT, INTERACTABLE_SNAPSHOT, JUMP_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
+    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, KNOCKBACK_SNAPSHOT, LEVEL_SNAPSHOT,
+    LIFETIME_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MANA_SNAPSHOT, MASS_SNAPSHOT,
     MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MATERIAL_METALLIC_SNAPSHOT,
     MATERIAL_ROUGHNESS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT,
     MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, MOVE_SPEED_SNAPSHOT,
@@ -1252,6 +1253,15 @@ fn run_scripts(world: &mut World) {
             );
         }
         TINT_SNAPSHOT.with(|s| *s.borrow_mut() = tint_map);
+    }
+    {
+        use bsengine_core::ChromaticAberration;
+        let mut ca_map = HashMap::new();
+        let mut q = world.query::<(Entity, &Name, &ChromaticAberration)>();
+        for (_, name, ca) in q.iter(world) {
+            ca_map.insert(name.0.clone(), (ca.intensity, ca.enabled));
+        }
+        CHROM_AB_SNAPSHOT.with(|s| *s.borrow_mut() = ca_map);
     }
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
 
@@ -3488,6 +3498,30 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut t) = world.get_mut::<Tint>(e) {
                         t.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetChromAbIntensity { name, intensity } => {
+                use bsengine_core::ChromaticAberration;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ca) = world.get_mut::<ChromaticAberration>(e) {
+                        ca.intensity = intensity.max(0.0);
+                    }
+                }
+            }
+            ScriptCommand::SetChromAbEnabled { name, enabled } => {
+                use bsengine_core::ChromaticAberration;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ca) = world.get_mut::<ChromaticAberration>(e) {
+                        ca.enabled = enabled;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds `setChromAbIntensity`, `setChromAbEnabled` write ops
- Adds `getChromAbIntensity`, `isChromAbEnabled` read ops
- Populates `CHROM_AB_SNAPSHOT` each frame from `ChromaticAberration` components
- 2 new tests (read + write); total 420 passing

## Test plan
- [ ] `cargo test -p bsengine-scripting` passes (420 tests)
- [ ] CI green on ubuntu + windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)