### PR TITLE
feat(scripting): add AmbientOcclusion scripting API

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -777,6 +777,26 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    SetAoRadius {
+        name: String,
+        radius: f32,
+    },
+    SetAoBias {
+        name: String,
+        bias: f32,
+    },
+    SetAoIntensity {
+        name: String,
+        intensity: f32,
+    },
+    SetAoSampleCount {
+        name: String,
+        count: u32,
+    },
+    SetAoEnabled {
+        name: String,
+        enabled: bool,
+    },
     PlayAnimation {
         name: String,
         clip: String,
@@ -1417,6 +1437,10 @@ thread_local! {
 
     // entity name → (lut_path, exposure, contrast, saturation, hue_shift, brightness, enabled)
     pub(crate) static COLOR_GRADING_SNAPSHOT: RefCell<HashMap<String, (String, f32, f32, f32, f32, f32, bool)>> =
+        RefCell::new(HashMap::new());
+
+    // entity name → (radius, bias, intensity, sample_count, enabled)
+    pub(crate) static AMBIENT_OCCLUSION_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, u32, bool)>> =
         RefCell::new(HashMap::new());
 }
 
@@ -5562,6 +5586,93 @@ pub fn bsengine_is_color_grading_enabled(#[string] name: String) -> bool {
 }
 
 #[op2(fast)]
+pub fn bsengine_set_ao_radius(#[string] name: String, radius: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAoRadius { name, radius })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_ao_bias(#[string] name: String, bias: f32) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SetAoBias { name, bias }));
+}
+
+#[op2(fast)]
+pub fn bsengine_set_ao_intensity(#[string] name: String, intensity: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAoIntensity { name, intensity })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_ao_sample_count(#[string] name: String, count: u32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAoSampleCount { name, count })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_ao_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAoEnabled { name, enabled })
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_ao_radius(#[string] name: String) -> f32 {
+    AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(radius, _, _, _, _)| *radius)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_ao_bias(#[string] name: String) -> f32 {
+    AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, bias, _, _, _)| *bias)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_ao_intensity(#[string] name: String) -> f32 {
+    AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, intensity, _, _)| *intensity)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_ao_sample_count(#[string] name: String) -> u32 {
+    AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, count, _)| *count)
+            .unwrap_or(0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_ao_enabled(#[string] name: String) -> bool {
+    AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, en)| *en)
+            .unwrap_or(true)
+    })
+}
+
+#[op2(fast)]
 pub fn bsengine_look_at(#[string] name: String, tx: f32, ty: f32, tz: f32) {
     let origin = TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(pos, _, _)| *pos));
     if let Some(pos) = origin {
@@ -6850,6 +6961,16 @@ deno_core::extension!(
         bsengine_get_color_grading_hue_shift,
         bsengine_get_color_grading_brightness,
         bsengine_is_color_grading_enabled,
+        bsengine_set_ao_radius,
+        bsengine_set_ao_bias,
+        bsengine_set_ao_intensity,
+        bsengine_set_ao_sample_count,
+        bsengine_set_ao_enabled,
+        bsengine_get_ao_radius,
+        bsengine_get_ao_bias,
+        bsengine_get_ao_intensity,
+        bsengine_get_ao_sample_count,
+        bsengine_is_ao_enabled,
     ],
 );
 
@@ -7333,6 +7454,16 @@ const Bsengine = {
     getColorGradingHueShift:(name)         => Deno.core.ops.bsengine_get_color_grading_hue_shift(name),
     getColorGradingBrightness:(name)       => Deno.core.ops.bsengine_get_color_grading_brightness(name),
     isColorGradingEnabled:(name)           => Deno.core.ops.bsengine_is_color_grading_enabled(name),
+    setAoRadius:        (name, v)          => Deno.core.ops.bsengine_set_ao_radius(name, v),
+    setAoBias:          (name, v)          => Deno.core.ops.bsengine_set_ao_bias(name, v),
+    setAoIntensity:     (name, v)          => Deno.core.ops.bsengine_set_ao_intensity(name, v),
+    setAoSampleCount:   (name, v)          => Deno.core.ops.bsengine_set_ao_sample_count(name, v),
+    setAoEnabled:       (name, v)          => Deno.core.ops.bsengine_set_ao_enabled(name, v),
+    getAoRadius:        (name)             => Deno.core.ops.bsengine_get_ao_radius(name),
+    getAoBias:          (name)             => Deno.core.ops.bsengine_get_ao_bias(name),
+    getAoIntensity:     (name)             => Deno.core.ops.bsengine_get_ao_intensity(name),
+    getAoSampleCount:   (name)             => Deno.core.ops.bsengine_get_ao_sample_count(name),
+    isAoEnabled:        (name)             => Deno.core.ops.bsengine_is_ao_enabled(name),
     lookAt:         (name, tx, ty, tz)     => Deno.core.ops.bsengine_look_at(name, tx, ty, tz),
 
     // Time
@@ -13830,6 +13961,58 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(
                 cmd,
                 super::ScriptCommand::SetColorGradingEnabled { name, enabled }
+                if name == "Cam" && !*enabled
+            )));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn ao_snapshot_read_ops() {
+        super::AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Cam".to_string(), (0.5, 0.025, 0.8, 8u32, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let radius = rt.eval(r#"Bsengine.getAoRadius("Cam");"#).unwrap();
+        assert!((radius.trim().parse::<f32>().unwrap() - 0.5).abs() < 0.001);
+        let bias = rt.eval(r#"Bsengine.getAoBias("Cam");"#).unwrap();
+        assert!((bias.trim().parse::<f32>().unwrap() - 0.025).abs() < 0.001);
+        let intensity = rt.eval(r#"Bsengine.getAoIntensity("Cam");"#).unwrap();
+        assert!((intensity.trim().parse::<f32>().unwrap() - 0.8).abs() < 0.001);
+        let count = rt.eval(r#"Bsengine.getAoSampleCount("Cam");"#).unwrap();
+        assert_eq!(count.trim(), "8");
+        let en = rt.eval(r#"Bsengine.isAoEnabled("Cam");"#).unwrap();
+        assert_eq!(en.trim(), "true");
+        super::AMBIENT_OCCLUSION_SNAPSHOT.with(|s| s.borrow_mut().remove("Cam"));
+    }
+
+    #[test]
+    fn ao_write_ops_queue_commands() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setAoRadius("Cam", 0.5);"#).unwrap();
+        rt.eval(r#"Bsengine.setAoBias("Cam", 0.025);"#).unwrap();
+        rt.eval(r#"Bsengine.setAoIntensity("Cam", 0.8);"#).unwrap();
+        rt.eval(r#"Bsengine.setAoSampleCount("Cam", 16);"#).unwrap();
+        rt.eval(r#"Bsengine.setAoEnabled("Cam", false);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetAoRadius { name, radius }
+                if name == "Cam" && (*radius - 0.5).abs() < 0.001
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetAoSampleCount { name, count }
+                if name == "Cam" && *count == 16
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetAoEnabled { name, enabled }
                 if name == "Cam" && !*enabled
             )));
         });

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -14,18 +14,18 @@ use bsengine_scene::{Name, PendingSceneLoad, Primitive, PrimitiveMesh, ScriptPat
 use glam::{EulerRot, Quat, Vec3};
 
 use crate::ops::{
-    ScriptCommand, SpawnParams, AMMO_SNAPSHOT, ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT,
-    ANIMATION_SNAPSHOT, ARMOR_SNAPSHOT, BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS,
-    CHARGE_SNAPSHOT, CHILDREN_SNAPSHOT, CHROM_AB_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT,
-    COLLISION_SNAPSHOT, COLOR_GRADING_SNAPSHOT, COMMAND_BUFFER, COOLDOWN_SNAPSHOT,
-    CROSSHAIR_SNAPSHOT, DASH_SNAPSHOT, DIALOGUE_SNAPSHOT, DISSOLVE_SNAPSHOT, EMISSIVE_SNAPSHOT,
-    ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, ENTITY_TAGS_SNAPSHOT, EXPERIENCE_SNAPSHOT,
-    FOOTSTEP_SNAPSHOT, FRICTION_SNAPSHOT, FUEL_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
-    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
-    GRAPPLE_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, GRID_SNAP_SNAPSHOT,
-    HEALTH_SNAPSHOT, INTERACTABLE_SNAPSHOT, JUMP_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
-    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, KNOCKBACK_SNAPSHOT, LEVEL_SNAPSHOT,
-    LIFETIME_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MANA_SNAPSHOT, MASS_SNAPSHOT,
+    ScriptCommand, SpawnParams, AMBIENT_OCCLUSION_SNAPSHOT, AMMO_SNAPSHOT,
+    ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT, ANIMATION_SNAPSHOT, ARMOR_SNAPSHOT,
+    BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, CHARGE_SNAPSHOT, CHILDREN_SNAPSHOT,
+    CHROM_AB_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT, COLOR_GRADING_SNAPSHOT,
+    COMMAND_BUFFER, COOLDOWN_SNAPSHOT, CROSSHAIR_SNAPSHOT, DASH_SNAPSHOT, DIALOGUE_SNAPSHOT,
+    DISSOLVE_SNAPSHOT, EMISSIVE_SNAPSHOT, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
+    ENTITY_TAGS_SNAPSHOT, EXPERIENCE_SNAPSHOT, FOOTSTEP_SNAPSHOT, FRICTION_SNAPSHOT, FUEL_SNAPSHOT,
+    GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
+    GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAPPLE_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT,
+    GRAVITY_SNAPSHOT, GRID_SNAP_SNAPSHOT, HEALTH_SNAPSHOT, INTERACTABLE_SNAPSHOT, JUMP_SNAPSHOT,
+    KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, KNOCKBACK_SNAPSHOT,
+    LEVEL_SNAPSHOT, LIFETIME_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, MANA_SNAPSHOT, MASS_SNAPSHOT,
     MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MATERIAL_METALLIC_SNAPSHOT,
     MATERIAL_ROUGHNESS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT,
     MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, MOVE_SPEED_SNAPSHOT,
@@ -1282,6 +1282,24 @@ fn run_scripts(world: &mut World) {
             );
         }
         COLOR_GRADING_SNAPSHOT.with(|s| *s.borrow_mut() = cg_map);
+    }
+    {
+        use bsengine_core::AmbientOcclusion;
+        let mut ao_map = HashMap::new();
+        let mut q = world.query::<(Entity, &Name, &AmbientOcclusion)>();
+        for (_, name, ao) in q.iter(world) {
+            ao_map.insert(
+                name.0.clone(),
+                (
+                    ao.radius,
+                    ao.bias,
+                    ao.intensity,
+                    ao.sample_count,
+                    ao.enabled,
+                ),
+            );
+        }
+        AMBIENT_OCCLUSION_SNAPSHOT.with(|s| *s.borrow_mut() = ao_map);
     }
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
 
@@ -3626,6 +3644,66 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut cg) = world.get_mut::<ColorGrading>(e) {
                         cg.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetAoRadius { name, radius } => {
+                use bsengine_core::AmbientOcclusion;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ao) = world.get_mut::<AmbientOcclusion>(e) {
+                        ao.radius = radius.max(0.0);
+                    }
+                }
+            }
+            ScriptCommand::SetAoBias { name, bias } => {
+                use bsengine_core::AmbientOcclusion;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ao) = world.get_mut::<AmbientOcclusion>(e) {
+                        ao.bias = bias.max(0.0);
+                    }
+                }
+            }
+            ScriptCommand::SetAoIntensity { name, intensity } => {
+                use bsengine_core::AmbientOcclusion;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ao) = world.get_mut::<AmbientOcclusion>(e) {
+                        ao.intensity = intensity.clamp(0.0, 1.0);
+                    }
+                }
+            }
+            ScriptCommand::SetAoSampleCount { name, count } => {
+                use bsengine_core::AmbientOcclusion;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ao) = world.get_mut::<AmbientOcclusion>(e) {
+                        ao.sample_count = count.max(1);
+                    }
+                }
+            }
+            ScriptCommand::SetAoEnabled { name, enabled } => {
+                use bsengine_core::AmbientOcclusion;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ao) = world.get_mut::<AmbientOcclusion>(e) {
+                        ao.enabled = enabled;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds write ops: `setAoRadius`, `setAoBias`, `setAoIntensity`, `setAoSampleCount`, `setAoEnabled`
- Adds read ops: `getAoRadius`, `getAoBias`, `getAoIntensity`, `getAoSampleCount`, `isAoEnabled`
- Populates `AMBIENT_OCCLUSION_SNAPSHOT` each frame from `AmbientOcclusion` components
- 2 new tests (read + write); total 424 passing

## Test plan
- [ ] `cargo test -p bsengine-scripting` passes (424 tests)
- [ ] CI green on ubuntu + windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)