### PR TITLE
feat(scripting): add Layer and Anchor scripting API

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -1013,6 +1013,24 @@ pub enum ScriptCommand {
         name: String,
         index: i32,
     },
+    SetLayer {
+        name: String,
+        bits: u32,
+    },
+    SetAnchorPreset {
+        name: String,
+        preset: u32,
+    },
+    SetAnchorCustom {
+        name: String,
+        x: f32,
+        y: f32,
+    },
+    SetAnchorOffset {
+        name: String,
+        x: f32,
+        y: f32,
+    },
     PlayAnimation {
         name: String,
         clip: String,
@@ -1711,6 +1729,14 @@ thread_local! {
         RefCell::new(HashMap::new());
     // entity name → z-index (i32; 0 = default draw order)
     pub(crate) static Z_INDEX_SNAPSHOT: RefCell<HashMap<String, i32>> =
+        RefCell::new(HashMap::new());
+    // entity name → layer bitmask (u32)
+    pub(crate) static LAYER_SNAPSHOT: RefCell<HashMap<String, u32>> =
+        RefCell::new(HashMap::new());
+    // entity name → (preset_u32, norm_x, norm_y, offset_x, offset_y)
+    // AnchorPreset: Center=0, TopLeft=1, TopCenter=2, TopRight=3,
+    //   MiddleLeft=4, MiddleRight=5, BottomLeft=6, BottomCenter=7, BottomRight=8, Custom=9
+    pub(crate) static ANCHOR_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32)>> =
         RefCell::new(HashMap::new());
 }
 
@@ -7015,6 +7041,87 @@ pub fn bsengine_get_z_index(#[string] name: String) -> i32 {
 }
 
 #[op2(fast)]
+pub fn bsengine_set_layer(#[string] name: String, bits: u32) {
+    COMMAND_BUFFER.with(|b| {
+        b.borrow_mut().push(ScriptCommand::SetLayer { name, bits });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_layer(#[string] name: String) -> u32 {
+    LAYER_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(u32::MAX))
+}
+
+#[op2(fast)]
+pub fn bsengine_set_anchor_preset(#[string] name: String, preset: u32) {
+    COMMAND_BUFFER.with(|b| {
+        b.borrow_mut()
+            .push(ScriptCommand::SetAnchorPreset { name, preset });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_anchor_custom(#[string] name: String, x: f32, y: f32) {
+    COMMAND_BUFFER.with(|b| {
+        b.borrow_mut()
+            .push(ScriptCommand::SetAnchorCustom { name, x, y });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_anchor_offset(#[string] name: String, x: f32, y: f32) {
+    COMMAND_BUFFER.with(|b| {
+        b.borrow_mut()
+            .push(ScriptCommand::SetAnchorOffset { name, x, y });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_anchor_preset(#[string] name: String) -> u32 {
+    ANCHOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(p, _, _, _, _)| *p).unwrap_or(0))
+}
+
+#[op2(fast)]
+pub fn bsengine_get_anchor_norm_x(#[string] name: String) -> f32 {
+    ANCHOR_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, nx, _, _, _)| *nx)
+            .unwrap_or(0.5)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_anchor_norm_y(#[string] name: String) -> f32 {
+    ANCHOR_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, ny, _, _)| *ny)
+            .unwrap_or(0.5)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_anchor_offset_x(#[string] name: String) -> f32 {
+    ANCHOR_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, ox, _)| *ox)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_anchor_offset_y(#[string] name: String) -> f32 {
+    ANCHOR_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, oy)| *oy)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
 pub fn bsengine_look_at(#[string] name: String, tx: f32, ty: f32, tz: f32) {
     let origin = TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(pos, _, _)| *pos));
     if let Some(pos) = origin {
@@ -7989,6 +8096,16 @@ deno_core::extension!(
         bsengine_is_outline_visible,
         bsengine_set_z_index,
         bsengine_get_z_index,
+        bsengine_set_layer,
+        bsengine_get_layer,
+        bsengine_set_anchor_preset,
+        bsengine_set_anchor_custom,
+        bsengine_set_anchor_offset,
+        bsengine_get_anchor_preset,
+        bsengine_get_anchor_norm_x,
+        bsengine_get_anchor_norm_y,
+        bsengine_get_anchor_offset_x,
+        bsengine_get_anchor_offset_y,
         bsengine_look_at,
         bsengine_get_time,
         bsengine_get_delta_time,
@@ -9050,6 +9167,16 @@ const Bsengine = {
     isOutlineVisible:(name)               => Deno.core.ops.bsengine_is_outline_visible(name),
     setZIndex:      (name, index)          => Deno.core.ops.bsengine_set_z_index(name, index),
     getZIndex:      (name)                 => Deno.core.ops.bsengine_get_z_index(name),
+    setLayer:       (name, bits)           => Deno.core.ops.bsengine_set_layer(name, bits),
+    getLayer:       (name)                 => Deno.core.ops.bsengine_get_layer(name),
+    setAnchorPreset:(name, preset)         => Deno.core.ops.bsengine_set_anchor_preset(name, preset),
+    setAnchorCustom:(name, x, y)           => Deno.core.ops.bsengine_set_anchor_custom(name, x, y),
+    setAnchorOffset:(name, x, y)           => Deno.core.ops.bsengine_set_anchor_offset(name, x, y),
+    getAnchorPreset:(name)                => Deno.core.ops.bsengine_get_anchor_preset(name),
+    getAnchorNormX: (name)                 => Deno.core.ops.bsengine_get_anchor_norm_x(name),
+    getAnchorNormY: (name)                 => Deno.core.ops.bsengine_get_anchor_norm_y(name),
+    getAnchorOffsetX:(name)               => Deno.core.ops.bsengine_get_anchor_offset_x(name),
+    getAnchorOffsetY:(name)               => Deno.core.ops.bsengine_get_anchor_offset_y(name),
     lookAt:         (name, tx, ty, tz)     => Deno.core.ops.bsengine_look_at(name, tx, ty, tz),
 
     // Time
@@ -16466,6 +16593,92 @@ JSON.stringify(received)
                 cmd,
                 super::ScriptCommand::SetZIndex { name, index }
                 if name == "Panel" && *index == -3
+            )));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_layer_read_ops() {
+        super::LAYER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert("Enemy".to_string(), 0b0101);
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let bits = rt.eval(r#"Bsengine.getLayer("Enemy");"#).unwrap();
+        assert_eq!(bits.trim().parse::<u32>().unwrap(), 5);
+        let unknown = rt.eval(r#"Bsengine.getLayer("Unknown");"#).unwrap();
+        assert_eq!(unknown.trim().parse::<u32>().unwrap(), u32::MAX);
+        super::LAYER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_layer_write_ops_queue_commands() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setLayer("Wall", 3);"#).unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetLayer { name, bits }
+                if name == "Wall" && *bits == 3
+            )));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_anchor_read_ops() {
+        super::ANCHOR_SNAPSHOT.with(|s| {
+            // TopRight preset: (3, 1.0, 1.0, 0.0, 0.0)
+            s.borrow_mut()
+                .insert("Button".to_string(), (3, 1.0, 1.0, 5.0, -2.0));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let preset = rt.eval(r#"Bsengine.getAnchorPreset("Button");"#).unwrap();
+        assert_eq!(preset.trim().parse::<u32>().unwrap(), 3);
+        let nx = rt.eval(r#"Bsengine.getAnchorNormX("Button");"#).unwrap();
+        assert!((nx.trim().parse::<f32>().unwrap() - 1.0).abs() < 0.001);
+        let ny = rt.eval(r#"Bsengine.getAnchorNormY("Button");"#).unwrap();
+        assert!((ny.trim().parse::<f32>().unwrap() - 1.0).abs() < 0.001);
+        let ox = rt.eval(r#"Bsengine.getAnchorOffsetX("Button");"#).unwrap();
+        assert!((ox.trim().parse::<f32>().unwrap() - 5.0).abs() < 0.001);
+        let oy = rt.eval(r#"Bsengine.getAnchorOffsetY("Button");"#).unwrap();
+        assert!((oy.trim().parse::<f32>().unwrap() - (-2.0)).abs() < 0.001);
+        let unknown_nx = rt.eval(r#"Bsengine.getAnchorNormX("Unknown");"#).unwrap();
+        assert!((unknown_nx.trim().parse::<f32>().unwrap() - 0.5).abs() < 0.001);
+        super::ANCHOR_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_anchor_write_ops_queue_commands() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setAnchorPreset("Panel", 6);"#).unwrap();
+        rt.eval(r#"Bsengine.setAnchorCustom("Panel", 0.25, 0.75);"#)
+            .unwrap();
+        rt.eval(r#"Bsengine.setAnchorOffset("Panel", 10.0, -5.0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetAnchorPreset { name, preset }
+                if name == "Panel" && *preset == 6
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetAnchorCustom { name, x, y }
+                if name == "Panel" && (*x - 0.25).abs() < 0.001 && (*y - 0.75).abs() < 0.001
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetAnchorOffset { name, x, y }
+                if name == "Panel" && (*x - 10.0).abs() < 0.001 && (*y - (-5.0)).abs() < 0.001
             )));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -15,18 +15,18 @@ use glam::{EulerRot, Quat, Vec3};
 
 use crate::ops::{
     ScriptCommand, SpawnParams, ABSORPTION_SNAPSHOT, AMBIENT_OCCLUSION_SNAPSHOT, AMMO_SNAPSHOT,
-    ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT, ANIMATION_SNAPSHOT, ARMOR_SNAPSHOT,
-    BILLBOARD_SNAPSHOT, BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, BUOYANCY_SNAPSHOT,
-    CHARGE_SNAPSHOT, CHILDREN_SNAPSHOT, CHROM_AB_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT,
-    COLLISION_SNAPSHOT, COLOR_GRADING_SNAPSHOT, COMMAND_BUFFER, COOLDOWN_SNAPSHOT,
-    CROSSHAIR_SNAPSHOT, DASH_SNAPSHOT, DEPTH_OF_FIELD_SNAPSHOT, DIALOGUE_SNAPSHOT,
-    DISSOLVE_SNAPSHOT, EMISSIVE_SNAPSHOT, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP,
-    ENTITY_TAGS_SNAPSHOT, EXPERIENCE_SNAPSHOT, FOG_SNAPSHOT, FOLLOW_SNAPSHOT, FOOTSTEP_SNAPSHOT,
-    FRICTION_SNAPSHOT, FUEL_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    ANCHOR_SNAPSHOT, ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT, ANIMATION_SNAPSHOT,
+    ARMOR_SNAPSHOT, BILLBOARD_SNAPSHOT, BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS,
+    BUOYANCY_SNAPSHOT, CHARGE_SNAPSHOT, CHILDREN_SNAPSHOT, CHROM_AB_SNAPSHOT,
+    COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT, COLOR_GRADING_SNAPSHOT, COMMAND_BUFFER,
+    COOLDOWN_SNAPSHOT, CROSSHAIR_SNAPSHOT, DASH_SNAPSHOT, DEPTH_OF_FIELD_SNAPSHOT,
+    DIALOGUE_SNAPSHOT, DISSOLVE_SNAPSHOT, EMISSIVE_SNAPSHOT, ENTITY_NAMES_SNAPSHOT,
+    ENTITY_NAME_MAP, ENTITY_TAGS_SNAPSHOT, EXPERIENCE_SNAPSHOT, FOG_SNAPSHOT, FOLLOW_SNAPSHOT,
+    FOOTSTEP_SNAPSHOT, FRICTION_SNAPSHOT, FUEL_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
     GRAPPLE_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, GRID_SNAP_SNAPSHOT,
     HEALTH_SNAPSHOT, INTERACTABLE_SNAPSHOT, JUMP_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
-    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, KNOCKBACK_SNAPSHOT, LEVEL_SNAPSHOT,
+    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, KNOCKBACK_SNAPSHOT, LAYER_SNAPSHOT, LEVEL_SNAPSHOT,
     LIFETIME_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, LOOK_AT_SNAPSHOT, MANA_SNAPSHOT, MASS_SNAPSHOT,
     MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MATERIAL_METALLIC_SNAPSHOT,
     MATERIAL_ROUGHNESS_SNAPSHOT, MOTION_BLUR_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
@@ -1568,6 +1568,39 @@ fn run_scripts(world: &mut World) {
             zi_map.insert(name.0.clone(), zi.value());
         }
         Z_INDEX_SNAPSHOT.with(|s| *s.borrow_mut() = zi_map);
+    }
+    {
+        use bsengine_core::Layer;
+        let mut l_map = HashMap::new();
+        let mut q = world.query::<(Entity, &Name, &Layer)>();
+        for (_, name, l) in q.iter(world) {
+            l_map.insert(name.0.clone(), l.bits());
+        }
+        LAYER_SNAPSHOT.with(|s| *s.borrow_mut() = l_map);
+    }
+    {
+        use bsengine_core::{Anchor, AnchorPreset};
+        let mut a_map = HashMap::new();
+        let mut q = world.query::<(Entity, &Name, &Anchor)>();
+        for (_, name, a) in q.iter(world) {
+            let (preset_u32, norm_x, norm_y) = match a.preset {
+                AnchorPreset::Center => (0u32, 0.5f32, 0.5f32),
+                AnchorPreset::TopLeft => (1, 0.0, 1.0),
+                AnchorPreset::TopCenter => (2, 0.5, 1.0),
+                AnchorPreset::TopRight => (3, 1.0, 1.0),
+                AnchorPreset::MiddleLeft => (4, 0.0, 0.5),
+                AnchorPreset::MiddleRight => (5, 1.0, 0.5),
+                AnchorPreset::BottomLeft => (6, 0.0, 0.0),
+                AnchorPreset::BottomCenter => (7, 0.5, 0.0),
+                AnchorPreset::BottomRight => (8, 1.0, 0.0),
+                AnchorPreset::Custom(v) => (9, v.x, v.y),
+            };
+            a_map.insert(
+                name.0.clone(),
+                (preset_u32, norm_x, norm_y, a.offset.x, a.offset.y),
+            );
+        }
+        ANCHOR_SNAPSHOT.with(|s| *s.borrow_mut() = a_map);
     }
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
 
@@ -4634,6 +4667,66 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut zi) = world.get_mut::<ZIndex>(e) {
                         *zi = ZIndex::new(index);
+                    }
+                }
+            }
+            ScriptCommand::SetLayer { name, bits } => {
+                use bsengine_core::Layer;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut l) = world.get_mut::<Layer>(e) {
+                        *l = Layer::new(bits);
+                    }
+                }
+            }
+            ScriptCommand::SetAnchorPreset { name, preset } => {
+                use bsengine_core::{Anchor, AnchorPreset};
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut a) = world.get_mut::<Anchor>(e) {
+                        a.preset = match preset {
+                            1 => AnchorPreset::TopLeft,
+                            2 => AnchorPreset::TopCenter,
+                            3 => AnchorPreset::TopRight,
+                            4 => AnchorPreset::MiddleLeft,
+                            5 => AnchorPreset::MiddleRight,
+                            6 => AnchorPreset::BottomLeft,
+                            7 => AnchorPreset::BottomCenter,
+                            8 => AnchorPreset::BottomRight,
+                            _ => AnchorPreset::Center,
+                        };
+                    }
+                }
+            }
+            ScriptCommand::SetAnchorCustom { name, x, y } => {
+                use bsengine_core::{Anchor, AnchorPreset};
+                use glam::Vec2;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut a) = world.get_mut::<Anchor>(e) {
+                        a.preset = AnchorPreset::Custom(Vec2::new(x, y));
+                    }
+                }
+            }
+            ScriptCommand::SetAnchorOffset { name, x, y } => {
+                use bsengine_core::Anchor;
+                use glam::Vec2;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut a) = world.get_mut::<Anchor>(e) {
+                        a.offset = Vec2::new(x, y);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds `setLayer`/`getLayer` ops for the `Layer` component (u32 bitmask; default = ALL bits set)
- Adds `setAnchorPreset`, `setAnchorCustom`, `setAnchorOffset`, `getAnchorPreset`, `getAnchorNormX/Y`, `getAnchorOffsetX/Y` ops for the `Anchor` component (AnchorPreset: Center=0 through BottomRight=8, Custom=9)

## Test plan
- [x] `test_layer_read_ops` — verifies bitmask read and unknown defaults to u32::MAX
- [x] `test_layer_write_ops_queue_commands` — verifies SetLayer queued correctly
- [x] `test_anchor_read_ops` — verifies preset, normalized XY, offset XY, unknown defaults (center = 0.5/0.5)
- [x] `test_anchor_write_ops_queue_commands` — verifies SetAnchorPreset, SetAnchorCustom, SetAnchorOffset queued correctly
- [x] All 456 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)