### PR TITLE
feat(scripting): add Amplify, Barrier, and Beacon scripting API

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -1148,6 +1148,70 @@ pub enum ScriptCommand {
     CalmAlarm {
         name: String,
     },
+    ApplyAmplify {
+        name: String,
+        duration: f32,
+    },
+    ClearAmplify {
+        name: String,
+    },
+    SetAmplifyDuration {
+        name: String,
+        duration: f32,
+    },
+    SetAmplifyPowerMultiplier {
+        name: String,
+        multiplier: f32,
+    },
+    SetAmplifyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SetBarrierCapacity {
+        name: String,
+        capacity: f32,
+    },
+    SetBarrierCurrent {
+        name: String,
+        current: f32,
+    },
+    SetBarrierRegenRate {
+        name: String,
+        rate: f32,
+    },
+    SetBarrierRegenDelay {
+        name: String,
+        delay: f32,
+    },
+    SetBarrierEnabled {
+        name: String,
+        enabled: bool,
+    },
+    RestoreBarrier {
+        name: String,
+    },
+    DrainBarrier {
+        name: String,
+    },
+    SetBeaconPriority {
+        name: String,
+        priority: u32,
+    },
+    SetBeaconBroadcastRadius {
+        name: String,
+        radius: f32,
+    },
+    SetBeaconEnabled {
+        name: String,
+        enabled: bool,
+    },
+    LightBeacon {
+        name: String,
+        duration: f32,
+    },
+    ExtinguishBeacon {
+        name: String,
+    },
     PlayAnimation {
         name: String,
         clip: String,
@@ -1874,6 +1938,15 @@ thread_local! {
         RefCell::new(HashMap::new());
     // entity name → (alert_duration, timer, detection_radius, just_triggered, just_calmed, enabled)
     pub(crate) static ALARM_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (duration, timer, power_multiplier, just_amplified, just_faded, enabled)
+    pub(crate) static AMPLIFY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (capacity, current, regen_rate, regen_delay, regen_timer, just_broken, just_restored, enabled)
+    pub(crate) static BARRIER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (priority, broadcast_radius, duration, timer, lit, just_lit, just_extinguished, enabled)
+    pub(crate) static BEACON_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, bool, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
 }
 
@@ -7836,6 +7909,449 @@ pub fn bsengine_get_alarm_remaining_fraction(#[string] name: String) -> f32 {
 }
 
 #[op2(fast)]
+pub fn bsengine_get_amplify_duration(#[string] name: String) -> f32 {
+    AMPLIFY_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(dur, _, _, _, _, _)| *dur)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_amplify_timer(#[string] name: String) -> f32 {
+    AMPLIFY_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, timer, _, _, _, _)| *timer)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_amplify_power_multiplier(#[string] name: String) -> f32 {
+    AMPLIFY_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, mul, _, _, _)| *mul)
+            .unwrap_or(1.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_amplify_active(#[string] name: String) -> bool {
+    AMPLIFY_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, timer, _, _, _, _)| *timer > 0.0)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_amplify_just_amplified(#[string] name: String) -> bool {
+    AMPLIFY_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, ja, _, _)| *ja)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_amplify_just_faded(#[string] name: String) -> bool {
+    AMPLIFY_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, jf, _)| *jf)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_amplify_enabled(#[string] name: String) -> bool {
+    AMPLIFY_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, _, en)| *en)
+            .unwrap_or(true)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_amplify_remaining_fraction(#[string] name: String) -> f32 {
+    AMPLIFY_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(dur, timer, _, _, _, _)| {
+                if *dur <= 0.0 {
+                    0.0
+                } else {
+                    (*timer / *dur).clamp(0.0, 1.0)
+                }
+            })
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_set_amplify_duration(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAmplifyDuration { name, duration });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_amplify_power_multiplier(#[string] name: String, multiplier: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAmplifyPowerMultiplier { name, multiplier });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_amplify_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetAmplifyEnabled { name, enabled });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_apply_amplify(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyAmplify { name, duration });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_clear_amplify(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::ClearAmplify { name });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_barrier_capacity(#[string] name: String) -> f32 {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(cap, _, _, _, _, _, _, _)| *cap)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_barrier_current(#[string] name: String) -> f32 {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, cur, _, _, _, _, _, _)| *cur)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_barrier_regen_rate(#[string] name: String) -> f32 {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, rate, _, _, _, _, _)| *rate)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_barrier_regen_delay(#[string] name: String) -> f32 {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, delay, _, _, _, _)| *delay)
+            .unwrap_or(3.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_barrier_regen_timer(#[string] name: String) -> f32 {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, rt, _, _, _)| *rt)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_barrier_active(#[string] name: String) -> bool {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, cur, _, _, _, _, _, _)| *cur > 0.0)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_barrier_full(#[string] name: String) -> bool {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(cap, cur, _, _, _, _, _, _)| *cur >= *cap)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_barrier_just_broken(#[string] name: String) -> bool {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, _, jb, _, _)| *jb)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_barrier_just_restored(#[string] name: String) -> bool {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, _, _, jr, _)| *jr)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_barrier_enabled(#[string] name: String) -> bool {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, _, _, _, en)| *en)
+            .unwrap_or(true)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_barrier_fraction(#[string] name: String) -> f32 {
+    BARRIER_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(cap, cur, _, _, _, _, _, _)| {
+                if *cap <= 0.0 {
+                    0.0
+                } else {
+                    (*cur / *cap).clamp(0.0, 1.0)
+                }
+            })
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_set_barrier_capacity(#[string] name: String, capacity: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetBarrierCapacity { name, capacity });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_barrier_current(#[string] name: String, current: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetBarrierCurrent { name, current });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_barrier_regen_rate(#[string] name: String, rate: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetBarrierRegenRate { name, rate });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_barrier_regen_delay(#[string] name: String, delay: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetBarrierRegenDelay { name, delay });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_barrier_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetBarrierEnabled { name, enabled });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_restore_barrier(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::RestoreBarrier { name });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_drain_barrier(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::DrainBarrier { name });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_get_beacon_priority(#[string] name: String) -> u32 {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(pri, _, _, _, _, _, _, _)| *pri)
+            .unwrap_or(0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_beacon_broadcast_radius(#[string] name: String) -> f32 {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, rad, _, _, _, _, _, _)| *rad)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_beacon_duration(#[string] name: String) -> f32 {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, dur, _, _, _, _, _)| *dur)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_beacon_timer(#[string] name: String) -> f32 {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, timer, _, _, _, _)| *timer)
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_beacon_lit(#[string] name: String) -> bool {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, lit, _, _, _)| *lit)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_beacon_permanent(#[string] name: String) -> bool {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, dur, _, lit, _, _, _)| *lit && *dur == 0.0)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_beacon_just_lit(#[string] name: String) -> bool {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, _, jl, _, _)| *jl)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_beacon_just_extinguished(#[string] name: String) -> bool {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, _, _, je, _)| *je)
+            .unwrap_or(false)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_is_beacon_enabled(#[string] name: String) -> bool {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, _, _, _, _, _, en)| *en)
+            .unwrap_or(true)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_get_beacon_remaining_fraction(#[string] name: String) -> f32 {
+    BEACON_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .map(|(_, _, dur, timer, lit, _, _, _)| {
+                if !*lit {
+                    0.0
+                } else if *dur <= 0.0 {
+                    1.0
+                } else {
+                    (*timer / *dur).clamp(0.0, 1.0)
+                }
+            })
+            .unwrap_or(0.0)
+    })
+}
+
+#[op2(fast)]
+pub fn bsengine_set_beacon_priority(#[string] name: String, priority: u32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetBeaconPriority { name, priority });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_beacon_broadcast_radius(#[string] name: String, radius: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetBeaconBroadcastRadius { name, radius });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_set_beacon_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetBeaconEnabled { name, enabled });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_light_beacon(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::LightBeacon { name, duration });
+    });
+}
+
+#[op2(fast)]
+pub fn bsengine_extinguish_beacon(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ExtinguishBeacon { name });
+    });
+}
+
+#[op2(fast)]
 pub fn bsengine_look_at(#[string] name: String, tx: f32, ty: f32, tz: f32) {
     let origin = TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(pos, _, _)| *pos));
     if let Some(pos) = origin {
@@ -8885,6 +9401,52 @@ deno_core::extension!(
         bsengine_trigger_alarm,
         bsengine_calm_alarm,
         bsengine_get_alarm_remaining_fraction,
+        bsengine_get_amplify_duration,
+        bsengine_get_amplify_timer,
+        bsengine_get_amplify_power_multiplier,
+        bsengine_is_amplify_active,
+        bsengine_is_amplify_just_amplified,
+        bsengine_is_amplify_just_faded,
+        bsengine_is_amplify_enabled,
+        bsengine_get_amplify_remaining_fraction,
+        bsengine_set_amplify_duration,
+        bsengine_set_amplify_power_multiplier,
+        bsengine_set_amplify_enabled,
+        bsengine_apply_amplify,
+        bsengine_clear_amplify,
+        bsengine_get_barrier_capacity,
+        bsengine_get_barrier_current,
+        bsengine_get_barrier_regen_rate,
+        bsengine_get_barrier_regen_delay,
+        bsengine_get_barrier_regen_timer,
+        bsengine_is_barrier_active,
+        bsengine_is_barrier_full,
+        bsengine_is_barrier_just_broken,
+        bsengine_is_barrier_just_restored,
+        bsengine_is_barrier_enabled,
+        bsengine_get_barrier_fraction,
+        bsengine_set_barrier_capacity,
+        bsengine_set_barrier_current,
+        bsengine_set_barrier_regen_rate,
+        bsengine_set_barrier_regen_delay,
+        bsengine_set_barrier_enabled,
+        bsengine_restore_barrier,
+        bsengine_drain_barrier,
+        bsengine_get_beacon_priority,
+        bsengine_get_beacon_broadcast_radius,
+        bsengine_get_beacon_duration,
+        bsengine_get_beacon_timer,
+        bsengine_is_beacon_lit,
+        bsengine_is_beacon_permanent,
+        bsengine_is_beacon_just_lit,
+        bsengine_is_beacon_just_extinguished,
+        bsengine_is_beacon_enabled,
+        bsengine_get_beacon_remaining_fraction,
+        bsengine_set_beacon_priority,
+        bsengine_set_beacon_broadcast_radius,
+        bsengine_set_beacon_enabled,
+        bsengine_light_beacon,
+        bsengine_extinguish_beacon,
         bsengine_look_at,
         bsengine_get_time,
         bsengine_get_delta_time,
@@ -10021,6 +10583,55 @@ const Bsengine = {
     triggerAlarm:   (name)                 => Deno.core.ops.bsengine_trigger_alarm(name),
     calmAlarm:      (name)                 => Deno.core.ops.bsengine_calm_alarm(name),
     getAlarmRemainingFraction:(name)       => Deno.core.ops.bsengine_get_alarm_remaining_fraction(name),
+    // Amplify
+    getAmplifyDuration:          (name)        => Deno.core.ops.bsengine_get_amplify_duration(name),
+    getAmplifyTimer:             (name)        => Deno.core.ops.bsengine_get_amplify_timer(name),
+    getAmplifyPowerMultiplier:   (name)        => Deno.core.ops.bsengine_get_amplify_power_multiplier(name),
+    isAmplifyActive:             (name)        => Deno.core.ops.bsengine_is_amplify_active(name),
+    isAmplifyJustAmplified:      (name)        => Deno.core.ops.bsengine_is_amplify_just_amplified(name),
+    isAmplifyJustFaded:          (name)        => Deno.core.ops.bsengine_is_amplify_just_faded(name),
+    isAmplifyEnabled:            (name)        => Deno.core.ops.bsengine_is_amplify_enabled(name),
+    getAmplifyRemainingFraction: (name)        => Deno.core.ops.bsengine_get_amplify_remaining_fraction(name),
+    setAmplifyDuration:          (name, dur)   => Deno.core.ops.bsengine_set_amplify_duration(name, dur),
+    setAmplifyPowerMultiplier:   (name, mul)   => Deno.core.ops.bsengine_set_amplify_power_multiplier(name, mul),
+    setAmplifyEnabled:           (name, en)    => Deno.core.ops.bsengine_set_amplify_enabled(name, en),
+    applyAmplify:                (name, dur)   => Deno.core.ops.bsengine_apply_amplify(name, dur),
+    clearAmplify:                (name)        => Deno.core.ops.bsengine_clear_amplify(name),
+    // Barrier
+    getBarrierCapacity:          (name)        => Deno.core.ops.bsengine_get_barrier_capacity(name),
+    getBarrierCurrent:           (name)        => Deno.core.ops.bsengine_get_barrier_current(name),
+    getBarrierRegenRate:         (name)        => Deno.core.ops.bsengine_get_barrier_regen_rate(name),
+    getBarrierRegenDelay:        (name)        => Deno.core.ops.bsengine_get_barrier_regen_delay(name),
+    getBarrierRegenTimer:        (name)        => Deno.core.ops.bsengine_get_barrier_regen_timer(name),
+    isBarrierActive:             (name)        => Deno.core.ops.bsengine_is_barrier_active(name),
+    isBarrierFull:               (name)        => Deno.core.ops.bsengine_is_barrier_full(name),
+    isBarrierJustBroken:         (name)        => Deno.core.ops.bsengine_is_barrier_just_broken(name),
+    isBarrierJustRestored:       (name)        => Deno.core.ops.bsengine_is_barrier_just_restored(name),
+    isBarrierEnabled:            (name)        => Deno.core.ops.bsengine_is_barrier_enabled(name),
+    getBarrierFraction:          (name)        => Deno.core.ops.bsengine_get_barrier_fraction(name),
+    setBarrierCapacity:          (name, cap)   => Deno.core.ops.bsengine_set_barrier_capacity(name, cap),
+    setBarrierCurrent:           (name, cur)   => Deno.core.ops.bsengine_set_barrier_current(name, cur),
+    setBarrierRegenRate:         (name, rate)  => Deno.core.ops.bsengine_set_barrier_regen_rate(name, rate),
+    setBarrierRegenDelay:        (name, delay) => Deno.core.ops.bsengine_set_barrier_regen_delay(name, delay),
+    setBarrierEnabled:           (name, en)    => Deno.core.ops.bsengine_set_barrier_enabled(name, en),
+    restoreBarrier:              (name)        => Deno.core.ops.bsengine_restore_barrier(name),
+    drainBarrier:                (name)        => Deno.core.ops.bsengine_drain_barrier(name),
+    // Beacon
+    getBeaconPriority:           (name)        => Deno.core.ops.bsengine_get_beacon_priority(name),
+    getBeaconBroadcastRadius:    (name)        => Deno.core.ops.bsengine_get_beacon_broadcast_radius(name),
+    getBeaconDuration:           (name)        => Deno.core.ops.bsengine_get_beacon_duration(name),
+    getBeaconTimer:              (name)        => Deno.core.ops.bsengine_get_beacon_timer(name),
+    isBeaconLit:                 (name)        => Deno.core.ops.bsengine_is_beacon_lit(name),
+    isBeaconPermanent:           (name)        => Deno.core.ops.bsengine_is_beacon_permanent(name),
+    isBeaconJustLit:             (name)        => Deno.core.ops.bsengine_is_beacon_just_lit(name),
+    isBeaconJustExtinguished:    (name)        => Deno.core.ops.bsengine_is_beacon_just_extinguished(name),
+    isBeaconEnabled:             (name)        => Deno.core.ops.bsengine_is_beacon_enabled(name),
+    getBeaconRemainingFraction:  (name)        => Deno.core.ops.bsengine_get_beacon_remaining_fraction(name),
+    setBeaconPriority:           (name, pri)   => Deno.core.ops.bsengine_set_beacon_priority(name, pri),
+    setBeaconBroadcastRadius:    (name, rad)   => Deno.core.ops.bsengine_set_beacon_broadcast_radius(name, rad),
+    setBeaconEnabled:            (name, en)    => Deno.core.ops.bsengine_set_beacon_enabled(name, en),
+    lightBeacon:                 (name, dur)   => Deno.core.ops.bsengine_light_beacon(name, dur),
+    extinguishBeacon:            (name)        => Deno.core.ops.bsengine_extinguish_beacon(name),
     lookAt:         (name, tx, ty, tz)     => Deno.core.ops.bsengine_look_at(name, tx, ty, tz),
 
     // Time
@@ -18027,6 +18638,287 @@ JSON.stringify(received)
                 cmd,
                 super::ScriptCommand::CalmAlarm { name }
                 if name == "Tower"
+            )));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_amplify_read_ops() {
+        super::AMPLIFY_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Caster".to_string(), (3.0, 2.0, 1.5, true, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        assert!(
+            (rt.eval(r#"Bsengine.getAmplifyDuration("Caster")"#)
+                .unwrap()
+                .trim()
+                .parse::<f32>()
+                .unwrap()
+                - 3.0)
+                .abs()
+                < 0.001
+        );
+        assert!(
+            (rt.eval(r#"Bsengine.getAmplifyPowerMultiplier("Caster")"#)
+                .unwrap()
+                .trim()
+                .parse::<f32>()
+                .unwrap()
+                - 1.5)
+                .abs()
+                < 0.001
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isAmplifyActive("Caster")"#)
+                .unwrap()
+                .trim(),
+            "true"
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isAmplifyJustAmplified("Caster")"#)
+                .unwrap()
+                .trim(),
+            "true"
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isAmplifyEnabled("Caster")"#)
+                .unwrap()
+                .trim(),
+            "true"
+        );
+        let frac = rt
+            .eval(r#"Bsengine.getAmplifyRemainingFraction("Caster")"#)
+            .unwrap()
+            .trim()
+            .parse::<f32>()
+            .unwrap();
+        assert!((frac - 2.0 / 3.0).abs() < 0.01);
+        super::AMPLIFY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_amplify_write_ops_queue_commands() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.applyAmplify("Caster", 5.0);"#).unwrap();
+        rt.eval(r#"Bsengine.clearAmplify("Caster");"#).unwrap();
+        rt.eval(r#"Bsengine.setAmplifyPowerMultiplier("Caster", 2.0);"#)
+            .unwrap();
+        rt.eval(r#"Bsengine.setAmplifyEnabled("Caster", false);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::ApplyAmplify { name, duration }
+                if name == "Caster" && (*duration - 5.0).abs() < 0.001
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::ClearAmplify { name }
+                if name == "Caster"
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetAmplifyPowerMultiplier { name, multiplier }
+                if name == "Caster" && (*multiplier - 2.0).abs() < 0.001
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetAmplifyEnabled { name, enabled }
+                if name == "Caster" && !enabled
+            )));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_barrier_read_ops() {
+        super::BARRIER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Shield".to_string(),
+                (100.0, 75.0, 10.0, 2.0, 0.5, false, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        assert!(
+            (rt.eval(r#"Bsengine.getBarrierCapacity("Shield")"#)
+                .unwrap()
+                .trim()
+                .parse::<f32>()
+                .unwrap()
+                - 100.0)
+                .abs()
+                < 0.001
+        );
+        assert!(
+            (rt.eval(r#"Bsengine.getBarrierCurrent("Shield")"#)
+                .unwrap()
+                .trim()
+                .parse::<f32>()
+                .unwrap()
+                - 75.0)
+                .abs()
+                < 0.001
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isBarrierActive("Shield")"#)
+                .unwrap()
+                .trim(),
+            "true"
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isBarrierFull("Shield")"#)
+                .unwrap()
+                .trim(),
+            "false"
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isBarrierEnabled("Shield")"#)
+                .unwrap()
+                .trim(),
+            "true"
+        );
+        let frac = rt
+            .eval(r#"Bsengine.getBarrierFraction("Shield")"#)
+            .unwrap()
+            .trim()
+            .parse::<f32>()
+            .unwrap();
+        assert!((frac - 0.75).abs() < 0.01);
+        super::BARRIER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_barrier_write_ops_queue_commands() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setBarrierCapacity("Shield", 200.0);"#)
+            .unwrap();
+        rt.eval(r#"Bsengine.restoreBarrier("Shield");"#).unwrap();
+        rt.eval(r#"Bsengine.drainBarrier("Shield");"#).unwrap();
+        rt.eval(r#"Bsengine.setBarrierEnabled("Shield", false);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetBarrierCapacity { name, capacity }
+                if name == "Shield" && (*capacity - 200.0).abs() < 0.001
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::RestoreBarrier { name }
+                if name == "Shield"
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::DrainBarrier { name }
+                if name == "Shield"
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetBarrierEnabled { name, enabled }
+                if name == "Shield" && !enabled
+            )));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_beacon_read_ops() {
+        super::BEACON_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Waypoint".to_string(),
+                (3u32, 25.0, 4.0, 2.0, true, false, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        assert_eq!(
+            rt.eval(r#"Bsengine.getBeaconPriority("Waypoint")"#)
+                .unwrap()
+                .trim(),
+            "3"
+        );
+        assert!(
+            (rt.eval(r#"Bsengine.getBeaconBroadcastRadius("Waypoint")"#)
+                .unwrap()
+                .trim()
+                .parse::<f32>()
+                .unwrap()
+                - 25.0)
+                .abs()
+                < 0.001
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isBeaconLit("Waypoint")"#)
+                .unwrap()
+                .trim(),
+            "true"
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isBeaconPermanent("Waypoint")"#)
+                .unwrap()
+                .trim(),
+            "false"
+        );
+        assert_eq!(
+            rt.eval(r#"Bsengine.isBeaconEnabled("Waypoint")"#)
+                .unwrap()
+                .trim(),
+            "true"
+        );
+        let frac = rt
+            .eval(r#"Bsengine.getBeaconRemainingFraction("Waypoint")"#)
+            .unwrap()
+            .trim()
+            .parse::<f32>()
+            .unwrap();
+        assert!((frac - 0.5).abs() < 0.01);
+        super::BEACON_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+
+    #[test]
+    fn test_beacon_write_ops_queue_commands() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.lightBeacon("Waypoint", 10.0);"#)
+            .unwrap();
+        rt.eval(r#"Bsengine.extinguishBeacon("Waypoint");"#)
+            .unwrap();
+        rt.eval(r#"Bsengine.setBeaconPriority("Waypoint", 5);"#)
+            .unwrap();
+        rt.eval(r#"Bsengine.setBeaconEnabled("Waypoint", false);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::LightBeacon { name, duration }
+                if name == "Waypoint" && (*duration - 10.0).abs() < 0.001
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::ExtinguishBeacon { name }
+                if name == "Waypoint"
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetBeaconPriority { name, priority }
+                if name == "Waypoint" && *priority == 5
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetBeaconEnabled { name, enabled }
+                if name == "Waypoint" && !enabled
             )));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -15,28 +15,29 @@ use glam::{EulerRot, Quat, Vec3};
 
 use crate::ops::{
     ScriptCommand, SpawnParams, ABILITY_SNAPSHOT, ABSORPTION_SNAPSHOT, ALARM_SNAPSHOT,
-    AMBIENT_OCCLUSION_SNAPSHOT, AMMO_SNAPSHOT, ANCHOR_SNAPSHOT, ANGULAR_DAMPING_SNAPSHOT,
-    ANGULAR_VELOCITY_SNAPSHOT, ANIMATION_SNAPSHOT, ARMOR_SNAPSHOT, BILLBOARD_SNAPSHOT,
-    BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, BUOYANCY_SNAPSHOT, CHARGE_SNAPSHOT,
-    CHILDREN_SNAPSHOT, CHROM_AB_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT,
-    COLOR_GRADING_SNAPSHOT, COMMAND_BUFFER, COOLDOWN_SNAPSHOT, CROSSHAIR_SNAPSHOT, DAMAGE_SNAPSHOT,
-    DASH_SNAPSHOT, DEPTH_OF_FIELD_SNAPSHOT, DIALOGUE_SNAPSHOT, DISSOLVE_SNAPSHOT,
-    EMISSIVE_SNAPSHOT, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, ENTITY_TAGS_SNAPSHOT,
-    EXPERIENCE_SNAPSHOT, FOG_SNAPSHOT, FOLLOW_SNAPSHOT, FOOTSTEP_SNAPSHOT, FRICTION_SNAPSHOT,
-    FUEL_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
-    GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAPPLE_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT,
-    GRAVITY_SNAPSHOT, GRID_SNAP_SNAPSHOT, HEALTH_SNAPSHOT, INTERACTABLE_SNAPSHOT, JUMP_SNAPSHOT,
-    KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, KNOCKBACK_SNAPSHOT,
-    LAYER_SNAPSHOT, LEVEL_SNAPSHOT, LIFETIME_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, LOOK_AT_SNAPSHOT,
-    MANA_SNAPSHOT, MASS_SNAPSHOT, MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT,
-    MATERIAL_METALLIC_SNAPSHOT, MATERIAL_ROUGHNESS_SNAPSHOT, MOTION_BLUR_SNAPSHOT,
-    MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
-    MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, MOVE_SPEED_SNAPSHOT, NAV_SNAPSHOT,
-    OUTLINE_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, PROJECTILE_SNAPSHOT, REGEN_SNAPSHOT,
-    RESTITUTION_SNAPSHOT, SCREEN_SHAKE_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SHIELD_SNAPSHOT,
-    SLEEP_SNAPSHOT, SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT, SPAWN_POINT_SNAPSHOT,
-    SPRING_SNAPSHOT, SPRINT_SNAPSHOT, STAMINA_SNAPSHOT, STATUS_EFFECT_SNAPSHOT, TAG_SNAPSHOT,
-    TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT, TONE_MAP_SNAPSHOT,
+    AMBIENT_OCCLUSION_SNAPSHOT, AMMO_SNAPSHOT, AMPLIFY_SNAPSHOT, ANCHOR_SNAPSHOT,
+    ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT, ANIMATION_SNAPSHOT, ARMOR_SNAPSHOT,
+    BARRIER_SNAPSHOT, BEACON_SNAPSHOT, BILLBOARD_SNAPSHOT, BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT,
+    BOOTSTRAP_JS, BUOYANCY_SNAPSHOT, CHARGE_SNAPSHOT, CHILDREN_SNAPSHOT, CHROM_AB_SNAPSHOT,
+    COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT, COLOR_GRADING_SNAPSHOT, COMMAND_BUFFER,
+    COOLDOWN_SNAPSHOT, CROSSHAIR_SNAPSHOT, DAMAGE_SNAPSHOT, DASH_SNAPSHOT, DEPTH_OF_FIELD_SNAPSHOT,
+    DIALOGUE_SNAPSHOT, DISSOLVE_SNAPSHOT, EMISSIVE_SNAPSHOT, ENTITY_NAMES_SNAPSHOT,
+    ENTITY_NAME_MAP, ENTITY_TAGS_SNAPSHOT, EXPERIENCE_SNAPSHOT, FOG_SNAPSHOT, FOLLOW_SNAPSHOT,
+    FOOTSTEP_SNAPSHOT, FRICTION_SNAPSHOT, FUEL_SNAPSHOT, GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT,
+    GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT, GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT,
+    GRAPPLE_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT, GRID_SNAP_SNAPSHOT,
+    HEALTH_SNAPSHOT, INTERACTABLE_SNAPSHOT, JUMP_SNAPSHOT, KEY_JUST_PRESSED_SNAPSHOT,
+    KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, KNOCKBACK_SNAPSHOT, LAYER_SNAPSHOT, LEVEL_SNAPSHOT,
+    LIFETIME_SNAPSHOT, LINEAR_DAMPING_SNAPSHOT, LOOK_AT_SNAPSHOT, MANA_SNAPSHOT, MASS_SNAPSHOT,
+    MATERIAL_COLOR_SNAPSHOT, MATERIAL_EMISSIVE_SNAPSHOT, MATERIAL_METALLIC_SNAPSHOT,
+    MATERIAL_ROUGHNESS_SNAPSHOT, MOTION_BLUR_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
+    MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
+    MOUSE_PRESSED_SNAPSHOT, MOVE_SPEED_SNAPSHOT, NAV_SNAPSHOT, OUTLINE_SNAPSHOT, PARENT_SNAPSHOT,
+    PHYSICS_WORLD_PTR, PROJECTILE_SNAPSHOT, REGEN_SNAPSHOT, RESTITUTION_SNAPSHOT,
+    SCREEN_SHAKE_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SHIELD_SNAPSHOT, SLEEP_SNAPSHOT,
+    SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT, SPAWN_POINT_SNAPSHOT, SPRING_SNAPSHOT,
+    SPRINT_SNAPSHOT, STAMINA_SNAPSHOT, STATUS_EFFECT_SNAPSHOT, TAG_SNAPSHOT, TIMER_SNAPSHOT,
+    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT, TONE_MAP_SNAPSHOT,
     TRANSFORM_SNAPSHOT, TRIGGER_SNAPSHOT, TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT, VIGNETTE_SNAPSHOT,
     VISIBLE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
@@ -1708,6 +1709,67 @@ fn run_scripts(world: &mut World) {
             );
         }
         ALARM_SNAPSHOT.with(|s| *s.borrow_mut() = al_map);
+    }
+    {
+        use bsengine_core::Amplify;
+        let mut amp_map = HashMap::new();
+        let mut q = world.query::<(Entity, &Name, &Amplify)>();
+        for (_, name, amp) in q.iter(world) {
+            amp_map.insert(
+                name.0.clone(),
+                (
+                    amp.duration,
+                    amp.timer,
+                    amp.power_multiplier,
+                    amp.just_amplified,
+                    amp.just_faded,
+                    amp.enabled,
+                ),
+            );
+        }
+        AMPLIFY_SNAPSHOT.with(|s| *s.borrow_mut() = amp_map);
+    }
+    {
+        use bsengine_core::Barrier;
+        let mut bar_map = HashMap::new();
+        let mut q = world.query::<(Entity, &Name, &Barrier)>();
+        for (_, name, bar) in q.iter(world) {
+            bar_map.insert(
+                name.0.clone(),
+                (
+                    bar.capacity,
+                    bar.current,
+                    bar.regen_rate,
+                    bar.regen_delay,
+                    bar.regen_timer,
+                    bar.just_broken,
+                    bar.just_restored,
+                    bar.enabled,
+                ),
+            );
+        }
+        BARRIER_SNAPSHOT.with(|s| *s.borrow_mut() = bar_map);
+    }
+    {
+        use bsengine_core::Beacon;
+        let mut bec_map = HashMap::new();
+        let mut q = world.query::<(Entity, &Name, &Beacon)>();
+        for (_, name, bec) in q.iter(world) {
+            bec_map.insert(
+                name.0.clone(),
+                (
+                    bec.priority,
+                    bec.broadcast_radius,
+                    bec.duration,
+                    bec.timer,
+                    bec.lit,
+                    bec.just_lit,
+                    bec.just_extinguished,
+                    bec.enabled,
+                ),
+            );
+        }
+        BEACON_SNAPSHOT.with(|s| *s.borrow_mut() = bec_map);
     }
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
 
@@ -5206,6 +5268,210 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut al) = world.get_mut::<Alarm>(e) {
                         al.calm();
+                    }
+                }
+            }
+            ScriptCommand::ApplyAmplify { name, duration } => {
+                use bsengine_core::Amplify;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut amp) = world.get_mut::<Amplify>(e) {
+                        amp.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::ClearAmplify { name } => {
+                use bsengine_core::Amplify;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut amp) = world.get_mut::<Amplify>(e) {
+                        amp.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetAmplifyDuration { name, duration } => {
+                use bsengine_core::Amplify;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut amp) = world.get_mut::<Amplify>(e) {
+                        amp.duration = duration;
+                    }
+                }
+            }
+            ScriptCommand::SetAmplifyPowerMultiplier { name, multiplier } => {
+                use bsengine_core::Amplify;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut amp) = world.get_mut::<Amplify>(e) {
+                        amp.power_multiplier = multiplier.max(1.0);
+                    }
+                }
+            }
+            ScriptCommand::SetAmplifyEnabled { name, enabled } => {
+                use bsengine_core::Amplify;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut amp) = world.get_mut::<Amplify>(e) {
+                        amp.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetBarrierCapacity { name, capacity } => {
+                use bsengine_core::Barrier;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bar) = world.get_mut::<Barrier>(e) {
+                        bar.capacity = capacity.max(0.0);
+                    }
+                }
+            }
+            ScriptCommand::SetBarrierCurrent { name, current } => {
+                use bsengine_core::Barrier;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bar) = world.get_mut::<Barrier>(e) {
+                        bar.current = current.clamp(0.0, bar.capacity);
+                    }
+                }
+            }
+            ScriptCommand::SetBarrierRegenRate { name, rate } => {
+                use bsengine_core::Barrier;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bar) = world.get_mut::<Barrier>(e) {
+                        bar.regen_rate = rate.max(0.0);
+                    }
+                }
+            }
+            ScriptCommand::SetBarrierRegenDelay { name, delay } => {
+                use bsengine_core::Barrier;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bar) = world.get_mut::<Barrier>(e) {
+                        bar.regen_delay = delay.max(0.0);
+                    }
+                }
+            }
+            ScriptCommand::SetBarrierEnabled { name, enabled } => {
+                use bsengine_core::Barrier;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bar) = world.get_mut::<Barrier>(e) {
+                        bar.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::RestoreBarrier { name } => {
+                use bsengine_core::Barrier;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bar) = world.get_mut::<Barrier>(e) {
+                        bar.restore();
+                    }
+                }
+            }
+            ScriptCommand::DrainBarrier { name } => {
+                use bsengine_core::Barrier;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bar) = world.get_mut::<Barrier>(e) {
+                        bar.drain();
+                    }
+                }
+            }
+            ScriptCommand::SetBeaconPriority { name, priority } => {
+                use bsengine_core::Beacon;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bec) = world.get_mut::<Beacon>(e) {
+                        bec.priority = priority;
+                    }
+                }
+            }
+            ScriptCommand::SetBeaconBroadcastRadius { name, radius } => {
+                use bsengine_core::Beacon;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bec) = world.get_mut::<Beacon>(e) {
+                        bec.broadcast_radius = radius.max(0.0);
+                    }
+                }
+            }
+            ScriptCommand::SetBeaconEnabled { name, enabled } => {
+                use bsengine_core::Beacon;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bec) = world.get_mut::<Beacon>(e) {
+                        bec.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::LightBeacon { name, duration } => {
+                use bsengine_core::Beacon;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bec) = world.get_mut::<Beacon>(e) {
+                        bec.light(duration);
+                    }
+                }
+            }
+            ScriptCommand::ExtinguishBeacon { name } => {
+                use bsengine_core::Beacon;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut bec) = world.get_mut::<Beacon>(e) {
+                        bec.extinguish();
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Exposes `Amplify` component: `getAmplifyDuration`, `getAmplifyTimer`, `getAmplifyPowerMultiplier`, `isAmplifyActive`, `isAmplifyJustAmplified`, `isAmplifyJustFaded`, `isAmplifyEnabled`, `getAmplifyRemainingFraction`, `setAmplifyDuration`, `setAmplifyPowerMultiplier`, `setAmplifyEnabled`, `applyAmplify`, `clearAmplify`
- Exposes `Barrier` component: `getBarrierCapacity`, `getBarrierCurrent`, `getBarrierRegenRate`, `getBarrierRegenDelay`, `getBarrierRegenTimer`, `isBarrierActive`, `isBarrierFull`, `isBarrierJustBroken`, `isBarrierJustRestored`, `isBarrierEnabled`, `getBarrierFraction`, `setBarrierCapacity`, `setBarrierCurrent`, `setBarrierRegenRate`, `setBarrierRegenDelay`, `setBarrierEnabled`, `restoreBarrier`, `drainBarrier`
- Exposes `Beacon` component: `getBeaconPriority`, `getBeaconBroadcastRadius`, `getBeaconDuration`, `getBeaconTimer`, `isBeaconLit`, `isBeaconPermanent`, `isBeaconJustLit`, `isBeaconJustExtinguished`, `isBeaconEnabled`, `getBeaconRemainingFraction`, `setBeaconPriority`, `setBeaconBroadcastRadius`, `setBeaconEnabled`, `lightBeacon`, `extinguishBeacon`
- 6 new tests covering read ops and write command queuing for all three components

## Test plan
- [x] `cargo test -p bsengine-scripting` — 475 tests pass
- [x] `cargo +nightly fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)