### PR TITLE
feat(scripting): add Wed/Wedge/Wee/Weed/Weedy/Weep/Weft/Weigh scripting API (72 ops)

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4840,6 +4840,96 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    PledgeWed {
+        name: String,
+        amount: f32,
+    },
+    SeverWed {
+        name: String,
+        amount: f32,
+    },
+    SetWedEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SplitWedge {
+        name: String,
+        amount: f32,
+    },
+    ExtractWedge {
+        name: String,
+        amount: f32,
+    },
+    SetWedgeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    CheerWee {
+        name: String,
+        amount: f32,
+    },
+    SubdueWee {
+        name: String,
+        amount: f32,
+    },
+    SetWeeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    CullWeed {
+        name: String,
+        amount: f32,
+    },
+    SetWeedEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SpreadWeedy {
+        name: String,
+        amount: f32,
+    },
+    ClearWeedy {
+        name: String,
+        amount: f32,
+    },
+    SetWeedyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    MournWeep {
+        name: String,
+        amount: f32,
+    },
+    ConsoleWeep {
+        name: String,
+        amount: f32,
+    },
+    SetWeepEnabled {
+        name: String,
+        enabled: bool,
+    },
+    FrayWeft {
+        name: String,
+    },
+    MendWeft {
+        name: String,
+    },
+    SetWeftEnabled {
+        name: String,
+        enabled: bool,
+    },
+    LoadWeigh {
+        name: String,
+        amount: f32,
+    },
+    LightenWeigh {
+        name: String,
+        amount: f32,
+    },
+    SetWeighEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -6067,6 +6157,22 @@ thread_local! {
     pub(crate) static WEASEL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static WEB_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WED_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEDGE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEED_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEEDY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEEP_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEFT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEIGH_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -12940,6 +13046,365 @@ pub fn bsengine_set_web_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetWebEnabled { name, enabled })
+    });
+}
+// ── Wed ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wed_bond(#[string] name: String) -> f32 {
+    WED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wed_max_bond(#[string] name: String) -> f32 {
+    WED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wed_bind_rate(#[string] name: String) -> f32 {
+    WED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wed_just_wedded(#[string] name: String) -> bool {
+    WED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wed_just_sundered(#[string] name: String) -> bool {
+    WED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wed_enabled(#[string] name: String) -> bool {
+    WED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_pledge_wed(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::PledgeWed { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_sever_wed(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SeverWed { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wed_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWedEnabled { name, enabled })
+    });
+}
+// ── Wedge ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wedge_drive(#[string] name: String) -> f32 {
+    WEDGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wedge_max_drive(#[string] name: String) -> f32 {
+    WEDGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wedge_split_rate(#[string] name: String) -> f32 {
+    WEDGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wedge_just_driven(#[string] name: String) -> bool {
+    WEDGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wedge_just_loose(#[string] name: String) -> bool {
+    WEDGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wedge_enabled(#[string] name: String) -> bool {
+    WEDGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_split_wedge(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SplitWedge { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_extract_wedge(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ExtractWedge { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wedge_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWedgeEnabled { name, enabled })
+    });
+}
+// ── Wee ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wee_glee(#[string] name: String) -> f32 {
+    WEE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wee_max_glee(#[string] name: String) -> f32 {
+    WEE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wee_cheer_rate(#[string] name: String) -> f32 {
+    WEE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wee_just_gleeful(#[string] name: String) -> bool {
+    WEE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wee_just_subdued(#[string] name: String) -> bool {
+    WEE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wee_enabled(#[string] name: String) -> bool {
+    WEE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_cheer_wee(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CheerWee { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_subdue_wee(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SubdueWee { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wee_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeeEnabled { name, enabled })
+    });
+}
+// ── Weed ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weed_level(#[string] name: String) -> f32 {
+    WEED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weed_max_weed(#[string] name: String) -> f32 {
+    WEED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weed_grow_rate(#[string] name: String) -> f32 {
+    WEED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weed_just_overgrown(#[string] name: String) -> bool {
+    WEED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weed_just_cleared(#[string] name: String) -> bool {
+    WEED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weed_enabled(#[string] name: String) -> bool {
+    WEED_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_cull_weed(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CullWeed { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weed_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeedEnabled { name, enabled })
+    });
+}
+// ── Weedy ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weedy_overgrowth(#[string] name: String) -> f32 {
+    WEEDY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weedy_max_overgrowth(#[string] name: String) -> f32 {
+    WEEDY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weedy_spread_rate(#[string] name: String) -> f32 {
+    WEEDY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weedy_just_overrun(#[string] name: String) -> bool {
+    WEEDY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weedy_just_cleared(#[string] name: String) -> bool {
+    WEEDY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weedy_enabled(#[string] name: String) -> bool {
+    WEEDY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_spread_weedy(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SpreadWeedy { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_clear_weedy(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ClearWeedy { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weedy_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeedyEnabled { name, enabled })
+    });
+}
+// ── Weep ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weep_grief(#[string] name: String) -> f32 {
+    WEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weep_max_grief(#[string] name: String) -> f32 {
+    WEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weep_sorrow_rate(#[string] name: String) -> f32 {
+    WEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weep_just_weeping(#[string] name: String) -> bool {
+    WEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weep_just_consoled(#[string] name: String) -> bool {
+    WEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weep_enabled(#[string] name: String) -> bool {
+    WEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_mourn_weep(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::MournWeep { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_console_weep(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ConsoleWeep { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weep_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeepEnabled { name, enabled })
+    });
+}
+// ── Weft ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weft_density(#[string] name: String) -> f32 {
+    WEFT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weft_max_density(#[string] name: String) -> f32 {
+    WEFT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weft_weave_rate(#[string] name: String) -> f32 {
+    WEFT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weft_fraying(#[string] name: String) -> bool {
+    WEFT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weft_just_rent(#[string] name: String) -> bool {
+    WEFT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weft_just_mended(#[string] name: String) -> bool {
+    WEFT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weft_enabled(#[string] name: String) -> bool {
+    WEFT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_fray_weft(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::FrayWeft { name }));
+}
+#[op2(fast)]
+pub fn bsengine_mend_weft(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::MendWeft { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_weft_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeftEnabled { name, enabled })
+    });
+}
+// ── Weigh ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weigh_burden(#[string] name: String) -> f32 {
+    WEIGH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weigh_max_burden(#[string] name: String) -> f32 {
+    WEIGH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weigh_load_rate(#[string] name: String) -> f32 {
+    WEIGH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weigh_just_laden(#[string] name: String) -> bool {
+    WEIGH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weigh_just_light(#[string] name: String) -> bool {
+    WEIGH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weigh_enabled(#[string] name: String) -> bool {
+    WEIGH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_load_weigh(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::LoadWeigh { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_lighten_weigh(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::LightenWeigh { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weigh_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeighEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -33239,6 +33704,78 @@ deno_core::extension!(
         bsengine_apply_web,
         bsengine_struggle_web,
         bsengine_set_web_enabled,
+        bsengine_get_wed_bond,
+        bsengine_get_wed_max_bond,
+        bsengine_get_wed_bind_rate,
+        bsengine_is_wed_just_wedded,
+        bsengine_is_wed_just_sundered,
+        bsengine_is_wed_enabled,
+        bsengine_pledge_wed,
+        bsengine_sever_wed,
+        bsengine_set_wed_enabled,
+        bsengine_get_wedge_drive,
+        bsengine_get_wedge_max_drive,
+        bsengine_get_wedge_split_rate,
+        bsengine_is_wedge_just_driven,
+        bsengine_is_wedge_just_loose,
+        bsengine_is_wedge_enabled,
+        bsengine_split_wedge,
+        bsengine_extract_wedge,
+        bsengine_set_wedge_enabled,
+        bsengine_get_wee_glee,
+        bsengine_get_wee_max_glee,
+        bsengine_get_wee_cheer_rate,
+        bsengine_is_wee_just_gleeful,
+        bsengine_is_wee_just_subdued,
+        bsengine_is_wee_enabled,
+        bsengine_cheer_wee,
+        bsengine_subdue_wee,
+        bsengine_set_wee_enabled,
+        bsengine_get_weed_level,
+        bsengine_get_weed_max_weed,
+        bsengine_get_weed_grow_rate,
+        bsengine_is_weed_just_overgrown,
+        bsengine_is_weed_just_cleared,
+        bsengine_is_weed_enabled,
+        bsengine_cull_weed,
+        bsengine_set_weed_enabled,
+        bsengine_get_weedy_overgrowth,
+        bsengine_get_weedy_max_overgrowth,
+        bsengine_get_weedy_spread_rate,
+        bsengine_is_weedy_just_overrun,
+        bsengine_is_weedy_just_cleared,
+        bsengine_is_weedy_enabled,
+        bsengine_spread_weedy,
+        bsengine_clear_weedy,
+        bsengine_set_weedy_enabled,
+        bsengine_get_weep_grief,
+        bsengine_get_weep_max_grief,
+        bsengine_get_weep_sorrow_rate,
+        bsengine_is_weep_just_weeping,
+        bsengine_is_weep_just_consoled,
+        bsengine_is_weep_enabled,
+        bsengine_mourn_weep,
+        bsengine_console_weep,
+        bsengine_set_weep_enabled,
+        bsengine_get_weft_density,
+        bsengine_get_weft_max_density,
+        bsengine_get_weft_weave_rate,
+        bsengine_is_weft_fraying,
+        bsengine_is_weft_just_rent,
+        bsengine_is_weft_just_mended,
+        bsengine_is_weft_enabled,
+        bsengine_fray_weft,
+        bsengine_mend_weft,
+        bsengine_set_weft_enabled,
+        bsengine_get_weigh_burden,
+        bsengine_get_weigh_max_burden,
+        bsengine_get_weigh_load_rate,
+        bsengine_is_weigh_just_laden,
+        bsengine_is_weigh_just_light,
+        bsengine_is_weigh_enabled,
+        bsengine_load_weigh,
+        bsengine_lighten_weigh,
+        bsengine_set_weigh_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -36950,6 +37487,78 @@ const Bsengine = {
     applyWeb:                   (name, amount)      => Deno.core.ops.bsengine_apply_web(name, amount),
     struggleWeb:                (name, amount)      => Deno.core.ops.bsengine_struggle_web(name, amount),
     setWebEnabled:              (name, v)           => Deno.core.ops.bsengine_set_web_enabled(name, v),
+    getWedBond:                 (name)              => Deno.core.ops.bsengine_get_wed_bond(name),
+    getWedMaxBond:              (name)              => Deno.core.ops.bsengine_get_wed_max_bond(name),
+    getWedBindRate:             (name)              => Deno.core.ops.bsengine_get_wed_bind_rate(name),
+    isWedJustWedded:            (name)              => Deno.core.ops.bsengine_is_wed_just_wedded(name),
+    isWedJustSundered:          (name)              => Deno.core.ops.bsengine_is_wed_just_sundered(name),
+    isWedEnabled:               (name)              => Deno.core.ops.bsengine_is_wed_enabled(name),
+    pledgeWed:                  (name, amount)      => Deno.core.ops.bsengine_pledge_wed(name, amount),
+    severWed:                   (name, amount)      => Deno.core.ops.bsengine_sever_wed(name, amount),
+    setWedEnabled:              (name, v)           => Deno.core.ops.bsengine_set_wed_enabled(name, v),
+    getWedgeDrive:              (name)              => Deno.core.ops.bsengine_get_wedge_drive(name),
+    getWedgeMaxDrive:           (name)              => Deno.core.ops.bsengine_get_wedge_max_drive(name),
+    getWedgeSplitRate:          (name)              => Deno.core.ops.bsengine_get_wedge_split_rate(name),
+    isWedgeJustDriven:          (name)              => Deno.core.ops.bsengine_is_wedge_just_driven(name),
+    isWedgeJustLoose:           (name)              => Deno.core.ops.bsengine_is_wedge_just_loose(name),
+    isWedgeEnabled:             (name)              => Deno.core.ops.bsengine_is_wedge_enabled(name),
+    splitWedge:                 (name, amount)      => Deno.core.ops.bsengine_split_wedge(name, amount),
+    extractWedge:               (name, amount)      => Deno.core.ops.bsengine_extract_wedge(name, amount),
+    setWedgeEnabled:            (name, v)           => Deno.core.ops.bsengine_set_wedge_enabled(name, v),
+    getWeeGlee:                 (name)              => Deno.core.ops.bsengine_get_wee_glee(name),
+    getWeeMaxGlee:              (name)              => Deno.core.ops.bsengine_get_wee_max_glee(name),
+    getWeeCheerRate:            (name)              => Deno.core.ops.bsengine_get_wee_cheer_rate(name),
+    isWeeJustGleeful:           (name)              => Deno.core.ops.bsengine_is_wee_just_gleeful(name),
+    isWeeJustSubdued:           (name)              => Deno.core.ops.bsengine_is_wee_just_subdued(name),
+    isWeeEnabled:               (name)              => Deno.core.ops.bsengine_is_wee_enabled(name),
+    cheerWee:                   (name, amount)      => Deno.core.ops.bsengine_cheer_wee(name, amount),
+    subdueWee:                  (name, amount)      => Deno.core.ops.bsengine_subdue_wee(name, amount),
+    setWeeEnabled:              (name, v)           => Deno.core.ops.bsengine_set_wee_enabled(name, v),
+    getWeedLevel:               (name)              => Deno.core.ops.bsengine_get_weed_level(name),
+    getWeedMaxWeed:             (name)              => Deno.core.ops.bsengine_get_weed_max_weed(name),
+    getWeedGrowRate:            (name)              => Deno.core.ops.bsengine_get_weed_grow_rate(name),
+    isWeedJustOvergrown:        (name)              => Deno.core.ops.bsengine_is_weed_just_overgrown(name),
+    isWeedJustCleared:          (name)              => Deno.core.ops.bsengine_is_weed_just_cleared(name),
+    isWeedEnabled:              (name)              => Deno.core.ops.bsengine_is_weed_enabled(name),
+    cullWeed:                   (name, amount)      => Deno.core.ops.bsengine_cull_weed(name, amount),
+    setWeedEnabled:             (name, v)           => Deno.core.ops.bsengine_set_weed_enabled(name, v),
+    getWeedyOvergrowth:         (name)              => Deno.core.ops.bsengine_get_weedy_overgrowth(name),
+    getWeedyMaxOvergrowth:      (name)              => Deno.core.ops.bsengine_get_weedy_max_overgrowth(name),
+    getWeedySpreadRate:         (name)              => Deno.core.ops.bsengine_get_weedy_spread_rate(name),
+    isWeedyJustOverrun:         (name)              => Deno.core.ops.bsengine_is_weedy_just_overrun(name),
+    isWeedyJustCleared:         (name)              => Deno.core.ops.bsengine_is_weedy_just_cleared(name),
+    isWeedyEnabled:             (name)              => Deno.core.ops.bsengine_is_weedy_enabled(name),
+    spreadWeedy:                (name, amount)      => Deno.core.ops.bsengine_spread_weedy(name, amount),
+    clearWeedy:                 (name, amount)      => Deno.core.ops.bsengine_clear_weedy(name, amount),
+    setWeedyEnabled:            (name, v)           => Deno.core.ops.bsengine_set_weedy_enabled(name, v),
+    getWeepGrief:               (name)              => Deno.core.ops.bsengine_get_weep_grief(name),
+    getWeepMaxGrief:            (name)              => Deno.core.ops.bsengine_get_weep_max_grief(name),
+    getWeepSorrowRate:          (name)              => Deno.core.ops.bsengine_get_weep_sorrow_rate(name),
+    isWeepJustWeeping:          (name)              => Deno.core.ops.bsengine_is_weep_just_weeping(name),
+    isWeepJustConsoled:         (name)              => Deno.core.ops.bsengine_is_weep_just_consoled(name),
+    isWeepEnabled:              (name)              => Deno.core.ops.bsengine_is_weep_enabled(name),
+    mournWeep:                  (name, amount)      => Deno.core.ops.bsengine_mourn_weep(name, amount),
+    consoleWeep:                (name, amount)      => Deno.core.ops.bsengine_console_weep(name, amount),
+    setWeepEnabled:             (name, v)           => Deno.core.ops.bsengine_set_weep_enabled(name, v),
+    getWeftDensity:             (name)              => Deno.core.ops.bsengine_get_weft_density(name),
+    getWeftMaxDensity:          (name)              => Deno.core.ops.bsengine_get_weft_max_density(name),
+    getWeftWeaveRate:           (name)              => Deno.core.ops.bsengine_get_weft_weave_rate(name),
+    isWeftFraying:              (name)              => Deno.core.ops.bsengine_is_weft_fraying(name),
+    isWeftJustRent:             (name)              => Deno.core.ops.bsengine_is_weft_just_rent(name),
+    isWeftJustMended:           (name)              => Deno.core.ops.bsengine_is_weft_just_mended(name),
+    isWeftEnabled:              (name)              => Deno.core.ops.bsengine_is_weft_enabled(name),
+    frayWeft:                   (name)              => Deno.core.ops.bsengine_fray_weft(name),
+    mendWeft:                   (name)              => Deno.core.ops.bsengine_mend_weft(name),
+    setWeftEnabled:             (name, v)           => Deno.core.ops.bsengine_set_weft_enabled(name, v),
+    getWeighBurden:             (name)              => Deno.core.ops.bsengine_get_weigh_burden(name),
+    getWeighMaxBurden:          (name)              => Deno.core.ops.bsengine_get_weigh_max_burden(name),
+    getWeighLoadRate:           (name)              => Deno.core.ops.bsengine_get_weigh_load_rate(name),
+    isWeighJustLaden:           (name)              => Deno.core.ops.bsengine_is_weigh_just_laden(name),
+    isWeighJustLight:           (name)              => Deno.core.ops.bsengine_is_weigh_just_light(name),
+    isWeighEnabled:             (name)              => Deno.core.ops.bsengine_is_weigh_enabled(name),
+    loadWeigh:                  (name, amount)      => Deno.core.ops.bsengine_load_weigh(name, amount),
+    lightenWeigh:               (name, amount)      => Deno.core.ops.bsengine_lighten_weigh(name, amount),
+    setWeighEnabled:            (name, v)           => Deno.core.ops.bsengine_set_weigh_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -61580,6 +62189,431 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyWeb { name, amount } if name == "Grunt" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StruggleWeb { name, amount } if name == "Grunt" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWebEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wed_read_ops() {
+        super::WED_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWedBond("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWedMaxBond("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWedBindRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWedJustWedded("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWedJustSundered("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isWedEnabled("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WED_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wed_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.pledgeWed("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.severWed("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWedEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::PledgeWed { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SeverWed { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWedEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wedge_read_ops() {
+        super::WEDGE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWedgeDrive("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWedgeMaxDrive("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWedgeSplitRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWedgeJustDriven("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWedgeJustLoose("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWedgeEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEDGE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wedge_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.splitWedge("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.extractWedge("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWedgeEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SplitWedge { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ExtractWedge { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWedgeEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wee_read_ops() {
+        super::WEE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWeeGlee("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeeMaxGlee("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeeCheerRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeeJustGleeful("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeeJustSubdued("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isWeeEnabled("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wee_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.cheerWee("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.subdueWee("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWeeEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CheerWee { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SubdueWee { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeeEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weed_read_ops() {
+        super::WEED_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWeedLevel("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeedMaxWeed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeedGrowRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeedJustOvergrown("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeedJustCleared("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeedEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEED_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weed_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.cullWeed("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWeedEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CullWeed { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeedEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weedy_read_ops() {
+        super::WEEDY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWeedyOvergrowth("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeedyMaxOvergrowth("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeedySpreadRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeedyJustOverrun("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeedyJustCleared("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeedyEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEEDY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weedy_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.spreadWeedy("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearWeedy("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWeedyEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SpreadWeedy { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearWeedy { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeedyEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weep_read_ops() {
+        super::WEEP_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWeepGrief("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeepMaxGrief("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeepSorrowRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeepJustWeeping("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeepJustConsoled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeepEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEEP_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weep_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.mournWeep("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.consoleWeep("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWeepEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::MournWeep { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ConsoleWeep { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeepEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weft_read_ops() {
+        super::WEFT_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWeftDensity("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeftMaxDensity("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeftWeaveRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeftFraying("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeftJustRent("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeftJustMended("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeftEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEFT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weft_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.frayWeft("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.mendWeft("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWeftEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf
+                .iter()
+                .any(|cmd| matches!(cmd, super::ScriptCommand::FrayWeft { name } if name == "Grunt")));
+            assert!(buf
+                .iter()
+                .any(|cmd| matches!(cmd, super::ScriptCommand::MendWeft { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeftEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weigh_read_ops() {
+        super::WEIGH_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWeighBurden("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeighMaxBurden("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeighLoadRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeighJustLaden("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeighJustLight("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeighEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEIGH_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weigh_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.loadWeigh("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.lightenWeigh("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWeighEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::LoadWeigh { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::LightenWeigh { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeighEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -88,8 +88,9 @@ use crate::ops::{
     WANE_SNAPSHOT, WANGLE_SNAPSHOT, WANTON_SNAPSHOT, WANT_SNAPSHOT, WARD_SNAPSHOT, WARM_SNAPSHOT,
     WARN_SNAPSHOT, WARP_SNAPSHOT, WARY_SNAPSHOT, WASH_SNAPSHOT, WASP_SNAPSHOT, WASTE_SNAPSHOT,
     WATER_BODY_SNAPSHOT, WAVER_SNAPSHOT, WAVE_SNAPSHOT, WAX_SNAPSHOT, WAY_SNAPSHOT, WEAL_SNAPSHOT,
-    WEARY_SNAPSHOT, WEASEL_SNAPSHOT, WEATHER_SNAPSHOT, WEAVE_SNAPSHOT, WEB_SNAPSHOT, WIND_SNAPSHOT,
-    WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    WEARY_SNAPSHOT, WEASEL_SNAPSHOT, WEATHER_SNAPSHOT, WEAVE_SNAPSHOT, WEB_SNAPSHOT,
+    WEDGE_SNAPSHOT, WED_SNAPSHOT, WEEDY_SNAPSHOT, WEED_SNAPSHOT, WEEP_SNAPSHOT, WEE_SNAPSHOT,
+    WEFT_SNAPSHOT, WEIGH_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -3048,6 +3049,159 @@ fn run_scripts(world: &mut World) {
             );
         }
         WEB_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wed;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wed)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.bond,
+                    w.max_bond,
+                    w.bind_rate,
+                    w.just_wedded,
+                    w.just_sundered,
+                    w.enabled,
+                ),
+            );
+        }
+        WED_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wedge;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wedge)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.drive,
+                    w.max_drive,
+                    w.split_rate,
+                    w.just_driven,
+                    w.just_loose,
+                    w.enabled,
+                ),
+            );
+        }
+        WEDGE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wee;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wee)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.glee,
+                    w.max_glee,
+                    w.cheer_rate,
+                    w.just_gleeful,
+                    w.just_subdued,
+                    w.enabled,
+                ),
+            );
+        }
+        WEE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weed;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weed)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.weed_level,
+                    w.max_weed,
+                    w.grow_rate,
+                    w.just_overgrown,
+                    w.just_cleared,
+                    w.enabled,
+                ),
+            );
+        }
+        WEED_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weedy;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weedy)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.overgrowth,
+                    w.max_overgrowth,
+                    w.spread_rate,
+                    w.just_overrun,
+                    w.just_cleared,
+                    w.enabled,
+                ),
+            );
+        }
+        WEEDY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weep;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weep)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.grief,
+                    w.max_grief,
+                    w.sorrow_rate,
+                    w.just_weeping,
+                    w.just_consoled,
+                    w.enabled,
+                ),
+            );
+        }
+        WEEP_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weft;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weft)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.weft_density,
+                    w.max_density,
+                    w.weave_rate,
+                    w.fraying,
+                    w.just_rent,
+                    w.just_mended,
+                    w.enabled,
+                ),
+            );
+        }
+        WEFT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weigh;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weigh)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.burden,
+                    w.max_burden,
+                    w.load_rate,
+                    w.just_laden,
+                    w.just_light,
+                    w.enabled,
+                ),
+            );
+        }
+        WEIGH_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -22885,6 +23039,259 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut w) = world.get_mut::<bsengine_core::Web>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::PledgeWed { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wed>(e) {
+                        w.pledge(amount);
+                    }
+                }
+            }
+            ScriptCommand::SeverWed { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wed>(e) {
+                        w.sever(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWedEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wed>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SplitWedge { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wedge>(e) {
+                        w.split(amount);
+                    }
+                }
+            }
+            ScriptCommand::ExtractWedge { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wedge>(e) {
+                        w.extract(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWedgeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wedge>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::CheerWee { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wee>(e) {
+                        w.cheer(amount);
+                    }
+                }
+            }
+            ScriptCommand::SubdueWee { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wee>(e) {
+                        w.subdue(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWeeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wee>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::CullWeed { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weed>(e) {
+                        w.cull(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWeedEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weed>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SpreadWeedy { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weedy>(e) {
+                        w.spread(amount);
+                    }
+                }
+            }
+            ScriptCommand::ClearWeedy { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weedy>(e) {
+                        w.clear(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWeedyEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weedy>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::MournWeep { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weep>(e) {
+                        w.mourn(amount);
+                    }
+                }
+            }
+            ScriptCommand::ConsoleWeep { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weep>(e) {
+                        w.console(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWeepEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weep>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::FrayWeft { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weft>(e) {
+                        w.fray();
+                    }
+                }
+            }
+            ScriptCommand::MendWeft { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weft>(e) {
+                        w.mend();
+                    }
+                }
+            }
+            ScriptCommand::SetWeftEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weft>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::LoadWeigh { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weigh>(e) {
+                        w.load(amount);
+                    }
+                }
+            }
+            ScriptCommand::LightenWeigh { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weigh>(e) {
+                        w.lighten(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWeighEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weigh>(e) {
                         w.enabled = enabled;
                     }
                 }


### PR DESCRIPTION
## Summary
- Adds 72 scripting ops for 8 new components: Wed, Wedge, Wee, Weed, Weedy, Weep, Weft, Weigh
- Read ops: snapshot-based getters and boolean state queries
- Write ops: method calls and field setters via ScriptCommand queue
- 16 new tests (read + write per component); total suite now 1013

## Test plan
- [x] `cargo test -p bsengine-scripting` — 1013 passed, 0 failed
- [x] `cargo +nightly fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)