### PR TITLE
feat(scripting): add Wax/Way/Weal/Weary/Weather/Weave/Weasel/Web scripting API (72 ops)

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -3871,6 +3871,64 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    ApplyTaint {
+        name: String,
+        duration: f32,
+    },
+    ClearTaint {
+        name: String,
+    },
+    SetTaintEnabled {
+        name: String,
+        enabled: bool,
+    },
+    IncrementTally {
+        name: String,
+        amount: u32,
+    },
+    ResetTally {
+        name: String,
+    },
+    SetTallyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SetGripping {
+        name: String,
+        gripping: bool,
+    },
+    SetTalonEnabled {
+        name: String,
+        enabled: bool,
+    },
+    EngageTaper {
+        name: String,
+    },
+    DisengageTaper {
+        name: String,
+    },
+    SetTaperEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ActivateTaunt {
+        name: String,
+    },
+    DeactivateTaunt {
+        name: String,
+    },
+    SetTauntEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ApplyFreeze {
+        name: String,
+        intensity: f32,
+    },
+    SetThawEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -4942,6 +5000,18 @@ thread_local! {
         RefCell::new(HashMap::new());
     // entity name → (state, swim_speed, dive_speed, ascent_speed, breath_remaining, max_breath, breath_drain_rate, breath_regen_rate, depth, submerge_depth, wants_dive, wants_surface, enabled)
     pub(crate) static SWIM_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32, f32, f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TAINT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TALLY_SNAPSHOT: RefCell<HashMap<String, (u32, u32, bool, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TALON_SNAPSHOT: RefCell<HashMap<String, (bool, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TAPER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TAUNT_SNAPSHOT: RefCell<HashMap<String, (bool, f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static THAW_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -8240,6 +8310,258 @@ pub fn bsengine_set_swim_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetSwimEnabled { name, enabled })
+    });
+}
+// ── Taint ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_taint_duration(#[string] name: String) -> f32 {
+    TAINT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_taint_timer(#[string] name: String) -> f32 {
+    TAINT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_taint_healing_reduction(#[string] name: String) -> f32 {
+    TAINT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_tainted(#[string] name: String) -> bool {
+    TAINT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_cleansed(#[string] name: String) -> bool {
+    TAINT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_taint_enabled(#[string] name: String) -> bool {
+    TAINT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_taint(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyTaint { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_clear_taint(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearTaint { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_taint_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTaintEnabled { name, enabled })
+    });
+}
+// ── Tally ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_tally_count(#[string] name: String) -> u32 {
+    TALLY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tally_goal(#[string] name: String) -> u32 {
+    TALLY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_incremented(#[string] name: String) -> bool {
+    TALLY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_tally_completed(#[string] name: String) -> bool {
+    TALLY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_tally_reset(#[string] name: String) -> bool {
+    TALLY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_tally_enabled(#[string] name: String) -> bool {
+    TALLY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_increment_tally(#[string] name: String, amount: u32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::IncrementTally { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_reset_tally(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResetTally { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_tally_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTallyEnabled { name, enabled })
+    });
+}
+// ── Talon ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_is_talon_active(#[string] name: String) -> bool {
+    TALON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_get_talon_grip_bonus(#[string] name: String) -> f32 {
+    TALON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_talon_slip_resistance(#[string] name: String) -> f32 {
+    TALON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_gripped(#[string] name: String) -> bool {
+    TALON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_released(#[string] name: String) -> bool {
+    TALON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_talon_enabled(#[string] name: String) -> bool {
+    TALON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_gripping(#[string] name: String, gripping: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetGripping { name, gripping })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_talon_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTalonEnabled { name, enabled })
+    });
+}
+// ── Taper ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_taper_elapsed_time(#[string] name: String) -> f32 {
+    TAPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_taper_max_reduction_time(#[string] name: String) -> f32 {
+    TAPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_taper_damage_reduction(#[string] name: String) -> f32 {
+    TAPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_taper_in_combat(#[string] name: String) -> bool {
+    TAPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_taper_peaked(#[string] name: String) -> bool {
+    TAPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_taper_enabled(#[string] name: String) -> bool {
+    TAPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_engage_taper(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::EngageTaper { name }));
+}
+#[op2(fast)]
+pub fn bsengine_disengage_taper(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::DisengageTaper { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_taper_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTaperEnabled { name, enabled })
+    });
+}
+// ── Taunt ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_is_taunt_active(#[string] name: String) -> bool {
+    TAUNT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_get_taunt_radius(#[string] name: String) -> f32 {
+    TAUNT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_taunt_threat_boost(#[string] name: String) -> f32 {
+    TAUNT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_taunt_duration(#[string] name: String) -> f32 {
+    TAUNT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_taunt_timer(#[string] name: String) -> f32 {
+    TAUNT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_taunt_activated(#[string] name: String) -> bool {
+    TAUNT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_taunt_expired(#[string] name: String) -> bool {
+    TAUNT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_taunt_enabled(#[string] name: String) -> bool {
+    TAUNT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_activate_taunt(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ActivateTaunt { name }));
+}
+#[op2(fast)]
+pub fn bsengine_deactivate_taunt(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::DeactivateTaunt { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_taunt_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTauntEnabled { name, enabled })
+    });
+}
+// ── Thaw ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_thaw_fraction(#[string] name: String) -> f32 {
+    THAW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(1.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_thaw_rate(#[string] name: String) -> f32 {
+    THAW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_thaw_freeze_penalty(#[string] name: String) -> f32 {
+    THAW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_thawed(#[string] name: String) -> bool {
+    THAW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_frozen(#[string] name: String) -> bool {
+    THAW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_thaw_enabled(#[string] name: String) -> bool {
+    THAW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_freeze(#[string] name: String, intensity: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyFreeze { name, intensity })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_thaw_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetThawEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -27822,6 +28144,60 @@ deno_core::extension!(
         bsengine_set_wants_dive,
         bsengine_set_wants_surface,
         bsengine_set_swim_enabled,
+        bsengine_get_taint_duration,
+        bsengine_get_taint_timer,
+        bsengine_get_taint_healing_reduction,
+        bsengine_is_just_tainted,
+        bsengine_is_just_cleansed,
+        bsengine_is_taint_enabled,
+        bsengine_apply_taint,
+        bsengine_clear_taint,
+        bsengine_set_taint_enabled,
+        bsengine_get_tally_count,
+        bsengine_get_tally_goal,
+        bsengine_is_just_incremented,
+        bsengine_is_just_tally_completed,
+        bsengine_is_just_tally_reset,
+        bsengine_is_tally_enabled,
+        bsengine_increment_tally,
+        bsengine_reset_tally,
+        bsengine_set_tally_enabled,
+        bsengine_is_talon_active,
+        bsengine_get_talon_grip_bonus,
+        bsengine_get_talon_slip_resistance,
+        bsengine_is_just_gripped,
+        bsengine_is_just_released,
+        bsengine_is_talon_enabled,
+        bsengine_set_gripping,
+        bsengine_set_talon_enabled,
+        bsengine_get_taper_elapsed_time,
+        bsengine_get_taper_max_reduction_time,
+        bsengine_get_taper_damage_reduction,
+        bsengine_is_taper_in_combat,
+        bsengine_is_just_taper_peaked,
+        bsengine_is_taper_enabled,
+        bsengine_engage_taper,
+        bsengine_disengage_taper,
+        bsengine_set_taper_enabled,
+        bsengine_is_taunt_active,
+        bsengine_get_taunt_radius,
+        bsengine_get_taunt_threat_boost,
+        bsengine_get_taunt_duration,
+        bsengine_get_taunt_timer,
+        bsengine_is_just_taunt_activated,
+        bsengine_is_just_taunt_expired,
+        bsengine_is_taunt_enabled,
+        bsengine_activate_taunt,
+        bsengine_deactivate_taunt,
+        bsengine_set_taunt_enabled,
+        bsengine_get_thaw_fraction,
+        bsengine_get_thaw_rate,
+        bsengine_get_thaw_freeze_penalty,
+        bsengine_is_just_thawed,
+        bsengine_is_just_frozen,
+        bsengine_is_thaw_enabled,
+        bsengine_apply_freeze,
+        bsengine_set_thaw_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -30816,6 +31192,60 @@ const Bsengine = {
     setWantsDive:               (name, v)           => Deno.core.ops.bsengine_set_wants_dive(name, v),
     setWantsSurface:            (name, v)           => Deno.core.ops.bsengine_set_wants_surface(name, v),
     setSwimEnabled:             (name, v)           => Deno.core.ops.bsengine_set_swim_enabled(name, v),
+    getTaintDuration:           (name)              => Deno.core.ops.bsengine_get_taint_duration(name),
+    getTaintTimer:              (name)              => Deno.core.ops.bsengine_get_taint_timer(name),
+    getTaintHealingReduction:   (name)              => Deno.core.ops.bsengine_get_taint_healing_reduction(name),
+    isJustTainted:              (name)              => Deno.core.ops.bsengine_is_just_tainted(name),
+    isJustCleansed:             (name)              => Deno.core.ops.bsengine_is_just_cleansed(name),
+    isTaintEnabled:             (name)              => Deno.core.ops.bsengine_is_taint_enabled(name),
+    applyTaint:                 (name, duration)    => Deno.core.ops.bsengine_apply_taint(name, duration),
+    clearTaint:                 (name)              => Deno.core.ops.bsengine_clear_taint(name),
+    setTaintEnabled:            (name, v)           => Deno.core.ops.bsengine_set_taint_enabled(name, v),
+    getTallyCount:              (name)              => Deno.core.ops.bsengine_get_tally_count(name),
+    getTallyGoal:               (name)              => Deno.core.ops.bsengine_get_tally_goal(name),
+    isJustIncremented:          (name)              => Deno.core.ops.bsengine_is_just_incremented(name),
+    isJustTallyCompleted:       (name)              => Deno.core.ops.bsengine_is_just_tally_completed(name),
+    isJustTallyReset:           (name)              => Deno.core.ops.bsengine_is_just_tally_reset(name),
+    isTallyEnabled:             (name)              => Deno.core.ops.bsengine_is_tally_enabled(name),
+    incrementTally:             (name, amount)      => Deno.core.ops.bsengine_increment_tally(name, amount),
+    resetTally:                 (name)              => Deno.core.ops.bsengine_reset_tally(name),
+    setTallyEnabled:            (name, v)           => Deno.core.ops.bsengine_set_tally_enabled(name, v),
+    isTalonActive:              (name)              => Deno.core.ops.bsengine_is_talon_active(name),
+    getTalonGripBonus:          (name)              => Deno.core.ops.bsengine_get_talon_grip_bonus(name),
+    getTalonSlipResistance:     (name)              => Deno.core.ops.bsengine_get_talon_slip_resistance(name),
+    isJustGripped:              (name)              => Deno.core.ops.bsengine_is_just_gripped(name),
+    isJustReleased:             (name)              => Deno.core.ops.bsengine_is_just_released(name),
+    isTalonEnabled:             (name)              => Deno.core.ops.bsengine_is_talon_enabled(name),
+    setGripping:                (name, v)           => Deno.core.ops.bsengine_set_gripping(name, v),
+    setTalonEnabled:            (name, v)           => Deno.core.ops.bsengine_set_talon_enabled(name, v),
+    getTaperElapsedTime:        (name)              => Deno.core.ops.bsengine_get_taper_elapsed_time(name),
+    getTaperMaxReductionTime:   (name)              => Deno.core.ops.bsengine_get_taper_max_reduction_time(name),
+    getTaperDamageReduction:    (name)              => Deno.core.ops.bsengine_get_taper_damage_reduction(name),
+    isTaperInCombat:            (name)              => Deno.core.ops.bsengine_is_taper_in_combat(name),
+    isJustTaperPeaked:          (name)              => Deno.core.ops.bsengine_is_just_taper_peaked(name),
+    isTaperEnabled:             (name)              => Deno.core.ops.bsengine_is_taper_enabled(name),
+    engageTaper:                (name)              => Deno.core.ops.bsengine_engage_taper(name),
+    disengageTaper:             (name)              => Deno.core.ops.bsengine_disengage_taper(name),
+    setTaperEnabled:            (name, v)           => Deno.core.ops.bsengine_set_taper_enabled(name, v),
+    isTauntActive:              (name)              => Deno.core.ops.bsengine_is_taunt_active(name),
+    getTauntRadius:             (name)              => Deno.core.ops.bsengine_get_taunt_radius(name),
+    getTauntThreatBoost:        (name)              => Deno.core.ops.bsengine_get_taunt_threat_boost(name),
+    getTauntDuration:           (name)              => Deno.core.ops.bsengine_get_taunt_duration(name),
+    getTauntTimer:              (name)              => Deno.core.ops.bsengine_get_taunt_timer(name),
+    isJustTauntActivated:       (name)              => Deno.core.ops.bsengine_is_just_taunt_activated(name),
+    isJustTauntExpired:         (name)              => Deno.core.ops.bsengine_is_just_taunt_expired(name),
+    isTauntEnabled:             (name)              => Deno.core.ops.bsengine_is_taunt_enabled(name),
+    activateTaunt:              (name)              => Deno.core.ops.bsengine_activate_taunt(name),
+    deactivateTaunt:            (name)              => Deno.core.ops.bsengine_deactivate_taunt(name),
+    setTauntEnabled:            (name, v)           => Deno.core.ops.bsengine_set_taunt_enabled(name, v),
+    getThawFraction:            (name)              => Deno.core.ops.bsengine_get_thaw_fraction(name),
+    getThawRate:                (name)              => Deno.core.ops.bsengine_get_thaw_rate(name),
+    getThawFreezePenalty:       (name)              => Deno.core.ops.bsengine_get_thaw_freeze_penalty(name),
+    isJustThawed:               (name)              => Deno.core.ops.bsengine_is_just_thawed(name),
+    isJustFrozen:               (name)              => Deno.core.ops.bsengine_is_just_frozen(name),
+    isThawEnabled:              (name)              => Deno.core.ops.bsengine_is_thaw_enabled(name),
+    applyFreeze:                (name, intensity)   => Deno.core.ops.bsengine_apply_freeze(name, intensity),
+    setThawEnabled:             (name, v)           => Deno.core.ops.bsengine_set_thaw_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -51238,6 +51668,328 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWantsDive { name, wants } if name == "Grunt" && *wants)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWantsSurface { name, wants } if name == "Grunt" && !wants)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSwimEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_taint_read_ops() {
+        super::TAINT_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (0.5f32, 0.25f32, 0.75f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTaintDuration("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTaintTimer("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getTaintHealingReduction("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTainted("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustCleansed("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTaintEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TAINT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_taint_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyTaint("Grunt", 2.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearTaint("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTaintEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyTaint { name, duration } if name == "Grunt" && *duration == 2.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearTaint { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTaintEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tally_read_ops() {
+        super::TALLY_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Grunt".to_string(), (3u32, 5u32, true, false, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTallyCount("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getTallyGoal("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustIncremented("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTallyCompleted("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTallyReset("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTallyEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TALLY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tally_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.incrementTally("Grunt", 2);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.resetTally("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTallyEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::IncrementTally { name, amount } if name == "Grunt" && *amount == 2)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ResetTally { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTallyEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_talon_read_ops() {
+        super::TALON_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (true, 0.5f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.isTalonActive("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.getTalonGripBonus("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTalonSlipResistance("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustGripped("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustReleased("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTalonEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TALON_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_talon_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setGripping("Grunt", true);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTalonEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetGripping { name, gripping } if name == "Grunt" && *gripping)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTalonEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_taper_read_ops() {
+        super::TAPER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (1.0f32, 2.0f32, 0.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTaperElapsedTime("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getTaperMaxReductionTime("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getTaperDamageReduction("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isTaperInCombat("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTaperPeaked("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTaperEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TAPER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_taper_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.engageTaper("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.disengageTaper("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTaperEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::EngageTaper { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DisengageTaper { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTaperEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_taunt_read_ops() {
+        super::TAUNT_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (true, 3.0f32, 1.5f32, 2.0f32, 0.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.isTauntActive("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.getTauntRadius("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getTauntThreatBoost("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTauntDuration("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getTauntTimer("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTauntActivated("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTauntExpired("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTauntEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TAUNT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_taunt_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.activateTaunt("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.deactivateTaunt("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTauntEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ActivateTaunt { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DeactivateTaunt { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTauntEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_thaw_read_ops() {
+        super::THAW_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (0.75f32, 1.0f32, 0.5f32, false, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getThawFraction("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt.eval(r#"String(Bsengine.getThawRate("Grunt"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getThawFreezePenalty("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustThawed("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustFrozen("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isThawEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::THAW_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_thaw_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyFreeze("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setThawEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyFreeze { name, intensity } if name == "Grunt" && *intensity == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetThawEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4019,6 +4019,93 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    AgitateUnrest {
+        name: String,
+        amount: f32,
+    },
+    CalmUnrest {
+        name: String,
+        amount: f32,
+    },
+    SetUnrestEnabled {
+        name: String,
+        enabled: bool,
+    },
+    PayUpkeep {
+        name: String,
+        amount: f32,
+    },
+    SetUpkeepEnabled {
+        name: String,
+        enabled: bool,
+    },
+    UrgeOn {
+        name: String,
+    },
+    UrgeOff {
+        name: String,
+    },
+    SetUrgeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ApplyVenom {
+        name: String,
+    },
+    ApplyVenomN {
+        name: String,
+        n: u32,
+    },
+    ClearVenom {
+        name: String,
+    },
+    SetVenomEnabled {
+        name: String,
+        enabled: bool,
+    },
+    AddVexStack {
+        name: String,
+    },
+    RemoveVexStack {
+        name: String,
+    },
+    ClearVex {
+        name: String,
+    },
+    SetVexEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ApplyVigor {
+        name: String,
+        duration: f32,
+    },
+    SetVigorEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ApplyVile {
+        name: String,
+        duration: f32,
+    },
+    CleanseVile {
+        name: String,
+    },
+    SetVileEnabled {
+        name: String,
+        enabled: bool,
+    },
+    DrainVoid {
+        name: String,
+        damage: f32,
+    },
+    ReleaseVoid {
+        name: String,
+    },
+    SetVoidEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5118,6 +5205,22 @@ thread_local! {
     pub(crate) static TROVE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, u32, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static TUSK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static UNREST_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static UPKEEP_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static URGE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VENOM_SNAPSHOT: RefCell<HashMap<String, (f32, u32, u32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VEX_SNAPSHOT: RefCell<HashMap<String, (u32, u32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VIGOR_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VILE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VOID_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -9027,6 +9130,372 @@ pub fn bsengine_set_tusk_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetTuskEnabled { name, enabled })
+    });
+}
+// ── Unrest ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_unrest_level(#[string] name: String) -> f32 {
+    UNREST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_unrest_max(#[string] name: String) -> f32 {
+    UNREST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_unrest_threshold(#[string] name: String) -> f32 {
+    UNREST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_unrest_decay_rate(#[string] name: String) -> f32 {
+    UNREST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_unrest_penalty(#[string] name: String) -> f32 {
+    UNREST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_became_restless(#[string] name: String) -> bool {
+    UNREST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_unrest_calmed(#[string] name: String) -> bool {
+    UNREST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_unrest_enabled(#[string] name: String) -> bool {
+    UNREST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_agitate_unrest(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AgitateUnrest { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_calm_unrest(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CalmUnrest { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_unrest_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetUnrestEnabled { name, enabled })
+    });
+}
+// ── Upkeep ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_upkeep_deficit(#[string] name: String) -> f32 {
+    UPKEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_upkeep_max_deficit(#[string] name: String) -> f32 {
+    UPKEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_upkeep_cost_per_second(#[string] name: String) -> f32 {
+    UPKEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_upkeep_penalty(#[string] name: String) -> f32 {
+    UPKEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_upkeep_just_defaulted(#[string] name: String) -> bool {
+    UPKEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_upkeep_just_cleared(#[string] name: String) -> bool {
+    UPKEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_upkeep_enabled(#[string] name: String) -> bool {
+    UPKEEP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_pay_upkeep(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::PayUpkeep { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_upkeep_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetUpkeepEnabled { name, enabled })
+    });
+}
+// ── Urge ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_urge_level(#[string] name: String) -> f32 {
+    URGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_urge_max(#[string] name: String) -> f32 {
+    URGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_urge_build_rate(#[string] name: String) -> f32 {
+    URGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_urge_decay_rate(#[string] name: String) -> f32 {
+    URGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_urge_drive_bonus(#[string] name: String) -> f32 {
+    URGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_urged(#[string] name: String) -> bool {
+    URGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_urge_just_peaked(#[string] name: String) -> bool {
+    URGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_urge_enabled(#[string] name: String) -> bool {
+    URGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_urge_on(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::UrgeOn { name }));
+}
+#[op2(fast)]
+pub fn bsengine_urge_off(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::UrgeOff { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_urge_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetUrgeEnabled { name, enabled })
+    });
+}
+// ── Venom ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_venom_damage_per_stack(#[string] name: String) -> f32 {
+    VENOM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_venom_stacks(#[string] name: String) -> u32 {
+    VENOM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_venom_max_stacks(#[string] name: String) -> u32 {
+    VENOM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_venom_duration(#[string] name: String) -> f32 {
+    VENOM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_venom_timer(#[string] name: String) -> f32 {
+    VENOM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_venom_just_applied(#[string] name: String) -> bool {
+    VENOM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_venom_just_expired(#[string] name: String) -> bool {
+    VENOM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_venom_enabled(#[string] name: String) -> bool {
+    VENOM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_venom(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ApplyVenom { name }));
+}
+#[op2(fast)]
+pub fn bsengine_apply_venom_n(#[string] name: String, n: u32) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ApplyVenomN { name, n }));
+}
+#[op2(fast)]
+pub fn bsengine_clear_venom(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearVenom { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_venom_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVenomEnabled { name, enabled })
+    });
+}
+// ── Vex ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vex_stacks(#[string] name: String) -> u32 {
+    VEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vex_max_stacks(#[string] name: String) -> u32 {
+    VEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vex_cc_amplify(#[string] name: String) -> f32 {
+    VEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vex_just_vexed(#[string] name: String) -> bool {
+    VEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vex_just_cleared(#[string] name: String) -> bool {
+    VEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vex_enabled(#[string] name: String) -> bool {
+    VEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_add_vex_stack(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::AddVexStack { name }));
+}
+#[op2(fast)]
+pub fn bsengine_remove_vex_stack(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::RemoveVexStack { name }));
+}
+#[op2(fast)]
+pub fn bsengine_clear_vex(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearVex { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_vex_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVexEnabled { name, enabled })
+    });
+}
+// ── Vigor ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vigor_duration(#[string] name: String) -> f32 {
+    VIGOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vigor_timer(#[string] name: String) -> f32 {
+    VIGOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vigor_health_regen(#[string] name: String) -> f32 {
+    VIGOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vigor_max_health_bonus(#[string] name: String) -> f32 {
+    VIGOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_invigorated(#[string] name: String) -> bool {
+    VIGOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vigor_just_faded(#[string] name: String) -> bool {
+    VIGOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vigor_enabled(#[string] name: String) -> bool {
+    VIGOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_vigor(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyVigor { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vigor_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVigorEnabled { name, enabled })
+    });
+}
+// ── Vile ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vile_duration(#[string] name: String) -> f32 {
+    VILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vile_timer(#[string] name: String) -> f32 {
+    VILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vile_heal_reduction(#[string] name: String) -> f32 {
+    VILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vile_just_applied(#[string] name: String) -> bool {
+    VILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vile_just_cleared(#[string] name: String) -> bool {
+    VILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vile_enabled(#[string] name: String) -> bool {
+    VILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_vile(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyVile { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_cleanse_vile(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::CleanseVile { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_vile_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVileEnabled { name, enabled })
+    });
+}
+// ── Void ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_void_charge(#[string] name: String) -> f32 {
+    VOID_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_void_max_charge(#[string] name: String) -> f32 {
+    VOID_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_void_drain_fraction(#[string] name: String) -> f32 {
+    VOID_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_void_just_peaked(#[string] name: String) -> bool {
+    VOID_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_void_enabled(#[string] name: String) -> bool {
+    VOID_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_drain_void(#[string] name: String, damage: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DrainVoid { name, damage })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_release_void(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ReleaseVoid { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_void_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVoidEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -28738,6 +29207,85 @@ deno_core::extension!(
         bsengine_impact_tusk,
         bsengine_reset_tusk,
         bsengine_set_tusk_enabled,
+        bsengine_get_unrest_level,
+        bsengine_get_unrest_max,
+        bsengine_get_unrest_threshold,
+        bsengine_get_unrest_decay_rate,
+        bsengine_get_unrest_penalty,
+        bsengine_is_just_became_restless,
+        bsengine_is_just_unrest_calmed,
+        bsengine_is_unrest_enabled,
+        bsengine_agitate_unrest,
+        bsengine_calm_unrest,
+        bsengine_set_unrest_enabled,
+        bsengine_get_upkeep_deficit,
+        bsengine_get_upkeep_max_deficit,
+        bsengine_get_upkeep_cost_per_second,
+        bsengine_get_upkeep_penalty,
+        bsengine_is_upkeep_just_defaulted,
+        bsengine_is_upkeep_just_cleared,
+        bsengine_is_upkeep_enabled,
+        bsengine_pay_upkeep,
+        bsengine_set_upkeep_enabled,
+        bsengine_get_urge_level,
+        bsengine_get_urge_max,
+        bsengine_get_urge_build_rate,
+        bsengine_get_urge_decay_rate,
+        bsengine_get_urge_drive_bonus,
+        bsengine_is_urged,
+        bsengine_is_urge_just_peaked,
+        bsengine_is_urge_enabled,
+        bsengine_urge_on,
+        bsengine_urge_off,
+        bsengine_set_urge_enabled,
+        bsengine_get_venom_damage_per_stack,
+        bsengine_get_venom_stacks,
+        bsengine_get_venom_max_stacks,
+        bsengine_get_venom_duration,
+        bsengine_get_venom_timer,
+        bsengine_is_venom_just_applied,
+        bsengine_is_venom_just_expired,
+        bsengine_is_venom_enabled,
+        bsengine_apply_venom,
+        bsengine_apply_venom_n,
+        bsengine_clear_venom,
+        bsengine_set_venom_enabled,
+        bsengine_get_vex_stacks,
+        bsengine_get_vex_max_stacks,
+        bsengine_get_vex_cc_amplify,
+        bsengine_is_vex_just_vexed,
+        bsengine_is_vex_just_cleared,
+        bsengine_is_vex_enabled,
+        bsengine_add_vex_stack,
+        bsengine_remove_vex_stack,
+        bsengine_clear_vex,
+        bsengine_set_vex_enabled,
+        bsengine_get_vigor_duration,
+        bsengine_get_vigor_timer,
+        bsengine_get_vigor_health_regen,
+        bsengine_get_vigor_max_health_bonus,
+        bsengine_is_just_invigorated,
+        bsengine_is_vigor_just_faded,
+        bsengine_is_vigor_enabled,
+        bsengine_apply_vigor,
+        bsengine_set_vigor_enabled,
+        bsengine_get_vile_duration,
+        bsengine_get_vile_timer,
+        bsengine_get_vile_heal_reduction,
+        bsengine_is_vile_just_applied,
+        bsengine_is_vile_just_cleared,
+        bsengine_is_vile_enabled,
+        bsengine_apply_vile,
+        bsengine_cleanse_vile,
+        bsengine_set_vile_enabled,
+        bsengine_get_void_charge,
+        bsengine_get_void_max_charge,
+        bsengine_get_void_drain_fraction,
+        bsengine_is_void_just_peaked,
+        bsengine_is_void_enabled,
+        bsengine_drain_void,
+        bsengine_release_void,
+        bsengine_set_void_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -31861,6 +32409,85 @@ const Bsengine = {
     impactTusk:                 (name)              => Deno.core.ops.bsengine_impact_tusk(name),
     resetTusk:                  (name)              => Deno.core.ops.bsengine_reset_tusk(name),
     setTuskEnabled:             (name, v)           => Deno.core.ops.bsengine_set_tusk_enabled(name, v),
+    getUnrestLevel:             (name)              => Deno.core.ops.bsengine_get_unrest_level(name),
+    getUnrestMax:               (name)              => Deno.core.ops.bsengine_get_unrest_max(name),
+    getUnrestThreshold:         (name)              => Deno.core.ops.bsengine_get_unrest_threshold(name),
+    getUnrestDecayRate:         (name)              => Deno.core.ops.bsengine_get_unrest_decay_rate(name),
+    getUnrestPenalty:           (name)              => Deno.core.ops.bsengine_get_unrest_penalty(name),
+    isJustBecameRestless:       (name)              => Deno.core.ops.bsengine_is_just_became_restless(name),
+    isJustUnrestCalmed:         (name)              => Deno.core.ops.bsengine_is_just_unrest_calmed(name),
+    isUnrestEnabled:            (name)              => Deno.core.ops.bsengine_is_unrest_enabled(name),
+    agitateUnrest:              (name, amount)      => Deno.core.ops.bsengine_agitate_unrest(name, amount),
+    calmUnrest:                 (name, amount)      => Deno.core.ops.bsengine_calm_unrest(name, amount),
+    setUnrestEnabled:           (name, v)           => Deno.core.ops.bsengine_set_unrest_enabled(name, v),
+    getUpkeepDeficit:           (name)              => Deno.core.ops.bsengine_get_upkeep_deficit(name),
+    getUpkeepMaxDeficit:        (name)              => Deno.core.ops.bsengine_get_upkeep_max_deficit(name),
+    getUpkeepCostPerSecond:     (name)              => Deno.core.ops.bsengine_get_upkeep_cost_per_second(name),
+    getUpkeepPenalty:           (name)              => Deno.core.ops.bsengine_get_upkeep_penalty(name),
+    isUpkeepJustDefaulted:      (name)              => Deno.core.ops.bsengine_is_upkeep_just_defaulted(name),
+    isUpkeepJustCleared:        (name)              => Deno.core.ops.bsengine_is_upkeep_just_cleared(name),
+    isUpkeepEnabled:            (name)              => Deno.core.ops.bsengine_is_upkeep_enabled(name),
+    payUpkeep:                  (name, amount)      => Deno.core.ops.bsengine_pay_upkeep(name, amount),
+    setUpkeepEnabled:           (name, v)           => Deno.core.ops.bsengine_set_upkeep_enabled(name, v),
+    getUrgeLevel:               (name)              => Deno.core.ops.bsengine_get_urge_level(name),
+    getUrgeMax:                 (name)              => Deno.core.ops.bsengine_get_urge_max(name),
+    getUrgeBuildRate:           (name)              => Deno.core.ops.bsengine_get_urge_build_rate(name),
+    getUrgeDecayRate:           (name)              => Deno.core.ops.bsengine_get_urge_decay_rate(name),
+    getUrgeDriveBonus:          (name)              => Deno.core.ops.bsengine_get_urge_drive_bonus(name),
+    isUrged:                    (name)              => Deno.core.ops.bsengine_is_urged(name),
+    isUrgeJustPeaked:           (name)              => Deno.core.ops.bsengine_is_urge_just_peaked(name),
+    isUrgeEnabled:              (name)              => Deno.core.ops.bsengine_is_urge_enabled(name),
+    urgeOn:                     (name)              => Deno.core.ops.bsengine_urge_on(name),
+    urgeOff:                    (name)              => Deno.core.ops.bsengine_urge_off(name),
+    setUrgeEnabled:             (name, v)           => Deno.core.ops.bsengine_set_urge_enabled(name, v),
+    getVenomDamagePerStack:     (name)              => Deno.core.ops.bsengine_get_venom_damage_per_stack(name),
+    getVenomStacks:             (name)              => Deno.core.ops.bsengine_get_venom_stacks(name),
+    getVenomMaxStacks:          (name)              => Deno.core.ops.bsengine_get_venom_max_stacks(name),
+    getVenomDuration:           (name)              => Deno.core.ops.bsengine_get_venom_duration(name),
+    getVenomTimer:              (name)              => Deno.core.ops.bsengine_get_venom_timer(name),
+    isVenomJustApplied:         (name)              => Deno.core.ops.bsengine_is_venom_just_applied(name),
+    isVenomJustExpired:         (name)              => Deno.core.ops.bsengine_is_venom_just_expired(name),
+    isVenomEnabled:             (name)              => Deno.core.ops.bsengine_is_venom_enabled(name),
+    applyVenom:                 (name)              => Deno.core.ops.bsengine_apply_venom(name),
+    applyVenomN:                (name, n)           => Deno.core.ops.bsengine_apply_venom_n(name, n),
+    clearVenom:                 (name)              => Deno.core.ops.bsengine_clear_venom(name),
+    setVenomEnabled:            (name, v)           => Deno.core.ops.bsengine_set_venom_enabled(name, v),
+    getVexStacks:               (name)              => Deno.core.ops.bsengine_get_vex_stacks(name),
+    getVexMaxStacks:            (name)              => Deno.core.ops.bsengine_get_vex_max_stacks(name),
+    getVexCcAmplify:            (name)              => Deno.core.ops.bsengine_get_vex_cc_amplify(name),
+    isVexJustVexed:             (name)              => Deno.core.ops.bsengine_is_vex_just_vexed(name),
+    isVexJustCleared:           (name)              => Deno.core.ops.bsengine_is_vex_just_cleared(name),
+    isVexEnabled:               (name)              => Deno.core.ops.bsengine_is_vex_enabled(name),
+    addVexStack:                (name)              => Deno.core.ops.bsengine_add_vex_stack(name),
+    removeVexStack:             (name)              => Deno.core.ops.bsengine_remove_vex_stack(name),
+    clearVex:                   (name)              => Deno.core.ops.bsengine_clear_vex(name),
+    setVexEnabled:              (name, v)           => Deno.core.ops.bsengine_set_vex_enabled(name, v),
+    getVigorDuration:           (name)              => Deno.core.ops.bsengine_get_vigor_duration(name),
+    getVigorTimer:              (name)              => Deno.core.ops.bsengine_get_vigor_timer(name),
+    getVigorHealthRegen:        (name)              => Deno.core.ops.bsengine_get_vigor_health_regen(name),
+    getVigorMaxHealthBonus:     (name)              => Deno.core.ops.bsengine_get_vigor_max_health_bonus(name),
+    isJustInvigorated:          (name)              => Deno.core.ops.bsengine_is_just_invigorated(name),
+    isVigorJustFaded:           (name)              => Deno.core.ops.bsengine_is_vigor_just_faded(name),
+    isVigorEnabled:             (name)              => Deno.core.ops.bsengine_is_vigor_enabled(name),
+    applyVigor:                 (name, duration)    => Deno.core.ops.bsengine_apply_vigor(name, duration),
+    setVigorEnabled:            (name, v)           => Deno.core.ops.bsengine_set_vigor_enabled(name, v),
+    getVileDuration:            (name)              => Deno.core.ops.bsengine_get_vile_duration(name),
+    getVileTimer:               (name)              => Deno.core.ops.bsengine_get_vile_timer(name),
+    getVileHealReduction:       (name)              => Deno.core.ops.bsengine_get_vile_heal_reduction(name),
+    isVileJustApplied:          (name)              => Deno.core.ops.bsengine_is_vile_just_applied(name),
+    isVileJustCleared:          (name)              => Deno.core.ops.bsengine_is_vile_just_cleared(name),
+    isVileEnabled:              (name)              => Deno.core.ops.bsengine_is_vile_enabled(name),
+    applyVile:                  (name, duration)    => Deno.core.ops.bsengine_apply_vile(name, duration),
+    cleanseVile:                (name)              => Deno.core.ops.bsengine_cleanse_vile(name),
+    setVileEnabled:             (name, v)           => Deno.core.ops.bsengine_set_vile_enabled(name, v),
+    getVoidCharge:              (name)              => Deno.core.ops.bsengine_get_void_charge(name),
+    getVoidMaxCharge:           (name)              => Deno.core.ops.bsengine_get_void_max_charge(name),
+    getVoidDrainFraction:       (name)              => Deno.core.ops.bsengine_get_void_drain_fraction(name),
+    isVoidJustPeaked:           (name)              => Deno.core.ops.bsengine_is_void_just_peaked(name),
+    isVoidEnabled:              (name)              => Deno.core.ops.bsengine_is_void_enabled(name),
+    drainVoid:                  (name, damage)      => Deno.core.ops.bsengine_drain_void(name, damage),
+    releaseVoid:                (name)              => Deno.core.ops.bsengine_release_void(name),
+    setVoidEnabled:             (name, v)           => Deno.core.ops.bsengine_set_void_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -53046,6 +53673,448 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ImpactTusk { name } if name == "Grunt")));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ResetTusk { name } if name == "Grunt")));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTuskEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_unrest_read_ops() {
+        super::UNREST_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.75f32, 0.25f32, 0.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getUnrestLevel("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getUnrestMax("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getUnrestThreshold("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getUnrestDecayRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getUnrestPenalty("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustBecameRestless("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustUnrestCalmed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isUnrestEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::UNREST_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_unrest_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.agitateUnrest("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.calmUnrest("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setUnrestEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AgitateUnrest { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CalmUnrest { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetUnrestEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_upkeep_read_ops() {
+        super::UPKEEP_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 2.0f32, 1.0f32, 0.75f32, false, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getUpkeepDeficit("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getUpkeepMaxDeficit("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getUpkeepCostPerSecond("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getUpkeepPenalty("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.isUpkeepJustDefaulted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isUpkeepJustCleared("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isUpkeepEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::UPKEEP_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_upkeep_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.payUpkeep("Grunt", 1.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setUpkeepEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::PayUpkeep { name, amount } if name == "Grunt" && *amount == 1.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetUpkeepEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_urge_read_ops() {
+        super::URGE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, 0.5f32, 0.75f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getUrgeLevel("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getUrgeMax("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getUrgeBuildRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getUrgeDecayRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getUrgeDriveBonus("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt.eval(r#"String(Bsengine.isUrged("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isUrgeJustPeaked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isUrgeEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::URGE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_urge_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.urgeOn("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.urgeOff("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setUrgeEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::UrgeOn { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::UrgeOff { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetUrgeEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_venom_read_ops() {
+        super::VENOM_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (2.0f32, 3u32, 5u32, 3.0f32, 1.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVenomDamagePerStack("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getVenomStacks("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getVenomMaxStacks("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVenomDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getVenomTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isVenomJustApplied("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVenomJustExpired("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVenomEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VENOM_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_venom_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyVenom("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.applyVenomN("Grunt", 3);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearVenom("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVenomEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyVenom { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyVenomN { name, n } if name == "Grunt" && *n == 3)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearVenom { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVenomEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vex_read_ops() {
+        super::VEX_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (2u32, 5u32, 0.25f32, true, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getVexStacks("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getVexMaxStacks("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVexCcAmplify("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isVexJustVexed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVexJustCleared("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isVexEnabled("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VEX_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vex_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.addVexStack("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.removeVexStack("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearVex("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVexEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AddVexStack { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RemoveVexStack { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearVex { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVexEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vigor_read_ops() {
+        super::VIGOR_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (2.0f32, 1.5f32, 5.0f32, 20.0f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVigorDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getVigorTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVigorHealthRegen("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVigorMaxHealthBonus("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "20");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustInvigorated("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVigorJustFaded("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVigorEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VIGOR_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vigor_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyVigor("Grunt", 3.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVigorEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyVigor { name, duration } if name == "Grunt" && *duration == 3.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVigorEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vile_read_ops() {
+        super::VILE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (2.0f32, 1.5f32, 0.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVileDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt.eval(r#"String(Bsengine.getVileTimer("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVileHealReduction("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isVileJustApplied("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVileJustCleared("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVileEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VILE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vile_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyVile("Grunt", 2.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.cleanseVile("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVileEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyVile { name, duration } if name == "Grunt" && *duration == 2.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CleanseVile { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVileEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_void_read_ops() {
+        super::VOID_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.75f32, 1.0f32, 0.5f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVoidCharge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getVoidMaxCharge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVoidDrainFraction("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isVoidJustPeaked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVoidEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VOID_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_void_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.drainVoid("Grunt", 10.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.releaseVoid("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVoidEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DrainVoid { name, damage } if name == "Grunt" && *damage == 10.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ReleaseVoid { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVoidEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4743,6 +4743,103 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    ApplyWax {
+        name: String,
+        amount: f32,
+    },
+    SetWaxMaxWax {
+        name: String,
+        value: f32,
+    },
+    SetWaxEnabled {
+        name: String,
+        enabled: bool,
+    },
+    AdvanceWay {
+        name: String,
+        amount: f32,
+    },
+    RetreatWay {
+        name: String,
+        amount: f32,
+    },
+    SetWayEnabled {
+        name: String,
+        enabled: bool,
+    },
+    NourishWeal {
+        name: String,
+        amount: f32,
+    },
+    DepleteWeal {
+        name: String,
+        amount: f32,
+    },
+    SetWealEnabled {
+        name: String,
+        enabled: bool,
+    },
+    TireWeary {
+        name: String,
+        amount: f32,
+    },
+    RestWeary {
+        name: String,
+        amount: f32,
+    },
+    SetWearyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SetWeatherCloudCover {
+        name: String,
+        value: f32,
+    },
+    SetWeatherPrecipitationIntensity {
+        name: String,
+        value: f32,
+    },
+    SetWeatherTemperature {
+        name: String,
+        value: f32,
+    },
+    SetWeatherFogDensity {
+        name: String,
+        value: f32,
+    },
+    SetWeatherEnabled {
+        name: String,
+        enabled: bool,
+    },
+    BeginWeave {
+        name: String,
+    },
+    HaltWeave {
+        name: String,
+    },
+    SetWeaveEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SlipWeasel {
+        name: String,
+    },
+    SetWeaselEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ApplyWeb {
+        name: String,
+        amount: f32,
+    },
+    StruggleWeb {
+        name: String,
+        amount: f32,
+    },
+    SetWebEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5954,6 +6051,22 @@ thread_local! {
     pub(crate) static WAVE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static WAVER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAX_SNAPSHOT: RefCell<HashMap<String, (f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEAL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEARY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEATHER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEAVE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEASEL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WEB_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -12465,6 +12578,368 @@ pub fn bsengine_set_waver_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetWaverEnabled { name, enabled })
+    });
+}
+// ── Wax ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wax_level(#[string] name: String) -> f32 {
+    WAX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wax_max_wax(#[string] name: String) -> f32 {
+    WAX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wax_just_applied(#[string] name: String) -> bool {
+    WAX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wax_just_stripped(#[string] name: String) -> bool {
+    WAX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wax_enabled(#[string] name: String) -> bool {
+    WAX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_wax(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyWax { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wax_max_wax(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaxMaxWax { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wax_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaxEnabled { name, enabled })
+    });
+}
+// ── Way ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_way_progress(#[string] name: String) -> f32 {
+    WAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_way_max_progress(#[string] name: String) -> f32 {
+    WAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_way_traverse_rate(#[string] name: String) -> f32 {
+    WAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_way_just_arrived(#[string] name: String) -> bool {
+    WAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_way_just_turned(#[string] name: String) -> bool {
+    WAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_way_enabled(#[string] name: String) -> bool {
+    WAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_advance_way(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AdvanceWay { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_retreat_way(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RetreatWay { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_way_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWayEnabled { name, enabled })
+    });
+}
+// ── Weal ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weal_level(#[string] name: String) -> f32 {
+    WEAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weal_max_weal(#[string] name: String) -> f32 {
+    WEAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weal_regen_rate(#[string] name: String) -> f32 {
+    WEAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weal_just_flourished(#[string] name: String) -> bool {
+    WEAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weal_just_diminished(#[string] name: String) -> bool {
+    WEAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weal_enabled(#[string] name: String) -> bool {
+    WEAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_nourish_weal(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::NourishWeal { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_deplete_weal(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DepleteWeal { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weal_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWealEnabled { name, enabled })
+    });
+}
+// ── Weary ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weary_fatigue(#[string] name: String) -> f32 {
+    WEARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weary_max_fatigue(#[string] name: String) -> f32 {
+    WEARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weary_drain_rate(#[string] name: String) -> f32 {
+    WEARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weary_just_exhausted(#[string] name: String) -> bool {
+    WEARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weary_just_refreshed(#[string] name: String) -> bool {
+    WEARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weary_enabled(#[string] name: String) -> bool {
+    WEARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_tire_weary(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::TireWeary { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_rest_weary(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RestWeary { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weary_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWearyEnabled { name, enabled })
+    });
+}
+// ── Weather ──────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weather_cloud_cover(#[string] name: String) -> f32 {
+    WEATHER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weather_precipitation_intensity(#[string] name: String) -> f32 {
+    WEATHER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weather_temperature(#[string] name: String) -> f32 {
+    WEATHER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weather_fog_density(#[string] name: String) -> f32 {
+    WEATHER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weather_lightning_probability(#[string] name: String) -> f32 {
+    WEATHER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weather_enabled(#[string] name: String) -> bool {
+    WEATHER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_weather_cloud_cover(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeatherCloudCover { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weather_precipitation_intensity(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeatherPrecipitationIntensity { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weather_temperature(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeatherTemperature { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weather_fog_density(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeatherFogDensity { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_weather_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeatherEnabled { name, enabled })
+    });
+}
+// ── Weave ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weave_level(#[string] name: String) -> f32 {
+    WEAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weave_max_weave(#[string] name: String) -> f32 {
+    WEAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weave_buildup_rate(#[string] name: String) -> f32 {
+    WEAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weave_weaving(#[string] name: String) -> bool {
+    WEAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weave_just_peaked(#[string] name: String) -> bool {
+    WEAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weave_just_broken(#[string] name: String) -> bool {
+    WEAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weave_enabled(#[string] name: String) -> bool {
+    WEAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_begin_weave(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::BeginWeave { name }));
+}
+#[op2(fast)]
+pub fn bsengine_halt_weave(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::HaltWeave { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_weave_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeaveEnabled { name, enabled })
+    });
+}
+// ── Weasel ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_weasel_level(#[string] name: String) -> f32 {
+    WEASEL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weasel_max_weasel(#[string] name: String) -> f32 {
+    WEASEL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_weasel_regen_rate(#[string] name: String) -> f32 {
+    WEASEL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_weasel_just_slipped(#[string] name: String) -> bool {
+    WEASEL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_weasel_enabled(#[string] name: String) -> bool {
+    WEASEL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_slip_weasel(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SlipWeasel { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_weasel_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWeaselEnabled { name, enabled })
+    });
+}
+// ── Web ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_web_strength(#[string] name: String) -> f32 {
+    WEB_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_web_max_strength(#[string] name: String) -> f32 {
+    WEB_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_web_movement_penalty(#[string] name: String) -> f32 {
+    WEB_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_web_just_caught(#[string] name: String) -> bool {
+    WEB_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_web_just_broken(#[string] name: String) -> bool {
+    WEB_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_web_enabled(#[string] name: String) -> bool {
+    WEB_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_web(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyWeb { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_struggle_web(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::StruggleWeb { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_web_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWebEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -32692,6 +33167,78 @@ deno_core::extension!(
         bsengine_hesitate_waver,
         bsengine_resolve_waver,
         bsengine_set_waver_enabled,
+        bsengine_get_wax_level,
+        bsengine_get_wax_max_wax,
+        bsengine_is_wax_just_applied,
+        bsengine_is_wax_just_stripped,
+        bsengine_is_wax_enabled,
+        bsengine_apply_wax,
+        bsengine_set_wax_max_wax,
+        bsengine_set_wax_enabled,
+        bsengine_get_way_progress,
+        bsengine_get_way_max_progress,
+        bsengine_get_way_traverse_rate,
+        bsengine_is_way_just_arrived,
+        bsengine_is_way_just_turned,
+        bsengine_is_way_enabled,
+        bsengine_advance_way,
+        bsengine_retreat_way,
+        bsengine_set_way_enabled,
+        bsengine_get_weal_level,
+        bsengine_get_weal_max_weal,
+        bsengine_get_weal_regen_rate,
+        bsengine_is_weal_just_flourished,
+        bsengine_is_weal_just_diminished,
+        bsengine_is_weal_enabled,
+        bsengine_nourish_weal,
+        bsengine_deplete_weal,
+        bsengine_set_weal_enabled,
+        bsengine_get_weary_fatigue,
+        bsengine_get_weary_max_fatigue,
+        bsengine_get_weary_drain_rate,
+        bsengine_is_weary_just_exhausted,
+        bsengine_is_weary_just_refreshed,
+        bsengine_is_weary_enabled,
+        bsengine_tire_weary,
+        bsengine_rest_weary,
+        bsengine_set_weary_enabled,
+        bsengine_get_weather_cloud_cover,
+        bsengine_get_weather_precipitation_intensity,
+        bsengine_get_weather_temperature,
+        bsengine_get_weather_fog_density,
+        bsengine_get_weather_lightning_probability,
+        bsengine_is_weather_enabled,
+        bsengine_set_weather_cloud_cover,
+        bsengine_set_weather_precipitation_intensity,
+        bsengine_set_weather_temperature,
+        bsengine_set_weather_fog_density,
+        bsengine_set_weather_enabled,
+        bsengine_get_weave_level,
+        bsengine_get_weave_max_weave,
+        bsengine_get_weave_buildup_rate,
+        bsengine_is_weave_weaving,
+        bsengine_is_weave_just_peaked,
+        bsengine_is_weave_just_broken,
+        bsengine_is_weave_enabled,
+        bsengine_begin_weave,
+        bsengine_halt_weave,
+        bsengine_set_weave_enabled,
+        bsengine_get_weasel_level,
+        bsengine_get_weasel_max_weasel,
+        bsengine_get_weasel_regen_rate,
+        bsengine_is_weasel_just_slipped,
+        bsengine_is_weasel_enabled,
+        bsengine_slip_weasel,
+        bsengine_set_weasel_enabled,
+        bsengine_get_web_strength,
+        bsengine_get_web_max_strength,
+        bsengine_get_web_movement_penalty,
+        bsengine_is_web_just_caught,
+        bsengine_is_web_just_broken,
+        bsengine_is_web_enabled,
+        bsengine_apply_web,
+        bsengine_struggle_web,
+        bsengine_set_web_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -36331,6 +36878,78 @@ const Bsengine = {
     hesitateWaver:              (name, amount)      => Deno.core.ops.bsengine_hesitate_waver(name, amount),
     resolveWaver:               (name, amount)      => Deno.core.ops.bsengine_resolve_waver(name, amount),
     setWaverEnabled:            (name, v)           => Deno.core.ops.bsengine_set_waver_enabled(name, v),
+    getWaxLevel:                (name)              => Deno.core.ops.bsengine_get_wax_level(name),
+    getWaxMaxWax:               (name)              => Deno.core.ops.bsengine_get_wax_max_wax(name),
+    isWaxJustApplied:           (name)              => Deno.core.ops.bsengine_is_wax_just_applied(name),
+    isWaxJustStripped:          (name)              => Deno.core.ops.bsengine_is_wax_just_stripped(name),
+    isWaxEnabled:               (name)              => Deno.core.ops.bsengine_is_wax_enabled(name),
+    applyWax:                   (name, amount)      => Deno.core.ops.bsengine_apply_wax(name, amount),
+    setWaxMaxWax:               (name, v)           => Deno.core.ops.bsengine_set_wax_max_wax(name, v),
+    setWaxEnabled:              (name, v)           => Deno.core.ops.bsengine_set_wax_enabled(name, v),
+    getWayProgress:             (name)              => Deno.core.ops.bsengine_get_way_progress(name),
+    getWayMaxProgress:          (name)              => Deno.core.ops.bsengine_get_way_max_progress(name),
+    getWayTraverseRate:         (name)              => Deno.core.ops.bsengine_get_way_traverse_rate(name),
+    isWayJustArrived:           (name)              => Deno.core.ops.bsengine_is_way_just_arrived(name),
+    isWayJustTurned:            (name)              => Deno.core.ops.bsengine_is_way_just_turned(name),
+    isWayEnabled:               (name)              => Deno.core.ops.bsengine_is_way_enabled(name),
+    advanceWay:                 (name, amount)      => Deno.core.ops.bsengine_advance_way(name, amount),
+    retreatWay:                 (name, amount)      => Deno.core.ops.bsengine_retreat_way(name, amount),
+    setWayEnabled:              (name, v)           => Deno.core.ops.bsengine_set_way_enabled(name, v),
+    getWealLevel:               (name)              => Deno.core.ops.bsengine_get_weal_level(name),
+    getWealMaxWeal:             (name)              => Deno.core.ops.bsengine_get_weal_max_weal(name),
+    getWealRegenRate:           (name)              => Deno.core.ops.bsengine_get_weal_regen_rate(name),
+    isWealJustFlourished:       (name)              => Deno.core.ops.bsengine_is_weal_just_flourished(name),
+    isWealJustDiminished:       (name)              => Deno.core.ops.bsengine_is_weal_just_diminished(name),
+    isWealEnabled:              (name)              => Deno.core.ops.bsengine_is_weal_enabled(name),
+    nourishWeal:                (name, amount)      => Deno.core.ops.bsengine_nourish_weal(name, amount),
+    depleteWeal:                (name, amount)      => Deno.core.ops.bsengine_deplete_weal(name, amount),
+    setWealEnabled:             (name, v)           => Deno.core.ops.bsengine_set_weal_enabled(name, v),
+    getWearyFatigue:            (name)              => Deno.core.ops.bsengine_get_weary_fatigue(name),
+    getWearyMaxFatigue:         (name)              => Deno.core.ops.bsengine_get_weary_max_fatigue(name),
+    getWearyDrainRate:          (name)              => Deno.core.ops.bsengine_get_weary_drain_rate(name),
+    isWearyJustExhausted:       (name)              => Deno.core.ops.bsengine_is_weary_just_exhausted(name),
+    isWearyJustRefreshed:       (name)              => Deno.core.ops.bsengine_is_weary_just_refreshed(name),
+    isWearyEnabled:             (name)              => Deno.core.ops.bsengine_is_weary_enabled(name),
+    tireWeary:                  (name, amount)      => Deno.core.ops.bsengine_tire_weary(name, amount),
+    restWeary:                  (name, amount)      => Deno.core.ops.bsengine_rest_weary(name, amount),
+    setWearyEnabled:            (name, v)           => Deno.core.ops.bsengine_set_weary_enabled(name, v),
+    getWeatherCloudCover:       (name)              => Deno.core.ops.bsengine_get_weather_cloud_cover(name),
+    getWeatherPrecipitationIntensity: (name)        => Deno.core.ops.bsengine_get_weather_precipitation_intensity(name),
+    getWeatherTemperature:      (name)              => Deno.core.ops.bsengine_get_weather_temperature(name),
+    getWeatherFogDensity:       (name)              => Deno.core.ops.bsengine_get_weather_fog_density(name),
+    getWeatherLightningProbability: (name)          => Deno.core.ops.bsengine_get_weather_lightning_probability(name),
+    isWeatherEnabled:           (name)              => Deno.core.ops.bsengine_is_weather_enabled(name),
+    setWeatherCloudCover:       (name, v)           => Deno.core.ops.bsengine_set_weather_cloud_cover(name, v),
+    setWeatherPrecipitationIntensity: (name, v)     => Deno.core.ops.bsengine_set_weather_precipitation_intensity(name, v),
+    setWeatherTemperature:      (name, v)           => Deno.core.ops.bsengine_set_weather_temperature(name, v),
+    setWeatherFogDensity:       (name, v)           => Deno.core.ops.bsengine_set_weather_fog_density(name, v),
+    setWeatherEnabled:          (name, v)           => Deno.core.ops.bsengine_set_weather_enabled(name, v),
+    getWeaveLevel:              (name)              => Deno.core.ops.bsengine_get_weave_level(name),
+    getWeaveMaxWeave:           (name)              => Deno.core.ops.bsengine_get_weave_max_weave(name),
+    getWeaveBuildupRate:        (name)              => Deno.core.ops.bsengine_get_weave_buildup_rate(name),
+    isWeaveWeaving:             (name)              => Deno.core.ops.bsengine_is_weave_weaving(name),
+    isWeaveJustPeaked:          (name)              => Deno.core.ops.bsengine_is_weave_just_peaked(name),
+    isWeaveJustBroken:          (name)              => Deno.core.ops.bsengine_is_weave_just_broken(name),
+    isWeaveEnabled:             (name)              => Deno.core.ops.bsengine_is_weave_enabled(name),
+    beginWeave:                 (name)              => Deno.core.ops.bsengine_begin_weave(name),
+    haltWeave:                  (name)              => Deno.core.ops.bsengine_halt_weave(name),
+    setWeaveEnabled:            (name, v)           => Deno.core.ops.bsengine_set_weave_enabled(name, v),
+    getWeaselLevel:             (name)              => Deno.core.ops.bsengine_get_weasel_level(name),
+    getWeaselMaxWeasel:         (name)              => Deno.core.ops.bsengine_get_weasel_max_weasel(name),
+    getWeaselRegenRate:         (name)              => Deno.core.ops.bsengine_get_weasel_regen_rate(name),
+    isWeaselJustSlipped:        (name)              => Deno.core.ops.bsengine_is_weasel_just_slipped(name),
+    isWeaselEnabled:            (name)              => Deno.core.ops.bsengine_is_weasel_enabled(name),
+    slipWeasel:                 (name)              => Deno.core.ops.bsengine_slip_weasel(name),
+    setWeaselEnabled:           (name, v)           => Deno.core.ops.bsengine_set_weasel_enabled(name, v),
+    getWebStrength:             (name)              => Deno.core.ops.bsengine_get_web_strength(name),
+    getWebMaxStrength:          (name)              => Deno.core.ops.bsengine_get_web_max_strength(name),
+    getWebMovementPenalty:      (name)              => Deno.core.ops.bsengine_get_web_movement_penalty(name),
+    isWebJustCaught:            (name)              => Deno.core.ops.bsengine_is_web_just_caught(name),
+    isWebJustBroken:            (name)              => Deno.core.ops.bsengine_is_web_just_broken(name),
+    isWebEnabled:               (name)              => Deno.core.ops.bsengine_is_web_enabled(name),
+    applyWeb:                   (name, amount)      => Deno.core.ops.bsengine_apply_web(name, amount),
+    struggleWeb:                (name, amount)      => Deno.core.ops.bsengine_struggle_web(name, amount),
+    setWebEnabled:              (name, v)           => Deno.core.ops.bsengine_set_web_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -60531,6 +61150,436 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::HesitateWaver { name, amount } if name == "Grunt" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ResolveWaver { name, amount } if name == "Grunt" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaverEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wax_read_ops() {
+        super::WAX_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.5f32, 1.0f32, true, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWaxLevel("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getWaxMaxWax("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaxJustApplied("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaxJustStripped("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isWaxEnabled("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAX_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wax_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyWax("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaxMaxWax("Grunt", 1.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaxEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyWax { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaxMaxWax { name, value } if name == "Grunt" && *value == 1.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaxEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_way_read_ops() {
+        super::WAY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWayProgress("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWayMaxProgress("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWayTraverseRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWayJustArrived("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWayJustTurned("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isWayEnabled("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_way_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.advanceWay("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.retreatWay("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWayEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AdvanceWay { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RetreatWay { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWayEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weal_read_ops() {
+        super::WEAL_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWealLevel("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWealMaxWeal("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWealRegenRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWealJustFlourished("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWealJustDiminished("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWealEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEAL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weal_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.nourishWeal("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.depleteWeal("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWealEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::NourishWeal { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DepleteWeal { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWealEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weary_read_ops() {
+        super::WEARY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWearyFatigue("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWearyMaxFatigue("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWearyDrainRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWearyJustExhausted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWearyJustRefreshed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWearyEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEARY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weary_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.tireWeary("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.restWeary("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWearyEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::TireWeary { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RestWeary { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWearyEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weather_read_ops() {
+        super::WEATHER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 0.25f32, 0.125f32, 0.0625f32, 0.03125f32, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWeatherCloudCover("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeatherPrecipitationIntensity("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeatherTemperature("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.125");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeatherFogDensity("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.0625");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeatherLightningProbability("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.03125");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeatherEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEATHER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weather_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setWeatherCloudCover("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setWeatherPrecipitationIntensity("Grunt", 0.25);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setWeatherTemperature("Grunt", 0.125);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setWeatherFogDensity("Grunt", 0.0625);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(r#"Bsengine.setWeatherEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeatherCloudCover { name, value } if name == "Grunt" && *value == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeatherPrecipitationIntensity { name, value } if name == "Grunt" && *value == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeatherTemperature { name, value } if name == "Grunt" && *value == 0.125)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeatherFogDensity { name, value } if name == "Grunt" && *value == 0.0625)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeatherEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weave_read_ops() {
+        super::WEAVE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWeaveLevel("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeaveMaxWeave("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeaveBuildupRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeaveWeaving("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeaveJustPeaked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeaveJustBroken("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeaveEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEAVE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weave_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.beginWeave("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.haltWeave("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWeaveEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf
+                .iter()
+                .any(|cmd| matches!(cmd, super::ScriptCommand::BeginWeave { name } if name == "Grunt")));
+            assert!(buf
+                .iter()
+                .any(|cmd| matches!(cmd, super::ScriptCommand::HaltWeave { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeaveEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weasel_read_ops() {
+        super::WEASEL_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.5f32, 1.0f32, 0.25f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWeaselLevel("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeaselMaxWeasel("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWeaselRegenRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeaselJustSlipped("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWeaselEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEASEL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_weasel_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.slipWeasel("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWeaselEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf
+                .iter()
+                .any(|cmd| matches!(cmd, super::ScriptCommand::SlipWeasel { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWeaselEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_web_read_ops() {
+        super::WEB_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWebStrength("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWebMaxStrength("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWebMovementPenalty("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWebJustCaught("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWebJustBroken("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isWebEnabled("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WEB_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_web_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyWeb("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.struggleWeb("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWebEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyWeb { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StruggleWeb { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWebEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4302,6 +4302,125 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Vibrate ──────────────────────────────────────────────────────────────
+    TriggerVibrate {
+        name: String,
+        amplitude: f32,
+        frequency: f32,
+        duration: f32,
+    },
+    StopVibrate {
+        name: String,
+    },
+    SetVibrateEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Viewport ─────────────────────────────────────────────────────────────
+    SetViewportRect {
+        name: String,
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+    },
+    // ── Vision ───────────────────────────────────────────────────────────────
+    SetVisionRange {
+        name: String,
+        range: f32,
+    },
+    SetVisionFov {
+        name: String,
+        fov: f32,
+    },
+    SetVisionMask {
+        name: String,
+        mask: u32,
+    },
+    ResetVisionTimer {
+        name: String,
+    },
+    SetVisionEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── VolumetricLight ──────────────────────────────────────────────────────
+    SetVolumetricScattering {
+        name: String,
+        value: f32,
+    },
+    SetVolumetricAbsorption {
+        name: String,
+        value: f32,
+    },
+    SetVolumetricAnisotropy {
+        name: String,
+        value: f32,
+    },
+    SetVolumetricStepCount {
+        name: String,
+        count: u32,
+    },
+    SetVolumetricMaxDistance {
+        name: String,
+        value: f32,
+    },
+    SetVolumetricLightEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Volley ────────────────────────────────────────────────────────────────
+    LoadVolley {
+        name: String,
+        amount: f32,
+    },
+    ReleaseVolley {
+        name: String,
+        amount: f32,
+    },
+    SetVolleyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vortex ───────────────────────────────────────────────────────────────
+    WindVortex {
+        name: String,
+        amount: f32,
+    },
+    DissipateVortex {
+        name: String,
+        amount: f32,
+    },
+    SetVortexEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vow ──────────────────────────────────────────────────────────────────
+    SwearVow {
+        name: String,
+        amount: f32,
+    },
+    RenounceVow {
+        name: String,
+        amount: f32,
+    },
+    SetVowEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vulnerable ───────────────────────────────────────────────────────────
+    WeakenVulnerable {
+        name: String,
+        amount: f32,
+    },
+    FortifyVulnerable {
+        name: String,
+        amount: f32,
+    },
+    SetVulnerableEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5449,6 +5568,22 @@ thread_local! {
     pub(crate) static VISIT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static VISTA_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VIBRATE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VIEWPORT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VISION_SNAPSHOT: RefCell<HashMap<String, (f32, f32, u32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VOLUMETRIC_LIGHT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, u32, f32, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VOLLEY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VORTEX_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VOW_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VULNERABLE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -10431,6 +10566,414 @@ pub fn bsengine_set_vista_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetVistaEnabled { name, enabled })
+    });
+}
+// ── Vibrate ──────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vibrate_amplitude(#[string] name: String) -> f32 {
+    VIBRATE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vibrate_frequency(#[string] name: String) -> f32 {
+    VIBRATE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vibrate_duration(#[string] name: String) -> f32 {
+    VIBRATE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vibrate_elapsed(#[string] name: String) -> f32 {
+    VIBRATE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vibrate_decay_rate(#[string] name: String) -> f32 {
+    VIBRATE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vibrate_just_started(#[string] name: String) -> bool {
+    VIBRATE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vibrate_just_stopped(#[string] name: String) -> bool {
+    VIBRATE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vibrate_enabled(#[string] name: String) -> bool {
+    VIBRATE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_trigger_vibrate(
+    #[string] name: String,
+    amplitude: f32,
+    frequency: f32,
+    duration: f32,
+) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::TriggerVibrate {
+            name,
+            amplitude,
+            frequency,
+            duration,
+        })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_stop_vibrate(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StopVibrate { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_vibrate_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVibrateEnabled { name, enabled })
+    });
+}
+// ── Viewport ─────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_viewport_x(#[string] name: String) -> f32 {
+    VIEWPORT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_viewport_y(#[string] name: String) -> f32 {
+    VIEWPORT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_viewport_width(#[string] name: String) -> f32 {
+    VIEWPORT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(1.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_viewport_height(#[string] name: String) -> f32 {
+    VIEWPORT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(1.0))
+}
+#[op2(fast)]
+pub fn bsengine_set_viewport_rect(#[string] name: String, x: f32, y: f32, width: f32, height: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::SetViewportRect {
+            name,
+            x,
+            y,
+            width,
+            height,
+        })
+    });
+}
+// ── Vision ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vision_range(#[string] name: String) -> f32 {
+    VISION_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vision_fov(#[string] name: String) -> f32 {
+    VISION_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vision_mask(#[string] name: String) -> u32 {
+    VISION_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vision_in_view_duration(#[string] name: String) -> f32 {
+    VISION_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vision_detection_delay(#[string] name: String) -> f32 {
+    VISION_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vision_los_blocked(#[string] name: String) -> bool {
+    VISION_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_vision_has_target(#[string] name: String) -> bool {
+    VISION_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vision_enabled(#[string] name: String) -> bool {
+    VISION_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_vision_range(#[string] name: String, range: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVisionRange { name, range })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vision_fov(#[string] name: String, fov: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVisionFov { name, fov })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vision_mask(#[string] name: String, mask: u32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVisionMask { name, mask })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_reset_vision_timer(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ResetVisionTimer { name })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vision_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVisionEnabled { name, enabled })
+    });
+}
+// ── VolumetricLight ──────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_volumetric_scattering(#[string] name: String) -> f32 {
+    VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_volumetric_absorption(#[string] name: String) -> f32 {
+    VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_volumetric_anisotropy(#[string] name: String) -> f32 {
+    VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_volumetric_step_count(#[string] name: String) -> u32 {
+    VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_volumetric_max_distance(#[string] name: String) -> f32 {
+    VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_volumetric_light_enabled(#[string] name: String) -> bool {
+    VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_volumetric_scattering(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVolumetricScattering { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_volumetric_absorption(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVolumetricAbsorption { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_volumetric_anisotropy(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVolumetricAnisotropy { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_volumetric_step_count(#[string] name: String, count: u32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVolumetricStepCount { name, count })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_volumetric_max_distance(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVolumetricMaxDistance { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_volumetric_light_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVolumetricLightEnabled { name, enabled })
+    });
+}
+// ── Volley ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_volley_charge(#[string] name: String) -> f32 {
+    VOLLEY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_volley_max_charge(#[string] name: String) -> f32 {
+    VOLLEY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_volley_draw_rate(#[string] name: String) -> f32 {
+    VOLLEY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_volley_just_vollied(#[string] name: String) -> bool {
+    VOLLEY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_volley_just_spent(#[string] name: String) -> bool {
+    VOLLEY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_volley_enabled(#[string] name: String) -> bool {
+    VOLLEY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_load_volley(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::LoadVolley { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_release_volley(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ReleaseVolley { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_volley_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVolleyEnabled { name, enabled })
+    });
+}
+// ── Vortex ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vortex_spin(#[string] name: String) -> f32 {
+    VORTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vortex_max_spin(#[string] name: String) -> f32 {
+    VORTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vortex_spiral_rate(#[string] name: String) -> f32 {
+    VORTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vortex_just_formed(#[string] name: String) -> bool {
+    VORTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vortex_just_calm(#[string] name: String) -> bool {
+    VORTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vortex_enabled(#[string] name: String) -> bool {
+    VORTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_wind_vortex(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::WindVortex { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_dissipate_vortex(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DissipateVortex { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vortex_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVortexEnabled { name, enabled })
+    });
+}
+// ── Vow ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vow_pledge(#[string] name: String) -> f32 {
+    VOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vow_max_pledge(#[string] name: String) -> f32 {
+    VOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vow_devotion_rate(#[string] name: String) -> f32 {
+    VOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vow_just_bound(#[string] name: String) -> bool {
+    VOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vow_just_broken(#[string] name: String) -> bool {
+    VOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vow_enabled(#[string] name: String) -> bool {
+    VOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_swear_vow(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SwearVow { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_renounce_vow(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RenounceVow { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vow_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVowEnabled { name, enabled })
+    });
+}
+// ── Vulnerable ───────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vulnerable_exposure(#[string] name: String) -> f32 {
+    VULNERABLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vulnerable_max_exposure(#[string] name: String) -> f32 {
+    VULNERABLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vulnerable_breach_rate(#[string] name: String) -> f32 {
+    VULNERABLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vulnerable_just_exposed(#[string] name: String) -> bool {
+    VULNERABLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vulnerable_just_hardened(#[string] name: String) -> bool {
+    VULNERABLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vulnerable_enabled(#[string] name: String) -> bool {
+    VULNERABLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_weaken_vulnerable(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::WeakenVulnerable { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_fortify_vulnerable(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::FortifyVulnerable { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vulnerable_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVulnerableEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -30363,6 +30906,83 @@ deno_core::extension!(
         bsengine_illuminate_vista,
         bsengine_obscure_vista,
         bsengine_set_vista_enabled,
+        bsengine_get_vibrate_amplitude,
+        bsengine_get_vibrate_frequency,
+        bsengine_get_vibrate_duration,
+        bsengine_get_vibrate_elapsed,
+        bsengine_get_vibrate_decay_rate,
+        bsengine_is_vibrate_just_started,
+        bsengine_is_vibrate_just_stopped,
+        bsengine_is_vibrate_enabled,
+        bsengine_trigger_vibrate,
+        bsengine_stop_vibrate,
+        bsengine_set_vibrate_enabled,
+        bsengine_get_viewport_x,
+        bsengine_get_viewport_y,
+        bsengine_get_viewport_width,
+        bsengine_get_viewport_height,
+        bsengine_set_viewport_rect,
+        bsengine_get_vision_range,
+        bsengine_get_vision_fov,
+        bsengine_get_vision_mask,
+        bsengine_get_vision_in_view_duration,
+        bsengine_get_vision_detection_delay,
+        bsengine_is_vision_los_blocked,
+        bsengine_vision_has_target,
+        bsengine_is_vision_enabled,
+        bsengine_set_vision_range,
+        bsengine_set_vision_fov,
+        bsengine_set_vision_mask,
+        bsengine_reset_vision_timer,
+        bsengine_set_vision_enabled,
+        bsengine_get_volumetric_scattering,
+        bsengine_get_volumetric_absorption,
+        bsengine_get_volumetric_anisotropy,
+        bsengine_get_volumetric_step_count,
+        bsengine_get_volumetric_max_distance,
+        bsengine_is_volumetric_light_enabled,
+        bsengine_set_volumetric_scattering,
+        bsengine_set_volumetric_absorption,
+        bsengine_set_volumetric_anisotropy,
+        bsengine_set_volumetric_step_count,
+        bsengine_set_volumetric_max_distance,
+        bsengine_set_volumetric_light_enabled,
+        bsengine_get_volley_charge,
+        bsengine_get_volley_max_charge,
+        bsengine_get_volley_draw_rate,
+        bsengine_is_volley_just_vollied,
+        bsengine_is_volley_just_spent,
+        bsengine_is_volley_enabled,
+        bsengine_load_volley,
+        bsengine_release_volley,
+        bsengine_set_volley_enabled,
+        bsengine_get_vortex_spin,
+        bsengine_get_vortex_max_spin,
+        bsengine_get_vortex_spiral_rate,
+        bsengine_is_vortex_just_formed,
+        bsengine_is_vortex_just_calm,
+        bsengine_is_vortex_enabled,
+        bsengine_wind_vortex,
+        bsengine_dissipate_vortex,
+        bsengine_set_vortex_enabled,
+        bsengine_get_vow_pledge,
+        bsengine_get_vow_max_pledge,
+        bsengine_get_vow_devotion_rate,
+        bsengine_is_vow_just_bound,
+        bsengine_is_vow_just_broken,
+        bsengine_is_vow_enabled,
+        bsengine_swear_vow,
+        bsengine_renounce_vow,
+        bsengine_set_vow_enabled,
+        bsengine_get_vulnerable_exposure,
+        bsengine_get_vulnerable_max_exposure,
+        bsengine_get_vulnerable_breach_rate,
+        bsengine_is_vulnerable_just_exposed,
+        bsengine_is_vulnerable_just_hardened,
+        bsengine_is_vulnerable_enabled,
+        bsengine_weaken_vulnerable,
+        bsengine_fortify_vulnerable,
+        bsengine_set_vulnerable_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -33707,6 +34327,83 @@ const Bsengine = {
     illuminateVista:            (name, amount)      => Deno.core.ops.bsengine_illuminate_vista(name, amount),
     obscureVista:               (name, amount)      => Deno.core.ops.bsengine_obscure_vista(name, amount),
     setVistaEnabled:            (name, v)           => Deno.core.ops.bsengine_set_vista_enabled(name, v),
+    getVibrateAmplitude:        (name)              => Deno.core.ops.bsengine_get_vibrate_amplitude(name),
+    getVibrateFrequency:        (name)              => Deno.core.ops.bsengine_get_vibrate_frequency(name),
+    getVibrateDuration:         (name)              => Deno.core.ops.bsengine_get_vibrate_duration(name),
+    getVibrateElapsed:          (name)              => Deno.core.ops.bsengine_get_vibrate_elapsed(name),
+    getVibrateDecayRate:        (name)              => Deno.core.ops.bsengine_get_vibrate_decay_rate(name),
+    isVibrateJustStarted:       (name)              => Deno.core.ops.bsengine_is_vibrate_just_started(name),
+    isVibrateJustStopped:       (name)              => Deno.core.ops.bsengine_is_vibrate_just_stopped(name),
+    isVibrateEnabled:           (name)              => Deno.core.ops.bsengine_is_vibrate_enabled(name),
+    triggerVibrate:             (name, a, f, d)     => Deno.core.ops.bsengine_trigger_vibrate(name, a, f, d),
+    stopVibrate:                (name)              => Deno.core.ops.bsengine_stop_vibrate(name),
+    setVibrateEnabled:          (name, v)           => Deno.core.ops.bsengine_set_vibrate_enabled(name, v),
+    getViewportX:               (name)              => Deno.core.ops.bsengine_get_viewport_x(name),
+    getViewportY:               (name)              => Deno.core.ops.bsengine_get_viewport_y(name),
+    getViewportWidth:           (name)              => Deno.core.ops.bsengine_get_viewport_width(name),
+    getViewportHeight:          (name)              => Deno.core.ops.bsengine_get_viewport_height(name),
+    setViewportRect:            (name, x, y, w, h)  => Deno.core.ops.bsengine_set_viewport_rect(name, x, y, w, h),
+    getVisionRange:             (name)              => Deno.core.ops.bsengine_get_vision_range(name),
+    getVisionFov:               (name)              => Deno.core.ops.bsengine_get_vision_fov(name),
+    getVisionMask:              (name)              => Deno.core.ops.bsengine_get_vision_mask(name),
+    getVisionInViewDuration:    (name)              => Deno.core.ops.bsengine_get_vision_in_view_duration(name),
+    getVisionDetectionDelay:    (name)              => Deno.core.ops.bsengine_get_vision_detection_delay(name),
+    isVisionLosBlocked:         (name)              => Deno.core.ops.bsengine_is_vision_los_blocked(name),
+    visionHasTarget:            (name)              => Deno.core.ops.bsengine_vision_has_target(name),
+    isVisionEnabled:            (name)              => Deno.core.ops.bsengine_is_vision_enabled(name),
+    setVisionRange:             (name, v)           => Deno.core.ops.bsengine_set_vision_range(name, v),
+    setVisionFov:               (name, v)           => Deno.core.ops.bsengine_set_vision_fov(name, v),
+    setVisionMask:              (name, v)           => Deno.core.ops.bsengine_set_vision_mask(name, v),
+    resetVisionTimer:           (name)              => Deno.core.ops.bsengine_reset_vision_timer(name),
+    setVisionEnabled:           (name, v)           => Deno.core.ops.bsengine_set_vision_enabled(name, v),
+    getVolumetricScattering:    (name)              => Deno.core.ops.bsengine_get_volumetric_scattering(name),
+    getVolumetricAbsorption:    (name)              => Deno.core.ops.bsengine_get_volumetric_absorption(name),
+    getVolumetricAnisotropy:    (name)              => Deno.core.ops.bsengine_get_volumetric_anisotropy(name),
+    getVolumetricStepCount:     (name)              => Deno.core.ops.bsengine_get_volumetric_step_count(name),
+    getVolumetricMaxDistance:   (name)              => Deno.core.ops.bsengine_get_volumetric_max_distance(name),
+    isVolumetricLightEnabled:   (name)              => Deno.core.ops.bsengine_is_volumetric_light_enabled(name),
+    setVolumetricScattering:    (name, v)           => Deno.core.ops.bsengine_set_volumetric_scattering(name, v),
+    setVolumetricAbsorption:    (name, v)           => Deno.core.ops.bsengine_set_volumetric_absorption(name, v),
+    setVolumetricAnisotropy:    (name, v)           => Deno.core.ops.bsengine_set_volumetric_anisotropy(name, v),
+    setVolumetricStepCount:     (name, v)           => Deno.core.ops.bsengine_set_volumetric_step_count(name, v),
+    setVolumetricMaxDistance:   (name, v)           => Deno.core.ops.bsengine_set_volumetric_max_distance(name, v),
+    setVolumetricLightEnabled:  (name, v)           => Deno.core.ops.bsengine_set_volumetric_light_enabled(name, v),
+    getVolleyCharge:            (name)              => Deno.core.ops.bsengine_get_volley_charge(name),
+    getVolleyMaxCharge:         (name)              => Deno.core.ops.bsengine_get_volley_max_charge(name),
+    getVolleyDrawRate:          (name)              => Deno.core.ops.bsengine_get_volley_draw_rate(name),
+    isVolleyJustVollied:        (name)              => Deno.core.ops.bsengine_is_volley_just_vollied(name),
+    isVolleyJustSpent:          (name)              => Deno.core.ops.bsengine_is_volley_just_spent(name),
+    isVolleyEnabled:            (name)              => Deno.core.ops.bsengine_is_volley_enabled(name),
+    loadVolley:                 (name, amount)      => Deno.core.ops.bsengine_load_volley(name, amount),
+    releaseVolley:              (name, amount)      => Deno.core.ops.bsengine_release_volley(name, amount),
+    setVolleyEnabled:           (name, v)           => Deno.core.ops.bsengine_set_volley_enabled(name, v),
+    getVortexSpin:              (name)              => Deno.core.ops.bsengine_get_vortex_spin(name),
+    getVortexMaxSpin:           (name)              => Deno.core.ops.bsengine_get_vortex_max_spin(name),
+    getVortexSpiralRate:        (name)              => Deno.core.ops.bsengine_get_vortex_spiral_rate(name),
+    isVortexJustFormed:         (name)              => Deno.core.ops.bsengine_is_vortex_just_formed(name),
+    isVortexJustCalm:           (name)              => Deno.core.ops.bsengine_is_vortex_just_calm(name),
+    isVortexEnabled:            (name)              => Deno.core.ops.bsengine_is_vortex_enabled(name),
+    windVortex:                 (name, amount)      => Deno.core.ops.bsengine_wind_vortex(name, amount),
+    dissipateVortex:            (name, amount)      => Deno.core.ops.bsengine_dissipate_vortex(name, amount),
+    setVortexEnabled:           (name, v)           => Deno.core.ops.bsengine_set_vortex_enabled(name, v),
+    getVowPledge:               (name)              => Deno.core.ops.bsengine_get_vow_pledge(name),
+    getVowMaxPledge:            (name)              => Deno.core.ops.bsengine_get_vow_max_pledge(name),
+    getVowDevotionRate:         (name)              => Deno.core.ops.bsengine_get_vow_devotion_rate(name),
+    isVowJustBound:             (name)              => Deno.core.ops.bsengine_is_vow_just_bound(name),
+    isVowJustBroken:            (name)              => Deno.core.ops.bsengine_is_vow_just_broken(name),
+    isVowEnabled:               (name)              => Deno.core.ops.bsengine_is_vow_enabled(name),
+    swearVow:                   (name, amount)      => Deno.core.ops.bsengine_swear_vow(name, amount),
+    renounceVow:                (name, amount)      => Deno.core.ops.bsengine_renounce_vow(name, amount),
+    setVowEnabled:              (name, v)           => Deno.core.ops.bsengine_set_vow_enabled(name, v),
+    getVulnerableExposure:      (name)              => Deno.core.ops.bsengine_get_vulnerable_exposure(name),
+    getVulnerableMaxExposure:   (name)              => Deno.core.ops.bsengine_get_vulnerable_max_exposure(name),
+    getVulnerableBreachRate:    (name)              => Deno.core.ops.bsengine_get_vulnerable_breach_rate(name),
+    isVulnerableJustExposed:    (name)              => Deno.core.ops.bsengine_is_vulnerable_just_exposed(name),
+    isVulnerableJustHardened:   (name)              => Deno.core.ops.bsengine_is_vulnerable_just_hardened(name),
+    isVulnerableEnabled:        (name)              => Deno.core.ops.bsengine_is_vulnerable_enabled(name),
+    weakenVulnerable:           (name, amount)      => Deno.core.ops.bsengine_weaken_vulnerable(name, amount),
+    fortifyVulnerable:          (name, amount)      => Deno.core.ops.bsengine_fortify_vulnerable(name, amount),
+    setVulnerableEnabled:       (name, v)           => Deno.core.ops.bsengine_set_vulnerable_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -56154,6 +56851,471 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::IlluminateVista { name, amount } if name == "Grunt" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ObscureVista { name, amount } if name == "Grunt" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVistaEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vibrate_read_ops() {
+        super::VIBRATE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (
+                    0.5f32, 0.25f32, 1.0f32, 0.25f32, 0.125f32, true, false, true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVibrateAmplitude("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVibrateFrequency("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getVibrateDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVibrateElapsed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getVibrateDecayRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.125");
+        let r = rt
+            .eval(r#"String(Bsengine.isVibrateJustStarted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVibrateJustStopped("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVibrateEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VIBRATE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vibrate_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(
+            r#"Bsengine.triggerVibrate("Grunt", 0.5, 0.25, 1.0);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(r#"Bsengine.stopVibrate("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVibrateEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::TriggerVibrate { name, amplitude, frequency, duration } if name == "Grunt" && *amplitude == 0.5 && *frequency == 0.25 && *duration == 1.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StopVibrate { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVibrateEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_viewport_read_ops() {
+        super::VIEWPORT_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.25f32, 0.5f32, 0.75f32, 1.0f32));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getViewportX("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt.eval(r#"String(Bsengine.getViewportY("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getViewportWidth("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getViewportHeight("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        super::VIEWPORT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_viewport_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(
+            r#"Bsengine.setViewportRect("Grunt", 0.25, 0.5, 0.75, 1.0);"#,
+            "<test>",
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetViewportRect { name, x, y, width, height } if name == "Grunt" && *x == 0.25 && *y == 0.5 && *width == 0.75 && *height == 1.0)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vision_read_ops() {
+        super::VISION_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (
+                    10.0f32, 0.5f32, 255u32, 0.25f32, 0.125f32, true, false, true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVisionRange("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt.eval(r#"String(Bsengine.getVisionFov("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVisionMask("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "255");
+        let r = rt
+            .eval(r#"String(Bsengine.getVisionInViewDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getVisionDetectionDelay("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.125");
+        let r = rt
+            .eval(r#"String(Bsengine.isVisionLosBlocked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.visionHasTarget("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVisionEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VISION_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vision_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setVisionRange("Grunt", 10.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVisionFov("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVisionMask("Grunt", 255);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.resetVisionTimer("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVisionEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVisionRange { name, range } if name == "Grunt" && *range == 10.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVisionFov { name, fov } if name == "Grunt" && *fov == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVisionMask { name, mask } if name == "Grunt" && *mask == 255)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ResetVisionTimer { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVisionEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_volumetric_light_read_ops() {
+        super::VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 0.25f32, 0.125f32, 16u32, 25.0f32, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVolumetricScattering("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVolumetricAbsorption("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getVolumetricAnisotropy("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.125");
+        let r = rt
+            .eval(r#"String(Bsengine.getVolumetricStepCount("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "16");
+        let r = rt
+            .eval(r#"String(Bsengine.getVolumetricMaxDistance("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "25");
+        let r = rt
+            .eval(r#"String(Bsengine.isVolumetricLightEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_volumetric_light_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(
+            r#"Bsengine.setVolumetricScattering("Grunt", 0.5);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setVolumetricAbsorption("Grunt", 0.25);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setVolumetricAnisotropy("Grunt", 0.125);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(r#"Bsengine.setVolumetricStepCount("Grunt", 16);"#, "<test>")
+            .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setVolumetricMaxDistance("Grunt", 25.0);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setVolumetricLightEnabled("Grunt", false);"#,
+            "<test>",
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVolumetricScattering { name, value } if name == "Grunt" && *value == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVolumetricAbsorption { name, value } if name == "Grunt" && *value == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVolumetricAnisotropy { name, value } if name == "Grunt" && *value == 0.125)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVolumetricStepCount { name, count } if name == "Grunt" && *count == 16)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVolumetricMaxDistance { name, value } if name == "Grunt" && *value == 25.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVolumetricLightEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_volley_read_ops() {
+        super::VOLLEY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVolleyCharge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVolleyMaxCharge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVolleyDrawRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isVolleyJustVollied("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVolleyJustSpent("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVolleyEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VOLLEY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_volley_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.loadVolley("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.releaseVolley("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVolleyEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::LoadVolley { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ReleaseVolley { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVolleyEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vortex_read_ops() {
+        super::VORTEX_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVortexSpin("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVortexMaxSpin("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVortexSpiralRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isVortexJustFormed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVortexJustCalm("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVortexEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VORTEX_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vortex_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.windVortex("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.dissipateVortex("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVortexEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::WindVortex { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DissipateVortex { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVortexEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vow_read_ops() {
+        super::VOW_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getVowPledge("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVowMaxPledge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVowDevotionRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isVowJustBound("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVowJustBroken("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isVowEnabled("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VOW_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vow_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.swearVow("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.renounceVow("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVowEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SwearVow { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RenounceVow { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVowEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vulnerable_read_ops() {
+        super::VULNERABLE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVulnerableExposure("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVulnerableMaxExposure("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVulnerableBreachRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isVulnerableJustExposed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVulnerableJustHardened("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVulnerableEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VULNERABLE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vulnerable_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.weakenVulnerable("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.fortifyVulnerable("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setVulnerableEnabled("Grunt", false);"#,
+            "<test>",
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::WeakenVulnerable { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::FortifyVulnerable { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVulnerableEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4207,6 +4207,101 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Verve ────────────────────────────────────────────────────────────────
+    ActVerve {
+        name: String,
+    },
+    SetVerveEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vest ─────────────────────────────────────────────────────────────────
+    AbsorbVest {
+        name: String,
+        incoming: f32,
+    },
+    SetVestEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vice ─────────────────────────────────────────────────────────────────
+    CorruptVice {
+        name: String,
+        amount: f32,
+    },
+    PurifyVice {
+        name: String,
+        amount: f32,
+    },
+    SetViceEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vim ──────────────────────────────────────────────────────────────────
+    InvigorateVim {
+        name: String,
+        amount: f32,
+    },
+    SapVim {
+        name: String,
+        amount: f32,
+    },
+    SetVimEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Viper ────────────────────────────────────────────────────────────────
+    Envenomate {
+        name: String,
+        amount: f32,
+    },
+    DrainViper {
+        name: String,
+        amount: f32,
+    },
+    SetViperEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Viral ────────────────────────────────────────────────────────────────
+    ExposeViral {
+        name: String,
+        amount: f32,
+    },
+    ContainViral {
+        name: String,
+        amount: f32,
+    },
+    SetViralEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Visit ────────────────────────────────────────────────────────────────
+    ApproachVisit {
+        name: String,
+        amount: f32,
+    },
+    WithdrawVisit {
+        name: String,
+        amount: f32,
+    },
+    SetVisitEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vista ────────────────────────────────────────────────────────────────
+    IlluminateVista {
+        name: String,
+        amount: f32,
+    },
+    ObscureVista {
+        name: String,
+        amount: f32,
+    },
+    SetVistaEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5338,6 +5433,22 @@ thread_local! {
     pub(crate) static VERSE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static VERTEX_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VERVE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VEST_SNAPSHOT: RefCell<HashMap<String, (f32, u32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VICE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VIM_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VIPER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VIRAL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VISIT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VISTA_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -9972,6 +10083,354 @@ pub fn bsengine_set_vertex_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetVertexEnabled { name, enabled })
+    });
+}
+// ── Verve ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_verve_level(#[string] name: String) -> f32 {
+    VERVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_verve(#[string] name: String) -> f32 {
+    VERVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_verve_gain_per_action(#[string] name: String) -> f32 {
+    VERVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_verve_decay_rate(#[string] name: String) -> f32 {
+    VERVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_verve_action_bonus(#[string] name: String) -> f32 {
+    VERVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_verve_just_peaked(#[string] name: String) -> bool {
+    VERVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_verve_enabled(#[string] name: String) -> bool {
+    VERVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_act_verve(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ActVerve { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_verve_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVerveEnabled { name, enabled })
+    });
+}
+// ── Vest ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_absorption_per_hit(#[string] name: String) -> f32 {
+    VEST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_hits_absorbed(#[string] name: String) -> u32 {
+    VEST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_last_absorbed(#[string] name: String) -> f32 {
+    VEST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_absorbed(#[string] name: String) -> bool {
+    VEST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vest_enabled(#[string] name: String) -> bool {
+    VEST_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_absorb_vest(#[string] name: String, incoming: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AbsorbVest { name, incoming })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vest_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVestEnabled { name, enabled })
+    });
+}
+// ── Vice ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_corruption(#[string] name: String) -> f32 {
+    VICE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_corruption(#[string] name: String) -> f32 {
+    VICE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_temptation_rate(#[string] name: String) -> f32 {
+    VICE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_corrupted(#[string] name: String) -> bool {
+    VICE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_purified(#[string] name: String) -> bool {
+    VICE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vice_enabled(#[string] name: String) -> bool {
+    VICE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_corrupt_vice(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CorruptVice { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_purify_vice(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::PurifyVice { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vice_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetViceEnabled { name, enabled })
+    });
+}
+// ── Vim ───────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_drive(#[string] name: String) -> f32 {
+    VIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_drive(#[string] name: String) -> f32 {
+    VIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vim_vigor_rate(#[string] name: String) -> f32 {
+    VIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_energized(#[string] name: String) -> bool {
+    VIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_sapped(#[string] name: String) -> bool {
+    VIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vim_enabled(#[string] name: String) -> bool {
+    VIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_invigorate_vim(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::InvigorateVim { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_sap_vim(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SapVim { name, amount }));
+}
+#[op2(fast)]
+pub fn bsengine_set_vim_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVimEnabled { name, enabled })
+    });
+}
+// ── Viper ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_viper_venom(#[string] name: String) -> f32 {
+    VIPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_viper_max_venom(#[string] name: String) -> f32 {
+    VIPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_viper_toxin_rate(#[string] name: String) -> f32 {
+    VIPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_envenomed(#[string] name: String) -> bool {
+    VIPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_drained(#[string] name: String) -> bool {
+    VIPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_viper_enabled(#[string] name: String) -> bool {
+    VIPER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_envenomate(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::Envenomate { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_drain_viper(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DrainViper { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_viper_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetViperEnabled { name, enabled })
+    });
+}
+// ── Viral ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_contagion(#[string] name: String) -> f32 {
+    VIRAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_contagion(#[string] name: String) -> f32 {
+    VIRAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_spread_rate(#[string] name: String) -> f32 {
+    VIRAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_spread(#[string] name: String) -> bool {
+    VIRAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_contained(#[string] name: String) -> bool {
+    VIRAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_viral_enabled(#[string] name: String) -> bool {
+    VIRAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_expose_viral(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ExposeViral { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_contain_viral(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ContainViral { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_viral_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetViralEnabled { name, enabled })
+    });
+}
+// ── Visit ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_exposure(#[string] name: String) -> f32 {
+    VISIT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_exposure(#[string] name: String) -> f32 {
+    VISIT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_presence_rate(#[string] name: String) -> f32 {
+    VISIT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_visited(#[string] name: String) -> bool {
+    VISIT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_departed(#[string] name: String) -> bool {
+    VISIT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_visit_enabled(#[string] name: String) -> bool {
+    VISIT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_approach_visit(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApproachVisit { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_withdraw_visit(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::WithdrawVisit { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_visit_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVisitEnabled { name, enabled })
+    });
+}
+// ── Vista ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_clarity(#[string] name: String) -> f32 {
+    VISTA_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_clarity(#[string] name: String) -> f32 {
+    VISTA_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_reveal_rate(#[string] name: String) -> f32 {
+    VISTA_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_revealed(#[string] name: String) -> bool {
+    VISTA_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_dimmed(#[string] name: String) -> bool {
+    VISTA_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vista_enabled(#[string] name: String) -> bool {
+    VISTA_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_illuminate_vista(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::IlluminateVista { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_obscure_vista(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ObscureVista { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vista_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVistaEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -29834,6 +30293,76 @@ deno_core::extension!(
         bsengine_ascend_vertex,
         bsengine_descend_vertex,
         bsengine_set_vertex_enabled,
+        bsengine_get_verve_level,
+        bsengine_get_max_verve,
+        bsengine_get_verve_gain_per_action,
+        bsengine_get_verve_decay_rate,
+        bsengine_get_verve_action_bonus,
+        bsengine_is_verve_just_peaked,
+        bsengine_is_verve_enabled,
+        bsengine_act_verve,
+        bsengine_set_verve_enabled,
+        bsengine_get_absorption_per_hit,
+        bsengine_get_hits_absorbed,
+        bsengine_get_last_absorbed,
+        bsengine_is_just_absorbed,
+        bsengine_is_vest_enabled,
+        bsengine_absorb_vest,
+        bsengine_set_vest_enabled,
+        bsengine_get_corruption,
+        bsengine_get_max_corruption,
+        bsengine_get_temptation_rate,
+        bsengine_is_just_corrupted,
+        bsengine_is_just_purified,
+        bsengine_is_vice_enabled,
+        bsengine_corrupt_vice,
+        bsengine_purify_vice,
+        bsengine_set_vice_enabled,
+        bsengine_get_drive,
+        bsengine_get_max_drive,
+        bsengine_get_vim_vigor_rate,
+        bsengine_is_just_energized,
+        bsengine_is_just_sapped,
+        bsengine_is_vim_enabled,
+        bsengine_invigorate_vim,
+        bsengine_sap_vim,
+        bsengine_set_vim_enabled,
+        bsengine_get_viper_venom,
+        bsengine_get_viper_max_venom,
+        bsengine_get_viper_toxin_rate,
+        bsengine_is_just_envenomed,
+        bsengine_is_just_drained,
+        bsengine_is_viper_enabled,
+        bsengine_envenomate,
+        bsengine_drain_viper,
+        bsengine_set_viper_enabled,
+        bsengine_get_contagion,
+        bsengine_get_max_contagion,
+        bsengine_get_spread_rate,
+        bsengine_is_just_spread,
+        bsengine_is_just_contained,
+        bsengine_is_viral_enabled,
+        bsengine_expose_viral,
+        bsengine_contain_viral,
+        bsengine_set_viral_enabled,
+        bsengine_get_exposure,
+        bsengine_get_max_exposure,
+        bsengine_get_presence_rate,
+        bsengine_is_just_visited,
+        bsengine_is_just_departed,
+        bsengine_is_visit_enabled,
+        bsengine_approach_visit,
+        bsengine_withdraw_visit,
+        bsengine_set_visit_enabled,
+        bsengine_get_clarity,
+        bsengine_get_max_clarity,
+        bsengine_get_reveal_rate,
+        bsengine_is_just_revealed,
+        bsengine_is_just_dimmed,
+        bsengine_is_vista_enabled,
+        bsengine_illuminate_vista,
+        bsengine_obscure_vista,
+        bsengine_set_vista_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -33108,6 +33637,76 @@ const Bsengine = {
     ascendVertex:               (name, amount)      => Deno.core.ops.bsengine_ascend_vertex(name, amount),
     descendVertex:              (name, amount)      => Deno.core.ops.bsengine_descend_vertex(name, amount),
     setVertexEnabled:           (name, v)           => Deno.core.ops.bsengine_set_vertex_enabled(name, v),
+    getVerveLevel:              (name)              => Deno.core.ops.bsengine_get_verve_level(name),
+    getMaxVerve:                (name)              => Deno.core.ops.bsengine_get_max_verve(name),
+    getVerveGainPerAction:      (name)              => Deno.core.ops.bsengine_get_verve_gain_per_action(name),
+    getVerveDecayRate:          (name)              => Deno.core.ops.bsengine_get_verve_decay_rate(name),
+    getVerveActionBonus:        (name)              => Deno.core.ops.bsengine_get_verve_action_bonus(name),
+    isVerveJustPeaked:          (name)              => Deno.core.ops.bsengine_is_verve_just_peaked(name),
+    isVerveEnabled:             (name)              => Deno.core.ops.bsengine_is_verve_enabled(name),
+    actVerve:                   (name)              => Deno.core.ops.bsengine_act_verve(name),
+    setVerveEnabled:            (name, v)           => Deno.core.ops.bsengine_set_verve_enabled(name, v),
+    getAbsorptionPerHit:        (name)              => Deno.core.ops.bsengine_get_absorption_per_hit(name),
+    getHitsAbsorbed:            (name)              => Deno.core.ops.bsengine_get_hits_absorbed(name),
+    getLastAbsorbed:            (name)              => Deno.core.ops.bsengine_get_last_absorbed(name),
+    isJustAbsorbed:             (name)              => Deno.core.ops.bsengine_is_just_absorbed(name),
+    isVestEnabled:              (name)              => Deno.core.ops.bsengine_is_vest_enabled(name),
+    absorbVest:                 (name, amount)      => Deno.core.ops.bsengine_absorb_vest(name, amount),
+    setVestEnabled:             (name, v)           => Deno.core.ops.bsengine_set_vest_enabled(name, v),
+    getCorruption:              (name)              => Deno.core.ops.bsengine_get_corruption(name),
+    getMaxCorruption:           (name)              => Deno.core.ops.bsengine_get_max_corruption(name),
+    getTemptationRate:          (name)              => Deno.core.ops.bsengine_get_temptation_rate(name),
+    isJustCorrupted:            (name)              => Deno.core.ops.bsengine_is_just_corrupted(name),
+    isJustPurified:             (name)              => Deno.core.ops.bsengine_is_just_purified(name),
+    isViceEnabled:              (name)              => Deno.core.ops.bsengine_is_vice_enabled(name),
+    corruptVice:                (name, amount)      => Deno.core.ops.bsengine_corrupt_vice(name, amount),
+    purifyVice:                 (name, amount)      => Deno.core.ops.bsengine_purify_vice(name, amount),
+    setViceEnabled:             (name, v)           => Deno.core.ops.bsengine_set_vice_enabled(name, v),
+    getDrive:                   (name)              => Deno.core.ops.bsengine_get_drive(name),
+    getMaxDrive:                (name)              => Deno.core.ops.bsengine_get_max_drive(name),
+    getVimVigorRate:            (name)              => Deno.core.ops.bsengine_get_vim_vigor_rate(name),
+    isJustEnergized:            (name)              => Deno.core.ops.bsengine_is_just_energized(name),
+    isJustSapped:               (name)              => Deno.core.ops.bsengine_is_just_sapped(name),
+    isVimEnabled:               (name)              => Deno.core.ops.bsengine_is_vim_enabled(name),
+    invigorateVim:              (name, amount)      => Deno.core.ops.bsengine_invigorate_vim(name, amount),
+    sapVim:                     (name, amount)      => Deno.core.ops.bsengine_sap_vim(name, amount),
+    setVimEnabled:              (name, v)           => Deno.core.ops.bsengine_set_vim_enabled(name, v),
+    getViperVenom:              (name)              => Deno.core.ops.bsengine_get_viper_venom(name),
+    getViperMaxVenom:           (name)              => Deno.core.ops.bsengine_get_viper_max_venom(name),
+    getViperToxinRate:          (name)              => Deno.core.ops.bsengine_get_viper_toxin_rate(name),
+    isJustEnvenomed:            (name)              => Deno.core.ops.bsengine_is_just_envenomed(name),
+    isJustDrained:              (name)              => Deno.core.ops.bsengine_is_just_drained(name),
+    isViperEnabled:             (name)              => Deno.core.ops.bsengine_is_viper_enabled(name),
+    envenomate:                 (name, amount)      => Deno.core.ops.bsengine_envenomate(name, amount),
+    drainViper:                 (name, amount)      => Deno.core.ops.bsengine_drain_viper(name, amount),
+    setViperEnabled:            (name, v)           => Deno.core.ops.bsengine_set_viper_enabled(name, v),
+    getContagion:               (name)              => Deno.core.ops.bsengine_get_contagion(name),
+    getMaxContagion:            (name)              => Deno.core.ops.bsengine_get_max_contagion(name),
+    getSpreadRate:              (name)              => Deno.core.ops.bsengine_get_spread_rate(name),
+    isJustSpread:               (name)              => Deno.core.ops.bsengine_is_just_spread(name),
+    isJustContained:            (name)              => Deno.core.ops.bsengine_is_just_contained(name),
+    isViralEnabled:             (name)              => Deno.core.ops.bsengine_is_viral_enabled(name),
+    exposeViral:                (name, amount)      => Deno.core.ops.bsengine_expose_viral(name, amount),
+    containViral:               (name, amount)      => Deno.core.ops.bsengine_contain_viral(name, amount),
+    setViralEnabled:            (name, v)           => Deno.core.ops.bsengine_set_viral_enabled(name, v),
+    getExposure:                (name)              => Deno.core.ops.bsengine_get_exposure(name),
+    getMaxExposure:             (name)              => Deno.core.ops.bsengine_get_max_exposure(name),
+    getPresenceRate:            (name)              => Deno.core.ops.bsengine_get_presence_rate(name),
+    isJustVisited:              (name)              => Deno.core.ops.bsengine_is_just_visited(name),
+    isJustDeparted:             (name)              => Deno.core.ops.bsengine_is_just_departed(name),
+    isVisitEnabled:             (name)              => Deno.core.ops.bsengine_is_visit_enabled(name),
+    approachVisit:              (name, amount)      => Deno.core.ops.bsengine_approach_visit(name, amount),
+    withdrawVisit:              (name, amount)      => Deno.core.ops.bsengine_withdraw_visit(name, amount),
+    setVisitEnabled:            (name, v)           => Deno.core.ops.bsengine_set_visit_enabled(name, v),
+    getClarity:                 (name)              => Deno.core.ops.bsengine_get_clarity(name),
+    getMaxClarity:              (name)              => Deno.core.ops.bsengine_get_max_clarity(name),
+    getRevealRate:              (name)              => Deno.core.ops.bsengine_get_reveal_rate(name),
+    isJustRevealed:             (name)              => Deno.core.ops.bsengine_is_just_revealed(name),
+    isJustDimmed:               (name)              => Deno.core.ops.bsengine_is_just_dimmed(name),
+    isVistaEnabled:             (name)              => Deno.core.ops.bsengine_is_vista_enabled(name),
+    illuminateVista:            (name, amount)      => Deno.core.ops.bsengine_illuminate_vista(name, amount),
+    obscureVista:               (name, amount)      => Deno.core.ops.bsengine_obscure_vista(name, amount),
+    setVistaEnabled:            (name, v)           => Deno.core.ops.bsengine_set_vista_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -55151,6 +55750,410 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AscendVertex { name, amount } if name == "Grunt" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DescendVertex { name, amount } if name == "Grunt" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVertexEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verve_read_ops() {
+        super::VERVE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, 0.5f32, 0.75f32, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVerveLevel("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getMaxVerve("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVerveGainPerAction("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getVerveDecayRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVerveActionBonus("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.isVerveJustPeaked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVerveEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VERVE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verve_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.actVerve("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVerveEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ActVerve { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVerveEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vest_read_ops() {
+        super::VEST_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.5f32, 2u32, 0.25f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getAbsorptionPerHit("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getHitsAbsorbed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getLastAbsorbed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustAbsorbed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVestEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VEST_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vest_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.absorbVest("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVestEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AbsorbVest { name, incoming } if name == "Grunt" && *incoming == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVestEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vice_read_ops() {
+        super::VICE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getCorruption("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getMaxCorruption("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getTemptationRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustCorrupted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustPurified("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isViceEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VICE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vice_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.corruptVice("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.purifyVice("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setViceEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CorruptVice { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::PurifyVice { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetViceEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vim_read_ops() {
+        super::VIM_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getDrive("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getMaxDrive("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVimVigorRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustEnergized("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt.eval(r#"String(Bsengine.isJustSapped("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isVimEnabled("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VIM_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vim_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.invigorateVim("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.sapVim("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVimEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::InvigorateVim { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SapVim { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVimEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_viper_read_ops() {
+        super::VIPER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getViperVenom("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getViperMaxVenom("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getViperToxinRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustEnvenomed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustDrained("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isViperEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VIPER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_viper_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.envenomate("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.drainViper("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setViperEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::Envenomate { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DrainViper { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetViperEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_viral_read_ops() {
+        super::VIRAL_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getContagion("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getMaxContagion("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSpreadRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt.eval(r#"String(Bsengine.isJustSpread("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustContained("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isViralEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VIRAL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_viral_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.exposeViral("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.containViral("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setViralEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ExposeViral { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ContainViral { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetViralEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_visit_read_ops() {
+        super::VISIT_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getExposure("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getMaxExposure("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getPresenceRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustVisited("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustDeparted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVisitEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VISIT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_visit_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.approachVisit("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.withdrawVisit("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVisitEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApproachVisit { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::WithdrawVisit { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVisitEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vista_read_ops() {
+        super::VISTA_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getClarity("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getMaxClarity("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getRevealRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustRevealed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt.eval(r#"String(Bsengine.isJustDimmed("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVistaEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VISTA_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vista_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.illuminateVista("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.obscureVista("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVistaEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::IlluminateVista { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ObscureVista { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVistaEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -3784,6 +3784,93 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Sulk ─────────────────────────────────────────────────────────────────
+    BeginSulk {
+        name: String,
+    },
+    EndSulk {
+        name: String,
+    },
+    SetSulkEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Sunder ───────────────────────────────────────────────────────────────
+    ApplySunder {
+        name: String,
+        count: u32,
+    },
+    RepairSunder {
+        name: String,
+        count: u32,
+    },
+    RepairAllSunder {
+        name: String,
+    },
+    SetSunderEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Suppress ─────────────────────────────────────────────────────────────
+    ApplySuppress {
+        name: String,
+        duration: f32,
+    },
+    ClearSuppress {
+        name: String,
+    },
+    SetSuppressEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Surge ────────────────────────────────────────────────────────────────
+    ApplySurge {
+        name: String,
+        duration: f32,
+    },
+    ClearSurge {
+        name: String,
+    },
+    SetSurgeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Surround ─────────────────────────────────────────────────────────────
+    UpdateSurround {
+        name: String,
+        count: u32,
+    },
+    SetSurroundEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Survive ──────────────────────────────────────────────────────────────
+    AddSurviveCharge {
+        name: String,
+    },
+    SetSurviveEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Swim ─────────────────────────────────────────────────────────────────
+    EnterWater {
+        name: String,
+    },
+    ExitWater {
+        name: String,
+    },
+    SetWantsDive {
+        name: String,
+        wants: bool,
+    },
+    SetWantsSurface {
+        name: String,
+        wants: bool,
+    },
+    SetSwimEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -4834,6 +4921,27 @@ thread_local! {
         RefCell::new(HashMap::new());
     // entity name → (stumble_timer, stumble_duration, vulnerability_factor, move_penalty, stumble_count, stumbling, just_stumbled, just_recovered, enabled)
     pub(crate) static STUMBLE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, u32, bool, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (sulk_depth, sulk_rate, recovery_rate, support_penalty, sulking, just_sulked, just_snapped_out, enabled)
+    pub(crate) static SULK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (shards, max_shards, damage_reduction_per_shard, just_sundered, enabled)
+    pub(crate) static SUNDER_SNAPSHOT: RefCell<HashMap<String, (u32, u32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (duration, timer, potency_fraction, blocks_ultimates, just_suppressed, just_lifted, enabled)
+    pub(crate) static SUPPRESS_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (duration, timer, multiplier, just_surged, just_expired, enabled)
+    pub(crate) static SURGE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (adjacent_count, encircle_threshold, defense_bonus, just_encircled, just_cleared, enabled)
+    pub(crate) static SURROUND_SNAPSHOT: RefCell<HashMap<String, (u32, u32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (charges, max_charges, just_survived, enabled)
+    pub(crate) static SURVIVE_SNAPSHOT: RefCell<HashMap<String, (u32, u32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (state, swim_speed, dive_speed, ascent_speed, breath_remaining, max_breath, breath_drain_rate, breath_regen_rate, depth, submerge_depth, wants_dive, wants_surface, enabled)
+    pub(crate) static SWIM_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32, f32, f32, f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -7796,6 +7904,342 @@ pub fn bsengine_set_stumble_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetStumbleEnabled { name, enabled })
+    });
+}
+// ── Sulk ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_sulk_depth(#[string] name: String) -> f32 {
+    SULK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_sulk_rate(#[string] name: String) -> f32 {
+    SULK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_sulk_recovery_rate(#[string] name: String) -> f32 {
+    SULK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_sulk_support_penalty(#[string] name: String) -> f32 {
+    SULK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_sulking(#[string] name: String) -> bool {
+    SULK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_sulked(#[string] name: String) -> bool {
+    SULK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_snapped_out(#[string] name: String) -> bool {
+    SULK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_sulk_enabled(#[string] name: String) -> bool {
+    SULK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_begin_sulk(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::BeginSulk { name }));
+}
+#[op2(fast)]
+pub fn bsengine_end_sulk(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::EndSulk { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_sulk_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSulkEnabled { name, enabled })
+    });
+}
+// ── Sunder ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_sunder_shards(#[string] name: String) -> u32 {
+    SUNDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_sunder_max_shards(#[string] name: String) -> u32 {
+    SUNDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_sunder_damage_reduction_per_shard(#[string] name: String) -> f32 {
+    SUNDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_sundered(#[string] name: String) -> bool {
+    SUNDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_sunder_enabled(#[string] name: String) -> bool {
+    SUNDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_sunder(#[string] name: String, count: u32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplySunder { name, count })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_repair_sunder(#[string] name: String, count: u32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RepairSunder { name, count })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_repair_all_sunder(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::RepairAllSunder { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_sunder_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSunderEnabled { name, enabled })
+    });
+}
+// ── Suppress ─────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_suppress_duration(#[string] name: String) -> f32 {
+    SUPPRESS_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_suppress_timer(#[string] name: String) -> f32 {
+    SUPPRESS_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_suppress_potency_fraction(#[string] name: String) -> f32 {
+    SUPPRESS_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_suppress_blocks_ultimates(#[string] name: String) -> bool {
+    SUPPRESS_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_suppressed(#[string] name: String) -> bool {
+    SUPPRESS_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_suppress_lifted(#[string] name: String) -> bool {
+    SUPPRESS_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_suppress_enabled(#[string] name: String) -> bool {
+    SUPPRESS_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_suppress(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplySuppress { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_clear_suppress(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearSuppress { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_suppress_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSuppressEnabled { name, enabled })
+    });
+}
+// ── Surge ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_surge_duration(#[string] name: String) -> f32 {
+    SURGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_surge_timer(#[string] name: String) -> f32 {
+    SURGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_surge_multiplier(#[string] name: String) -> f32 {
+    SURGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_surged(#[string] name: String) -> bool {
+    SURGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_surge_expired(#[string] name: String) -> bool {
+    SURGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_surge_enabled(#[string] name: String) -> bool {
+    SURGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_surge(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplySurge { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_clear_surge(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearSurge { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_surge_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSurgeEnabled { name, enabled })
+    });
+}
+// ── Surround ─────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_surround_adjacent_count(#[string] name: String) -> u32 {
+    SURROUND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_surround_encircle_threshold(#[string] name: String) -> u32 {
+    SURROUND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_surround_defense_bonus(#[string] name: String) -> f32 {
+    SURROUND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_encircled(#[string] name: String) -> bool {
+    SURROUND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_surround_cleared(#[string] name: String) -> bool {
+    SURROUND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_surround_enabled(#[string] name: String) -> bool {
+    SURROUND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_update_surround(#[string] name: String, count: u32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::UpdateSurround { name, count })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_surround_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSurroundEnabled { name, enabled })
+    });
+}
+// ── Survive ──────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_survive_charges(#[string] name: String) -> u32 {
+    SURVIVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_survive_max_charges(#[string] name: String) -> u32 {
+    SURVIVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_survived(#[string] name: String) -> bool {
+    SURVIVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_survive_enabled(#[string] name: String) -> bool {
+    SURVIVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_add_survive_charge(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AddSurviveCharge { name })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_survive_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSurviveEnabled { name, enabled })
+    });
+}
+// ── Swim ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_swim_state(#[string] name: String) -> u32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_swim_speed(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_dive_speed(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_ascent_speed(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_breath_remaining(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_breath(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_breath_drain_rate(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_breath_regen_rate(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_swim_depth(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.8).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_submerge_depth(#[string] name: String) -> f32 {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.9).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wants_dive(#[string] name: String) -> bool {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.10).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wants_surface(#[string] name: String) -> bool {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.11).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_swim_enabled(#[string] name: String) -> bool {
+    SWIM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.12).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_enter_water(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::EnterWater { name }));
+}
+#[op2(fast)]
+pub fn bsengine_exit_water(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ExitWater { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wants_dive(#[string] name: String, wants: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWantsDive { name, wants })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wants_surface(#[string] name: String, wants: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWantsSurface { name, wants })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_swim_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSwimEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -27307,6 +27751,77 @@ deno_core::extension!(
         bsengine_is_stumble_enabled,
         bsengine_trigger_stumble,
         bsengine_set_stumble_enabled,
+        bsengine_get_sulk_depth,
+        bsengine_get_sulk_rate,
+        bsengine_get_sulk_recovery_rate,
+        bsengine_get_sulk_support_penalty,
+        bsengine_is_sulking,
+        bsengine_is_just_sulked,
+        bsengine_is_just_snapped_out,
+        bsengine_is_sulk_enabled,
+        bsengine_begin_sulk,
+        bsengine_end_sulk,
+        bsengine_set_sulk_enabled,
+        bsengine_get_sunder_shards,
+        bsengine_get_sunder_max_shards,
+        bsengine_get_sunder_damage_reduction_per_shard,
+        bsengine_is_just_sundered,
+        bsengine_is_sunder_enabled,
+        bsengine_apply_sunder,
+        bsengine_repair_sunder,
+        bsengine_repair_all_sunder,
+        bsengine_set_sunder_enabled,
+        bsengine_get_suppress_duration,
+        bsengine_get_suppress_timer,
+        bsengine_get_suppress_potency_fraction,
+        bsengine_is_suppress_blocks_ultimates,
+        bsengine_is_just_suppressed,
+        bsengine_is_just_suppress_lifted,
+        bsengine_is_suppress_enabled,
+        bsengine_apply_suppress,
+        bsengine_clear_suppress,
+        bsengine_set_suppress_enabled,
+        bsengine_get_surge_duration,
+        bsengine_get_surge_timer,
+        bsengine_get_surge_multiplier,
+        bsengine_is_just_surged,
+        bsengine_is_just_surge_expired,
+        bsengine_is_surge_enabled,
+        bsengine_apply_surge,
+        bsengine_clear_surge,
+        bsengine_set_surge_enabled,
+        bsengine_get_surround_adjacent_count,
+        bsengine_get_surround_encircle_threshold,
+        bsengine_get_surround_defense_bonus,
+        bsengine_is_just_encircled,
+        bsengine_is_just_surround_cleared,
+        bsengine_is_surround_enabled,
+        bsengine_update_surround,
+        bsengine_set_surround_enabled,
+        bsengine_get_survive_charges,
+        bsengine_get_survive_max_charges,
+        bsengine_is_just_survived,
+        bsengine_is_survive_enabled,
+        bsengine_add_survive_charge,
+        bsengine_set_survive_enabled,
+        bsengine_get_swim_state,
+        bsengine_get_swim_speed,
+        bsengine_get_dive_speed,
+        bsengine_get_ascent_speed,
+        bsengine_get_breath_remaining,
+        bsengine_get_max_breath,
+        bsengine_get_breath_drain_rate,
+        bsengine_get_breath_regen_rate,
+        bsengine_get_swim_depth,
+        bsengine_get_submerge_depth,
+        bsengine_is_wants_dive,
+        bsengine_is_wants_surface,
+        bsengine_is_swim_enabled,
+        bsengine_enter_water,
+        bsengine_exit_water,
+        bsengine_set_wants_dive,
+        bsengine_set_wants_surface,
+        bsengine_set_swim_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -30230,6 +30745,77 @@ const Bsengine = {
     isStumbleEnabled:           (name)              => Deno.core.ops.bsengine_is_stumble_enabled(name),
     triggerStumble:             (name)              => Deno.core.ops.bsengine_trigger_stumble(name),
     setStumbleEnabled:          (name, v)           => Deno.core.ops.bsengine_set_stumble_enabled(name, v),
+    getSulkDepth:               (name)              => Deno.core.ops.bsengine_get_sulk_depth(name),
+    getSulkRate:                (name)              => Deno.core.ops.bsengine_get_sulk_rate(name),
+    getSulkRecoveryRate:        (name)              => Deno.core.ops.bsengine_get_sulk_recovery_rate(name),
+    getSulkSupportPenalty:      (name)              => Deno.core.ops.bsengine_get_sulk_support_penalty(name),
+    isSulking:                  (name)              => Deno.core.ops.bsengine_is_sulking(name),
+    isJustSulked:               (name)              => Deno.core.ops.bsengine_is_just_sulked(name),
+    isJustSnappedOut:           (name)              => Deno.core.ops.bsengine_is_just_snapped_out(name),
+    isSulkEnabled:              (name)              => Deno.core.ops.bsengine_is_sulk_enabled(name),
+    beginSulk:                  (name)              => Deno.core.ops.bsengine_begin_sulk(name),
+    endSulk:                    (name)              => Deno.core.ops.bsengine_end_sulk(name),
+    setSulkEnabled:             (name, v)           => Deno.core.ops.bsengine_set_sulk_enabled(name, v),
+    getSunderShards:            (name)              => Deno.core.ops.bsengine_get_sunder_shards(name),
+    getSunderMaxShards:         (name)              => Deno.core.ops.bsengine_get_sunder_max_shards(name),
+    getSunderDrPerShard:        (name)              => Deno.core.ops.bsengine_get_sunder_damage_reduction_per_shard(name),
+    isJustSundered:             (name)              => Deno.core.ops.bsengine_is_just_sundered(name),
+    isSunderEnabled:            (name)              => Deno.core.ops.bsengine_is_sunder_enabled(name),
+    applySunder:                (name, count)       => Deno.core.ops.bsengine_apply_sunder(name, count),
+    repairSunder:               (name, count)       => Deno.core.ops.bsengine_repair_sunder(name, count),
+    repairAllSunder:            (name)              => Deno.core.ops.bsengine_repair_all_sunder(name),
+    setSunderEnabled:           (name, v)           => Deno.core.ops.bsengine_set_sunder_enabled(name, v),
+    getSuppressDuration:        (name)              => Deno.core.ops.bsengine_get_suppress_duration(name),
+    getSuppressTimer:           (name)              => Deno.core.ops.bsengine_get_suppress_timer(name),
+    getSuppressPotencyFraction: (name)              => Deno.core.ops.bsengine_get_suppress_potency_fraction(name),
+    isSuppressBlocksUltimates:  (name)              => Deno.core.ops.bsengine_is_suppress_blocks_ultimates(name),
+    isJustSuppressed:           (name)              => Deno.core.ops.bsengine_is_just_suppressed(name),
+    isJustSuppressLifted:       (name)              => Deno.core.ops.bsengine_is_just_suppress_lifted(name),
+    isSuppressEnabled:          (name)              => Deno.core.ops.bsengine_is_suppress_enabled(name),
+    applySuppress:              (name, duration)    => Deno.core.ops.bsengine_apply_suppress(name, duration),
+    clearSuppress:              (name)              => Deno.core.ops.bsengine_clear_suppress(name),
+    setSuppressEnabled:         (name, v)           => Deno.core.ops.bsengine_set_suppress_enabled(name, v),
+    getSurgeDuration:           (name)              => Deno.core.ops.bsengine_get_surge_duration(name),
+    getSurgeTimer:              (name)              => Deno.core.ops.bsengine_get_surge_timer(name),
+    getSurgeMultiplier:         (name)              => Deno.core.ops.bsengine_get_surge_multiplier(name),
+    isJustSurged:               (name)              => Deno.core.ops.bsengine_is_just_surged(name),
+    isJustSurgeExpired:         (name)              => Deno.core.ops.bsengine_is_just_surge_expired(name),
+    isSurgeEnabled:             (name)              => Deno.core.ops.bsengine_is_surge_enabled(name),
+    applySurge:                 (name, duration)    => Deno.core.ops.bsengine_apply_surge(name, duration),
+    clearSurge:                 (name)              => Deno.core.ops.bsengine_clear_surge(name),
+    setSurgeEnabled:            (name, v)           => Deno.core.ops.bsengine_set_surge_enabled(name, v),
+    getSurroundAdjacentCount:   (name)              => Deno.core.ops.bsengine_get_surround_adjacent_count(name),
+    getSurroundThreshold:       (name)              => Deno.core.ops.bsengine_get_surround_encircle_threshold(name),
+    getSurroundDefenseBonus:    (name)              => Deno.core.ops.bsengine_get_surround_defense_bonus(name),
+    isJustEncircled:            (name)              => Deno.core.ops.bsengine_is_just_encircled(name),
+    isJustSurroundCleared:      (name)              => Deno.core.ops.bsengine_is_just_surround_cleared(name),
+    isSurroundEnabled:          (name)              => Deno.core.ops.bsengine_is_surround_enabled(name),
+    updateSurround:             (name, count)       => Deno.core.ops.bsengine_update_surround(name, count),
+    setSurroundEnabled:         (name, v)           => Deno.core.ops.bsengine_set_surround_enabled(name, v),
+    getSurviveCharges:          (name)              => Deno.core.ops.bsengine_get_survive_charges(name),
+    getSurviveMaxCharges:       (name)              => Deno.core.ops.bsengine_get_survive_max_charges(name),
+    isJustSurvived:             (name)              => Deno.core.ops.bsengine_is_just_survived(name),
+    isSurviveEnabled:           (name)              => Deno.core.ops.bsengine_is_survive_enabled(name),
+    addSurviveCharge:           (name)              => Deno.core.ops.bsengine_add_survive_charge(name),
+    setSurviveEnabled:          (name, v)           => Deno.core.ops.bsengine_set_survive_enabled(name, v),
+    getSwimState:               (name)              => Deno.core.ops.bsengine_get_swim_state(name),
+    getSwimSpeed:               (name)              => Deno.core.ops.bsengine_get_swim_speed(name),
+    getDiveSpeed:               (name)              => Deno.core.ops.bsengine_get_dive_speed(name),
+    getAscentSpeed:             (name)              => Deno.core.ops.bsengine_get_ascent_speed(name),
+    getBreathRemaining:         (name)              => Deno.core.ops.bsengine_get_breath_remaining(name),
+    getMaxBreath:               (name)              => Deno.core.ops.bsengine_get_max_breath(name),
+    getBreathDrainRate:         (name)              => Deno.core.ops.bsengine_get_breath_drain_rate(name),
+    getBreathRegenRate:         (name)              => Deno.core.ops.bsengine_get_breath_regen_rate(name),
+    getSwimDepth:               (name)              => Deno.core.ops.bsengine_get_swim_depth(name),
+    getSubmergeDepth:           (name)              => Deno.core.ops.bsengine_get_submerge_depth(name),
+    isWantsDive:                (name)              => Deno.core.ops.bsengine_is_wants_dive(name),
+    isWantsSurface:             (name)              => Deno.core.ops.bsengine_is_wants_surface(name),
+    isSwimEnabled:              (name)              => Deno.core.ops.bsengine_is_swim_enabled(name),
+    enterWater:                 (name)              => Deno.core.ops.bsengine_enter_water(name),
+    exitWater:                  (name)              => Deno.core.ops.bsengine_exit_water(name),
+    setWantsDive:               (name, v)           => Deno.core.ops.bsengine_set_wants_dive(name, v),
+    setWantsSurface:            (name, v)           => Deno.core.ops.bsengine_set_wants_surface(name, v),
+    setSwimEnabled:             (name, v)           => Deno.core.ops.bsengine_set_swim_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -50252,6 +50838,406 @@ JSON.stringify(received)
             let buf = c.borrow();
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::TriggerStumble { name } if name == "Grunt")));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStumbleEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_sulk_read_ops() {
+        super::SULK_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (0.5f32, 1.0f32, 1.5f32, 0.25f32, true, false, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSulkDepth("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getSulkRate("Grunt"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSulkRecoveryRate("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSulkSupportPenalty("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt.eval(r#"String(Bsengine.isSulking("Grunt"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSulked("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSnappedOut("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSulkEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SULK_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_sulk_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.beginSulk("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.endSulk("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSulkEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BeginSulk { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::EndSulk { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSulkEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_sunder_read_ops() {
+        super::SUNDER_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Grunt".to_string(), (3u32, 5u32, 0.25f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSunderShards("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getSunderMaxShards("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSunderDrPerShard("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSundered("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSunderEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SUNDER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_sunder_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applySunder("Grunt", 2);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.repairSunder("Grunt", 1);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.repairAllSunder("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSunderEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplySunder { name, count } if name == "Grunt" && *count == 2)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RepairSunder { name, count } if name == "Grunt" && *count == 1)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RepairAllSunder { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSunderEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_suppress_read_ops() {
+        super::SUPPRESS_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (2.0f32, 0.5f32, 0.75f32, true, false, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSuppressDuration("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSuppressTimer("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSuppressPotencyFraction("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.isSuppressBlocksUltimates("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSuppressed("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSuppressLifted("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSuppressEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SUPPRESS_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_suppress_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applySuppress("Grunt", 2.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearSuppress("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSuppressEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplySuppress { name, duration } if name == "Grunt" && *duration == 2.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearSuppress { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSuppressEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_surge_read_ops() {
+        super::SURGE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (3.0f32, 1.5f32, 2.0f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSurgeDuration("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getSurgeTimer("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSurgeMultiplier("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSurged("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSurgeExpired("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSurgeEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SURGE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_surge_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applySurge("Grunt", 3.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearSurge("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSurgeEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplySurge { name, duration } if name == "Grunt" && *duration == 3.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearSurge { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSurgeEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_surround_read_ops() {
+        super::SURROUND_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Grunt".to_string(), (4u32, 3u32, 0.5f32, true, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSurroundAdjacentCount("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "4");
+        let r = rt
+            .eval(r#"String(Bsengine.getSurroundThreshold("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getSurroundDefenseBonus("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustEncircled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSurroundCleared("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSurroundEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SURROUND_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_surround_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.updateSurround("Grunt", 4);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSurroundEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::UpdateSurround { name, count } if name == "Grunt" && *count == 4)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSurroundEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_survive_read_ops() {
+        super::SURVIVE_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Grunt".to_string(), (2u32, 3u32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSurviveCharges("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSurviveMaxCharges("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSurvived("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSurviveEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SURVIVE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_survive_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.addSurviveCharge("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSurviveEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AddSurviveCharge { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSurviveEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_swim_read_ops() {
+        super::SWIM_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (
+                    1u32, 2.0f32, 1.5f32, 1.0f32, 0.75f32, 1.0f32, 0.25f32, 0.5f32, 3.0f32, 2.0f32,
+                    true, false, true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSwimState("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSwimSpeed("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getDiveSpeed("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getAscentSpeed("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getBreathRemaining("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getMaxBreath("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getBreathDrainRate("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getBreathRegenRate("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSwimDepth("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getSubmergeDepth("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt.eval(r#"String(Bsengine.isWantsDive("Grunt"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWantsSurface("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSwimEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SWIM_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_swim_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.enterWater("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.exitWater("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWantsDive("Grunt", true);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWantsSurface("Grunt", false);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSwimEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::EnterWater { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ExitWater { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWantsDive { name, wants } if name == "Grunt" && *wants)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWantsSurface { name, wants } if name == "Grunt" && !wants)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSwimEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4106,6 +4106,107 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Venture ───────────────────────────────────────────────────────────────
+    BeginVenture {
+        name: String,
+    },
+    EndVenture {
+        name: String,
+    },
+    SetVentureEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Verge ─────────────────────────────────────────────────────────────────
+    FeedVerge {
+        name: String,
+        amount: f32,
+    },
+    ConsumeVerge {
+        name: String,
+    },
+    SetVergeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Verify ────────────────────────────────────────────────────────────────
+    ConfirmVerify {
+        name: String,
+        amount: f32,
+    },
+    RefuteVerify {
+        name: String,
+        amount: f32,
+    },
+    SetVerifyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Verily ────────────────────────────────────────────────────────────────
+    AffirmVerily {
+        name: String,
+        amount: f32,
+    },
+    RecantVerily {
+        name: String,
+        amount: f32,
+    },
+    SetVerilyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vermin ────────────────────────────────────────────────────────────────
+    InfestVermin {
+        name: String,
+        amount: f32,
+    },
+    ExterminateVermin {
+        name: String,
+        amount: f32,
+    },
+    SetVerminEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vernal ────────────────────────────────────────────────────────────────
+    RenewVernal {
+        name: String,
+        amount: f32,
+    },
+    WitherVernal {
+        name: String,
+        amount: f32,
+    },
+    SetVernalEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Verse ─────────────────────────────────────────────────────────────────
+    ComposeVerse {
+        name: String,
+        amount: f32,
+    },
+    SilenceVerse {
+        name: String,
+        amount: f32,
+    },
+    SetVerseEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Vertex ────────────────────────────────────────────────────────────────
+    AscendVertex {
+        name: String,
+        amount: f32,
+    },
+    DescendVertex {
+        name: String,
+        amount: f32,
+    },
+    SetVertexEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5221,6 +5322,22 @@ thread_local! {
     pub(crate) static VILE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static VOID_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VENTURE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VERGE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VERIFY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VERILY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VERMIN_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VERNAL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VERSE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VERTEX_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -9496,6 +9613,365 @@ pub fn bsengine_set_void_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetVoidEnabled { name, enabled })
+    });
+}
+// ── Venture ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_venture_level(#[string] name: String) -> f32 {
+    VENTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_venture(#[string] name: String) -> f32 {
+    VENTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_venture_rate(#[string] name: String) -> f32 {
+    VENTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_recovery_rate(#[string] name: String) -> f32 {
+    VENTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_venture_damage_bonus(#[string] name: String) -> f32 {
+    VENTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_in_venture(#[string] name: String) -> bool {
+    VENTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_venture_just_peaked(#[string] name: String) -> bool {
+    VENTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_venture_enabled(#[string] name: String) -> bool {
+    VENTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_begin_venture(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::BeginVenture { name }));
+}
+#[op2(fast)]
+pub fn bsengine_end_venture(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::EndVenture { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_venture_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVentureEnabled { name, enabled })
+    });
+}
+// ── Verge ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_verge_charge(#[string] name: String) -> f32 {
+    VERGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_verge_charge_rate(#[string] name: String) -> f32 {
+    VERGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_verge_just_peaked(#[string] name: String) -> bool {
+    VERGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_verge_enabled(#[string] name: String) -> bool {
+    VERGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_feed_verge(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::FeedVerge { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_consume_verge(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ConsumeVerge { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_verge_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVergeEnabled { name, enabled })
+    });
+}
+// ── Verify ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_verify_confidence(#[string] name: String) -> f32 {
+    VERIFY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_verify_max_confidence(#[string] name: String) -> f32 {
+    VERIFY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_verify_probe_rate(#[string] name: String) -> f32 {
+    VERIFY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_verified(#[string] name: String) -> bool {
+    VERIFY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_refuted(#[string] name: String) -> bool {
+    VERIFY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_verify_enabled(#[string] name: String) -> bool {
+    VERIFY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_confirm_verify(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ConfirmVerify { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_refute_verify(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RefuteVerify { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_verify_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVerifyEnabled { name, enabled })
+    });
+}
+// ── Verily ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_verily_conviction(#[string] name: String) -> f32 {
+    VERILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_verily_max_conviction(#[string] name: String) -> f32 {
+    VERILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_verily_oath_rate(#[string] name: String) -> f32 {
+    VERILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_sworn(#[string] name: String) -> bool {
+    VERILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_recanted(#[string] name: String) -> bool {
+    VERILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_verily_enabled(#[string] name: String) -> bool {
+    VERILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_affirm_verily(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AffirmVerily { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_recant_verily(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RecantVerily { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_verily_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVerilyEnabled { name, enabled })
+    });
+}
+// ── Vermin ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vermin_infestation(#[string] name: String) -> f32 {
+    VERMIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_infestation(#[string] name: String) -> f32 {
+    VERMIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_swarm_rate(#[string] name: String) -> f32 {
+    VERMIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_swarmed(#[string] name: String) -> bool {
+    VERMIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_exterminated(#[string] name: String) -> bool {
+    VERMIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vermin_enabled(#[string] name: String) -> bool {
+    VERMIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_infest_vermin(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::InfestVermin { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_exterminate_vermin(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ExterminateVermin { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vermin_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVerminEnabled { name, enabled })
+    });
+}
+// ── Vernal ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_bloom(#[string] name: String) -> f32 {
+    VERNAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_bloom(#[string] name: String) -> f32 {
+    VERNAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vernal_thaw_rate(#[string] name: String) -> f32 {
+    VERNAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_bloomed(#[string] name: String) -> bool {
+    VERNAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_dormant(#[string] name: String) -> bool {
+    VERNAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vernal_enabled(#[string] name: String) -> bool {
+    VERNAL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_renew_vernal(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RenewVernal { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_wither_vernal(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::WitherVernal { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vernal_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVernalEnabled { name, enabled })
+    });
+}
+// ── Verse ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_verse_meter(#[string] name: String) -> f32 {
+    VERSE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_meter(#[string] name: String) -> f32 {
+    VERSE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_cadence_rate(#[string] name: String) -> f32 {
+    VERSE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_composed(#[string] name: String) -> bool {
+    VERSE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_verse_silenced(#[string] name: String) -> bool {
+    VERSE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_verse_enabled(#[string] name: String) -> bool {
+    VERSE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_compose_verse(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ComposeVerse { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_silence_verse(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SilenceVerse { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_verse_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVerseEnabled { name, enabled })
+    });
+}
+// ── Vertex ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vertex_apex(#[string] name: String) -> f32 {
+    VERTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_max_apex(#[string] name: String) -> f32 {
+    VERTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_ascent_rate(#[string] name: String) -> f32 {
+    VERTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vertex_just_peaked(#[string] name: String) -> bool {
+    VERTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vertex_just_grounded(#[string] name: String) -> bool {
+    VERTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vertex_enabled(#[string] name: String) -> bool {
+    VERTEX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_ascend_vertex(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AscendVertex { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_descend_vertex(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DescendVertex { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vertex_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVertexEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -29286,6 +29762,78 @@ deno_core::extension!(
         bsengine_drain_void,
         bsengine_release_void,
         bsengine_set_void_enabled,
+        bsengine_get_venture_level,
+        bsengine_get_max_venture,
+        bsengine_get_venture_rate,
+        bsengine_get_recovery_rate,
+        bsengine_get_venture_damage_bonus,
+        bsengine_is_in_venture,
+        bsengine_is_venture_just_peaked,
+        bsengine_is_venture_enabled,
+        bsengine_begin_venture,
+        bsengine_end_venture,
+        bsengine_set_venture_enabled,
+        bsengine_get_verge_charge,
+        bsengine_get_verge_charge_rate,
+        bsengine_is_verge_just_peaked,
+        bsengine_is_verge_enabled,
+        bsengine_feed_verge,
+        bsengine_consume_verge,
+        bsengine_set_verge_enabled,
+        bsengine_get_verify_confidence,
+        bsengine_get_verify_max_confidence,
+        bsengine_get_verify_probe_rate,
+        bsengine_is_just_verified,
+        bsengine_is_just_refuted,
+        bsengine_is_verify_enabled,
+        bsengine_confirm_verify,
+        bsengine_refute_verify,
+        bsengine_set_verify_enabled,
+        bsengine_get_verily_conviction,
+        bsengine_get_verily_max_conviction,
+        bsengine_get_verily_oath_rate,
+        bsengine_is_just_sworn,
+        bsengine_is_just_recanted,
+        bsengine_is_verily_enabled,
+        bsengine_affirm_verily,
+        bsengine_recant_verily,
+        bsengine_set_verily_enabled,
+        bsengine_get_vermin_infestation,
+        bsengine_get_max_infestation,
+        bsengine_get_swarm_rate,
+        bsengine_is_just_swarmed,
+        bsengine_is_just_exterminated,
+        bsengine_is_vermin_enabled,
+        bsengine_infest_vermin,
+        bsengine_exterminate_vermin,
+        bsengine_set_vermin_enabled,
+        bsengine_get_bloom,
+        bsengine_get_max_bloom,
+        bsengine_get_vernal_thaw_rate,
+        bsengine_is_just_bloomed,
+        bsengine_is_just_dormant,
+        bsengine_is_vernal_enabled,
+        bsengine_renew_vernal,
+        bsengine_wither_vernal,
+        bsengine_set_vernal_enabled,
+        bsengine_get_verse_meter,
+        bsengine_get_max_meter,
+        bsengine_get_cadence_rate,
+        bsengine_is_just_composed,
+        bsengine_is_just_verse_silenced,
+        bsengine_is_verse_enabled,
+        bsengine_compose_verse,
+        bsengine_silence_verse,
+        bsengine_set_verse_enabled,
+        bsengine_get_vertex_apex,
+        bsengine_get_max_apex,
+        bsengine_get_ascent_rate,
+        bsengine_is_vertex_just_peaked,
+        bsengine_is_vertex_just_grounded,
+        bsengine_is_vertex_enabled,
+        bsengine_ascend_vertex,
+        bsengine_descend_vertex,
+        bsengine_set_vertex_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -32488,6 +33036,78 @@ const Bsengine = {
     drainVoid:                  (name, damage)      => Deno.core.ops.bsengine_drain_void(name, damage),
     releaseVoid:                (name)              => Deno.core.ops.bsengine_release_void(name),
     setVoidEnabled:             (name, v)           => Deno.core.ops.bsengine_set_void_enabled(name, v),
+    getVentureLevel:            (name)              => Deno.core.ops.bsengine_get_venture_level(name),
+    getMaxVenture:              (name)              => Deno.core.ops.bsengine_get_max_venture(name),
+    getVentureRate:             (name)              => Deno.core.ops.bsengine_get_venture_rate(name),
+    getRecoveryRate:            (name)              => Deno.core.ops.bsengine_get_recovery_rate(name),
+    getVentureDamageBonus:      (name)              => Deno.core.ops.bsengine_get_venture_damage_bonus(name),
+    isInVenture:                (name)              => Deno.core.ops.bsengine_is_in_venture(name),
+    isVentureJustPeaked:        (name)              => Deno.core.ops.bsengine_is_venture_just_peaked(name),
+    isVentureEnabled:           (name)              => Deno.core.ops.bsengine_is_venture_enabled(name),
+    beginVenture:               (name)              => Deno.core.ops.bsengine_begin_venture(name),
+    endVenture:                 (name)              => Deno.core.ops.bsengine_end_venture(name),
+    setVentureEnabled:          (name, v)           => Deno.core.ops.bsengine_set_venture_enabled(name, v),
+    getVergeCharge:             (name)              => Deno.core.ops.bsengine_get_verge_charge(name),
+    getVergeChargeRate:         (name)              => Deno.core.ops.bsengine_get_verge_charge_rate(name),
+    isVergeJustPeaked:          (name)              => Deno.core.ops.bsengine_is_verge_just_peaked(name),
+    isVergeEnabled:             (name)              => Deno.core.ops.bsengine_is_verge_enabled(name),
+    feedVerge:                  (name, amount)      => Deno.core.ops.bsengine_feed_verge(name, amount),
+    consumeVerge:               (name)              => Deno.core.ops.bsengine_consume_verge(name),
+    setVergeEnabled:            (name, v)           => Deno.core.ops.bsengine_set_verge_enabled(name, v),
+    getVerifyConfidence:        (name)              => Deno.core.ops.bsengine_get_verify_confidence(name),
+    getVerifyMaxConfidence:     (name)              => Deno.core.ops.bsengine_get_verify_max_confidence(name),
+    getVerifyProbeRate:         (name)              => Deno.core.ops.bsengine_get_verify_probe_rate(name),
+    isJustVerified:             (name)              => Deno.core.ops.bsengine_is_just_verified(name),
+    isJustRefuted:              (name)              => Deno.core.ops.bsengine_is_just_refuted(name),
+    isVerifyEnabled:            (name)              => Deno.core.ops.bsengine_is_verify_enabled(name),
+    confirmVerify:              (name, amount)      => Deno.core.ops.bsengine_confirm_verify(name, amount),
+    refuteVerify:               (name, amount)      => Deno.core.ops.bsengine_refute_verify(name, amount),
+    setVerifyEnabled:           (name, v)           => Deno.core.ops.bsengine_set_verify_enabled(name, v),
+    getVerilyConviction:        (name)              => Deno.core.ops.bsengine_get_verily_conviction(name),
+    getVerilyMaxConviction:     (name)              => Deno.core.ops.bsengine_get_verily_max_conviction(name),
+    getVerilyOathRate:          (name)              => Deno.core.ops.bsengine_get_verily_oath_rate(name),
+    isJustSworn:                (name)              => Deno.core.ops.bsengine_is_just_sworn(name),
+    isJustRecanted:             (name)              => Deno.core.ops.bsengine_is_just_recanted(name),
+    isVerilyEnabled:            (name)              => Deno.core.ops.bsengine_is_verily_enabled(name),
+    affirmVerily:               (name, amount)      => Deno.core.ops.bsengine_affirm_verily(name, amount),
+    recantVerily:               (name, amount)      => Deno.core.ops.bsengine_recant_verily(name, amount),
+    setVerilyEnabled:           (name, v)           => Deno.core.ops.bsengine_set_verily_enabled(name, v),
+    getVerminInfestation:       (name)              => Deno.core.ops.bsengine_get_vermin_infestation(name),
+    getMaxInfestation:          (name)              => Deno.core.ops.bsengine_get_max_infestation(name),
+    getSwarmRate:               (name)              => Deno.core.ops.bsengine_get_swarm_rate(name),
+    isJustSwarmed:              (name)              => Deno.core.ops.bsengine_is_just_swarmed(name),
+    isJustExterminated:         (name)              => Deno.core.ops.bsengine_is_just_exterminated(name),
+    isVerminEnabled:            (name)              => Deno.core.ops.bsengine_is_vermin_enabled(name),
+    infestVermin:               (name, amount)      => Deno.core.ops.bsengine_infest_vermin(name, amount),
+    exterminateVermin:          (name, amount)      => Deno.core.ops.bsengine_exterminate_vermin(name, amount),
+    setVerminEnabled:           (name, v)           => Deno.core.ops.bsengine_set_vermin_enabled(name, v),
+    getBloom:                   (name)              => Deno.core.ops.bsengine_get_bloom(name),
+    getMaxBloom:                (name)              => Deno.core.ops.bsengine_get_max_bloom(name),
+    getVernalThawRate:          (name)              => Deno.core.ops.bsengine_get_vernal_thaw_rate(name),
+    isJustBloomed:              (name)              => Deno.core.ops.bsengine_is_just_bloomed(name),
+    isJustDormant:              (name)              => Deno.core.ops.bsengine_is_just_dormant(name),
+    isVernalEnabled:            (name)              => Deno.core.ops.bsengine_is_vernal_enabled(name),
+    renewVernal:                (name, amount)      => Deno.core.ops.bsengine_renew_vernal(name, amount),
+    witherVernal:               (name, amount)      => Deno.core.ops.bsengine_wither_vernal(name, amount),
+    setVernalEnabled:           (name, v)           => Deno.core.ops.bsengine_set_vernal_enabled(name, v),
+    getVerseMeter:              (name)              => Deno.core.ops.bsengine_get_verse_meter(name),
+    getMaxMeter:                (name)              => Deno.core.ops.bsengine_get_max_meter(name),
+    getCadenceRate:             (name)              => Deno.core.ops.bsengine_get_cadence_rate(name),
+    isJustComposed:             (name)              => Deno.core.ops.bsengine_is_just_composed(name),
+    isJustVerseSilenced:        (name)              => Deno.core.ops.bsengine_is_just_verse_silenced(name),
+    isVerseEnabled:             (name)              => Deno.core.ops.bsengine_is_verse_enabled(name),
+    composeVerse:               (name, amount)      => Deno.core.ops.bsengine_compose_verse(name, amount),
+    silenceVerse:               (name, amount)      => Deno.core.ops.bsengine_silence_verse(name, amount),
+    setVerseEnabled:            (name, v)           => Deno.core.ops.bsengine_set_verse_enabled(name, v),
+    getVertexApex:              (name)              => Deno.core.ops.bsengine_get_vertex_apex(name),
+    getMaxApex:                 (name)              => Deno.core.ops.bsengine_get_max_apex(name),
+    getAscentRate:              (name)              => Deno.core.ops.bsengine_get_ascent_rate(name),
+    isVertexJustPeaked:         (name)              => Deno.core.ops.bsengine_is_vertex_just_peaked(name),
+    isVertexJustGrounded:       (name)              => Deno.core.ops.bsengine_is_vertex_just_grounded(name),
+    isVertexEnabled:            (name)              => Deno.core.ops.bsengine_is_vertex_enabled(name),
+    ascendVertex:               (name, amount)      => Deno.core.ops.bsengine_ascend_vertex(name, amount),
+    descendVertex:              (name, amount)      => Deno.core.ops.bsengine_descend_vertex(name, amount),
+    setVertexEnabled:           (name, v)           => Deno.core.ops.bsengine_set_vertex_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -54115,6 +54735,422 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DrainVoid { name, damage } if name == "Grunt" && *damage == 10.0)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ReleaseVoid { name } if name == "Grunt")));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVoidEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_venture_read_ops() {
+        super::VENTURE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, 0.5f32, 0.75f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVentureLevel("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getMaxVenture("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVentureRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getRecoveryRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVentureDamageBonus("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt.eval(r#"String(Bsengine.isInVenture("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVentureJustPeaked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVentureEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VENTURE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_venture_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.beginVenture("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.endVenture("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVentureEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BeginVenture { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::EndVenture { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVentureEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verge_read_ops() {
+        super::VERGE_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.75f32, 0.5f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVergeCharge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getVergeChargeRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isVergeJustPeaked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVergeEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VERGE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verge_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.feedVerge("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.consumeVerge("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVergeEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::FeedVerge { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ConsumeVerge { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVergeEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verify_read_ops() {
+        super::VERIFY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVerifyConfidence("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVerifyMaxConfidence("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVerifyProbeRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustVerified("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustRefuted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVerifyEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VERIFY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verify_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.confirmVerify("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.refuteVerify("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVerifyEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ConfirmVerify { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RefuteVerify { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVerifyEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verily_read_ops() {
+        super::VERILY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, false, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVerilyConviction("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVerilyMaxConviction("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVerilyOathRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt.eval(r#"String(Bsengine.isJustSworn("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustRecanted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVerilyEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VERILY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verily_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.affirmVerily("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.recantVerily("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVerilyEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AffirmVerily { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RecantVerily { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVerilyEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vermin_read_ops() {
+        super::VERMIN_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVerminInfestation("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getMaxInfestation("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt.eval(r#"String(Bsengine.getSwarmRate("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSwarmed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustExterminated("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVerminEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VERMIN_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vermin_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.infestVermin("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.exterminateVermin("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVerminEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::InfestVermin { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ExterminateVermin { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVerminEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vernal_read_ops() {
+        super::VERNAL_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getBloom("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getMaxBloom("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVernalThawRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustBloomed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustDormant("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVernalEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VERNAL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vernal_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.renewVernal("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.witherVernal("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVernalEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RenewVernal { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::WitherVernal { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVernalEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verse_read_ops() {
+        super::VERSE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, false, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVerseMeter("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getMaxMeter("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getCadenceRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustComposed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustVerseSilenced("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVerseEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VERSE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_verse_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.composeVerse("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.silenceVerse("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVerseEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ComposeVerse { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SilenceVerse { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVerseEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vertex_read_ops() {
+        super::VERTEX_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVertexApex("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getMaxApex("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getAscentRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isVertexJustPeaked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVertexJustGrounded("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVertexEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VERTEX_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vertex_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.ascendVertex("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.descendVertex("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVertexEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AscendVertex { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DescendVertex { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVertexEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4529,6 +4529,113 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Wand ─────────────────────────────────────────────────────────────────
+    ChannelWand {
+        name: String,
+        amount: f32,
+    },
+    DischargeWand {
+        name: String,
+        amount: f32,
+    },
+    SetWandEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wane ─────────────────────────────────────────────────────────────────
+    StartWane {
+        name: String,
+        duration: f32,
+    },
+    StopWane {
+        name: String,
+    },
+    SetWaneEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wangle ───────────────────────────────────────────────────────────────
+    ManeuverWangle {
+        name: String,
+        amount: f32,
+    },
+    FoilWangle {
+        name: String,
+        amount: f32,
+    },
+    SetWangleEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Want ─────────────────────────────────────────────────────────────────
+    CraveWant {
+        name: String,
+        amount: f32,
+    },
+    SateWant {
+        name: String,
+        amount: f32,
+    },
+    SetWantEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wanton ───────────────────────────────────────────────────────────────
+    IndulgeWanton {
+        name: String,
+        amount: f32,
+    },
+    RestrainWanton {
+        name: String,
+        amount: f32,
+    },
+    SetWantonEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Ward ─────────────────────────────────────────────────────────────────
+    ReinforceWard {
+        name: String,
+        amount: f32,
+    },
+    AbsorbWard {
+        name: String,
+        amount: f32,
+    },
+    SetWardEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Warm ─────────────────────────────────────────────────────────────────
+    KindleWarm {
+        name: String,
+        amount: f32,
+    },
+    ChillWarm {
+        name: String,
+        amount: f32,
+    },
+    SetWarmEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Warp ─────────────────────────────────────────────────────────────────
+    SetWarpMaxRange {
+        name: String,
+        value: f32,
+    },
+    SetWarpChargeDuration {
+        name: String,
+        value: f32,
+    },
+    SetWarpCooldownDuration {
+        name: String,
+        value: f32,
+    },
+    SetWarpEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5708,6 +5815,22 @@ thread_local! {
     pub(crate) static WALL_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32, f32, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static WALTZ_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAND_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WANE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WANGLE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WANT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WANTON_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WARD_SNAPSHOT: RefCell<HashMap<String, (f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WARM_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WARP_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -11477,6 +11600,374 @@ pub fn bsengine_set_waltz_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetWaltzEnabled { name, enabled })
+    });
+}
+// ── Wand ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wand_charge(#[string] name: String) -> f32 {
+    WAND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wand_max_charge(#[string] name: String) -> f32 {
+    WAND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wand_channel_rate(#[string] name: String) -> f32 {
+    WAND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wand_just_charged(#[string] name: String) -> bool {
+    WAND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wand_just_spent(#[string] name: String) -> bool {
+    WAND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wand_enabled(#[string] name: String) -> bool {
+    WAND_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_channel_wand(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ChannelWand { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_discharge_wand(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DischargeWand { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wand_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWandEnabled { name, enabled })
+    });
+}
+// ── Wane ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wane_duration(#[string] name: String) -> f32 {
+    WANE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wane_timer(#[string] name: String) -> f32 {
+    WANE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wane_min_potency(#[string] name: String) -> f32 {
+    WANE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wane_just_waning(#[string] name: String) -> bool {
+    WANE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wane_just_expired(#[string] name: String) -> bool {
+    WANE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wane_enabled(#[string] name: String) -> bool {
+    WANE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_start_wane(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::StartWane { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_stop_wane(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StopWane { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wane_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaneEnabled { name, enabled })
+    });
+}
+// ── Wangle ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wangle_scheme(#[string] name: String) -> f32 {
+    WANGLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wangle_max_scheme(#[string] name: String) -> f32 {
+    WANGLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wangle_maneuver_rate(#[string] name: String) -> f32 {
+    WANGLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wangle_just_schemed(#[string] name: String) -> bool {
+    WANGLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wangle_just_foiled(#[string] name: String) -> bool {
+    WANGLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wangle_enabled(#[string] name: String) -> bool {
+    WANGLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_maneuver_wangle(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ManeuverWangle { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_foil_wangle(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::FoilWangle { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wangle_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWangleEnabled { name, enabled })
+    });
+}
+// ── Want ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_want_desire(#[string] name: String) -> f32 {
+    WANT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_want_max_desire(#[string] name: String) -> f32 {
+    WANT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_want_craving_rate(#[string] name: String) -> f32 {
+    WANT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_want_just_wanted(#[string] name: String) -> bool {
+    WANT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_want_just_sated(#[string] name: String) -> bool {
+    WANT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_want_enabled(#[string] name: String) -> bool {
+    WANT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_crave_want(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CraveWant { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_sate_want(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SateWant { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_want_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWantEnabled { name, enabled })
+    });
+}
+// ── Wanton ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wanton_excess(#[string] name: String) -> f32 {
+    WANTON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wanton_max_excess(#[string] name: String) -> f32 {
+    WANTON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wanton_indulge_rate(#[string] name: String) -> f32 {
+    WANTON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wanton_just_reckless(#[string] name: String) -> bool {
+    WANTON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wanton_just_restrained(#[string] name: String) -> bool {
+    WANTON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wanton_enabled(#[string] name: String) -> bool {
+    WANTON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_indulge_wanton(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::IndulgeWanton { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_restrain_wanton(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RestrainWanton { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wanton_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWantonEnabled { name, enabled })
+    });
+}
+// ── Ward ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_ward_hp(#[string] name: String) -> f32 {
+    WARD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_ward_max_hp(#[string] name: String) -> f32 {
+    WARD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_ward_just_broke(#[string] name: String) -> bool {
+    WARD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_ward_just_reinforced(#[string] name: String) -> bool {
+    WARD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_ward_enabled(#[string] name: String) -> bool {
+    WARD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_reinforce_ward(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ReinforceWard { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_absorb_ward(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AbsorbWard { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_ward_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWardEnabled { name, enabled })
+    });
+}
+// ── Warm ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_warm_heat(#[string] name: String) -> f32 {
+    WARM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_warm_max_heat(#[string] name: String) -> f32 {
+    WARM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_warm_kindle_rate(#[string] name: String) -> f32 {
+    WARM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_warm_just_warm(#[string] name: String) -> bool {
+    WARM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_warm_just_cold(#[string] name: String) -> bool {
+    WARM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_warm_enabled(#[string] name: String) -> bool {
+    WARM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_kindle_warm(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::KindleWarm { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_chill_warm(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ChillWarm { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_warm_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWarmEnabled { name, enabled })
+    });
+}
+// ── Warp ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_warp_phase(#[string] name: String) -> u32 {
+    WARP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_warp_max_range(#[string] name: String) -> f32 {
+    WARP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_warp_charge_duration(#[string] name: String) -> f32 {
+    WARP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_warp_cooldown_duration(#[string] name: String) -> f32 {
+    WARP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_warp_just_warped(#[string] name: String) -> bool {
+    WARP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_warp_enabled(#[string] name: String) -> bool {
+    WARP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_warp_max_range(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWarpMaxRange { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_warp_charge_duration(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWarpChargeDuration { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_warp_cooldown_duration(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWarpCooldownDuration { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_warp_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWarpEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -31560,6 +32051,78 @@ deno_core::extension!(
         bsengine_step_waltz,
         bsengine_halt_waltz,
         bsengine_set_waltz_enabled,
+        bsengine_get_wand_charge,
+        bsengine_get_wand_max_charge,
+        bsengine_get_wand_channel_rate,
+        bsengine_is_wand_just_charged,
+        bsengine_is_wand_just_spent,
+        bsengine_is_wand_enabled,
+        bsengine_channel_wand,
+        bsengine_discharge_wand,
+        bsengine_set_wand_enabled,
+        bsengine_get_wane_duration,
+        bsengine_get_wane_timer,
+        bsengine_get_wane_min_potency,
+        bsengine_is_wane_just_waning,
+        bsengine_is_wane_just_expired,
+        bsengine_is_wane_enabled,
+        bsengine_start_wane,
+        bsengine_stop_wane,
+        bsengine_set_wane_enabled,
+        bsengine_get_wangle_scheme,
+        bsengine_get_wangle_max_scheme,
+        bsengine_get_wangle_maneuver_rate,
+        bsengine_is_wangle_just_schemed,
+        bsengine_is_wangle_just_foiled,
+        bsengine_is_wangle_enabled,
+        bsengine_maneuver_wangle,
+        bsengine_foil_wangle,
+        bsengine_set_wangle_enabled,
+        bsengine_get_want_desire,
+        bsengine_get_want_max_desire,
+        bsengine_get_want_craving_rate,
+        bsengine_is_want_just_wanted,
+        bsengine_is_want_just_sated,
+        bsengine_is_want_enabled,
+        bsengine_crave_want,
+        bsengine_sate_want,
+        bsengine_set_want_enabled,
+        bsengine_get_wanton_excess,
+        bsengine_get_wanton_max_excess,
+        bsengine_get_wanton_indulge_rate,
+        bsengine_is_wanton_just_reckless,
+        bsengine_is_wanton_just_restrained,
+        bsengine_is_wanton_enabled,
+        bsengine_indulge_wanton,
+        bsengine_restrain_wanton,
+        bsengine_set_wanton_enabled,
+        bsengine_get_ward_hp,
+        bsengine_get_ward_max_hp,
+        bsengine_is_ward_just_broke,
+        bsengine_is_ward_just_reinforced,
+        bsengine_is_ward_enabled,
+        bsengine_reinforce_ward,
+        bsengine_absorb_ward,
+        bsengine_set_ward_enabled,
+        bsengine_get_warm_heat,
+        bsengine_get_warm_max_heat,
+        bsengine_get_warm_kindle_rate,
+        bsengine_is_warm_just_warm,
+        bsengine_is_warm_just_cold,
+        bsengine_is_warm_enabled,
+        bsengine_kindle_warm,
+        bsengine_chill_warm,
+        bsengine_set_warm_enabled,
+        bsengine_get_warp_phase,
+        bsengine_get_warp_max_range,
+        bsengine_get_warp_charge_duration,
+        bsengine_get_warp_cooldown_duration,
+        bsengine_is_warp_just_warped,
+        bsengine_is_warp_enabled,
+        bsengine_set_warp_max_range,
+        bsengine_set_warp_charge_duration,
+        bsengine_set_warp_cooldown_duration,
+        bsengine_set_warp_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -35055,6 +35618,78 @@ const Bsengine = {
     stepWaltz:                  (name, amount)      => Deno.core.ops.bsengine_step_waltz(name, amount),
     haltWaltz:                  (name, amount)      => Deno.core.ops.bsengine_halt_waltz(name, amount),
     setWaltzEnabled:            (name, v)           => Deno.core.ops.bsengine_set_waltz_enabled(name, v),
+    getWandCharge:              (name)              => Deno.core.ops.bsengine_get_wand_charge(name),
+    getWandMaxCharge:           (name)              => Deno.core.ops.bsengine_get_wand_max_charge(name),
+    getWandChannelRate:         (name)              => Deno.core.ops.bsengine_get_wand_channel_rate(name),
+    isWandJustCharged:          (name)              => Deno.core.ops.bsengine_is_wand_just_charged(name),
+    isWandJustSpent:            (name)              => Deno.core.ops.bsengine_is_wand_just_spent(name),
+    isWandEnabled:              (name)              => Deno.core.ops.bsengine_is_wand_enabled(name),
+    channelWand:                (name, amount)      => Deno.core.ops.bsengine_channel_wand(name, amount),
+    dischargeWand:              (name, amount)      => Deno.core.ops.bsengine_discharge_wand(name, amount),
+    setWandEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wand_enabled(name, v),
+    getWaneDuration:            (name)              => Deno.core.ops.bsengine_get_wane_duration(name),
+    getWaneTimer:               (name)              => Deno.core.ops.bsengine_get_wane_timer(name),
+    getWaneMinPotency:          (name)              => Deno.core.ops.bsengine_get_wane_min_potency(name),
+    isWaneJustWaning:           (name)              => Deno.core.ops.bsengine_is_wane_just_waning(name),
+    isWaneJustExpired:          (name)              => Deno.core.ops.bsengine_is_wane_just_expired(name),
+    isWaneEnabled:              (name)              => Deno.core.ops.bsengine_is_wane_enabled(name),
+    startWane:                  (name, duration)    => Deno.core.ops.bsengine_start_wane(name, duration),
+    stopWane:                   (name)              => Deno.core.ops.bsengine_stop_wane(name),
+    setWaneEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wane_enabled(name, v),
+    getWangleScheme:            (name)              => Deno.core.ops.bsengine_get_wangle_scheme(name),
+    getWangleMaxScheme:         (name)              => Deno.core.ops.bsengine_get_wangle_max_scheme(name),
+    getWangleManeuverRate:      (name)              => Deno.core.ops.bsengine_get_wangle_maneuver_rate(name),
+    isWangleJustSchemed:        (name)              => Deno.core.ops.bsengine_is_wangle_just_schemed(name),
+    isWangleJustFoiled:         (name)              => Deno.core.ops.bsengine_is_wangle_just_foiled(name),
+    isWangleEnabled:            (name)              => Deno.core.ops.bsengine_is_wangle_enabled(name),
+    maneuverWangle:             (name, amount)      => Deno.core.ops.bsengine_maneuver_wangle(name, amount),
+    foilWangle:                 (name, amount)      => Deno.core.ops.bsengine_foil_wangle(name, amount),
+    setWangleEnabled:           (name, v)           => Deno.core.ops.bsengine_set_wangle_enabled(name, v),
+    getWantDesire:              (name)              => Deno.core.ops.bsengine_get_want_desire(name),
+    getWantMaxDesire:           (name)              => Deno.core.ops.bsengine_get_want_max_desire(name),
+    getWantCravingRate:         (name)              => Deno.core.ops.bsengine_get_want_craving_rate(name),
+    isWantJustWanted:           (name)              => Deno.core.ops.bsengine_is_want_just_wanted(name),
+    isWantJustSated:            (name)              => Deno.core.ops.bsengine_is_want_just_sated(name),
+    isWantEnabled:              (name)              => Deno.core.ops.bsengine_is_want_enabled(name),
+    craveWant:                  (name, amount)      => Deno.core.ops.bsengine_crave_want(name, amount),
+    sateWant:                   (name, amount)      => Deno.core.ops.bsengine_sate_want(name, amount),
+    setWantEnabled:             (name, v)           => Deno.core.ops.bsengine_set_want_enabled(name, v),
+    getWantonExcess:            (name)              => Deno.core.ops.bsengine_get_wanton_excess(name),
+    getWantonMaxExcess:         (name)              => Deno.core.ops.bsengine_get_wanton_max_excess(name),
+    getWantonIndulgeRate:       (name)              => Deno.core.ops.bsengine_get_wanton_indulge_rate(name),
+    isWantonJustReckless:       (name)              => Deno.core.ops.bsengine_is_wanton_just_reckless(name),
+    isWantonJustRestrained:     (name)              => Deno.core.ops.bsengine_is_wanton_just_restrained(name),
+    isWantonEnabled:            (name)              => Deno.core.ops.bsengine_is_wanton_enabled(name),
+    indulgeWanton:              (name, amount)      => Deno.core.ops.bsengine_indulge_wanton(name, amount),
+    restrainWanton:             (name, amount)      => Deno.core.ops.bsengine_restrain_wanton(name, amount),
+    setWantonEnabled:           (name, v)           => Deno.core.ops.bsengine_set_wanton_enabled(name, v),
+    getWardHp:                  (name)              => Deno.core.ops.bsengine_get_ward_hp(name),
+    getWardMaxHp:               (name)              => Deno.core.ops.bsengine_get_ward_max_hp(name),
+    isWardJustBroke:            (name)              => Deno.core.ops.bsengine_is_ward_just_broke(name),
+    isWardJustReinforced:       (name)              => Deno.core.ops.bsengine_is_ward_just_reinforced(name),
+    isWardEnabled:              (name)              => Deno.core.ops.bsengine_is_ward_enabled(name),
+    reinforceWard:              (name, amount)      => Deno.core.ops.bsengine_reinforce_ward(name, amount),
+    absorbWard:                 (name, amount)      => Deno.core.ops.bsengine_absorb_ward(name, amount),
+    setWardEnabled:             (name, v)           => Deno.core.ops.bsengine_set_ward_enabled(name, v),
+    getWarmHeat:                (name)              => Deno.core.ops.bsengine_get_warm_heat(name),
+    getWarmMaxHeat:             (name)              => Deno.core.ops.bsengine_get_warm_max_heat(name),
+    getWarmKindleRate:          (name)              => Deno.core.ops.bsengine_get_warm_kindle_rate(name),
+    isWarmJustWarm:             (name)              => Deno.core.ops.bsengine_is_warm_just_warm(name),
+    isWarmJustCold:             (name)              => Deno.core.ops.bsengine_is_warm_just_cold(name),
+    isWarmEnabled:              (name)              => Deno.core.ops.bsengine_is_warm_enabled(name),
+    kindleWarm:                 (name, amount)      => Deno.core.ops.bsengine_kindle_warm(name, amount),
+    chillWarm:                  (name, amount)      => Deno.core.ops.bsengine_chill_warm(name, amount),
+    setWarmEnabled:             (name, v)           => Deno.core.ops.bsengine_set_warm_enabled(name, v),
+    getWarpPhase:               (name)              => Deno.core.ops.bsengine_get_warp_phase(name),
+    getWarpMaxRange:            (name)              => Deno.core.ops.bsengine_get_warp_max_range(name),
+    getWarpChargeDuration:      (name)              => Deno.core.ops.bsengine_get_warp_charge_duration(name),
+    getWarpCooldownDuration:    (name)              => Deno.core.ops.bsengine_get_warp_cooldown_duration(name),
+    isWarpJustWarped:           (name)              => Deno.core.ops.bsengine_is_warp_just_warped(name),
+    isWarpEnabled:              (name)              => Deno.core.ops.bsengine_is_warp_enabled(name),
+    setWarpMaxRange:            (name, v)           => Deno.core.ops.bsengine_set_warp_max_range(name, v),
+    setWarpChargeDuration:      (name, v)           => Deno.core.ops.bsengine_set_warp_charge_duration(name, v),
+    setWarpCooldownDuration:    (name, v)           => Deno.core.ops.bsengine_set_warp_cooldown_duration(name, v),
+    setWarpEnabled:             (name, v)           => Deno.core.ops.bsengine_set_warp_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -58402,6 +59037,431 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StepWaltz { name, amount } if name == "Grunt" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::HaltWaltz { name, amount } if name == "Grunt" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaltzEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wand_read_ops() {
+        super::WAND_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWandCharge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWandMaxCharge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWandChannelRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWandJustCharged("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWandJustSpent("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWandEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAND_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wand_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.channelWand("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.dischargeWand("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWandEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ChannelWand { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DischargeWand { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWandEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wane_read_ops() {
+        super::WANE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 0.25f32, 0.125f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWaneDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getWaneTimer("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaneMinPotency("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.125");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaneJustWaning("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaneJustExpired("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaneEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WANE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wane_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.startWane("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.stopWane("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaneEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StartWane { name, duration } if name == "Grunt" && *duration == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StopWane { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaneEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wangle_read_ops() {
+        super::WANGLE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWangleScheme("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWangleMaxScheme("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWangleManeuverRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWangleJustSchemed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWangleJustFoiled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWangleEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WANGLE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wangle_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.maneuverWangle("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.foilWangle("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWangleEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ManeuverWangle { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::FoilWangle { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWangleEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_want_read_ops() {
+        super::WANT_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWantDesire("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWantMaxDesire("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWantCravingRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWantJustWanted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWantJustSated("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWantEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WANT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_want_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.craveWant("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.sateWant("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWantEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CraveWant { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SateWant { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWantEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wanton_read_ops() {
+        super::WANTON_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWantonExcess("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWantonMaxExcess("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWantonIndulgeRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWantonJustReckless("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWantonJustRestrained("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWantonEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WANTON_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wanton_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.indulgeWanton("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.restrainWanton("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWantonEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::IndulgeWanton { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RestrainWanton { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWantonEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_ward_read_ops() {
+        super::WARD_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.5f32, 1.0f32, true, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWardHp("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.getWardMaxHp("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.isWardJustBroke("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWardJustReinforced("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWardEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WARD_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_ward_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.reinforceWard("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.absorbWard("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWardEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ReinforceWard { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AbsorbWard { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWardEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_warm_read_ops() {
+        super::WARM_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWarmHeat("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWarmMaxHeat("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWarmKindleRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWarmJustWarm("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWarmJustCold("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWarmEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WARM_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_warm_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.kindleWarm("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.chillWarm("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWarmEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::KindleWarm { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ChillWarm { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarmEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_warp_read_ops() {
+        super::WARP_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0u32, 0.5f32, 0.25f32, 1.0f32, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWarpPhase("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0");
+        let r = rt
+            .eval(r#"String(Bsengine.getWarpMaxRange("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWarpChargeDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getWarpCooldownDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.isWarpJustWarped("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWarpEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WARP_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_warp_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setWarpMaxRange("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setWarpChargeDuration("Grunt", 0.25);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setWarpCooldownDuration("Grunt", 1.0);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(r#"Bsengine.setWarpEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarpMaxRange { name, value } if name == "Grunt" && *value == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarpChargeDuration { name, value } if name == "Grunt" && *value == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarpCooldownDuration { name, value } if name == "Grunt" && *value == 1.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarpEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4421,6 +4421,114 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Vulture ──────────────────────────────────────────────────────────────
+    CircleVulture {
+        name: String,
+        amount: f32,
+    },
+    ScatterVulture {
+        name: String,
+        amount: f32,
+    },
+    SetVultureEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wage ─────────────────────────────────────────────────────────────────
+    EarnWage {
+        name: String,
+        amount: f32,
+    },
+    SpendWage {
+        name: String,
+        amount: f32,
+    },
+    SetWageEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wager ────────────────────────────────────────────────────────────────
+    BetWager {
+        name: String,
+        amount: f32,
+    },
+    ForfeitWager {
+        name: String,
+        amount: f32,
+    },
+    SetWagerEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wail ─────────────────────────────────────────────────────────────────
+    LamentWail {
+        name: String,
+        amount: f32,
+    },
+    ConsoleWail {
+        name: String,
+        amount: f32,
+    },
+    SetWailEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wake ─────────────────────────────────────────────────────────────────
+    RouseWake {
+        name: String,
+        amount: f32,
+    },
+    LullWake {
+        name: String,
+        amount: f32,
+    },
+    SetWakeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Walk ─────────────────────────────────────────────────────────────────
+    StepWalk {
+        name: String,
+        amount: f32,
+    },
+    RestWalk {
+        name: String,
+        amount: f32,
+    },
+    SetWalkEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wall ─────────────────────────────────────────────────────────────────
+    SetWallRunSpeed {
+        name: String,
+        value: f32,
+    },
+    SetWallSlideSpeed {
+        name: String,
+        value: f32,
+    },
+    SetWallJumpForce {
+        name: String,
+        value: f32,
+    },
+    SetWallEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Waltz ────────────────────────────────────────────────────────────────
+    StepWaltz {
+        name: String,
+        amount: f32,
+    },
+    HaltWaltz {
+        name: String,
+        amount: f32,
+    },
+    SetWaltzEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5584,6 +5692,22 @@ thread_local! {
     pub(crate) static VOW_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static VULNERABLE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static VULTURE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAGE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAGER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAIL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAKE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WALK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WALL_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32, f32, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WALTZ_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -10974,6 +11098,385 @@ pub fn bsengine_set_vulnerable_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetVulnerableEnabled { name, enabled })
+    });
+}
+// ── Vulture ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_vulture_patience(#[string] name: String) -> f32 {
+    VULTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vulture_max_patience(#[string] name: String) -> f32 {
+    VULTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_vulture_wait_rate(#[string] name: String) -> f32 {
+    VULTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_vulture_just_descended(#[string] name: String) -> bool {
+    VULTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vulture_just_scattered(#[string] name: String) -> bool {
+    VULTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_vulture_enabled(#[string] name: String) -> bool {
+    VULTURE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_circle_vulture(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CircleVulture { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_scatter_vulture(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ScatterVulture { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_vulture_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVultureEnabled { name, enabled })
+    });
+}
+// ── Wage ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wage_earnings(#[string] name: String) -> f32 {
+    WAGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wage_max_earnings(#[string] name: String) -> f32 {
+    WAGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wage_income_rate(#[string] name: String) -> f32 {
+    WAGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wage_just_paid(#[string] name: String) -> bool {
+    WAGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wage_just_broke(#[string] name: String) -> bool {
+    WAGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wage_enabled(#[string] name: String) -> bool {
+    WAGE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_earn_wage(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::EarnWage { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_spend_wage(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SpendWage { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wage_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWageEnabled { name, enabled })
+    });
+}
+// ── Wager ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wager_stake(#[string] name: String) -> f32 {
+    WAGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wager_max_stake(#[string] name: String) -> f32 {
+    WAGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wager_risk_rate(#[string] name: String) -> f32 {
+    WAGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wager_just_won(#[string] name: String) -> bool {
+    WAGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wager_just_lost(#[string] name: String) -> bool {
+    WAGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wager_enabled(#[string] name: String) -> bool {
+    WAGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_bet_wager(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::BetWager { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_forfeit_wager(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ForfeitWager { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wager_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWagerEnabled { name, enabled })
+    });
+}
+// ── Wail ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wail_grief(#[string] name: String) -> f32 {
+    WAIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wail_max_grief(#[string] name: String) -> f32 {
+    WAIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wail_keen_rate(#[string] name: String) -> f32 {
+    WAIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wail_just_wailed(#[string] name: String) -> bool {
+    WAIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wail_just_calmed(#[string] name: String) -> bool {
+    WAIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wail_enabled(#[string] name: String) -> bool {
+    WAIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_lament_wail(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::LamentWail { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_console_wail(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ConsoleWail { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wail_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWailEnabled { name, enabled })
+    });
+}
+// ── Wake ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wake_arousal(#[string] name: String) -> f32 {
+    WAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wake_max_arousal(#[string] name: String) -> f32 {
+    WAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wake_alert_rate(#[string] name: String) -> f32 {
+    WAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wake_just_woken(#[string] name: String) -> bool {
+    WAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wake_just_slept(#[string] name: String) -> bool {
+    WAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wake_enabled(#[string] name: String) -> bool {
+    WAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_rouse_wake(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RouseWake { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_lull_wake(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::LullWake { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wake_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWakeEnabled { name, enabled })
+    });
+}
+// ── Walk ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_walk_stride(#[string] name: String) -> f32 {
+    WALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_walk_max_stride(#[string] name: String) -> f32 {
+    WALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_walk_pace_rate(#[string] name: String) -> f32 {
+    WALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_walk_just_striding(#[string] name: String) -> bool {
+    WALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_walk_just_halted(#[string] name: String) -> bool {
+    WALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_walk_enabled(#[string] name: String) -> bool {
+    WALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_step_walk(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::StepWalk { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_rest_walk(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RestWalk { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_walk_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWalkEnabled { name, enabled })
+    });
+}
+// ── Wall ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wall_state(#[string] name: String) -> u32 {
+    WALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wall_run_speed(#[string] name: String) -> f32 {
+    WALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wall_slide_speed(#[string] name: String) -> f32 {
+    WALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wall_gravity_scale(#[string] name: String) -> f32 {
+    WALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wall_run_timer(#[string] name: String) -> f32 {
+    WALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wall_jump_force(#[string] name: String) -> f32 {
+    WALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wall_enabled(#[string] name: String) -> bool {
+    WALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_wall_run_speed(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWallRunSpeed { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wall_slide_speed(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWallSlideSpeed { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wall_jump_force(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWallJumpForce { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wall_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWallEnabled { name, enabled })
+    });
+}
+// ── Waltz ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_waltz_rhythm(#[string] name: String) -> f32 {
+    WALTZ_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_waltz_max_rhythm(#[string] name: String) -> f32 {
+    WALTZ_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_waltz_grace_rate(#[string] name: String) -> f32 {
+    WALTZ_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_waltz_just_dancing(#[string] name: String) -> bool {
+    WALTZ_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_waltz_just_still(#[string] name: String) -> bool {
+    WALTZ_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_waltz_enabled(#[string] name: String) -> bool {
+    WALTZ_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_step_waltz(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::StepWaltz { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_halt_waltz(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::HaltWaltz { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_waltz_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaltzEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -30983,6 +31486,80 @@ deno_core::extension!(
         bsengine_weaken_vulnerable,
         bsengine_fortify_vulnerable,
         bsengine_set_vulnerable_enabled,
+        bsengine_get_vulture_patience,
+        bsengine_get_vulture_max_patience,
+        bsengine_get_vulture_wait_rate,
+        bsengine_is_vulture_just_descended,
+        bsengine_is_vulture_just_scattered,
+        bsengine_is_vulture_enabled,
+        bsengine_circle_vulture,
+        bsengine_scatter_vulture,
+        bsengine_set_vulture_enabled,
+        bsengine_get_wage_earnings,
+        bsengine_get_wage_max_earnings,
+        bsengine_get_wage_income_rate,
+        bsengine_is_wage_just_paid,
+        bsengine_is_wage_just_broke,
+        bsengine_is_wage_enabled,
+        bsengine_earn_wage,
+        bsengine_spend_wage,
+        bsengine_set_wage_enabled,
+        bsengine_get_wager_stake,
+        bsengine_get_wager_max_stake,
+        bsengine_get_wager_risk_rate,
+        bsengine_is_wager_just_won,
+        bsengine_is_wager_just_lost,
+        bsengine_is_wager_enabled,
+        bsengine_bet_wager,
+        bsengine_forfeit_wager,
+        bsengine_set_wager_enabled,
+        bsengine_get_wail_grief,
+        bsengine_get_wail_max_grief,
+        bsengine_get_wail_keen_rate,
+        bsengine_is_wail_just_wailed,
+        bsengine_is_wail_just_calmed,
+        bsengine_is_wail_enabled,
+        bsengine_lament_wail,
+        bsengine_console_wail,
+        bsengine_set_wail_enabled,
+        bsengine_get_wake_arousal,
+        bsengine_get_wake_max_arousal,
+        bsengine_get_wake_alert_rate,
+        bsengine_is_wake_just_woken,
+        bsengine_is_wake_just_slept,
+        bsengine_is_wake_enabled,
+        bsengine_rouse_wake,
+        bsengine_lull_wake,
+        bsengine_set_wake_enabled,
+        bsengine_get_walk_stride,
+        bsengine_get_walk_max_stride,
+        bsengine_get_walk_pace_rate,
+        bsengine_is_walk_just_striding,
+        bsengine_is_walk_just_halted,
+        bsengine_is_walk_enabled,
+        bsengine_step_walk,
+        bsengine_rest_walk,
+        bsengine_set_walk_enabled,
+        bsengine_get_wall_state,
+        bsengine_get_wall_run_speed,
+        bsengine_get_wall_slide_speed,
+        bsengine_get_wall_gravity_scale,
+        bsengine_get_wall_run_timer,
+        bsengine_get_wall_jump_force,
+        bsengine_is_wall_enabled,
+        bsengine_set_wall_run_speed,
+        bsengine_set_wall_slide_speed,
+        bsengine_set_wall_jump_force,
+        bsengine_set_wall_enabled,
+        bsengine_get_waltz_rhythm,
+        bsengine_get_waltz_max_rhythm,
+        bsengine_get_waltz_grace_rate,
+        bsengine_is_waltz_just_dancing,
+        bsengine_is_waltz_just_still,
+        bsengine_is_waltz_enabled,
+        bsengine_step_waltz,
+        bsengine_halt_waltz,
+        bsengine_set_waltz_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -34404,6 +34981,80 @@ const Bsengine = {
     weakenVulnerable:           (name, amount)      => Deno.core.ops.bsengine_weaken_vulnerable(name, amount),
     fortifyVulnerable:          (name, amount)      => Deno.core.ops.bsengine_fortify_vulnerable(name, amount),
     setVulnerableEnabled:       (name, v)           => Deno.core.ops.bsengine_set_vulnerable_enabled(name, v),
+    getVulturePatience:         (name)              => Deno.core.ops.bsengine_get_vulture_patience(name),
+    getVultureMaxPatience:      (name)              => Deno.core.ops.bsengine_get_vulture_max_patience(name),
+    getVultureWaitRate:         (name)              => Deno.core.ops.bsengine_get_vulture_wait_rate(name),
+    isVultureJustDescended:     (name)              => Deno.core.ops.bsengine_is_vulture_just_descended(name),
+    isVultureJustScattered:     (name)              => Deno.core.ops.bsengine_is_vulture_just_scattered(name),
+    isVultureEnabled:           (name)              => Deno.core.ops.bsengine_is_vulture_enabled(name),
+    circleVulture:              (name, amount)      => Deno.core.ops.bsengine_circle_vulture(name, amount),
+    scatterVulture:             (name, amount)      => Deno.core.ops.bsengine_scatter_vulture(name, amount),
+    setVultureEnabled:          (name, v)           => Deno.core.ops.bsengine_set_vulture_enabled(name, v),
+    getWageEarnings:            (name)              => Deno.core.ops.bsengine_get_wage_earnings(name),
+    getWageMaxEarnings:         (name)              => Deno.core.ops.bsengine_get_wage_max_earnings(name),
+    getWageIncomeRate:          (name)              => Deno.core.ops.bsengine_get_wage_income_rate(name),
+    isWageJustPaid:             (name)              => Deno.core.ops.bsengine_is_wage_just_paid(name),
+    isWageJustBroke:            (name)              => Deno.core.ops.bsengine_is_wage_just_broke(name),
+    isWageEnabled:              (name)              => Deno.core.ops.bsengine_is_wage_enabled(name),
+    earnWage:                   (name, amount)      => Deno.core.ops.bsengine_earn_wage(name, amount),
+    spendWage:                  (name, amount)      => Deno.core.ops.bsengine_spend_wage(name, amount),
+    setWageEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wage_enabled(name, v),
+    getWagerStake:              (name)              => Deno.core.ops.bsengine_get_wager_stake(name),
+    getWagerMaxStake:           (name)              => Deno.core.ops.bsengine_get_wager_max_stake(name),
+    getWagerRiskRate:           (name)              => Deno.core.ops.bsengine_get_wager_risk_rate(name),
+    isWagerJustWon:             (name)              => Deno.core.ops.bsengine_is_wager_just_won(name),
+    isWagerJustLost:            (name)              => Deno.core.ops.bsengine_is_wager_just_lost(name),
+    isWagerEnabled:             (name)              => Deno.core.ops.bsengine_is_wager_enabled(name),
+    betWager:                   (name, amount)      => Deno.core.ops.bsengine_bet_wager(name, amount),
+    forfeitWager:               (name, amount)      => Deno.core.ops.bsengine_forfeit_wager(name, amount),
+    setWagerEnabled:            (name, v)           => Deno.core.ops.bsengine_set_wager_enabled(name, v),
+    getWailGrief:               (name)              => Deno.core.ops.bsengine_get_wail_grief(name),
+    getWailMaxGrief:            (name)              => Deno.core.ops.bsengine_get_wail_max_grief(name),
+    getWailKeenRate:            (name)              => Deno.core.ops.bsengine_get_wail_keen_rate(name),
+    isWailJustWailed:           (name)              => Deno.core.ops.bsengine_is_wail_just_wailed(name),
+    isWailJustCalmed:           (name)              => Deno.core.ops.bsengine_is_wail_just_calmed(name),
+    isWailEnabled:              (name)              => Deno.core.ops.bsengine_is_wail_enabled(name),
+    lamentWail:                 (name, amount)      => Deno.core.ops.bsengine_lament_wail(name, amount),
+    consoleWail:                (name, amount)      => Deno.core.ops.bsengine_console_wail(name, amount),
+    setWailEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wail_enabled(name, v),
+    getWakeArousal:             (name)              => Deno.core.ops.bsengine_get_wake_arousal(name),
+    getWakeMaxArousal:          (name)              => Deno.core.ops.bsengine_get_wake_max_arousal(name),
+    getWakeAlertRate:           (name)              => Deno.core.ops.bsengine_get_wake_alert_rate(name),
+    isWakeJustWoken:            (name)              => Deno.core.ops.bsengine_is_wake_just_woken(name),
+    isWakeJustSlept:            (name)              => Deno.core.ops.bsengine_is_wake_just_slept(name),
+    isWakeEnabled:              (name)              => Deno.core.ops.bsengine_is_wake_enabled(name),
+    rouseWake:                  (name, amount)      => Deno.core.ops.bsengine_rouse_wake(name, amount),
+    lullWake:                   (name, amount)      => Deno.core.ops.bsengine_lull_wake(name, amount),
+    setWakeEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wake_enabled(name, v),
+    getWalkStride:              (name)              => Deno.core.ops.bsengine_get_walk_stride(name),
+    getWalkMaxStride:           (name)              => Deno.core.ops.bsengine_get_walk_max_stride(name),
+    getWalkPaceRate:            (name)              => Deno.core.ops.bsengine_get_walk_pace_rate(name),
+    isWalkJustStriding:         (name)              => Deno.core.ops.bsengine_is_walk_just_striding(name),
+    isWalkJustHalted:           (name)              => Deno.core.ops.bsengine_is_walk_just_halted(name),
+    isWalkEnabled:              (name)              => Deno.core.ops.bsengine_is_walk_enabled(name),
+    stepWalk:                   (name, amount)      => Deno.core.ops.bsengine_step_walk(name, amount),
+    restWalk:                   (name, amount)      => Deno.core.ops.bsengine_rest_walk(name, amount),
+    setWalkEnabled:             (name, v)           => Deno.core.ops.bsengine_set_walk_enabled(name, v),
+    getWallState:               (name)              => Deno.core.ops.bsengine_get_wall_state(name),
+    getWallRunSpeed:            (name)              => Deno.core.ops.bsengine_get_wall_run_speed(name),
+    getWallSlideSpeed:          (name)              => Deno.core.ops.bsengine_get_wall_slide_speed(name),
+    getWallGravityScale:        (name)              => Deno.core.ops.bsengine_get_wall_gravity_scale(name),
+    getWallRunTimer:            (name)              => Deno.core.ops.bsengine_get_wall_run_timer(name),
+    getWallJumpForce:           (name)              => Deno.core.ops.bsengine_get_wall_jump_force(name),
+    isWallEnabled:              (name)              => Deno.core.ops.bsengine_is_wall_enabled(name),
+    setWallRunSpeed:            (name, v)           => Deno.core.ops.bsengine_set_wall_run_speed(name, v),
+    setWallSlideSpeed:          (name, v)           => Deno.core.ops.bsengine_set_wall_slide_speed(name, v),
+    setWallJumpForce:           (name, v)           => Deno.core.ops.bsengine_set_wall_jump_force(name, v),
+    setWallEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wall_enabled(name, v),
+    getWaltzRhythm:             (name)              => Deno.core.ops.bsengine_get_waltz_rhythm(name),
+    getWaltzMaxRhythm:          (name)              => Deno.core.ops.bsengine_get_waltz_max_rhythm(name),
+    getWaltzGraceRate:          (name)              => Deno.core.ops.bsengine_get_waltz_grace_rate(name),
+    isWaltzJustDancing:         (name)              => Deno.core.ops.bsengine_is_waltz_just_dancing(name),
+    isWaltzJustStill:           (name)              => Deno.core.ops.bsengine_is_waltz_just_still(name),
+    isWaltzEnabled:             (name)              => Deno.core.ops.bsengine_is_waltz_enabled(name),
+    stepWaltz:                  (name, amount)      => Deno.core.ops.bsengine_step_waltz(name, amount),
+    haltWaltz:                  (name, amount)      => Deno.core.ops.bsengine_halt_waltz(name, amount),
+    setWaltzEnabled:            (name, v)           => Deno.core.ops.bsengine_set_waltz_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -57316,6 +57967,441 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::WeakenVulnerable { name, amount } if name == "Grunt" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::FortifyVulnerable { name, amount } if name == "Grunt" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVulnerableEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vulture_read_ops() {
+        super::VULTURE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getVulturePatience("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getVultureMaxPatience("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getVultureWaitRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isVultureJustDescended("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isVultureJustScattered("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isVultureEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::VULTURE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_vulture_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.circleVulture("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.scatterVulture("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setVultureEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CircleVulture { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ScatterVulture { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetVultureEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wage_read_ops() {
+        super::WAGE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWageEarnings("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWageMaxEarnings("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWageIncomeRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWageJustPaid("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWageJustBroke("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWageEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAGE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wage_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.earnWage("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.spendWage("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWageEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::EarnWage { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SpendWage { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWageEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wager_read_ops() {
+        super::WAGER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWagerStake("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWagerMaxStake("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWagerRiskRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWagerJustWon("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWagerJustLost("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWagerEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAGER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wager_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.betWager("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.forfeitWager("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWagerEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BetWager { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ForfeitWager { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWagerEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wail_read_ops() {
+        super::WAIL_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWailGrief("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWailMaxGrief("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWailKeenRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWailJustWailed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWailJustCalmed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWailEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAIL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wail_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.lamentWail("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.consoleWail("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWailEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::LamentWail { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ConsoleWail { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWailEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wake_read_ops() {
+        super::WAKE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWakeArousal("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWakeMaxArousal("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWakeAlertRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWakeJustWoken("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWakeJustSlept("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWakeEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAKE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wake_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.rouseWake("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.lullWake("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWakeEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RouseWake { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::LullWake { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWakeEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_walk_read_ops() {
+        super::WALK_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWalkStride("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWalkMaxStride("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWalkPaceRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWalkJustStriding("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWalkJustHalted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWalkEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WALK_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_walk_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.stepWalk("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.restWalk("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWalkEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StepWalk { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RestWalk { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWalkEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wall_read_ops() {
+        super::WALL_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (1u32, 0.5f32, 0.25f32, 0.125f32, 0.5f32, 1.0f32, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWallState("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWallRunSpeed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWallSlideSpeed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getWallGravityScale("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.125");
+        let r = rt
+            .eval(r#"String(Bsengine.getWallRunTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWallJumpForce("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.isWallEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WALL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wall_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setWallRunSpeed("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWallSlideSpeed("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWallJumpForce("Grunt", 1.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWallEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWallRunSpeed { name, value } if name == "Grunt" && *value == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWallSlideSpeed { name, value } if name == "Grunt" && *value == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWallJumpForce { name, value } if name == "Grunt" && *value == 1.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWallEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_waltz_read_ops() {
+        super::WALTZ_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWaltzRhythm("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaltzMaxRhythm("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaltzGraceRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaltzJustDancing("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaltzJustStill("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaltzEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WALTZ_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_waltz_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.stepWaltz("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.haltWaltz("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaltzEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StepWaltz { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::HaltWaltz { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaltzEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -3562,6 +3562,118 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Silence ──────────────────────────────────────────────────────────────
+    ApplySilence {
+        name: String,
+        duration: f32,
+    },
+    ClearSilence {
+        name: String,
+    },
+    SetSilenceEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Siphon ───────────────────────────────────────────────────────────────
+    StartSiphon {
+        name: String,
+        duration: f32,
+    },
+    StopSiphon {
+        name: String,
+    },
+    SetSiphonEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Slam ─────────────────────────────────────────────────────────────────
+    BeginSlam {
+        name: String,
+        height: f32,
+    },
+    LandSlam {
+        name: String,
+    },
+    SetSlamEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Slay ─────────────────────────────────────────────────────────────────
+    RegisterKill {
+        name: String,
+    },
+    SetSlayEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Slide ────────────────────────────────────────────────────────────────
+    StartSlide {
+        name: String,
+        dir_x: f32,
+        dir_y: f32,
+        dir_z: f32,
+    },
+    CancelSlide {
+        name: String,
+    },
+    SetSlideEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Slime ────────────────────────────────────────────────────────────────
+    ApplySlime {
+        name: String,
+        duration: f32,
+    },
+    CleanseSlime {
+        name: String,
+    },
+    SetSlimeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Slink ────────────────────────────────────────────────────────────────
+    EngageSlink {
+        name: String,
+    },
+    DisengageSlink {
+        name: String,
+    },
+    SetSlinkEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── SlowMo ───────────────────────────────────────────────────────────────
+    SetSlowMoEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Smoke ────────────────────────────────────────────────────────────────
+    SetSmokeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Snare ────────────────────────────────────────────────────────────────
+    ApplySnare {
+        name: String,
+        duration: f32,
+    },
+    ClearSnare {
+        name: String,
+    },
+    SetSnareEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Soak ─────────────────────────────────────────────────────────────────
+    AbsorbSoak {
+        name: String,
+        amount: f32,
+    },
+    SetSoakEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -4543,6 +4655,39 @@ thread_local! {
         RefCell::new(HashMap::new());
     // entity name → (shunt_resistance, last_shunt_magnitude, shunts_received, cooldown_timer, cooldown, just_shunted, enabled)
     pub(crate) static SHUNT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, u32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (duration, timer, just_silenced, just_unsilenced, enabled)
+    pub(crate) static SILENCE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (duration, timer, drain_per_second, return_fraction, just_started, just_ended, enabled)
+    pub(crate) static SIPHON_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (phase, slam_speed, impact_radius, impact_force, min_height, launch_height, recovery_time, recovery_timer, cooldown, cooldown_timer, wants_slam, enabled)
+    pub(crate) static SLAM_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32, f32, f32, f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (kill_count, threshold, trigger_count, just_triggered, enabled)
+    pub(crate) static SLAY_SNAPSHOT: RefCell<HashMap<String, (u32, u32, u32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (phase, dir_x, dir_y, dir_z, duration, brake_start, elapsed, slide_speed, wants_slide, crouch_scale, enabled)
+    pub(crate) static SLIDE_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32, f32, f32, f32, bool, f32, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (slime_timer, slow_factor, slimed, just_slimed, just_cleansed, enabled)
+    pub(crate) static SLIME_SNAPSHOT: RefCell<HashMap<String, (f32, f32, bool, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (active, speed_reduction, noise_reduction, just_engaged, just_disengaged, enabled)
+    pub(crate) static SLINK_SNAPSHOT: RefCell<HashMap<String, (bool, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (target_scale, current_scale, blend_speed, max_duration, elapsed, charge, drain_rate, source, enabled)
+    pub(crate) static SLOW_MO_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, f32, f32, u32, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (style, rate, color_r, color_g, color_b, color_a, particle_speed, spread_rate, particle_lifetime, offset_x, offset_y, offset_z, burst_duration, elapsed, enabled)
+    pub(crate) static SMOKE_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (duration, timer, slow_fraction, escape_chance, just_snared, just_escaped, enabled)
+    pub(crate) static SNARE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (soak_level, decay_rate, fire_resistance, lightning_amplify, just_soaked, just_dried, enabled)
+    pub(crate) static SOAK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -7021,6 +7166,543 @@ pub fn bsengine_set_shunt_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetShuntEnabled { name, enabled })
+    });
+}
+// ── Silence ──────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_silence_duration(#[string] name: String) -> f32 {
+    SILENCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_silence_timer(#[string] name: String) -> f32 {
+    SILENCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_silenced(#[string] name: String) -> bool {
+    SILENCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_unsilenced(#[string] name: String) -> bool {
+    SILENCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_silence_enabled(#[string] name: String) -> bool {
+    SILENCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_silence(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplySilence { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_clear_silence(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearSilence { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_silence_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSilenceEnabled { name, enabled })
+    });
+}
+// ── Siphon ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_siphon_duration(#[string] name: String) -> f32 {
+    SIPHON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_siphon_timer(#[string] name: String) -> f32 {
+    SIPHON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_siphon_drain_per_second(#[string] name: String) -> f32 {
+    SIPHON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_siphon_return_fraction(#[string] name: String) -> f32 {
+    SIPHON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_siphon_just_started(#[string] name: String) -> bool {
+    SIPHON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_siphon_just_ended(#[string] name: String) -> bool {
+    SIPHON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_siphon_enabled(#[string] name: String) -> bool {
+    SIPHON_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_start_siphon(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::StartSiphon { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_stop_siphon(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StopSiphon { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_siphon_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSiphonEnabled { name, enabled })
+    });
+}
+// ── Slam ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_slam_phase(#[string] name: String) -> u32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_speed(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_impact_radius(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_impact_force(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_min_height(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_launch_height(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_recovery_time(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_recovery_timer(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_cooldown(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.8).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slam_cooldown_timer(#[string] name: String) -> f32 {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.9).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_slam_wants_slam(#[string] name: String) -> bool {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.10).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_slam_enabled(#[string] name: String) -> bool {
+    SLAM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.11).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_begin_slam(#[string] name: String, height: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::BeginSlam { name, height })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_land_slam(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::LandSlam { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_slam_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSlamEnabled { name, enabled })
+    });
+}
+// ── Slay ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_slay_kill_count(#[string] name: String) -> u32 {
+    SLAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slay_threshold(#[string] name: String) -> u32 {
+    SLAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slay_trigger_count(#[string] name: String) -> u32 {
+    SLAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_is_slay_just_triggered(#[string] name: String) -> bool {
+    SLAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_slay_enabled(#[string] name: String) -> bool {
+    SLAY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_register_kill(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::RegisterKill { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_slay_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSlayEnabled { name, enabled })
+    });
+}
+// ── Slide ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_slide_phase(#[string] name: String) -> u32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slide_direction_x(#[string] name: String) -> f32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slide_direction_y(#[string] name: String) -> f32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slide_direction_z(#[string] name: String) -> f32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slide_duration(#[string] name: String) -> f32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slide_brake_start(#[string] name: String) -> f32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slide_elapsed(#[string] name: String) -> f32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slide_speed(#[string] name: String) -> f32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_slide_wants_slide(#[string] name: String) -> bool {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.8).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_get_slide_crouch_scale(#[string] name: String) -> f32 {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.9).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_slide_enabled(#[string] name: String) -> bool {
+    SLIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.10).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_start_slide(#[string] name: String, dir_x: f32, dir_y: f32, dir_z: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::StartSlide {
+            name,
+            dir_x,
+            dir_y,
+            dir_z,
+        })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_cancel_slide(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::CancelSlide { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_slide_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSlideEnabled { name, enabled })
+    });
+}
+// ── Slime ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_slime_timer(#[string] name: String) -> f32 {
+    SLIME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slime_slow_factor(#[string] name: String) -> f32 {
+    SLIME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_slimed(#[string] name: String) -> bool {
+    SLIME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_slimed(#[string] name: String) -> bool {
+    SLIME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_slime_cleansed(#[string] name: String) -> bool {
+    SLIME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_slime_enabled(#[string] name: String) -> bool {
+    SLIME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_slime(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplySlime { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_cleanse_slime(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::CleanseSlime { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_slime_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSlimeEnabled { name, enabled })
+    });
+}
+// ── Slink ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_is_slink_active(#[string] name: String) -> bool {
+    SLINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_get_slink_speed_reduction(#[string] name: String) -> f32 {
+    SLINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slink_noise_reduction(#[string] name: String) -> f32 {
+    SLINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_slink_just_engaged(#[string] name: String) -> bool {
+    SLINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_slink_just_disengaged(#[string] name: String) -> bool {
+    SLINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_slink_enabled(#[string] name: String) -> bool {
+    SLINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_engage_slink(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::EngageSlink { name }));
+}
+#[op2(fast)]
+pub fn bsengine_disengage_slink(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::DisengageSlink { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_slink_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSlinkEnabled { name, enabled })
+    });
+}
+// ── SlowMo ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_slow_mo_target_scale(#[string] name: String) -> f32 {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slow_mo_current_scale(#[string] name: String) -> f32 {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slow_mo_blend_speed(#[string] name: String) -> f32 {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slow_mo_max_duration(#[string] name: String) -> f32 {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slow_mo_elapsed(#[string] name: String) -> f32 {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slow_mo_charge(#[string] name: String) -> f32 {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slow_mo_drain_rate(#[string] name: String) -> f32 {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_slow_mo_source(#[string] name: String) -> u32 {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_is_slow_mo_enabled(#[string] name: String) -> bool {
+    SLOW_MO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.8).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_slow_mo_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSlowMoEnabled { name, enabled })
+    });
+}
+// ── Smoke ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_smoke_style(#[string] name: String) -> u32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_rate(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_color_r(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_color_g(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_color_b(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_color_a(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_particle_speed(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_spread_rate(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_particle_lifetime(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.8).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_offset_x(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.9).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_offset_y(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.10).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_offset_z(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.11).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_burst_duration(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.12).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_smoke_elapsed(#[string] name: String) -> f32 {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.13).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_smoke_enabled(#[string] name: String) -> bool {
+    SMOKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.14).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_smoke_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSmokeEnabled { name, enabled })
+    });
+}
+// ── Snare ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_snare_duration(#[string] name: String) -> f32 {
+    SNARE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_snare_timer(#[string] name: String) -> f32 {
+    SNARE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_snare_slow_fraction(#[string] name: String) -> f32 {
+    SNARE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_snare_escape_chance(#[string] name: String) -> f32 {
+    SNARE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_snared(#[string] name: String) -> bool {
+    SNARE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_snare_escaped(#[string] name: String) -> bool {
+    SNARE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_snare_enabled(#[string] name: String) -> bool {
+    SNARE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_snare(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplySnare { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_clear_snare(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearSnare { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_snare_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSnareEnabled { name, enabled })
+    });
+}
+// ── Soak ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_soak_level(#[string] name: String) -> f32 {
+    SOAK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_soak_decay_rate(#[string] name: String) -> f32 {
+    SOAK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_soak_fire_resistance(#[string] name: String) -> f32 {
+    SOAK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_soak_lightning_amplify(#[string] name: String) -> f32 {
+    SOAK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_soaked(#[string] name: String) -> bool {
+    SOAK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_dried(#[string] name: String) -> bool {
+    SOAK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_soak_enabled(#[string] name: String) -> bool {
+    SOAK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_absorb_soak(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AbsorbSoak { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_soak_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSoakEnabled { name, enabled })
     });
 }
 #[op2(fast)]
@@ -25772,6 +26454,123 @@ deno_core::extension!(
         bsengine_set_shunt_resistance,
         bsengine_set_shunt_cooldown,
         bsengine_set_shunt_enabled,
+        bsengine_get_silence_duration,
+        bsengine_get_silence_timer,
+        bsengine_is_just_silenced,
+        bsengine_is_just_unsilenced,
+        bsengine_is_silence_enabled,
+        bsengine_apply_silence,
+        bsengine_clear_silence,
+        bsengine_set_silence_enabled,
+        bsengine_get_siphon_duration,
+        bsengine_get_siphon_timer,
+        bsengine_get_siphon_drain_per_second,
+        bsengine_get_siphon_return_fraction,
+        bsengine_is_siphon_just_started,
+        bsengine_is_siphon_just_ended,
+        bsengine_is_siphon_enabled,
+        bsengine_start_siphon,
+        bsengine_stop_siphon,
+        bsengine_set_siphon_enabled,
+        bsengine_get_slam_phase,
+        bsengine_get_slam_speed,
+        bsengine_get_slam_impact_radius,
+        bsengine_get_slam_impact_force,
+        bsengine_get_slam_min_height,
+        bsengine_get_slam_launch_height,
+        bsengine_get_slam_recovery_time,
+        bsengine_get_slam_recovery_timer,
+        bsengine_get_slam_cooldown,
+        bsengine_get_slam_cooldown_timer,
+        bsengine_slam_wants_slam,
+        bsengine_is_slam_enabled,
+        bsengine_begin_slam,
+        bsengine_land_slam,
+        bsengine_set_slam_enabled,
+        bsengine_get_slay_kill_count,
+        bsengine_get_slay_threshold,
+        bsengine_get_slay_trigger_count,
+        bsengine_is_slay_just_triggered,
+        bsengine_is_slay_enabled,
+        bsengine_register_kill,
+        bsengine_set_slay_enabled,
+        bsengine_get_slide_phase,
+        bsengine_get_slide_direction_x,
+        bsengine_get_slide_direction_y,
+        bsengine_get_slide_direction_z,
+        bsengine_get_slide_duration,
+        bsengine_get_slide_brake_start,
+        bsengine_get_slide_elapsed,
+        bsengine_get_slide_speed,
+        bsengine_slide_wants_slide,
+        bsengine_get_slide_crouch_scale,
+        bsengine_is_slide_enabled,
+        bsengine_start_slide,
+        bsengine_cancel_slide,
+        bsengine_set_slide_enabled,
+        bsengine_get_slime_timer,
+        bsengine_get_slime_slow_factor,
+        bsengine_is_slimed,
+        bsengine_is_just_slimed,
+        bsengine_is_just_slime_cleansed,
+        bsengine_is_slime_enabled,
+        bsengine_apply_slime,
+        bsengine_cleanse_slime,
+        bsengine_set_slime_enabled,
+        bsengine_is_slink_active,
+        bsengine_get_slink_speed_reduction,
+        bsengine_get_slink_noise_reduction,
+        bsengine_is_slink_just_engaged,
+        bsengine_is_slink_just_disengaged,
+        bsengine_is_slink_enabled,
+        bsengine_engage_slink,
+        bsengine_disengage_slink,
+        bsengine_set_slink_enabled,
+        bsengine_get_slow_mo_target_scale,
+        bsengine_get_slow_mo_current_scale,
+        bsengine_get_slow_mo_blend_speed,
+        bsengine_get_slow_mo_max_duration,
+        bsengine_get_slow_mo_elapsed,
+        bsengine_get_slow_mo_charge,
+        bsengine_get_slow_mo_drain_rate,
+        bsengine_get_slow_mo_source,
+        bsengine_is_slow_mo_enabled,
+        bsengine_set_slow_mo_enabled,
+        bsengine_get_smoke_style,
+        bsengine_get_smoke_rate,
+        bsengine_get_smoke_color_r,
+        bsengine_get_smoke_color_g,
+        bsengine_get_smoke_color_b,
+        bsengine_get_smoke_color_a,
+        bsengine_get_smoke_particle_speed,
+        bsengine_get_smoke_spread_rate,
+        bsengine_get_smoke_particle_lifetime,
+        bsengine_get_smoke_offset_x,
+        bsengine_get_smoke_offset_y,
+        bsengine_get_smoke_offset_z,
+        bsengine_get_smoke_burst_duration,
+        bsengine_get_smoke_elapsed,
+        bsengine_is_smoke_enabled,
+        bsengine_set_smoke_enabled,
+        bsengine_get_snare_duration,
+        bsengine_get_snare_timer,
+        bsengine_get_snare_slow_fraction,
+        bsengine_get_snare_escape_chance,
+        bsengine_is_just_snared,
+        bsengine_is_just_snare_escaped,
+        bsengine_is_snare_enabled,
+        bsengine_apply_snare,
+        bsengine_clear_snare,
+        bsengine_set_snare_enabled,
+        bsengine_get_soak_level,
+        bsengine_get_soak_decay_rate,
+        bsengine_get_soak_fire_resistance,
+        bsengine_get_soak_lightning_amplify,
+        bsengine_is_just_soaked,
+        bsengine_is_just_dried,
+        bsengine_is_soak_enabled,
+        bsengine_absorb_soak,
+        bsengine_set_soak_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -28472,6 +29271,123 @@ const Bsengine = {
     setShuntResistance:         (name, v)           => Deno.core.ops.bsengine_set_shunt_resistance(name, v),
     setShuntCooldown:           (name, v)           => Deno.core.ops.bsengine_set_shunt_cooldown(name, v),
     setShuntEnabled:            (name, v)           => Deno.core.ops.bsengine_set_shunt_enabled(name, v),
+    getSilenceDuration:         (name)              => Deno.core.ops.bsengine_get_silence_duration(name),
+    getSilenceTimer:            (name)              => Deno.core.ops.bsengine_get_silence_timer(name),
+    isJustSilenced:             (name)              => Deno.core.ops.bsengine_is_just_silenced(name),
+    isJustUnsilenced:           (name)              => Deno.core.ops.bsengine_is_just_unsilenced(name),
+    isSilenceEnabled:           (name)              => Deno.core.ops.bsengine_is_silence_enabled(name),
+    applySilence:               (name, duration)    => Deno.core.ops.bsengine_apply_silence(name, duration),
+    clearSilence:               (name)              => Deno.core.ops.bsengine_clear_silence(name),
+    setSilenceEnabled:          (name, v)           => Deno.core.ops.bsengine_set_silence_enabled(name, v),
+    getSiphonDuration:          (name)              => Deno.core.ops.bsengine_get_siphon_duration(name),
+    getSiphonTimer:             (name)              => Deno.core.ops.bsengine_get_siphon_timer(name),
+    getSiphonDrainPerSecond:    (name)              => Deno.core.ops.bsengine_get_siphon_drain_per_second(name),
+    getSiphonReturnFraction:    (name)              => Deno.core.ops.bsengine_get_siphon_return_fraction(name),
+    isSiphonJustStarted:        (name)              => Deno.core.ops.bsengine_is_siphon_just_started(name),
+    isSiphonJustEnded:          (name)              => Deno.core.ops.bsengine_is_siphon_just_ended(name),
+    isSiphonEnabled:            (name)              => Deno.core.ops.bsengine_is_siphon_enabled(name),
+    startSiphon:                (name, duration)    => Deno.core.ops.bsengine_start_siphon(name, duration),
+    stopSiphon:                 (name)              => Deno.core.ops.bsengine_stop_siphon(name),
+    setSiphonEnabled:           (name, v)           => Deno.core.ops.bsengine_set_siphon_enabled(name, v),
+    getSlamPhase:               (name)              => Deno.core.ops.bsengine_get_slam_phase(name),
+    getSlamSpeed:               (name)              => Deno.core.ops.bsengine_get_slam_speed(name),
+    getSlamImpactRadius:        (name)              => Deno.core.ops.bsengine_get_slam_impact_radius(name),
+    getSlamImpactForce:         (name)              => Deno.core.ops.bsengine_get_slam_impact_force(name),
+    getSlamMinHeight:           (name)              => Deno.core.ops.bsengine_get_slam_min_height(name),
+    getSlamLaunchHeight:        (name)              => Deno.core.ops.bsengine_get_slam_launch_height(name),
+    getSlamRecoveryTime:        (name)              => Deno.core.ops.bsengine_get_slam_recovery_time(name),
+    getSlamRecoveryTimer:       (name)              => Deno.core.ops.bsengine_get_slam_recovery_timer(name),
+    getSlamCooldown:            (name)              => Deno.core.ops.bsengine_get_slam_cooldown(name),
+    getSlamCooldownTimer:       (name)              => Deno.core.ops.bsengine_get_slam_cooldown_timer(name),
+    slamWantsSlam:              (name)              => Deno.core.ops.bsengine_slam_wants_slam(name),
+    isSlamEnabled:              (name)              => Deno.core.ops.bsengine_is_slam_enabled(name),
+    beginSlam:                  (name, height)      => Deno.core.ops.bsengine_begin_slam(name, height),
+    landSlam:                   (name)              => Deno.core.ops.bsengine_land_slam(name),
+    setSlamEnabled:             (name, v)           => Deno.core.ops.bsengine_set_slam_enabled(name, v),
+    getSlayKillCount:           (name)              => Deno.core.ops.bsengine_get_slay_kill_count(name),
+    getSlayThreshold:           (name)              => Deno.core.ops.bsengine_get_slay_threshold(name),
+    getSlayTriggerCount:        (name)              => Deno.core.ops.bsengine_get_slay_trigger_count(name),
+    isSlayJustTriggered:        (name)              => Deno.core.ops.bsengine_is_slay_just_triggered(name),
+    isSlayEnabled:              (name)              => Deno.core.ops.bsengine_is_slay_enabled(name),
+    registerKill:               (name)              => Deno.core.ops.bsengine_register_kill(name),
+    setSlayEnabled:             (name, v)           => Deno.core.ops.bsengine_set_slay_enabled(name, v),
+    getSlidePhase:              (name)              => Deno.core.ops.bsengine_get_slide_phase(name),
+    getSlideDirectionX:         (name)              => Deno.core.ops.bsengine_get_slide_direction_x(name),
+    getSlideDirectionY:         (name)              => Deno.core.ops.bsengine_get_slide_direction_y(name),
+    getSlideDirectionZ:         (name)              => Deno.core.ops.bsengine_get_slide_direction_z(name),
+    getSlideDuration:           (name)              => Deno.core.ops.bsengine_get_slide_duration(name),
+    getSlideBrakeStart:         (name)              => Deno.core.ops.bsengine_get_slide_brake_start(name),
+    getSlideElapsed:            (name)              => Deno.core.ops.bsengine_get_slide_elapsed(name),
+    getSlideSpeed:              (name)              => Deno.core.ops.bsengine_get_slide_speed(name),
+    slideWantsSlide:            (name)              => Deno.core.ops.bsengine_slide_wants_slide(name),
+    getSlideCrouchScale:        (name)              => Deno.core.ops.bsengine_get_slide_crouch_scale(name),
+    isSlideEnabled:             (name)              => Deno.core.ops.bsengine_is_slide_enabled(name),
+    startSlide:                 (name, x, y, z)    => Deno.core.ops.bsengine_start_slide(name, x, y, z),
+    cancelSlide:                (name)              => Deno.core.ops.bsengine_cancel_slide(name),
+    setSlideEnabled:            (name, v)           => Deno.core.ops.bsengine_set_slide_enabled(name, v),
+    getSlimeTimer:              (name)              => Deno.core.ops.bsengine_get_slime_timer(name),
+    getSlimeSlowFactor:         (name)              => Deno.core.ops.bsengine_get_slime_slow_factor(name),
+    isSlimed:                   (name)              => Deno.core.ops.bsengine_is_slimed(name),
+    isJustSlimed:               (name)              => Deno.core.ops.bsengine_is_just_slimed(name),
+    isJustSlimeCleansed:        (name)              => Deno.core.ops.bsengine_is_just_slime_cleansed(name),
+    isSlimeEnabled:             (name)              => Deno.core.ops.bsengine_is_slime_enabled(name),
+    applySlime:                 (name, duration)    => Deno.core.ops.bsengine_apply_slime(name, duration),
+    cleanseSlime:               (name)              => Deno.core.ops.bsengine_cleanse_slime(name),
+    setSlimeEnabled:            (name, v)           => Deno.core.ops.bsengine_set_slime_enabled(name, v),
+    isSlinkActive:              (name)              => Deno.core.ops.bsengine_is_slink_active(name),
+    getSlinkSpeedReduction:     (name)              => Deno.core.ops.bsengine_get_slink_speed_reduction(name),
+    getSlinkNoiseReduction:     (name)              => Deno.core.ops.bsengine_get_slink_noise_reduction(name),
+    isSlinkJustEngaged:         (name)              => Deno.core.ops.bsengine_is_slink_just_engaged(name),
+    isSlinkJustDisengaged:      (name)              => Deno.core.ops.bsengine_is_slink_just_disengaged(name),
+    isSlinkEnabled:             (name)              => Deno.core.ops.bsengine_is_slink_enabled(name),
+    engageSlink:                (name)              => Deno.core.ops.bsengine_engage_slink(name),
+    disengageSlink:             (name)              => Deno.core.ops.bsengine_disengage_slink(name),
+    setSlinkEnabled:            (name, v)           => Deno.core.ops.bsengine_set_slink_enabled(name, v),
+    getSlowMoTargetScale:       (name)              => Deno.core.ops.bsengine_get_slow_mo_target_scale(name),
+    getSlowMoCurrentScale:      (name)              => Deno.core.ops.bsengine_get_slow_mo_current_scale(name),
+    getSlowMoBlendSpeed:        (name)              => Deno.core.ops.bsengine_get_slow_mo_blend_speed(name),
+    getSlowMoMaxDuration:       (name)              => Deno.core.ops.bsengine_get_slow_mo_max_duration(name),
+    getSlowMoElapsed:           (name)              => Deno.core.ops.bsengine_get_slow_mo_elapsed(name),
+    getSlowMoCharge:            (name)              => Deno.core.ops.bsengine_get_slow_mo_charge(name),
+    getSlowMoDrainRate:         (name)              => Deno.core.ops.bsengine_get_slow_mo_drain_rate(name),
+    getSlowMoSource:            (name)              => Deno.core.ops.bsengine_get_slow_mo_source(name),
+    isSlowMoEnabled:            (name)              => Deno.core.ops.bsengine_is_slow_mo_enabled(name),
+    setSlowMoEnabled:           (name, v)           => Deno.core.ops.bsengine_set_slow_mo_enabled(name, v),
+    getSmokeStyle:              (name)              => Deno.core.ops.bsengine_get_smoke_style(name),
+    getSmokeRate:               (name)              => Deno.core.ops.bsengine_get_smoke_rate(name),
+    getSmokeColorR:             (name)              => Deno.core.ops.bsengine_get_smoke_color_r(name),
+    getSmokeColorG:             (name)              => Deno.core.ops.bsengine_get_smoke_color_g(name),
+    getSmokeColorB:             (name)              => Deno.core.ops.bsengine_get_smoke_color_b(name),
+    getSmokeColorA:             (name)              => Deno.core.ops.bsengine_get_smoke_color_a(name),
+    getSmokeParticleSpeed:      (name)              => Deno.core.ops.bsengine_get_smoke_particle_speed(name),
+    getSmokeSpreadRate:         (name)              => Deno.core.ops.bsengine_get_smoke_spread_rate(name),
+    getSmokeParticleLifetime:   (name)              => Deno.core.ops.bsengine_get_smoke_particle_lifetime(name),
+    getSmokeOffsetX:            (name)              => Deno.core.ops.bsengine_get_smoke_offset_x(name),
+    getSmokeOffsetY:            (name)              => Deno.core.ops.bsengine_get_smoke_offset_y(name),
+    getSmokeOffsetZ:            (name)              => Deno.core.ops.bsengine_get_smoke_offset_z(name),
+    getSmokeBurstDuration:      (name)              => Deno.core.ops.bsengine_get_smoke_burst_duration(name),
+    getSmokeElapsed:            (name)              => Deno.core.ops.bsengine_get_smoke_elapsed(name),
+    isSmokeEnabled:             (name)              => Deno.core.ops.bsengine_is_smoke_enabled(name),
+    setSmokeEnabled:            (name, v)           => Deno.core.ops.bsengine_set_smoke_enabled(name, v),
+    getSnareDuration:           (name)              => Deno.core.ops.bsengine_get_snare_duration(name),
+    getSnareTimer:              (name)              => Deno.core.ops.bsengine_get_snare_timer(name),
+    getSnareSlowFraction:       (name)              => Deno.core.ops.bsengine_get_snare_slow_fraction(name),
+    getSnareEscapeChance:       (name)              => Deno.core.ops.bsengine_get_snare_escape_chance(name),
+    isJustSnared:               (name)              => Deno.core.ops.bsengine_is_just_snared(name),
+    isJustSnareEscaped:         (name)              => Deno.core.ops.bsengine_is_just_snare_escaped(name),
+    isSnareEnabled:             (name)              => Deno.core.ops.bsengine_is_snare_enabled(name),
+    applySnare:                 (name, duration)    => Deno.core.ops.bsengine_apply_snare(name, duration),
+    clearSnare:                 (name)              => Deno.core.ops.bsengine_clear_snare(name),
+    setSnareEnabled:            (name, v)           => Deno.core.ops.bsengine_set_snare_enabled(name, v),
+    getSoakLevel:               (name)              => Deno.core.ops.bsengine_get_soak_level(name),
+    getSoakDecayRate:           (name)              => Deno.core.ops.bsengine_get_soak_decay_rate(name),
+    getSoakFireResistance:      (name)              => Deno.core.ops.bsengine_get_soak_fire_resistance(name),
+    getSoakLightningAmplify:    (name)              => Deno.core.ops.bsengine_get_soak_lightning_amplify(name),
+    isJustSoaked:               (name)              => Deno.core.ops.bsengine_is_just_soaked(name),
+    isJustDried:                (name)              => Deno.core.ops.bsengine_is_just_dried(name),
+    isSoakEnabled:              (name)              => Deno.core.ops.bsengine_is_soak_enabled(name),
+    absorbSoak:                 (name, amount)      => Deno.core.ops.bsengine_absorb_soak(name, amount),
+    setSoakEnabled:             (name, v)           => Deno.core.ops.bsengine_set_soak_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -47193,6 +48109,669 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetShuntResistance { name, resistance } if name == "Tank" && (*resistance - 0.75).abs() < 1e-5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetShuntCooldown { name, cooldown } if name == "Tank" && (*cooldown - 2.0).abs() < 1e-5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetShuntEnabled { name, enabled } if name == "Tank" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_silence_read_ops() {
+        super::SILENCE_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Mage".to_string(), (2.0f32, 0.5f32, true, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSilenceDuration("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSilenceTimer("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSilenced("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustUnsilenced("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSilenceEnabled("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SILENCE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_silence_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applySilence("Mage", 3.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearSilence("Mage");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSilenceEnabled("Mage", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplySilence { name, duration } if name == "Mage" && (*duration - 3.0).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearSilence { name } if name == "Mage")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSilenceEnabled { name, enabled } if name == "Mage" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_siphon_read_ops() {
+        super::SIPHON_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Mage".to_string(),
+                (4.0f32, 1.0f32, 0.5f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSiphonDuration("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "4");
+        let r = rt
+            .eval(r#"String(Bsengine.getSiphonTimer("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSiphonDrainPerSecond("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSiphonReturnFraction("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isSiphonJustStarted("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSiphonJustEnded("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSiphonEnabled("Mage"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SIPHON_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_siphon_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.startSiphon("Mage", 3.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.stopSiphon("Mage");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSiphonEnabled("Mage", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StartSiphon { name, duration } if name == "Mage" && (*duration - 3.0).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StopSiphon { name } if name == "Mage")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSiphonEnabled { name, enabled } if name == "Mage" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slam_read_ops() {
+        super::SLAM_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Warrior".to_string(),
+                (
+                    1u32, 10.0f32, 2.0f32, 5.0f32, 1.0f32, 4.0f32, 0.5f32, 0.25f32, 2.0f32,
+                    0.75f32, true, true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamPhase("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamSpeed("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamImpactRadius("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamImpactForce("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamMinHeight("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamLaunchHeight("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "4");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamRecoveryTime("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamRecoveryTimer("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamCooldown("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlamCooldownTimer("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.slamWantsSlam("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlamEnabled("Warrior"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SLAM_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slam_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.beginSlam("Warrior", 3.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.landSlam("Warrior");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSlamEnabled("Warrior", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BeginSlam { name, height } if name == "Warrior" && (*height - 3.0).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::LandSlam { name } if name == "Warrior")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSlamEnabled { name, enabled } if name == "Warrior" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slay_read_ops() {
+        super::SLAY_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hunter".to_string(), (5u32, 10u32, 2u32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSlayKillCount("Hunter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlayThreshold("Hunter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlayTriggerCount("Hunter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlayJustTriggered("Hunter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlayEnabled("Hunter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SLAY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slay_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.registerKill("Hunter");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSlayEnabled("Hunter", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RegisterKill { name } if name == "Hunter")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSlayEnabled { name, enabled } if name == "Hunter" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slide_read_ops() {
+        super::SLIDE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Runner".to_string(),
+                (
+                    1u32, 1.0f32, 0.0f32, 0.0f32, 0.75f32, 0.5f32, 0.25f32, 8.0f32, true, 0.5f32,
+                    true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSlidePhase("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlideDirectionX("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlideDirectionY("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlideDirectionZ("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlideDuration("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlideBrakeStart("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlideElapsed("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlideSpeed("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "8");
+        let r = rt
+            .eval(r#"String(Bsengine.slideWantsSlide("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlideCrouchScale("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlideEnabled("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SLIDE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slide_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.startSlide("Runner", 1.0, 0.0, 0.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.cancelSlide("Runner");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSlideEnabled("Runner", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StartSlide { name, dir_x, dir_y, dir_z } if name == "Runner" && (*dir_x - 1.0).abs() < 1e-5 && dir_y.abs() < 1e-5 && dir_z.abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CancelSlide { name } if name == "Runner")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSlideEnabled { name, enabled } if name == "Runner" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slime_read_ops() {
+        super::SLIME_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Goo".to_string(), (1.5f32, 0.5f32, true, true, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getSlimeTimer("Goo"))"#).unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlimeSlowFactor("Goo"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt.eval(r#"String(Bsengine.isSlimed("Goo"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt.eval(r#"String(Bsengine.isJustSlimed("Goo"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSlimeCleansed("Goo"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlimeEnabled("Goo"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SLIME_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slime_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applySlime("Goo", 2.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.cleanseSlime("Goo");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSlimeEnabled("Goo", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplySlime { name, duration } if name == "Goo" && (*duration - 2.0).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CleanseSlime { name } if name == "Goo")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSlimeEnabled { name, enabled } if name == "Goo" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slink_read_ops() {
+        super::SLINK_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Thief".to_string(),
+                (true, 0.25f32, 0.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.isSlinkActive("Thief"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlinkSpeedReduction("Thief"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlinkNoiseReduction("Thief"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlinkJustEngaged("Thief"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlinkJustDisengaged("Thief"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlinkEnabled("Thief"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SLINK_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slink_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.engageSlink("Thief");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.disengageSlink("Thief");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSlinkEnabled("Thief", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::EngageSlink { name } if name == "Thief")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DisengageSlink { name } if name == "Thief")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSlinkEnabled { name, enabled } if name == "Thief" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slow_mo_read_ops() {
+        super::SLOW_MO_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "World".to_string(),
+                (
+                    0.25f32, 0.5f32, 2.0f32, 4.0f32, 1.0f32, 0.75f32, 0.5f32, 0u32, true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSlowMoTargetScale("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlowMoCurrentScale("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlowMoBlendSpeed("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlowMoMaxDuration("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "4");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlowMoElapsed("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlowMoCharge("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlowMoDrainRate("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSlowMoSource("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0");
+        let r = rt
+            .eval(r#"String(Bsengine.isSlowMoEnabled("World"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SLOW_MO_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_slow_mo_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setSlowMoEnabled("World", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSlowMoEnabled { name, enabled } if name == "World" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_smoke_read_ops() {
+        super::SMOKE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Barrel".to_string(),
+                (
+                    1u32, 2.0f32, 0.5f32, 0.5f32, 0.5f32, 1.0f32, 1.0f32, 0.25f32, 2.0f32, 0.0f32,
+                    0.0f32, 0.0f32, 0.5f32, 1.0f32, true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeStyle("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeRate("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeColorR("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeColorG("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeColorB("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeColorA("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeParticleSpeed("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeSpreadRate("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeParticleLifetime("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeOffsetX("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeOffsetY("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeOffsetZ("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeBurstDuration("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSmokeElapsed("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.isSmokeEnabled("Barrel"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SMOKE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_smoke_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setSmokeEnabled("Barrel", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSmokeEnabled { name, enabled } if name == "Barrel" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_snare_read_ops() {
+        super::SNARE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Rabbit".to_string(),
+                (3.0f32, 1.5f32, 0.5f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSnareDuration("Rabbit"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getSnareTimer("Rabbit"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSnareSlowFraction("Rabbit"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSnareEscapeChance("Rabbit"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSnared("Rabbit"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSnareEscaped("Rabbit"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSnareEnabled("Rabbit"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SNARE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_snare_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applySnare("Rabbit", 2.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearSnare("Rabbit");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSnareEnabled("Rabbit", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplySnare { name, duration } if name == "Rabbit" && (*duration - 2.0).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearSnare { name } if name == "Rabbit")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSnareEnabled { name, enabled } if name == "Rabbit" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_soak_read_ops() {
+        super::SOAK_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Wet".to_string(),
+                (0.75f32, 0.25f32, 0.5f32, 1.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getSoakLevel("Wet"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getSoakDecayRate("Wet"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getSoakFireResistance("Wet"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSoakLightningAmplify("Wet"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt.eval(r#"String(Bsengine.isJustSoaked("Wet"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt.eval(r#"String(Bsengine.isJustDried("Wet"))"#).unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isSoakEnabled("Wet"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SOAK_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_soak_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.absorbSoak("Wet", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSoakEnabled("Wet", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AbsorbSoak { name, amount } if name == "Wet" && (*amount - 0.5).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSoakEnabled { name, enabled } if name == "Wet" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -3674,6 +3674,116 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Spike ────────────────────────────────────────────────────────────────
+    ExtendSpike {
+        name: String,
+        duration: f32,
+    },
+    RetractSpike {
+        name: String,
+    },
+    SetSpikeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Splinter ─────────────────────────────────────────────────────────────
+    SetSplinterEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Stagger ──────────────────────────────────────────────────────────────
+    ApplyStagger {
+        name: String,
+        force: f32,
+    },
+    ResetStagger {
+        name: String,
+    },
+    SetStaggerEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Stake ────────────────────────────────────────────────────────────────
+    SetStakeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Stalk ────────────────────────────────────────────────────────────────
+    BeginStalk {
+        name: String,
+    },
+    SetStalkEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Stance ───────────────────────────────────────────────────────────────
+    SetStance {
+        name: String,
+        kind: u32,
+    },
+    SetStanceEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Stat ─────────────────────────────────────────────────────────────────
+    AddStatBonus {
+        name: String,
+        amount: f32,
+    },
+    RemoveStatBonus {
+        name: String,
+        amount: f32,
+    },
+    // ── Stealth ──────────────────────────────────────────────────────────────
+    StartSneaking {
+        name: String,
+    },
+    StopSneaking {
+        name: String,
+    },
+    AddNoise {
+        name: String,
+        amount: f32,
+    },
+    SetStealthEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Stomp ────────────────────────────────────────────────────────────────
+    TriggerStomp {
+        name: String,
+    },
+    SetStompEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Stride ───────────────────────────────────────────────────────────────
+    StepStride {
+        name: String,
+    },
+    BreakStride {
+        name: String,
+    },
+    SetStrideEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Strife ───────────────────────────────────────────────────────────────
+    HitStrife {
+        name: String,
+    },
+    SetStrifeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Stumble ──────────────────────────────────────────────────────────────
+    TriggerStumble {
+        name: String,
+    },
+    SetStumbleEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -4688,6 +4798,42 @@ thread_local! {
         RefCell::new(HashMap::new());
     // entity name → (soak_level, decay_rate, fire_resistance, lightning_amplify, just_soaked, just_dried, enabled)
     pub(crate) static SOAK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (duration, timer, damage, push_force, just_extended, just_retracted, enabled)
+    pub(crate) static SPIKE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (threshold, radius, damage_fraction, cooldown, cooldown_timer, just_splintered, enabled)
+    pub(crate) static SPLINTER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (phase, stagger_threshold, stagger_duration, stagger_timer, recovery_duration, recovery_timer, stagger_count, resist, just_staggered, enabled)
+    pub(crate) static STAGGER_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, f32, f32, u32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (active, hold_timer, min_hold, damage_bonus, just_staked, just_broke, enabled)
+    pub(crate) static STAKE_SNAPSHOT: RefCell<HashMap<String, (bool, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (active, damage_multiplier, just_began, just_consumed, enabled)
+    pub(crate) static STALK_SNAPSHOT: RefCell<HashMap<String, (bool, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (current, offense_bonus, defense_reduction, just_changed, enabled)
+    pub(crate) static STANCE_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (base, bonus, multiplier, min, max)
+    pub(crate) static STAT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (base_visibility, visibility_modifier, noise_level, noise_decay_rate, sneaking, sneak_visibility_scale, enabled)
+    pub(crate) static STEALTH_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, f32, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (magnitude, impact_radius, damage_per_unit, just_stomped, enabled)
+    pub(crate) static STOMP_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (stride_count, max_strides, speed_bonus, just_peaked, just_broke, enabled)
+    pub(crate) static STRIDE_SNAPSHOT: RefCell<HashMap<String, (u32, u32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (strife, max_strife, gain_per_hit, decay_rate, just_peaked, enabled)
+    pub(crate) static STRIFE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    // entity name → (stumble_timer, stumble_duration, vulnerability_factor, move_penalty, stumble_count, stumbling, just_stumbled, just_recovered, enabled)
+    pub(crate) static STUMBLE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, u32, bool, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -7166,6 +7312,490 @@ pub fn bsengine_set_shunt_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetShuntEnabled { name, enabled })
+    });
+}
+// ── Spike ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_spike_duration(#[string] name: String) -> f32 {
+    SPIKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_spike_timer(#[string] name: String) -> f32 {
+    SPIKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_spike_damage(#[string] name: String) -> f32 {
+    SPIKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_spike_push_force(#[string] name: String) -> f32 {
+    SPIKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_spike_just_extended(#[string] name: String) -> bool {
+    SPIKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_spike_just_retracted(#[string] name: String) -> bool {
+    SPIKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_spike_enabled(#[string] name: String) -> bool {
+    SPIKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_extend_spike(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ExtendSpike { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_retract_spike(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::RetractSpike { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_spike_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSpikeEnabled { name, enabled })
+    });
+}
+// ── Splinter ─────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_splinter_threshold(#[string] name: String) -> f32 {
+    SPLINTER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_splinter_radius(#[string] name: String) -> f32 {
+    SPLINTER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_splinter_damage_fraction(#[string] name: String) -> f32 {
+    SPLINTER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_splinter_cooldown(#[string] name: String) -> f32 {
+    SPLINTER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_splinter_cooldown_timer(#[string] name: String) -> f32 {
+    SPLINTER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_splintered(#[string] name: String) -> bool {
+    SPLINTER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_splinter_enabled(#[string] name: String) -> bool {
+    SPLINTER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_splinter_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSplinterEnabled { name, enabled })
+    });
+}
+// ── Stagger ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_stagger_phase(#[string] name: String) -> u32 {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stagger_threshold(#[string] name: String) -> f32 {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stagger_duration(#[string] name: String) -> f32 {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stagger_timer(#[string] name: String) -> f32 {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stagger_recovery_duration(#[string] name: String) -> f32 {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stagger_recovery_timer(#[string] name: String) -> f32 {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stagger_count(#[string] name: String) -> u32 {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stagger_resist(#[string] name: String) -> f32 {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_staggered(#[string] name: String) -> bool {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.8).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stagger_enabled(#[string] name: String) -> bool {
+    STAGGER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.9).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_stagger(#[string] name: String, force: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyStagger { name, force })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_reset_stagger(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResetStagger { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_stagger_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStaggerEnabled { name, enabled })
+    });
+}
+// ── Stake ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_is_stake_active(#[string] name: String) -> bool {
+    STAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_get_stake_hold_timer(#[string] name: String) -> f32 {
+    STAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stake_min_hold(#[string] name: String) -> f32 {
+    STAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stake_damage_bonus(#[string] name: String) -> f32 {
+    STAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_stake_just_staked(#[string] name: String) -> bool {
+    STAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stake_just_broke(#[string] name: String) -> bool {
+    STAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stake_enabled(#[string] name: String) -> bool {
+    STAKE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_stake_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStakeEnabled { name, enabled })
+    });
+}
+// ── Stalk ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_is_stalk_active(#[string] name: String) -> bool {
+    STALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_get_stalk_damage_multiplier(#[string] name: String) -> f32 {
+    STALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_stalk_just_began(#[string] name: String) -> bool {
+    STALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stalk_just_consumed(#[string] name: String) -> bool {
+    STALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stalk_enabled(#[string] name: String) -> bool {
+    STALK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_begin_stalk(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::BeginStalk { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_stalk_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStalkEnabled { name, enabled })
+    });
+}
+// ── Stance ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_stance_current(#[string] name: String) -> u32 {
+    STANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stance_offense_bonus(#[string] name: String) -> f32 {
+    STANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stance_defense_reduction(#[string] name: String) -> f32 {
+    STANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_stance_just_changed(#[string] name: String) -> bool {
+    STANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stance_enabled(#[string] name: String) -> bool {
+    STANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_stance(#[string] name: String, kind: u32) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SetStance { name, kind }));
+}
+#[op2(fast)]
+pub fn bsengine_set_stance_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStanceEnabled { name, enabled })
+    });
+}
+// ── Stat ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_stat_base(#[string] name: String) -> f32 {
+    STAT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stat_bonus(#[string] name: String) -> f32 {
+    STAT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stat_multiplier(#[string] name: String) -> f32 {
+    STAT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stat_min(#[string] name: String) -> f32 {
+    STAT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stat_max(#[string] name: String) -> f32 {
+    STAT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_add_stat_bonus(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AddStatBonus { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_remove_stat_bonus(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RemoveStatBonus { name, amount })
+    });
+}
+// ── Stealth ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_stealth_base_visibility(#[string] name: String) -> f32 {
+    STEALTH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stealth_visibility_modifier(#[string] name: String) -> f32 {
+    STEALTH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stealth_noise_level(#[string] name: String) -> f32 {
+    STEALTH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stealth_noise_decay_rate(#[string] name: String) -> f32 {
+    STEALTH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_sneaking(#[string] name: String) -> bool {
+    STEALTH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_get_stealth_sneak_visibility_scale(#[string] name: String) -> f32 {
+    STEALTH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_stealth_enabled(#[string] name: String) -> bool {
+    STEALTH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_start_sneaking(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StartSneaking { name }));
+}
+#[op2(fast)]
+pub fn bsengine_stop_sneaking(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StopSneaking { name }));
+}
+#[op2(fast)]
+pub fn bsengine_add_noise(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AddNoise { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_stealth_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStealthEnabled { name, enabled })
+    });
+}
+// ── Stomp ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_stomp_magnitude(#[string] name: String) -> f32 {
+    STOMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stomp_impact_radius(#[string] name: String) -> f32 {
+    STOMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stomp_damage_per_unit(#[string] name: String) -> f32 {
+    STOMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_stomped(#[string] name: String) -> bool {
+    STOMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stomp_enabled(#[string] name: String) -> bool {
+    STOMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_trigger_stomp(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::TriggerStomp { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_stomp_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStompEnabled { name, enabled })
+    });
+}
+// ── Stride ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_stride_count(#[string] name: String) -> u32 {
+    STRIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stride_max_strides(#[string] name: String) -> u32 {
+    STRIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stride_speed_bonus(#[string] name: String) -> f32 {
+    STRIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_stride_just_peaked(#[string] name: String) -> bool {
+    STRIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stride_just_broke(#[string] name: String) -> bool {
+    STRIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stride_enabled(#[string] name: String) -> bool {
+    STRIDE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_step_stride(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StepStride { name }));
+}
+#[op2(fast)]
+pub fn bsengine_break_stride(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::BreakStride { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_stride_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStrideEnabled { name, enabled })
+    });
+}
+// ── Strife ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_strife_value(#[string] name: String) -> f32 {
+    STRIFE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_strife_max(#[string] name: String) -> f32 {
+    STRIFE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_strife_gain_per_hit(#[string] name: String) -> f32 {
+    STRIFE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_strife_decay_rate(#[string] name: String) -> f32 {
+    STRIFE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_strife_just_peaked(#[string] name: String) -> bool {
+    STRIFE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_strife_enabled(#[string] name: String) -> bool {
+    STRIFE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_hit_strife(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::HitStrife { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_strife_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStrifeEnabled { name, enabled })
+    });
+}
+// ── Stumble ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_stumble_timer(#[string] name: String) -> f32 {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stumble_duration(#[string] name: String) -> f32 {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stumble_vulnerability_factor(#[string] name: String) -> f32 {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stumble_move_penalty(#[string] name: String) -> f32 {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_stumble_count(#[string] name: String) -> u32 {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_is_stumbling(#[string] name: String) -> bool {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_stumbled(#[string] name: String) -> bool {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_stumble_recovered(#[string] name: String) -> bool {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_stumble_enabled(#[string] name: String) -> bool {
+    STUMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.8).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_trigger_stumble(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::TriggerStumble { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_stumble_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetStumbleEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -26571,6 +27201,112 @@ deno_core::extension!(
         bsengine_is_soak_enabled,
         bsengine_absorb_soak,
         bsengine_set_soak_enabled,
+        bsengine_get_spike_duration,
+        bsengine_get_spike_timer,
+        bsengine_get_spike_damage,
+        bsengine_get_spike_push_force,
+        bsengine_is_spike_just_extended,
+        bsengine_is_spike_just_retracted,
+        bsengine_is_spike_enabled,
+        bsengine_extend_spike,
+        bsengine_retract_spike,
+        bsengine_set_spike_enabled,
+        bsengine_get_splinter_threshold,
+        bsengine_get_splinter_radius,
+        bsengine_get_splinter_damage_fraction,
+        bsengine_get_splinter_cooldown,
+        bsengine_get_splinter_cooldown_timer,
+        bsengine_is_just_splintered,
+        bsengine_is_splinter_enabled,
+        bsengine_set_splinter_enabled,
+        bsengine_get_stagger_phase,
+        bsengine_get_stagger_threshold,
+        bsengine_get_stagger_duration,
+        bsengine_get_stagger_timer,
+        bsengine_get_stagger_recovery_duration,
+        bsengine_get_stagger_recovery_timer,
+        bsengine_get_stagger_count,
+        bsengine_get_stagger_resist,
+        bsengine_is_just_staggered,
+        bsengine_is_stagger_enabled,
+        bsengine_apply_stagger,
+        bsengine_reset_stagger,
+        bsengine_set_stagger_enabled,
+        bsengine_is_stake_active,
+        bsengine_get_stake_hold_timer,
+        bsengine_get_stake_min_hold,
+        bsengine_get_stake_damage_bonus,
+        bsengine_is_stake_just_staked,
+        bsengine_is_stake_just_broke,
+        bsengine_is_stake_enabled,
+        bsengine_set_stake_enabled,
+        bsengine_is_stalk_active,
+        bsengine_get_stalk_damage_multiplier,
+        bsengine_is_stalk_just_began,
+        bsengine_is_stalk_just_consumed,
+        bsengine_is_stalk_enabled,
+        bsengine_begin_stalk,
+        bsengine_set_stalk_enabled,
+        bsengine_get_stance_current,
+        bsengine_get_stance_offense_bonus,
+        bsengine_get_stance_defense_reduction,
+        bsengine_is_stance_just_changed,
+        bsengine_is_stance_enabled,
+        bsengine_set_stance,
+        bsengine_set_stance_enabled,
+        bsengine_get_stat_base,
+        bsengine_get_stat_bonus,
+        bsengine_get_stat_multiplier,
+        bsengine_get_stat_min,
+        bsengine_get_stat_max,
+        bsengine_add_stat_bonus,
+        bsengine_remove_stat_bonus,
+        bsengine_get_stealth_base_visibility,
+        bsengine_get_stealth_visibility_modifier,
+        bsengine_get_stealth_noise_level,
+        bsengine_get_stealth_noise_decay_rate,
+        bsengine_is_sneaking,
+        bsengine_get_stealth_sneak_visibility_scale,
+        bsengine_is_stealth_enabled,
+        bsengine_start_sneaking,
+        bsengine_stop_sneaking,
+        bsengine_add_noise,
+        bsengine_set_stealth_enabled,
+        bsengine_get_stomp_magnitude,
+        bsengine_get_stomp_impact_radius,
+        bsengine_get_stomp_damage_per_unit,
+        bsengine_is_just_stomped,
+        bsengine_is_stomp_enabled,
+        bsengine_trigger_stomp,
+        bsengine_set_stomp_enabled,
+        bsengine_get_stride_count,
+        bsengine_get_stride_max_strides,
+        bsengine_get_stride_speed_bonus,
+        bsengine_is_stride_just_peaked,
+        bsengine_is_stride_just_broke,
+        bsengine_is_stride_enabled,
+        bsengine_step_stride,
+        bsengine_break_stride,
+        bsengine_set_stride_enabled,
+        bsengine_get_strife_value,
+        bsengine_get_strife_max,
+        bsengine_get_strife_gain_per_hit,
+        bsengine_get_strife_decay_rate,
+        bsengine_is_strife_just_peaked,
+        bsengine_is_strife_enabled,
+        bsengine_hit_strife,
+        bsengine_set_strife_enabled,
+        bsengine_get_stumble_timer,
+        bsengine_get_stumble_duration,
+        bsengine_get_stumble_vulnerability_factor,
+        bsengine_get_stumble_move_penalty,
+        bsengine_get_stumble_count,
+        bsengine_is_stumbling,
+        bsengine_is_just_stumbled,
+        bsengine_is_just_stumble_recovered,
+        bsengine_is_stumble_enabled,
+        bsengine_trigger_stumble,
+        bsengine_set_stumble_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -29388,6 +30124,112 @@ const Bsengine = {
     isSoakEnabled:              (name)              => Deno.core.ops.bsengine_is_soak_enabled(name),
     absorbSoak:                 (name, amount)      => Deno.core.ops.bsengine_absorb_soak(name, amount),
     setSoakEnabled:             (name, v)           => Deno.core.ops.bsengine_set_soak_enabled(name, v),
+    getSpikeDuration:           (name)              => Deno.core.ops.bsengine_get_spike_duration(name),
+    getSpikeTimer:              (name)              => Deno.core.ops.bsengine_get_spike_timer(name),
+    getSpikeDamage:             (name)              => Deno.core.ops.bsengine_get_spike_damage(name),
+    getSpikePushForce:          (name)              => Deno.core.ops.bsengine_get_spike_push_force(name),
+    isSpikeJustExtended:        (name)              => Deno.core.ops.bsengine_is_spike_just_extended(name),
+    isSpikeJustRetracted:       (name)              => Deno.core.ops.bsengine_is_spike_just_retracted(name),
+    isSpikeEnabled:             (name)              => Deno.core.ops.bsengine_is_spike_enabled(name),
+    extendSpike:                (name, duration)    => Deno.core.ops.bsengine_extend_spike(name, duration),
+    retractSpike:               (name)              => Deno.core.ops.bsengine_retract_spike(name),
+    setSpikeEnabled:            (name, v)           => Deno.core.ops.bsengine_set_spike_enabled(name, v),
+    getSplinterThreshold:       (name)              => Deno.core.ops.bsengine_get_splinter_threshold(name),
+    getSplinterRadius:          (name)              => Deno.core.ops.bsengine_get_splinter_radius(name),
+    getSplinterDamageFraction:  (name)              => Deno.core.ops.bsengine_get_splinter_damage_fraction(name),
+    getSplinterCooldown:        (name)              => Deno.core.ops.bsengine_get_splinter_cooldown(name),
+    getSplinterCooldownTimer:   (name)              => Deno.core.ops.bsengine_get_splinter_cooldown_timer(name),
+    isJustSplintered:           (name)              => Deno.core.ops.bsengine_is_just_splintered(name),
+    isSplinterEnabled:          (name)              => Deno.core.ops.bsengine_is_splinter_enabled(name),
+    setSplinterEnabled:         (name, v)           => Deno.core.ops.bsengine_set_splinter_enabled(name, v),
+    getStaggerPhase:            (name)              => Deno.core.ops.bsengine_get_stagger_phase(name),
+    getStaggerThreshold:        (name)              => Deno.core.ops.bsengine_get_stagger_threshold(name),
+    getStaggerDuration:         (name)              => Deno.core.ops.bsengine_get_stagger_duration(name),
+    getStaggerTimer:            (name)              => Deno.core.ops.bsengine_get_stagger_timer(name),
+    getStaggerRecoveryDuration: (name)              => Deno.core.ops.bsengine_get_stagger_recovery_duration(name),
+    getStaggerRecoveryTimer:    (name)              => Deno.core.ops.bsengine_get_stagger_recovery_timer(name),
+    getStaggerCount:            (name)              => Deno.core.ops.bsengine_get_stagger_count(name),
+    getStaggerResist:           (name)              => Deno.core.ops.bsengine_get_stagger_resist(name),
+    isJustStaggered:            (name)              => Deno.core.ops.bsengine_is_just_staggered(name),
+    isStaggerEnabled:           (name)              => Deno.core.ops.bsengine_is_stagger_enabled(name),
+    applyStagger:               (name, force)       => Deno.core.ops.bsengine_apply_stagger(name, force),
+    resetStagger:               (name)              => Deno.core.ops.bsengine_reset_stagger(name),
+    setStaggerEnabled:          (name, v)           => Deno.core.ops.bsengine_set_stagger_enabled(name, v),
+    isStakeActive:              (name)              => Deno.core.ops.bsengine_is_stake_active(name),
+    getStakeHoldTimer:          (name)              => Deno.core.ops.bsengine_get_stake_hold_timer(name),
+    getStakeMinHold:            (name)              => Deno.core.ops.bsengine_get_stake_min_hold(name),
+    getStakeDamageBonus:        (name)              => Deno.core.ops.bsengine_get_stake_damage_bonus(name),
+    isStakeJustStaked:          (name)              => Deno.core.ops.bsengine_is_stake_just_staked(name),
+    isStakeJustBroke:           (name)              => Deno.core.ops.bsengine_is_stake_just_broke(name),
+    isStakeEnabled:             (name)              => Deno.core.ops.bsengine_is_stake_enabled(name),
+    setStakeEnabled:            (name, v)           => Deno.core.ops.bsengine_set_stake_enabled(name, v),
+    isStalkActive:              (name)              => Deno.core.ops.bsengine_is_stalk_active(name),
+    getStalkDamageMultiplier:   (name)              => Deno.core.ops.bsengine_get_stalk_damage_multiplier(name),
+    isStalkJustBegan:           (name)              => Deno.core.ops.bsengine_is_stalk_just_began(name),
+    isStalkJustConsumed:        (name)              => Deno.core.ops.bsengine_is_stalk_just_consumed(name),
+    isStalkEnabled:             (name)              => Deno.core.ops.bsengine_is_stalk_enabled(name),
+    beginStalk:                 (name)              => Deno.core.ops.bsengine_begin_stalk(name),
+    setStalkEnabled:            (name, v)           => Deno.core.ops.bsengine_set_stalk_enabled(name, v),
+    getStanceCurrent:           (name)              => Deno.core.ops.bsengine_get_stance_current(name),
+    getStanceOffenseBonus:      (name)              => Deno.core.ops.bsengine_get_stance_offense_bonus(name),
+    getStanceDefenseReduction:  (name)              => Deno.core.ops.bsengine_get_stance_defense_reduction(name),
+    isStanceJustChanged:        (name)              => Deno.core.ops.bsengine_is_stance_just_changed(name),
+    isStanceEnabled:            (name)              => Deno.core.ops.bsengine_is_stance_enabled(name),
+    setStance:                  (name, kind)        => Deno.core.ops.bsengine_set_stance(name, kind),
+    setStanceEnabled:           (name, v)           => Deno.core.ops.bsengine_set_stance_enabled(name, v),
+    getStatBase:                (name)              => Deno.core.ops.bsengine_get_stat_base(name),
+    getStatBonus:               (name)              => Deno.core.ops.bsengine_get_stat_bonus(name),
+    getStatMultiplier:          (name)              => Deno.core.ops.bsengine_get_stat_multiplier(name),
+    getStatMin:                 (name)              => Deno.core.ops.bsengine_get_stat_min(name),
+    getStatMax:                 (name)              => Deno.core.ops.bsengine_get_stat_max(name),
+    addStatBonus:               (name, amount)      => Deno.core.ops.bsengine_add_stat_bonus(name, amount),
+    removeStatBonus:            (name, amount)      => Deno.core.ops.bsengine_remove_stat_bonus(name, amount),
+    getStealthBaseVisibility:   (name)              => Deno.core.ops.bsengine_get_stealth_base_visibility(name),
+    getStealthVisibilityMod:    (name)              => Deno.core.ops.bsengine_get_stealth_visibility_modifier(name),
+    getStealthNoiseLevel:       (name)              => Deno.core.ops.bsengine_get_stealth_noise_level(name),
+    getStealthNoiseDecayRate:   (name)              => Deno.core.ops.bsengine_get_stealth_noise_decay_rate(name),
+    isSneaking:                 (name)              => Deno.core.ops.bsengine_is_sneaking(name),
+    getStealthSneakVisScale:    (name)              => Deno.core.ops.bsengine_get_stealth_sneak_visibility_scale(name),
+    isStealthEnabled:           (name)              => Deno.core.ops.bsengine_is_stealth_enabled(name),
+    startSneaking:              (name)              => Deno.core.ops.bsengine_start_sneaking(name),
+    stopSneaking:               (name)              => Deno.core.ops.bsengine_stop_sneaking(name),
+    addNoise:                   (name, amount)      => Deno.core.ops.bsengine_add_noise(name, amount),
+    setStealthEnabled:          (name, v)           => Deno.core.ops.bsengine_set_stealth_enabled(name, v),
+    getStompMagnitude:          (name)              => Deno.core.ops.bsengine_get_stomp_magnitude(name),
+    getStompImpactRadius:       (name)              => Deno.core.ops.bsengine_get_stomp_impact_radius(name),
+    getStompDamagePerUnit:      (name)              => Deno.core.ops.bsengine_get_stomp_damage_per_unit(name),
+    isJustStomped:              (name)              => Deno.core.ops.bsengine_is_just_stomped(name),
+    isStompEnabled:             (name)              => Deno.core.ops.bsengine_is_stomp_enabled(name),
+    triggerStomp:               (name)              => Deno.core.ops.bsengine_trigger_stomp(name),
+    setStompEnabled:            (name, v)           => Deno.core.ops.bsengine_set_stomp_enabled(name, v),
+    getStrideCount:             (name)              => Deno.core.ops.bsengine_get_stride_count(name),
+    getStrideMaxStrides:        (name)              => Deno.core.ops.bsengine_get_stride_max_strides(name),
+    getStrideSpeedBonus:        (name)              => Deno.core.ops.bsengine_get_stride_speed_bonus(name),
+    isStrideJustPeaked:         (name)              => Deno.core.ops.bsengine_is_stride_just_peaked(name),
+    isStrideJustBroke:          (name)              => Deno.core.ops.bsengine_is_stride_just_broke(name),
+    isStrideEnabled:            (name)              => Deno.core.ops.bsengine_is_stride_enabled(name),
+    stepStride:                 (name)              => Deno.core.ops.bsengine_step_stride(name),
+    breakStride:                (name)              => Deno.core.ops.bsengine_break_stride(name),
+    setStrideEnabled:           (name, v)           => Deno.core.ops.bsengine_set_stride_enabled(name, v),
+    getStrifeValue:             (name)              => Deno.core.ops.bsengine_get_strife_value(name),
+    getStrifeMax:               (name)              => Deno.core.ops.bsengine_get_strife_max(name),
+    getStrifeGainPerHit:        (name)              => Deno.core.ops.bsengine_get_strife_gain_per_hit(name),
+    getStrifeDecayRate:         (name)              => Deno.core.ops.bsengine_get_strife_decay_rate(name),
+    isStrifeJustPeaked:         (name)              => Deno.core.ops.bsengine_is_strife_just_peaked(name),
+    isStrifeEnabled:            (name)              => Deno.core.ops.bsengine_is_strife_enabled(name),
+    hitStrife:                  (name)              => Deno.core.ops.bsengine_hit_strife(name),
+    setStrifeEnabled:           (name, v)           => Deno.core.ops.bsengine_set_strife_enabled(name, v),
+    getStumbleTimer:            (name)              => Deno.core.ops.bsengine_get_stumble_timer(name),
+    getStumbleDuration:         (name)              => Deno.core.ops.bsengine_get_stumble_duration(name),
+    getStumbleVulnerabilityFactor: (name)           => Deno.core.ops.bsengine_get_stumble_vulnerability_factor(name),
+    getStumbleMovePenalty:      (name)              => Deno.core.ops.bsengine_get_stumble_move_penalty(name),
+    getStumbleCount:            (name)              => Deno.core.ops.bsengine_get_stumble_count(name),
+    isStumbling:                (name)              => Deno.core.ops.bsengine_is_stumbling(name),
+    isJustStumbled:             (name)              => Deno.core.ops.bsengine_is_just_stumbled(name),
+    isJustStumbleRecovered:     (name)              => Deno.core.ops.bsengine_is_just_stumble_recovered(name),
+    isStumbleEnabled:           (name)              => Deno.core.ops.bsengine_is_stumble_enabled(name),
+    triggerStumble:             (name)              => Deno.core.ops.bsengine_trigger_stumble(name),
+    setStumbleEnabled:          (name, v)           => Deno.core.ops.bsengine_set_stumble_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -48772,6 +49614,644 @@ JSON.stringify(received)
             let buf = c.borrow();
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AbsorbSoak { name, amount } if name == "Wet" && (*amount - 0.5).abs() < 1e-5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSoakEnabled { name, enabled } if name == "Wet" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_spike_read_ops() {
+        super::SPIKE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hedgehog".to_string(),
+                (2.0f32, 0.5f32, 3.0f32, 1.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSpikeDuration("Hedgehog"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSpikeTimer("Hedgehog"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSpikeDamage("Hedgehog"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getSpikePushForce("Hedgehog"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isSpikeJustExtended("Hedgehog"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSpikeJustRetracted("Hedgehog"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isSpikeEnabled("Hedgehog"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SPIKE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_spike_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.extendSpike("Hedgehog", 1.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.retractSpike("Hedgehog");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setSpikeEnabled("Hedgehog", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ExtendSpike { name, duration } if name == "Hedgehog" && (*duration - 1.5).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RetractSpike { name } if name == "Hedgehog")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSpikeEnabled { name, enabled } if name == "Hedgehog" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_splinter_read_ops() {
+        super::SPLINTER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Glass".to_string(),
+                (10.0f32, 2.0f32, 0.5f32, 1.0f32, 0.25f32, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getSplinterThreshold("Glass"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt
+            .eval(r#"String(Bsengine.getSplinterRadius("Glass"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getSplinterDamageFraction("Glass"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getSplinterCooldown("Glass"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getSplinterCooldownTimer("Glass"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustSplintered("Glass"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isSplinterEnabled("Glass"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::SPLINTER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_splinter_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setSplinterEnabled("Glass", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetSplinterEnabled { name, enabled } if name == "Glass" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stagger_read_ops() {
+        super::STAGGER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Boss".to_string(),
+                (
+                    1u32, 20.0f32, 0.5f32, 0.25f32, 1.0f32, 0.75f32, 3u32, 0.5f32, true, true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getStaggerPhase("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getStaggerThreshold("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "20");
+        let r = rt
+            .eval(r#"String(Bsengine.getStaggerDuration("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getStaggerTimer("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getStaggerRecoveryDuration("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getStaggerRecoveryTimer("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getStaggerCount("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.getStaggerResist("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustStaggered("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isStaggerEnabled("Boss"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STAGGER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stagger_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyStagger("Boss", 15.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.resetStagger("Boss");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setStaggerEnabled("Boss", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyStagger { name, force } if name == "Boss" && (*force - 15.0).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ResetStagger { name } if name == "Boss")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStaggerEnabled { name, enabled } if name == "Boss" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stake_read_ops() {
+        super::STAKE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Knight".to_string(),
+                (true, 0.5f32, 0.25f32, 1.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.isStakeActive("Knight"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.getStakeHoldTimer("Knight"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getStakeMinHold("Knight"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getStakeDamageBonus("Knight"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isStakeJustStaked("Knight"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isStakeJustBroke("Knight"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isStakeEnabled("Knight"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STAKE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stake_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setStakeEnabled("Knight", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStakeEnabled { name, enabled } if name == "Knight" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stalk_read_ops() {
+        super::STALK_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Predator".to_string(), (true, 2.0f32, true, false, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.isStalkActive("Predator"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.getStalkDamageMultiplier("Predator"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.isStalkJustBegan("Predator"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isStalkJustConsumed("Predator"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isStalkEnabled("Predator"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STALK_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stalk_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.beginStalk("Predator");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setStalkEnabled("Predator", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BeginStalk { name } if name == "Predator")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStalkEnabled { name, enabled } if name == "Predator" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stance_read_ops() {
+        super::STANCE_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Fighter".to_string(), (1u32, 0.25f32, 0.5f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getStanceCurrent("Fighter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getStanceOffenseBonus("Fighter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getStanceDefenseReduction("Fighter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isStanceJustChanged("Fighter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isStanceEnabled("Fighter"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STANCE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stance_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setStance("Fighter", 2);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setStanceEnabled("Fighter", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStance { name, kind } if name == "Fighter" && *kind == 2)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStanceEnabled { name, enabled } if name == "Fighter" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stat_read_ops() {
+        super::STAT_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (10.0f32, 2.0f32, 1.5f32, 0.0f32, 20.0f32),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getStatBase("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt.eval(r#"String(Bsengine.getStatBonus("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getStatMultiplier("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt.eval(r#"String(Bsengine.getStatMin("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0");
+        let r = rt.eval(r#"String(Bsengine.getStatMax("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "20");
+        super::STAT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stat_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.addStatBonus("Hero", 5.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.removeStatBonus("Hero", 2.0);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AddStatBonus { name, amount } if name == "Hero" && (*amount - 5.0).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RemoveStatBonus { name, amount } if name == "Hero" && (*amount - 2.0).abs() < 1e-5)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stealth_read_ops() {
+        super::STEALTH_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Rogue".to_string(),
+                (0.5f32, 0.25f32, 0.75f32, 1.0f32, true, 0.5f32, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getStealthBaseVisibility("Rogue"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getStealthVisibilityMod("Rogue"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getStealthNoiseLevel("Rogue"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getStealthNoiseDecayRate("Rogue"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt.eval(r#"String(Bsengine.isSneaking("Rogue"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.getStealthSneakVisScale("Rogue"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isStealthEnabled("Rogue"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STEALTH_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stealth_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.startSneaking("Rogue");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.stopSneaking("Rogue");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.addNoise("Rogue", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setStealthEnabled("Rogue", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StartSneaking { name } if name == "Rogue")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StopSneaking { name } if name == "Rogue")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AddNoise { name, amount } if name == "Rogue" && (*amount - 0.5).abs() < 1e-5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStealthEnabled { name, enabled } if name == "Rogue" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stomp_read_ops() {
+        super::STOMP_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Giant".to_string(), (4.0f32, 2.0f32, 1.5f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getStompMagnitude("Giant"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "4");
+        let r = rt
+            .eval(r#"String(Bsengine.getStompImpactRadius("Giant"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getStompDamagePerUnit("Giant"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustStomped("Giant"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isStompEnabled("Giant"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STOMP_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stomp_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.triggerStomp("Giant");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setStompEnabled("Giant", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::TriggerStomp { name } if name == "Giant")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStompEnabled { name, enabled } if name == "Giant" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stride_read_ops() {
+        super::STRIDE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Runner".to_string(),
+                (5u32, 10u32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getStrideCount("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getStrideMaxStrides("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt
+            .eval(r#"String(Bsengine.getStrideSpeedBonus("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isStrideJustPeaked("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isStrideJustBroke("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isStrideEnabled("Runner"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STRIDE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stride_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.stepStride("Runner");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.breakStride("Runner");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setStrideEnabled("Runner", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StepStride { name } if name == "Runner")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BreakStride { name } if name == "Runner")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStrideEnabled { name, enabled } if name == "Runner" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_strife_read_ops() {
+        super::STRIFE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Berserker".to_string(),
+                (0.75f32, 1.0f32, 0.25f32, 0.5f32, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getStrifeValue("Berserker"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getStrifeMax("Berserker"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getStrifeGainPerHit("Berserker"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getStrifeDecayRate("Berserker"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isStrifeJustPeaked("Berserker"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isStrifeEnabled("Berserker"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STRIFE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_strife_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.hitStrife("Berserker");"#, "<test>")
+            .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setStrifeEnabled("Berserker", false);"#,
+            "<test>",
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::HitStrife { name } if name == "Berserker")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStrifeEnabled { name, enabled } if name == "Berserker" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stumble_read_ops() {
+        super::STUMBLE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grunt".to_string(),
+                (
+                    0.5f32, 1.0f32, 1.5f32, 0.25f32, 2u32, true, true, false, true,
+                ),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getStumbleTimer("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getStumbleDuration("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getStumbleVulnerabilityFactor("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getStumbleMovePenalty("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getStumbleCount("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt.eval(r#"String(Bsengine.isStumbling("Grunt"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustStumbled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustStumbleRecovered("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isStumbleEnabled("Grunt"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::STUMBLE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_stumble_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.triggerStumble("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setStumbleEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::TriggerStumble { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetStumbleEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -4636,6 +4636,113 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    SetWarnHpThreshold {
+        name: String,
+        value: f32,
+    },
+    SetWarnCooldown {
+        name: String,
+        value: f32,
+    },
+    SetWarnEnabled {
+        name: String,
+        enabled: bool,
+    },
+    AlertWary {
+        name: String,
+        amount: f32,
+    },
+    SettleWary {
+        name: String,
+        amount: f32,
+    },
+    SetWaryEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SoilWash {
+        name: String,
+        amount: f32,
+    },
+    CleanseWash {
+        name: String,
+        amount: f32,
+    },
+    SetWashEnabled {
+        name: String,
+        enabled: bool,
+    },
+    InjectWasp {
+        name: String,
+        amount: f32,
+    },
+    NeutralizeWasp {
+        name: String,
+        amount: f32,
+    },
+    SetWaspEnabled {
+        name: String,
+        enabled: bool,
+    },
+    CleanseWaste {
+        name: String,
+        amount: f32,
+    },
+    SetWasteDecayRate {
+        name: String,
+        value: f32,
+    },
+    SetWasteEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SetWaterBodyWaveHeight {
+        name: String,
+        value: f32,
+    },
+    SetWaterBodyWaveSpeed {
+        name: String,
+        value: f32,
+    },
+    SetWaterBodyRoughness {
+        name: String,
+        value: f32,
+    },
+    SetWaterBodyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    EmitWave {
+        name: String,
+    },
+    SetWaveMaxRadius {
+        name: String,
+        value: f32,
+    },
+    SetWaveExpansionRate {
+        name: String,
+        value: f32,
+    },
+    SetWaveDamage {
+        name: String,
+        value: f32,
+    },
+    SetWaveEnabled {
+        name: String,
+        enabled: bool,
+    },
+    HesitateWaver {
+        name: String,
+        amount: f32,
+    },
+    ResolveWaver {
+        name: String,
+        amount: f32,
+    },
+    SetWaverEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5831,6 +5938,22 @@ thread_local! {
     pub(crate) static WARM_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static WARP_SNAPSHOT: RefCell<HashMap<String, (u32, f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WARN_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WARY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WASH_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WASP_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WASTE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WATER_BODY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAVE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WAVER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -11968,6 +12091,380 @@ pub fn bsengine_set_warp_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetWarpEnabled { name, enabled })
+    });
+}
+// ── Warn ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_warn_hp_threshold(#[string] name: String) -> f32 {
+    WARN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_warn_cooldown(#[string] name: String) -> f32 {
+    WARN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_warn_cooldown_timer(#[string] name: String) -> f32 {
+    WARN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_warn_just_triggered(#[string] name: String) -> bool {
+    WARN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_warn_enabled(#[string] name: String) -> bool {
+    WARN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_warn_hp_threshold(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWarnHpThreshold { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_warn_cooldown(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWarnCooldown { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_warn_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWarnEnabled { name, enabled })
+    });
+}
+// ── Wary ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wary_level(#[string] name: String) -> f32 {
+    WARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wary_max_wary(#[string] name: String) -> f32 {
+    WARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wary_threshold(#[string] name: String) -> f32 {
+    WARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wary_just_alerted(#[string] name: String) -> bool {
+    WARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wary_just_calmed(#[string] name: String) -> bool {
+    WARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wary_enabled(#[string] name: String) -> bool {
+    WARY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_alert_wary(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AlertWary { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_settle_wary(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SettleWary { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wary_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaryEnabled { name, enabled })
+    });
+}
+// ── Wash ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wash_grime(#[string] name: String) -> f32 {
+    WASH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wash_max_grime(#[string] name: String) -> f32 {
+    WASH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wash_soil_rate(#[string] name: String) -> f32 {
+    WASH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wash_just_clean(#[string] name: String) -> bool {
+    WASH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wash_just_grimy(#[string] name: String) -> bool {
+    WASH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wash_enabled(#[string] name: String) -> bool {
+    WASH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_soil_wash(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SoilWash { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_cleanse_wash(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CleanseWash { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wash_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWashEnabled { name, enabled })
+    });
+}
+// ── Wasp ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wasp_sting(#[string] name: String) -> f32 {
+    WASP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wasp_max_sting(#[string] name: String) -> f32 {
+    WASP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wasp_venom_rate(#[string] name: String) -> f32 {
+    WASP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wasp_just_venomous(#[string] name: String) -> bool {
+    WASP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wasp_just_spent(#[string] name: String) -> bool {
+    WASP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wasp_enabled(#[string] name: String) -> bool {
+    WASP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_inject_wasp(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::InjectWasp { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_neutralize_wasp(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::NeutralizeWasp { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wasp_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaspEnabled { name, enabled })
+    });
+}
+// ── Waste ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_waste_accumulated(#[string] name: String) -> f32 {
+    WASTE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_waste_decay_rate(#[string] name: String) -> f32 {
+    WASTE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_waste_just_peaked(#[string] name: String) -> bool {
+    WASTE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_waste_enabled(#[string] name: String) -> bool {
+    WASTE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_cleanse_waste(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CleanseWaste { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_waste_decay_rate(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWasteDecayRate { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_waste_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWasteEnabled { name, enabled })
+    });
+}
+// ── WaterBody ────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_water_body_wave_height(#[string] name: String) -> f32 {
+    WATER_BODY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_water_body_wave_speed(#[string] name: String) -> f32 {
+    WATER_BODY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_water_body_roughness(#[string] name: String) -> f32 {
+    WATER_BODY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_water_body_ssr_intensity(#[string] name: String) -> f32 {
+    WATER_BODY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_water_body_enabled(#[string] name: String) -> bool {
+    WATER_BODY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_set_water_body_wave_height(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaterBodyWaveHeight { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_water_body_wave_speed(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaterBodyWaveSpeed { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_water_body_roughness(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaterBodyRoughness { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_water_body_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaterBodyEnabled { name, enabled })
+    });
+}
+// ── Wave ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wave_radius(#[string] name: String) -> f32 {
+    WAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wave_max_radius(#[string] name: String) -> f32 {
+    WAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wave_expansion_rate(#[string] name: String) -> f32 {
+    WAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wave_damage(#[string] name: String) -> f32 {
+    WAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wave_just_emitted(#[string] name: String) -> bool {
+    WAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wave_just_dissipated(#[string] name: String) -> bool {
+    WAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wave_enabled(#[string] name: String) -> bool {
+    WAVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_emit_wave(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::EmitWave { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wave_max_radius(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaveMaxRadius { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wave_expansion_rate(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaveExpansionRate { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wave_damage(#[string] name: String, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaveDamage { name, value })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wave_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaveEnabled { name, enabled })
+    });
+}
+// ── Waver ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_waver_doubt(#[string] name: String) -> f32 {
+    WAVER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_waver_max_doubt(#[string] name: String) -> f32 {
+    WAVER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_waver_waver_rate(#[string] name: String) -> f32 {
+    WAVER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_waver_just_wavered(#[string] name: String) -> bool {
+    WAVER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_waver_just_resolved(#[string] name: String) -> bool {
+    WAVER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_waver_enabled(#[string] name: String) -> bool {
+    WAVER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_hesitate_waver(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::HesitateWaver { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_resolve_waver(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ResolveWaver { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_waver_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWaverEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -32123,6 +32620,78 @@ deno_core::extension!(
         bsengine_set_warp_charge_duration,
         bsengine_set_warp_cooldown_duration,
         bsengine_set_warp_enabled,
+        bsengine_get_warn_hp_threshold,
+        bsengine_get_warn_cooldown,
+        bsengine_get_warn_cooldown_timer,
+        bsengine_is_warn_just_triggered,
+        bsengine_is_warn_enabled,
+        bsengine_set_warn_hp_threshold,
+        bsengine_set_warn_cooldown,
+        bsengine_set_warn_enabled,
+        bsengine_get_wary_level,
+        bsengine_get_wary_max_wary,
+        bsengine_get_wary_threshold,
+        bsengine_is_wary_just_alerted,
+        bsengine_is_wary_just_calmed,
+        bsengine_is_wary_enabled,
+        bsengine_alert_wary,
+        bsengine_settle_wary,
+        bsengine_set_wary_enabled,
+        bsengine_get_wash_grime,
+        bsengine_get_wash_max_grime,
+        bsengine_get_wash_soil_rate,
+        bsengine_is_wash_just_clean,
+        bsengine_is_wash_just_grimy,
+        bsengine_is_wash_enabled,
+        bsengine_soil_wash,
+        bsengine_cleanse_wash,
+        bsengine_set_wash_enabled,
+        bsengine_get_wasp_sting,
+        bsengine_get_wasp_max_sting,
+        bsengine_get_wasp_venom_rate,
+        bsengine_is_wasp_just_venomous,
+        bsengine_is_wasp_just_spent,
+        bsengine_is_wasp_enabled,
+        bsengine_inject_wasp,
+        bsengine_neutralize_wasp,
+        bsengine_set_wasp_enabled,
+        bsengine_get_waste_accumulated,
+        bsengine_get_waste_decay_rate,
+        bsengine_is_waste_just_peaked,
+        bsengine_is_waste_enabled,
+        bsengine_cleanse_waste,
+        bsengine_set_waste_decay_rate,
+        bsengine_set_waste_enabled,
+        bsengine_get_water_body_wave_height,
+        bsengine_get_water_body_wave_speed,
+        bsengine_get_water_body_roughness,
+        bsengine_get_water_body_ssr_intensity,
+        bsengine_is_water_body_enabled,
+        bsengine_set_water_body_wave_height,
+        bsengine_set_water_body_wave_speed,
+        bsengine_set_water_body_roughness,
+        bsengine_set_water_body_enabled,
+        bsengine_get_wave_radius,
+        bsengine_get_wave_max_radius,
+        bsengine_get_wave_expansion_rate,
+        bsengine_get_wave_damage,
+        bsengine_is_wave_just_emitted,
+        bsengine_is_wave_just_dissipated,
+        bsengine_is_wave_enabled,
+        bsengine_emit_wave,
+        bsengine_set_wave_max_radius,
+        bsengine_set_wave_expansion_rate,
+        bsengine_set_wave_damage,
+        bsengine_set_wave_enabled,
+        bsengine_get_waver_doubt,
+        bsengine_get_waver_max_doubt,
+        bsengine_get_waver_waver_rate,
+        bsengine_is_waver_just_wavered,
+        bsengine_is_waver_just_resolved,
+        bsengine_is_waver_enabled,
+        bsengine_hesitate_waver,
+        bsengine_resolve_waver,
+        bsengine_set_waver_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -35690,6 +36259,78 @@ const Bsengine = {
     setWarpChargeDuration:      (name, v)           => Deno.core.ops.bsengine_set_warp_charge_duration(name, v),
     setWarpCooldownDuration:    (name, v)           => Deno.core.ops.bsengine_set_warp_cooldown_duration(name, v),
     setWarpEnabled:             (name, v)           => Deno.core.ops.bsengine_set_warp_enabled(name, v),
+    getWarnHpThreshold:         (name)              => Deno.core.ops.bsengine_get_warn_hp_threshold(name),
+    getWarnCooldown:            (name)              => Deno.core.ops.bsengine_get_warn_cooldown(name),
+    getWarnCooldownTimer:       (name)              => Deno.core.ops.bsengine_get_warn_cooldown_timer(name),
+    isWarnJustTriggered:        (name)              => Deno.core.ops.bsengine_is_warn_just_triggered(name),
+    isWarnEnabled:              (name)              => Deno.core.ops.bsengine_is_warn_enabled(name),
+    setWarnHpThreshold:         (name, v)           => Deno.core.ops.bsengine_set_warn_hp_threshold(name, v),
+    setWarnCooldown:            (name, v)           => Deno.core.ops.bsengine_set_warn_cooldown(name, v),
+    setWarnEnabled:             (name, v)           => Deno.core.ops.bsengine_set_warn_enabled(name, v),
+    getWaryLevel:               (name)              => Deno.core.ops.bsengine_get_wary_level(name),
+    getWaryMaxWary:             (name)              => Deno.core.ops.bsengine_get_wary_max_wary(name),
+    getWaryThreshold:           (name)              => Deno.core.ops.bsengine_get_wary_threshold(name),
+    isWaryJustAlerted:          (name)              => Deno.core.ops.bsengine_is_wary_just_alerted(name),
+    isWaryJustCalmed:           (name)              => Deno.core.ops.bsengine_is_wary_just_calmed(name),
+    isWaryEnabled:              (name)              => Deno.core.ops.bsengine_is_wary_enabled(name),
+    alertWary:                  (name, amount)      => Deno.core.ops.bsengine_alert_wary(name, amount),
+    settleWary:                 (name, amount)      => Deno.core.ops.bsengine_settle_wary(name, amount),
+    setWaryEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wary_enabled(name, v),
+    getWashGrime:               (name)              => Deno.core.ops.bsengine_get_wash_grime(name),
+    getWashMaxGrime:            (name)              => Deno.core.ops.bsengine_get_wash_max_grime(name),
+    getWashSoilRate:            (name)              => Deno.core.ops.bsengine_get_wash_soil_rate(name),
+    isWashJustClean:            (name)              => Deno.core.ops.bsengine_is_wash_just_clean(name),
+    isWashJustGrimy:            (name)              => Deno.core.ops.bsengine_is_wash_just_grimy(name),
+    isWashEnabled:              (name)              => Deno.core.ops.bsengine_is_wash_enabled(name),
+    soilWash:                   (name, amount)      => Deno.core.ops.bsengine_soil_wash(name, amount),
+    cleanseWash:                (name, amount)      => Deno.core.ops.bsengine_cleanse_wash(name, amount),
+    setWashEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wash_enabled(name, v),
+    getWaspSting:               (name)              => Deno.core.ops.bsengine_get_wasp_sting(name),
+    getWaspMaxSting:            (name)              => Deno.core.ops.bsengine_get_wasp_max_sting(name),
+    getWaspVenomRate:           (name)              => Deno.core.ops.bsengine_get_wasp_venom_rate(name),
+    isWaspJustVenomous:         (name)              => Deno.core.ops.bsengine_is_wasp_just_venomous(name),
+    isWaspJustSpent:            (name)              => Deno.core.ops.bsengine_is_wasp_just_spent(name),
+    isWaspEnabled:              (name)              => Deno.core.ops.bsengine_is_wasp_enabled(name),
+    injectWasp:                 (name, amount)      => Deno.core.ops.bsengine_inject_wasp(name, amount),
+    neutralizeWasp:             (name, amount)      => Deno.core.ops.bsengine_neutralize_wasp(name, amount),
+    setWaspEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wasp_enabled(name, v),
+    getWasteAccumulated:        (name)              => Deno.core.ops.bsengine_get_waste_accumulated(name),
+    getWasteDecayRate:          (name)              => Deno.core.ops.bsengine_get_waste_decay_rate(name),
+    isWasteJustPeaked:          (name)              => Deno.core.ops.bsengine_is_waste_just_peaked(name),
+    isWasteEnabled:             (name)              => Deno.core.ops.bsengine_is_waste_enabled(name),
+    cleanseWaste:               (name, amount)      => Deno.core.ops.bsengine_cleanse_waste(name, amount),
+    setWasteDecayRate:          (name, v)           => Deno.core.ops.bsengine_set_waste_decay_rate(name, v),
+    setWasteEnabled:            (name, v)           => Deno.core.ops.bsengine_set_waste_enabled(name, v),
+    getWaterBodyWaveHeight:     (name)              => Deno.core.ops.bsengine_get_water_body_wave_height(name),
+    getWaterBodyWaveSpeed:      (name)              => Deno.core.ops.bsengine_get_water_body_wave_speed(name),
+    getWaterBodyRoughness:      (name)              => Deno.core.ops.bsengine_get_water_body_roughness(name),
+    getWaterBodySsrIntensity:   (name)              => Deno.core.ops.bsengine_get_water_body_ssr_intensity(name),
+    isWaterBodyEnabled:         (name)              => Deno.core.ops.bsengine_is_water_body_enabled(name),
+    setWaterBodyWaveHeight:     (name, v)           => Deno.core.ops.bsengine_set_water_body_wave_height(name, v),
+    setWaterBodyWaveSpeed:      (name, v)           => Deno.core.ops.bsengine_set_water_body_wave_speed(name, v),
+    setWaterBodyRoughness:      (name, v)           => Deno.core.ops.bsengine_set_water_body_roughness(name, v),
+    setWaterBodyEnabled:        (name, v)           => Deno.core.ops.bsengine_set_water_body_enabled(name, v),
+    getWaveRadius:              (name)              => Deno.core.ops.bsengine_get_wave_radius(name),
+    getWaveMaxRadius:           (name)              => Deno.core.ops.bsengine_get_wave_max_radius(name),
+    getWaveExpansionRate:       (name)              => Deno.core.ops.bsengine_get_wave_expansion_rate(name),
+    getWaveDamage:              (name)              => Deno.core.ops.bsengine_get_wave_damage(name),
+    isWaveJustEmitted:          (name)              => Deno.core.ops.bsengine_is_wave_just_emitted(name),
+    isWaveJustDissipated:       (name)              => Deno.core.ops.bsengine_is_wave_just_dissipated(name),
+    isWaveEnabled:              (name)              => Deno.core.ops.bsengine_is_wave_enabled(name),
+    emitWave:                   (name)              => Deno.core.ops.bsengine_emit_wave(name),
+    setWaveMaxRadius:           (name, v)           => Deno.core.ops.bsengine_set_wave_max_radius(name, v),
+    setWaveExpansionRate:       (name, v)           => Deno.core.ops.bsengine_set_wave_expansion_rate(name, v),
+    setWaveDamage:              (name, v)           => Deno.core.ops.bsengine_set_wave_damage(name, v),
+    setWaveEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wave_enabled(name, v),
+    getWaverDoubt:              (name)              => Deno.core.ops.bsengine_get_waver_doubt(name),
+    getWaverMaxDoubt:           (name)              => Deno.core.ops.bsengine_get_waver_max_doubt(name),
+    getWaverWaverRate:          (name)              => Deno.core.ops.bsengine_get_waver_waver_rate(name),
+    isWaverJustWavered:         (name)              => Deno.core.ops.bsengine_is_waver_just_wavered(name),
+    isWaverJustResolved:        (name)              => Deno.core.ops.bsengine_is_waver_just_resolved(name),
+    isWaverEnabled:             (name)              => Deno.core.ops.bsengine_is_waver_enabled(name),
+    hesitateWaver:              (name, amount)      => Deno.core.ops.bsengine_hesitate_waver(name, amount),
+    resolveWaver:               (name, amount)      => Deno.core.ops.bsengine_resolve_waver(name, amount),
+    setWaverEnabled:            (name, v)           => Deno.core.ops.bsengine_set_waver_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -59462,6 +60103,434 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarpChargeDuration { name, value } if name == "Grunt" && *value == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarpCooldownDuration { name, value } if name == "Grunt" && *value == 1.0)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarpEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_warn_read_ops() {
+        super::WARN_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.25f32, 0.5f32, 0.125f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWarnHpThreshold("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getWarnCooldown("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWarnCooldownTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.125");
+        let r = rt
+            .eval(r#"String(Bsengine.isWarnJustTriggered("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWarnEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WARN_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_warn_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.setWarnHpThreshold("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWarnCooldown("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWarnEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarnHpThreshold { name, value } if name == "Grunt" && *value == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarnCooldown { name, value } if name == "Grunt" && *value == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWarnEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wary_read_ops() {
+        super::WARY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWaryLevel("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaryMaxWary("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaryThreshold("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaryJustAlerted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaryJustCalmed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaryEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WARY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wary_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.alertWary("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.settleWary("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaryEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AlertWary { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SettleWary { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaryEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wash_read_ops() {
+        super::WASH_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWashGrime("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWashMaxGrime("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWashSoilRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWashJustClean("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWashJustGrimy("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWashEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WASH_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wash_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.soilWash("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.cleanseWash("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWashEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SoilWash { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CleanseWash { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWashEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wasp_read_ops() {
+        super::WASP_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWaspSting("Hero"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaspMaxSting("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaspVenomRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaspJustVenomous("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaspJustSpent("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaspEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WASP_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wasp_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.injectWasp("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.neutralizeWasp("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaspEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::InjectWasp { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::NeutralizeWasp { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaspEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_waste_read_ops() {
+        super::WASTE_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (0.5f32, 0.25f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWasteAccumulated("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWasteDecayRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWasteJustPeaked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWasteEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WASTE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_waste_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.cleanseWaste("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWasteDecayRate("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWasteEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CleanseWaste { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWasteDecayRate { name, value } if name == "Grunt" && *value == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWasteEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_water_body_read_ops() {
+        super::WATER_BODY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 0.25f32, 0.125f32, 0.0625f32, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWaterBodyWaveHeight("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaterBodyWaveSpeed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaterBodyRoughness("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.125");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaterBodySsrIntensity("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.0625");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaterBodyEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WATER_BODY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_water_body_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(
+            r#"Bsengine.setWaterBodyWaveHeight("Grunt", 0.5);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setWaterBodyWaveSpeed("Grunt", 0.25);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(
+            r#"Bsengine.setWaterBodyRoughness("Grunt", 0.125);"#,
+            "<test>",
+        )
+        .unwrap();
+        rt.exec_source(r#"Bsengine.setWaterBodyEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaterBodyWaveHeight { name, value } if name == "Grunt" && *value == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaterBodyWaveSpeed { name, value } if name == "Grunt" && *value == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaterBodyRoughness { name, value } if name == "Grunt" && *value == 0.125)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaterBodyEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wave_read_ops() {
+        super::WAVE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, 0.5f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWaveRadius("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaveMaxRadius("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaveExpansionRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaveDamage("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaveJustEmitted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaveJustDissipated("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaveEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAVE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wave_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.emitWave("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaveMaxRadius("Grunt", 1.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaveExpansionRate("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaveDamage("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaveEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::EmitWave { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaveMaxRadius { name, value } if name == "Grunt" && *value == 1.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaveExpansionRate { name, value } if name == "Grunt" && *value == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaveDamage { name, value } if name == "Grunt" && *value == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaveEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_waver_read_ops() {
+        super::WAVER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWaverDoubt("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaverMaxDoubt("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWaverWaverRate("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaverJustWavered("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaverJustResolved("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWaverEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WAVER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_waver_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.hesitateWaver("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.resolveWaver("Grunt", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWaverEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::HesitateWaver { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ResolveWaver { name, amount } if name == "Grunt" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWaverEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -3929,6 +3929,96 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    StartTrample {
+        name: String,
+        duration: f32,
+    },
+    StopTrample {
+        name: String,
+    },
+    SetTrampleEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ApplyTrance {
+        name: String,
+        duration: f32,
+    },
+    ClearTrance {
+        name: String,
+    },
+    SetTranceEnabled {
+        name: String,
+        enabled: bool,
+    },
+    EnterTranquil {
+        name: String,
+        duration: f32,
+    },
+    InterruptTranquil {
+        name: String,
+    },
+    SetTranquilEnabled {
+        name: String,
+        enabled: bool,
+    },
+    FixTransfix {
+        name: String,
+        duration: f32,
+    },
+    BreakTransfix {
+        name: String,
+    },
+    SetTransfixEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ApplyTremble {
+        name: String,
+        duration: f32,
+    },
+    ClearTremble {
+        name: String,
+    },
+    SetTrembleEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ActivateTremor {
+        name: String,
+    },
+    DeactivateTremor {
+        name: String,
+    },
+    SetTremorEnabled {
+        name: String,
+        enabled: bool,
+    },
+    AddTroveValue {
+        name: String,
+        amount: f32,
+    },
+    ConsumeTrove {
+        name: String,
+    },
+    SetTroveEnabled {
+        name: String,
+        enabled: bool,
+    },
+    ChargeTusk {
+        name: String,
+        dist: f32,
+    },
+    ImpactTusk {
+        name: String,
+    },
+    ResetTusk {
+        name: String,
+    },
+    SetTuskEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -5012,6 +5102,22 @@ thread_local! {
     pub(crate) static TAUNT_SNAPSHOT: RefCell<HashMap<String, (bool, f32, f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static THAW_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TRAMPLE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TRANCE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TRANQUIL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TRANSFIX_SNAPSHOT: RefCell<HashMap<String, (bool, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TREMBLE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TREMOR_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TROVE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, u32, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static TUSK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -8562,6 +8668,365 @@ pub fn bsengine_set_thaw_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetThawEnabled { name, enabled })
+    });
+}
+// ── Trample ──────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_trample_duration(#[string] name: String) -> f32 {
+    TRAMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trample_timer(#[string] name: String) -> f32 {
+    TRAMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trample_damage(#[string] name: String) -> f32 {
+    TRAMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trample_push_force(#[string] name: String) -> f32 {
+    TRAMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trample_radius(#[string] name: String) -> f32 {
+    TRAMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_trample_started(#[string] name: String) -> bool {
+    TRAMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_trample_ended(#[string] name: String) -> bool {
+    TRAMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_trample_enabled(#[string] name: String) -> bool {
+    TRAMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.7).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_start_trample(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::StartTrample { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_stop_trample(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StopTrample { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_trample_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTrampleEnabled { name, enabled })
+    });
+}
+// ── Trance ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_trance_duration(#[string] name: String) -> f32 {
+    TRANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trance_timer(#[string] name: String) -> f32 {
+    TRANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trance_regen_multiplier(#[string] name: String) -> f32 {
+    TRANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_trance_entered(#[string] name: String) -> bool {
+    TRANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_trance_exited(#[string] name: String) -> bool {
+    TRANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_trance_enabled(#[string] name: String) -> bool {
+    TRANCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_trance(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyTrance { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_clear_trance(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearTrance { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_trance_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTranceEnabled { name, enabled })
+    });
+}
+// ── Tranquil ─────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_tranquil_duration(#[string] name: String) -> f32 {
+    TRANQUIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tranquil_timer(#[string] name: String) -> f32 {
+    TRANQUIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tranquil_regen_multiplier(#[string] name: String) -> f32 {
+    TRANQUIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_tranquil_entered(#[string] name: String) -> bool {
+    TRANQUIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_tranquil_exited(#[string] name: String) -> bool {
+    TRANQUIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_tranquil_enabled(#[string] name: String) -> bool {
+    TRANQUIL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_enter_tranquil(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::EnterTranquil { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_interrupt_tranquil(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::InterruptTranquil { name })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_tranquil_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTranquilEnabled { name, enabled })
+    });
+}
+// ── Transfix ─────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_is_transfix_active(#[string] name: String) -> bool {
+    TRANSFIX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_get_transfix_timer(#[string] name: String) -> f32 {
+    TRANSFIX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_transfix_lock_range(#[string] name: String) -> f32 {
+    TRANSFIX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_transfix_locked(#[string] name: String) -> bool {
+    TRANSFIX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_transfix_broken(#[string] name: String) -> bool {
+    TRANSFIX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_transfix_enabled(#[string] name: String) -> bool {
+    TRANSFIX_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_fix_transfix(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::FixTransfix { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_break_transfix(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::BreakTransfix { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_transfix_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTransfixEnabled { name, enabled })
+    });
+}
+// ── Tremble ──────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_tremble_duration(#[string] name: String) -> f32 {
+    TREMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tremble_timer(#[string] name: String) -> f32 {
+    TREMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tremble_intensity(#[string] name: String) -> f32 {
+    TREMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_just_trembling(#[string] name: String) -> bool {
+    TREMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_tremble_just_stopped(#[string] name: String) -> bool {
+    TREMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_tremble_enabled(#[string] name: String) -> bool {
+    TREMBLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_apply_tremble(#[string] name: String, duration: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ApplyTremble { name, duration })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_clear_tremble(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearTremble { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_tremble_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTrembleEnabled { name, enabled })
+    });
+}
+// ── Tremor ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_tremor_pulse_interval(#[string] name: String) -> f32 {
+    TREMOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tremor_pulse_timer(#[string] name: String) -> f32 {
+    TREMOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tremor_radius(#[string] name: String) -> f32 {
+    TREMOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tremor_stagger_strength(#[string] name: String) -> f32 {
+    TREMOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_tremor_active(#[string] name: String) -> bool {
+    TREMOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_tremor_just_pulsed(#[string] name: String) -> bool {
+    TREMOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_tremor_enabled(#[string] name: String) -> bool {
+    TREMOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.6).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_activate_tremor(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ActivateTremor { name }));
+}
+#[op2(fast)]
+pub fn bsengine_deactivate_tremor(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DeactivateTremor { name })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_tremor_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTremorEnabled { name, enabled })
+    });
+}
+// ── Trove ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_trove_value(#[string] name: String) -> f32 {
+    TROVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trove_threshold(#[string] name: String) -> f32 {
+    TROVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trove_reward_multiplier(#[string] name: String) -> f32 {
+    TROVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_trove_count(#[string] name: String) -> u32 {
+    TROVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(0))
+}
+#[op2(fast)]
+pub fn bsengine_is_trove_just_activated(#[string] name: String) -> bool {
+    TROVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_trove_enabled(#[string] name: String) -> bool {
+    TROVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_add_trove_value(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AddTroveValue { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_consume_trove(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ConsumeTrove { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_trove_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTroveEnabled { name, enabled })
+    });
+}
+// ── Tusk ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_tusk_current_charge(#[string] name: String) -> f32 {
+    TUSK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tusk_full_charge_dist(#[string] name: String) -> f32 {
+    TUSK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_tusk_max_bonus(#[string] name: String) -> f32 {
+    TUSK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_tusk_just_hit(#[string] name: String) -> bool {
+    TUSK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_tusk_enabled(#[string] name: String) -> bool {
+    TUSK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_charge_tusk(#[string] name: String, dist: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ChargeTusk { name, dist })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_impact_tusk(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ImpactTusk { name }));
+}
+#[op2(fast)]
+pub fn bsengine_reset_tusk(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResetTusk { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_tusk_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetTuskEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -28198,6 +28663,81 @@ deno_core::extension!(
         bsengine_is_thaw_enabled,
         bsengine_apply_freeze,
         bsengine_set_thaw_enabled,
+        bsengine_get_trample_duration,
+        bsengine_get_trample_timer,
+        bsengine_get_trample_damage,
+        bsengine_get_trample_push_force,
+        bsengine_get_trample_radius,
+        bsengine_is_just_trample_started,
+        bsengine_is_just_trample_ended,
+        bsengine_is_trample_enabled,
+        bsengine_start_trample,
+        bsengine_stop_trample,
+        bsengine_set_trample_enabled,
+        bsengine_get_trance_duration,
+        bsengine_get_trance_timer,
+        bsengine_get_trance_regen_multiplier,
+        bsengine_is_just_trance_entered,
+        bsengine_is_just_trance_exited,
+        bsengine_is_trance_enabled,
+        bsengine_apply_trance,
+        bsengine_clear_trance,
+        bsengine_set_trance_enabled,
+        bsengine_get_tranquil_duration,
+        bsengine_get_tranquil_timer,
+        bsengine_get_tranquil_regen_multiplier,
+        bsengine_is_just_tranquil_entered,
+        bsengine_is_just_tranquil_exited,
+        bsengine_is_tranquil_enabled,
+        bsengine_enter_tranquil,
+        bsengine_interrupt_tranquil,
+        bsengine_set_tranquil_enabled,
+        bsengine_is_transfix_active,
+        bsengine_get_transfix_timer,
+        bsengine_get_transfix_lock_range,
+        bsengine_is_just_transfix_locked,
+        bsengine_is_just_transfix_broken,
+        bsengine_is_transfix_enabled,
+        bsengine_fix_transfix,
+        bsengine_break_transfix,
+        bsengine_set_transfix_enabled,
+        bsengine_get_tremble_duration,
+        bsengine_get_tremble_timer,
+        bsengine_get_tremble_intensity,
+        bsengine_is_just_trembling,
+        bsengine_is_tremble_just_stopped,
+        bsengine_is_tremble_enabled,
+        bsengine_apply_tremble,
+        bsengine_clear_tremble,
+        bsengine_set_tremble_enabled,
+        bsengine_get_tremor_pulse_interval,
+        bsengine_get_tremor_pulse_timer,
+        bsengine_get_tremor_radius,
+        bsengine_get_tremor_stagger_strength,
+        bsengine_is_tremor_active,
+        bsengine_is_tremor_just_pulsed,
+        bsengine_is_tremor_enabled,
+        bsengine_activate_tremor,
+        bsengine_deactivate_tremor,
+        bsengine_set_tremor_enabled,
+        bsengine_get_trove_value,
+        bsengine_get_trove_threshold,
+        bsengine_get_trove_reward_multiplier,
+        bsengine_get_trove_count,
+        bsengine_is_trove_just_activated,
+        bsengine_is_trove_enabled,
+        bsengine_add_trove_value,
+        bsengine_consume_trove,
+        bsengine_set_trove_enabled,
+        bsengine_get_tusk_current_charge,
+        bsengine_get_tusk_full_charge_dist,
+        bsengine_get_tusk_max_bonus,
+        bsengine_is_tusk_just_hit,
+        bsengine_is_tusk_enabled,
+        bsengine_charge_tusk,
+        bsengine_impact_tusk,
+        bsengine_reset_tusk,
+        bsengine_set_tusk_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -31246,6 +31786,81 @@ const Bsengine = {
     isThawEnabled:              (name)              => Deno.core.ops.bsengine_is_thaw_enabled(name),
     applyFreeze:                (name, intensity)   => Deno.core.ops.bsengine_apply_freeze(name, intensity),
     setThawEnabled:             (name, v)           => Deno.core.ops.bsengine_set_thaw_enabled(name, v),
+    getTrampleDuration:         (name)              => Deno.core.ops.bsengine_get_trample_duration(name),
+    getTrampleTimer:            (name)              => Deno.core.ops.bsengine_get_trample_timer(name),
+    getTrampleDamage:           (name)              => Deno.core.ops.bsengine_get_trample_damage(name),
+    getTramplePushForce:        (name)              => Deno.core.ops.bsengine_get_trample_push_force(name),
+    getTrampleRadius:           (name)              => Deno.core.ops.bsengine_get_trample_radius(name),
+    isJustTrampleStarted:       (name)              => Deno.core.ops.bsengine_is_just_trample_started(name),
+    isJustTrampleEnded:         (name)              => Deno.core.ops.bsengine_is_just_trample_ended(name),
+    isTrampleEnabled:           (name)              => Deno.core.ops.bsengine_is_trample_enabled(name),
+    startTrample:               (name, duration)    => Deno.core.ops.bsengine_start_trample(name, duration),
+    stopTrample:                (name)              => Deno.core.ops.bsengine_stop_trample(name),
+    setTrampleEnabled:          (name, v)           => Deno.core.ops.bsengine_set_trample_enabled(name, v),
+    getTranceDuration:          (name)              => Deno.core.ops.bsengine_get_trance_duration(name),
+    getTranceTimer:             (name)              => Deno.core.ops.bsengine_get_trance_timer(name),
+    getTranceRegenMultiplier:   (name)              => Deno.core.ops.bsengine_get_trance_regen_multiplier(name),
+    isJustTranceEntered:        (name)              => Deno.core.ops.bsengine_is_just_trance_entered(name),
+    isJustTranceExited:         (name)              => Deno.core.ops.bsengine_is_just_trance_exited(name),
+    isTranceEnabled:            (name)              => Deno.core.ops.bsengine_is_trance_enabled(name),
+    applyTrance:                (name, duration)    => Deno.core.ops.bsengine_apply_trance(name, duration),
+    clearTrance:                (name)              => Deno.core.ops.bsengine_clear_trance(name),
+    setTranceEnabled:           (name, v)           => Deno.core.ops.bsengine_set_trance_enabled(name, v),
+    getTranquilDuration:        (name)              => Deno.core.ops.bsengine_get_tranquil_duration(name),
+    getTranquilTimer:           (name)              => Deno.core.ops.bsengine_get_tranquil_timer(name),
+    getTranquilRegenMultiplier: (name)              => Deno.core.ops.bsengine_get_tranquil_regen_multiplier(name),
+    isJustTranquilEntered:      (name)              => Deno.core.ops.bsengine_is_just_tranquil_entered(name),
+    isJustTranquilExited:       (name)              => Deno.core.ops.bsengine_is_just_tranquil_exited(name),
+    isTranquilEnabled:          (name)              => Deno.core.ops.bsengine_is_tranquil_enabled(name),
+    enterTranquil:              (name, duration)    => Deno.core.ops.bsengine_enter_tranquil(name, duration),
+    interruptTranquil:          (name)              => Deno.core.ops.bsengine_interrupt_tranquil(name),
+    setTranquilEnabled:         (name, v)           => Deno.core.ops.bsengine_set_tranquil_enabled(name, v),
+    isTransfixActive:           (name)              => Deno.core.ops.bsengine_is_transfix_active(name),
+    getTransfixTimer:           (name)              => Deno.core.ops.bsengine_get_transfix_timer(name),
+    getTransfixLockRange:       (name)              => Deno.core.ops.bsengine_get_transfix_lock_range(name),
+    isJustTransfixLocked:       (name)              => Deno.core.ops.bsengine_is_just_transfix_locked(name),
+    isJustTransfixBroken:       (name)              => Deno.core.ops.bsengine_is_just_transfix_broken(name),
+    isTransfixEnabled:          (name)              => Deno.core.ops.bsengine_is_transfix_enabled(name),
+    fixTransfix:                (name, duration)    => Deno.core.ops.bsengine_fix_transfix(name, duration),
+    breakTransfix:              (name)              => Deno.core.ops.bsengine_break_transfix(name),
+    setTransfixEnabled:         (name, v)           => Deno.core.ops.bsengine_set_transfix_enabled(name, v),
+    getTrembleDuration:         (name)              => Deno.core.ops.bsengine_get_tremble_duration(name),
+    getTrembleTimer:            (name)              => Deno.core.ops.bsengine_get_tremble_timer(name),
+    getTrembleIntensity:        (name)              => Deno.core.ops.bsengine_get_tremble_intensity(name),
+    isJustTrembling:            (name)              => Deno.core.ops.bsengine_is_just_trembling(name),
+    isTrembleJustStopped:       (name)              => Deno.core.ops.bsengine_is_tremble_just_stopped(name),
+    isTrembleEnabled:           (name)              => Deno.core.ops.bsengine_is_tremble_enabled(name),
+    applyTremble:               (name, duration)    => Deno.core.ops.bsengine_apply_tremble(name, duration),
+    clearTremble:               (name)              => Deno.core.ops.bsengine_clear_tremble(name),
+    setTrembleEnabled:          (name, v)           => Deno.core.ops.bsengine_set_tremble_enabled(name, v),
+    getTremorPulseInterval:     (name)              => Deno.core.ops.bsengine_get_tremor_pulse_interval(name),
+    getTremorPulseTimer:        (name)              => Deno.core.ops.bsengine_get_tremor_pulse_timer(name),
+    getTremorRadius:            (name)              => Deno.core.ops.bsengine_get_tremor_radius(name),
+    getTremorStaggerStrength:   (name)              => Deno.core.ops.bsengine_get_tremor_stagger_strength(name),
+    isTremorActive:             (name)              => Deno.core.ops.bsengine_is_tremor_active(name),
+    isTremorJustPulsed:         (name)              => Deno.core.ops.bsengine_is_tremor_just_pulsed(name),
+    isTremorEnabled:            (name)              => Deno.core.ops.bsengine_is_tremor_enabled(name),
+    activateTremor:             (name)              => Deno.core.ops.bsengine_activate_tremor(name),
+    deactivateTremor:           (name)              => Deno.core.ops.bsengine_deactivate_tremor(name),
+    setTremorEnabled:           (name, v)           => Deno.core.ops.bsengine_set_tremor_enabled(name, v),
+    getTroveValue:              (name)              => Deno.core.ops.bsengine_get_trove_value(name),
+    getTroveThreshold:          (name)              => Deno.core.ops.bsengine_get_trove_threshold(name),
+    getTroveRewardMultiplier:   (name)              => Deno.core.ops.bsengine_get_trove_reward_multiplier(name),
+    getTroveCount:              (name)              => Deno.core.ops.bsengine_get_trove_count(name),
+    isTroveJustActivated:       (name)              => Deno.core.ops.bsengine_is_trove_just_activated(name),
+    isTroveEnabled:             (name)              => Deno.core.ops.bsengine_is_trove_enabled(name),
+    addTroveValue:              (name, amount)      => Deno.core.ops.bsengine_add_trove_value(name, amount),
+    consumeTrove:               (name)              => Deno.core.ops.bsengine_consume_trove(name),
+    setTroveEnabled:            (name, v)           => Deno.core.ops.bsengine_set_trove_enabled(name, v),
+    getTuskCurrentCharge:       (name)              => Deno.core.ops.bsengine_get_tusk_current_charge(name),
+    getTuskFullChargeDist:      (name)              => Deno.core.ops.bsengine_get_tusk_full_charge_dist(name),
+    getTuskMaxBonus:            (name)              => Deno.core.ops.bsengine_get_tusk_max_bonus(name),
+    isTuskJustHit:              (name)              => Deno.core.ops.bsengine_is_tusk_just_hit(name),
+    isTuskEnabled:              (name)              => Deno.core.ops.bsengine_is_tusk_enabled(name),
+    chargeTusk:                 (name, dist)        => Deno.core.ops.bsengine_charge_tusk(name, dist),
+    impactTusk:                 (name)              => Deno.core.ops.bsengine_impact_tusk(name),
+    resetTusk:                  (name)              => Deno.core.ops.bsengine_reset_tusk(name),
+    setTuskEnabled:             (name, v)           => Deno.core.ops.bsengine_set_tusk_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -51990,6 +52605,447 @@ JSON.stringify(received)
             let buf = c.borrow();
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyFreeze { name, intensity } if name == "Grunt" && *intensity == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetThawEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_trample_read_ops() {
+        super::TRAMPLE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (2.0f32, 1.5f32, 10.0f32, 5.0f32, 1.0f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTrampleDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getTrampleTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTrampleDamage("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt
+            .eval(r#"String(Bsengine.getTramplePushForce("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTrampleRadius("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTrampleStarted("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTrampleEnded("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTrampleEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TRAMPLE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_trample_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.startTrample("Grunt", 3.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.stopTrample("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTrampleEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StartTrample { name, duration } if name == "Grunt" && *duration == 3.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StopTrample { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTrampleEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_trance_read_ops() {
+        super::TRANCE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (2.0f32, 1.5f32, 3.0f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTranceDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getTranceTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTranceRegenMultiplier("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTranceEntered("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTranceExited("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTranceEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TRANCE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_trance_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyTrance("Grunt", 2.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearTrance("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTranceEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyTrance { name, duration } if name == "Grunt" && *duration == 2.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearTrance { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTranceEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tranquil_read_ops() {
+        super::TRANQUIL_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (2.0f32, 1.5f32, 2.0f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTranquilDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getTranquilTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTranquilRegenMultiplier("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTranquilEntered("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTranquilExited("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTranquilEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TRANQUIL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tranquil_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.enterTranquil("Grunt", 3.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.interruptTranquil("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTranquilEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::EnterTranquil { name, duration } if name == "Grunt" && *duration == 3.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::InterruptTranquil { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTranquilEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_transfix_read_ops() {
+        super::TRANSFIX_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (true, 1.5f32, 10.0f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.isTransfixActive("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.getTransfixTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTransfixLockRange("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTransfixLocked("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTransfixBroken("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTransfixEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TRANSFIX_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_transfix_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.fixTransfix("Grunt", 2.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.breakTransfix("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTransfixEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::FixTransfix { name, duration } if name == "Grunt" && *duration == 2.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BreakTransfix { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTransfixEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tremble_read_ops() {
+        super::TREMBLE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (2.0f32, 1.5f32, 0.75f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTrembleDuration("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getTrembleTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTrembleIntensity("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.isJustTrembling("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isTrembleJustStopped("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTrembleEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TREMBLE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tremble_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.applyTremble("Grunt", 2.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.clearTremble("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTrembleEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ApplyTremble { name, duration } if name == "Grunt" && *duration == 2.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ClearTremble { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTrembleEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tremor_read_ops() {
+        super::TREMOR_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (1.0f32, 0.5f32, 5.0f32, 2.0f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTremorPulseInterval("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getTremorPulseTimer("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTremorRadius("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTremorStaggerStrength("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.isTremorActive("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isTremorJustPulsed("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isTremorEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TREMOR_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tremor_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.activateTremor("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.deactivateTremor("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTremorEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ActivateTremor { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DeactivateTremor { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTremorEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_trove_read_ops() {
+        super::TROVE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Hero".to_string(),
+                (0.75f32, 1.0f32, 2.0f32, 3u32, true, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTroveValue("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.75");
+        let r = rt
+            .eval(r#"String(Bsengine.getTroveThreshold("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getTroveRewardMultiplier("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getTroveCount("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "3");
+        let r = rt
+            .eval(r#"String(Bsengine.isTroveJustActivated("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isTroveEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TROVE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_trove_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.addTroveValue("Grunt", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.consumeTrove("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTroveEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AddTroveValue { name, amount } if name == "Grunt" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ConsumeTrove { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTroveEnabled { name, enabled } if name == "Grunt" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tusk_read_ops() {
+        super::TUSK_SNAPSHOT.with(|s| {
+            s.borrow_mut()
+                .insert("Hero".to_string(), (2.0f32, 5.0f32, 10.0f32, true, true));
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getTuskCurrentCharge("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "2");
+        let r = rt
+            .eval(r#"String(Bsengine.getTuskFullChargeDist("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "5");
+        let r = rt
+            .eval(r#"String(Bsengine.getTuskMaxBonus("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "10");
+        let r = rt
+            .eval(r#"String(Bsengine.isTuskJustHit("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isTuskEnabled("Hero"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::TUSK_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_tusk_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.chargeTusk("Grunt", 1.0);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.impactTusk("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.resetTusk("Grunt");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setTuskEnabled("Grunt", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ChargeTusk { name, dist } if name == "Grunt" && *dist == 1.0)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ImpactTusk { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ResetTusk { name } if name == "Grunt")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetTuskEnabled { name, enabled } if name == "Grunt" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -79,8 +79,9 @@ use crate::ops::{
     TUSK_SNAPSHOT, TWEEN_SNAPSHOT, UNREST_SNAPSHOT, UPKEEP_SNAPSHOT, URGE_SNAPSHOT,
     VELOCITY_SNAPSHOT, VENOM_SNAPSHOT, VENTURE_SNAPSHOT, VERGE_SNAPSHOT, VERIFY_SNAPSHOT,
     VERILY_SNAPSHOT, VERMIN_SNAPSHOT, VERNAL_SNAPSHOT, VERSE_SNAPSHOT, VERTEX_SNAPSHOT,
-    VEX_SNAPSHOT, VIGNETTE_SNAPSHOT, VIGOR_SNAPSHOT, VILE_SNAPSHOT, VISIBLE_SNAPSHOT,
-    VOID_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    VERVE_SNAPSHOT, VEST_SNAPSHOT, VEX_SNAPSHOT, VICE_SNAPSHOT, VIGNETTE_SNAPSHOT, VIGOR_SNAPSHOT,
+    VILE_SNAPSHOT, VIM_SNAPSHOT, VIPER_SNAPSHOT, VIRAL_SNAPSHOT, VISIBLE_SNAPSHOT, VISIT_SNAPSHOT,
+    VISTA_SNAPSHOT, VOID_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -2136,6 +2137,158 @@ fn run_scripts(world: &mut World) {
             );
         }
         VERTEX_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Verve;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Verve)>();
+        for (name, vv) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vv.verve_level,
+                    vv.max_verve,
+                    vv.gain_per_action,
+                    vv.decay_rate,
+                    vv.action_bonus,
+                    vv.just_peaked,
+                    vv.enabled,
+                ),
+            );
+        }
+        VERVE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vest;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vest)>();
+        for (name, vst) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vst.absorption_per_hit,
+                    vst.hits_absorbed,
+                    vst.last_absorbed,
+                    vst.just_absorbed,
+                    vst.enabled,
+                ),
+            );
+        }
+        VEST_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vice;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vice)>();
+        for (name, vc) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vc.corruption,
+                    vc.max_corruption,
+                    vc.temptation_rate,
+                    vc.just_corrupted,
+                    vc.just_purified,
+                    vc.enabled,
+                ),
+            );
+        }
+        VICE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vim;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vim)>();
+        for (name, vm) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vm.drive,
+                    vm.max_drive,
+                    vm.vigor_rate,
+                    vm.just_energized,
+                    vm.just_sapped,
+                    vm.enabled,
+                ),
+            );
+        }
+        VIM_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Viper;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Viper)>();
+        for (name, vp) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vp.venom,
+                    vp.max_venom,
+                    vp.toxin_rate,
+                    vp.just_envenomed,
+                    vp.just_drained,
+                    vp.enabled,
+                ),
+            );
+        }
+        VIPER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Viral;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Viral)>();
+        for (name, vrl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vrl.contagion,
+                    vrl.max_contagion,
+                    vrl.spread_rate,
+                    vrl.just_spread,
+                    vrl.just_contained,
+                    vrl.enabled,
+                ),
+            );
+        }
+        VIRAL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Visit;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Visit)>();
+        for (name, vi) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vi.exposure,
+                    vi.max_exposure,
+                    vi.presence_rate,
+                    vi.just_visited,
+                    vi.just_departed,
+                    vi.enabled,
+                ),
+            );
+        }
+        VISIT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vista;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vista)>();
+        for (name, vta) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vta.clarity,
+                    vta.max_clarity,
+                    vta.reveal_rate,
+                    vta.just_revealed,
+                    vta.just_dimmed,
+                    vta.enabled,
+                ),
+            );
+        }
+        VISTA_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -20299,6 +20452,248 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut vx) = world.get_mut::<bsengine_core::Vertex>(e) {
                         vx.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ActVerve { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vv) = world.get_mut::<bsengine_core::Verve>(e) {
+                        vv.act();
+                    }
+                }
+            }
+            ScriptCommand::SetVerveEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vv) = world.get_mut::<bsengine_core::Verve>(e) {
+                        vv.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AbsorbVest { name, incoming } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vst) = world.get_mut::<bsengine_core::Vest>(e) {
+                        vst.absorb(incoming);
+                    }
+                }
+            }
+            ScriptCommand::SetVestEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vst) = world.get_mut::<bsengine_core::Vest>(e) {
+                        vst.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::CorruptVice { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vc) = world.get_mut::<bsengine_core::Vice>(e) {
+                        vc.corrupt(amount);
+                    }
+                }
+            }
+            ScriptCommand::PurifyVice { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vc) = world.get_mut::<bsengine_core::Vice>(e) {
+                        vc.purify(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetViceEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vc) = world.get_mut::<bsengine_core::Vice>(e) {
+                        vc.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::InvigorateVim { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vm) = world.get_mut::<bsengine_core::Vim>(e) {
+                        vm.invigorate(amount);
+                    }
+                }
+            }
+            ScriptCommand::SapVim { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vm) = world.get_mut::<bsengine_core::Vim>(e) {
+                        vm.sap(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVimEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vm) = world.get_mut::<bsengine_core::Vim>(e) {
+                        vm.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::Envenomate { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vp) = world.get_mut::<bsengine_core::Viper>(e) {
+                        vp.envenomate(amount);
+                    }
+                }
+            }
+            ScriptCommand::DrainViper { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vp) = world.get_mut::<bsengine_core::Viper>(e) {
+                        vp.drain(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetViperEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vp) = world.get_mut::<bsengine_core::Viper>(e) {
+                        vp.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ExposeViral { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vrl) = world.get_mut::<bsengine_core::Viral>(e) {
+                        vrl.expose(amount);
+                    }
+                }
+            }
+            ScriptCommand::ContainViral { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vrl) = world.get_mut::<bsengine_core::Viral>(e) {
+                        vrl.contain(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetViralEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vrl) = world.get_mut::<bsengine_core::Viral>(e) {
+                        vrl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApproachVisit { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vi) = world.get_mut::<bsengine_core::Visit>(e) {
+                        vi.approach(amount);
+                    }
+                }
+            }
+            ScriptCommand::WithdrawVisit { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vi) = world.get_mut::<bsengine_core::Visit>(e) {
+                        vi.withdraw(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVisitEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vi) = world.get_mut::<bsengine_core::Visit>(e) {
+                        vi.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::IlluminateVista { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vta) = world.get_mut::<bsengine_core::Vista>(e) {
+                        vta.illuminate(amount);
+                    }
+                }
+            }
+            ScriptCommand::ObscureVista { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vta) = world.get_mut::<bsengine_core::Vista>(e) {
+                        vta.obscure(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVistaEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vta) = world.get_mut::<bsengine_core::Vista>(e) {
+                        vta.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -86,7 +86,9 @@ use crate::ops::{
     VOW_SNAPSHOT, VULNERABLE_SNAPSHOT, VULTURE_SNAPSHOT, WAGER_SNAPSHOT, WAGE_SNAPSHOT,
     WAIL_SNAPSHOT, WAKE_SNAPSHOT, WALK_SNAPSHOT, WALL_SNAPSHOT, WALTZ_SNAPSHOT, WAND_SNAPSHOT,
     WANE_SNAPSHOT, WANGLE_SNAPSHOT, WANTON_SNAPSHOT, WANT_SNAPSHOT, WARD_SNAPSHOT, WARM_SNAPSHOT,
-    WARP_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    WARN_SNAPSHOT, WARP_SNAPSHOT, WARY_SNAPSHOT, WASH_SNAPSHOT, WASP_SNAPSHOT, WASTE_SNAPSHOT,
+    WATER_BODY_SNAPSHOT, WAVER_SNAPSHOT, WAVE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
+    Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -2750,6 +2752,150 @@ fn run_scripts(world: &mut World) {
             );
         }
         WARP_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Warn;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Warn)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.hp_threshold,
+                    w.cooldown,
+                    w.cooldown_timer,
+                    w.just_triggered,
+                    w.enabled,
+                ),
+            );
+        }
+        WARN_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wary;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wary)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.wary_level,
+                    w.max_wary,
+                    w.threshold,
+                    w.just_alerted,
+                    w.just_calmed,
+                    w.enabled,
+                ),
+            );
+        }
+        WARY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wash;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wash)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.grime,
+                    w.max_grime,
+                    w.soil_rate,
+                    w.just_clean,
+                    w.just_grimy,
+                    w.enabled,
+                ),
+            );
+        }
+        WASH_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wasp;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wasp)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.sting,
+                    w.max_sting,
+                    w.venom_rate,
+                    w.just_venomous,
+                    w.just_spent,
+                    w.enabled,
+                ),
+            );
+        }
+        WASP_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Waste;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Waste)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (w.accumulated, w.decay_rate, w.just_peaked, w.enabled),
+            );
+        }
+        WASTE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::WaterBody;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &WaterBody)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.wave_height,
+                    w.wave_speed,
+                    w.roughness,
+                    w.ssr_intensity,
+                    w.enabled,
+                ),
+            );
+        }
+        WATER_BODY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wave;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wave)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.radius,
+                    w.max_radius,
+                    w.expansion_rate,
+                    w.damage,
+                    w.just_emitted,
+                    w.just_dissipated,
+                    w.enabled,
+                ),
+            );
+        }
+        WAVE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Waver;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Waver)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.doubt,
+                    w.max_doubt,
+                    w.waver_rate,
+                    w.just_wavered,
+                    w.just_resolved,
+                    w.enabled,
+                ),
+            );
+        }
+        WAVER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -22015,6 +22161,303 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut w) = world.get_mut::<bsengine_core::Warp>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetWarnHpThreshold { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warn>(e) {
+                        w.hp_threshold = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWarnCooldown { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warn>(e) {
+                        w.cooldown = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWarnEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warn>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AlertWary { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wary>(e) {
+                        w.alert(amount);
+                    }
+                }
+            }
+            ScriptCommand::SettleWary { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wary>(e) {
+                        w.settle(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWaryEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wary>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SoilWash { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wash>(e) {
+                        w.soil(amount);
+                    }
+                }
+            }
+            ScriptCommand::CleanseWash { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wash>(e) {
+                        w.cleanse(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWashEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wash>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::InjectWasp { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wasp>(e) {
+                        w.inject(amount);
+                    }
+                }
+            }
+            ScriptCommand::NeutralizeWasp { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wasp>(e) {
+                        w.neutralize(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWaspEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wasp>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::CleanseWaste { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waste>(e) {
+                        w.cleanse(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWasteDecayRate { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waste>(e) {
+                        w.decay_rate = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWasteEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waste>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetWaterBodyWaveHeight { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::WaterBody>(e) {
+                        w.wave_height = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWaterBodyWaveSpeed { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::WaterBody>(e) {
+                        w.wave_speed = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWaterBodyRoughness { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::WaterBody>(e) {
+                        w.roughness = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWaterBodyEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::WaterBody>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::EmitWave { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wave>(e) {
+                        w.emit();
+                    }
+                }
+            }
+            ScriptCommand::SetWaveMaxRadius { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wave>(e) {
+                        w.max_radius = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWaveExpansionRate { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wave>(e) {
+                        w.expansion_rate = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWaveDamage { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wave>(e) {
+                        w.damage = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWaveEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wave>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::HesitateWaver { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waver>(e) {
+                        w.hesitate(amount);
+                    }
+                }
+            }
+            ScriptCommand::ResolveWaver { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waver>(e) {
+                        w.resolve(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWaverEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waver>(e) {
                         w.enabled = enabled;
                     }
                 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -70,10 +70,11 @@ use crate::ops::{
     SPAWN_POINT_SNAPSHOT, SPIKE_SNAPSHOT, SPLINTER_SNAPSHOT, SPRING_SNAPSHOT, SPRINT_SNAPSHOT,
     STAGGER_SNAPSHOT, STAKE_SNAPSHOT, STALK_SNAPSHOT, STAMINA_SNAPSHOT, STANCE_SNAPSHOT,
     STATUS_EFFECT_SNAPSHOT, STAT_SNAPSHOT, STEALTH_SNAPSHOT, STOMP_SNAPSHOT, STRIDE_SNAPSHOT,
-    STRIFE_SNAPSHOT, STUMBLE_SNAPSHOT, STUN_SNAPSHOT, TAG_SNAPSHOT, TIMER_SNAPSHOT,
-    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT, TONE_MAP_SNAPSHOT,
-    TRANSFORM_SNAPSHOT, TRIGGER_SNAPSHOT, TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT, VIGNETTE_SNAPSHOT,
-    VISIBLE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    STRIFE_SNAPSHOT, STUMBLE_SNAPSHOT, STUN_SNAPSHOT, SULK_SNAPSHOT, SUNDER_SNAPSHOT,
+    SUPPRESS_SNAPSHOT, SURGE_SNAPSHOT, SURROUND_SNAPSHOT, SURVIVE_SNAPSHOT, SWIM_SNAPSHOT,
+    TAG_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT,
+    TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT, TRIGGER_SNAPSHOT, TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT,
+    VIGNETTE_SNAPSHOT, VISIBLE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -1418,6 +1419,141 @@ fn run_scripts(world: &mut World) {
             );
         }
         STUMBLE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Sulk;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Sulk)>();
+        for (name, sl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sl.sulk_depth,
+                    sl.sulk_rate,
+                    sl.recovery_rate,
+                    sl.support_penalty,
+                    sl.sulking,
+                    sl.just_sulked,
+                    sl.just_snapped_out,
+                    sl.enabled,
+                ),
+            );
+        }
+        SULK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Sunder;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Sunder)>();
+        for (name, sd) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sd.shards,
+                    sd.max_shards,
+                    sd.damage_reduction_per_shard,
+                    sd.just_sundered,
+                    sd.enabled,
+                ),
+            );
+        }
+        SUNDER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Suppress;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Suppress)>();
+        for (name, sp) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sp.duration,
+                    sp.timer,
+                    sp.potency_fraction,
+                    sp.blocks_ultimates,
+                    sp.just_suppressed,
+                    sp.just_lifted,
+                    sp.enabled,
+                ),
+            );
+        }
+        SUPPRESS_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Surge;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Surge)>();
+        for (name, sg) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sg.duration,
+                    sg.timer,
+                    sg.multiplier,
+                    sg.just_surged,
+                    sg.just_expired,
+                    sg.enabled,
+                ),
+            );
+        }
+        SURGE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Surround;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Surround)>();
+        for (name, sr) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sr.adjacent_count,
+                    sr.encircle_threshold,
+                    sr.defense_bonus,
+                    sr.just_encircled,
+                    sr.just_cleared,
+                    sr.enabled,
+                ),
+            );
+        }
+        SURROUND_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Survive;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Survive)>();
+        for (name, sv) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (sv.charges, sv.max_charges, sv.just_survived, sv.enabled),
+            );
+        }
+        SURVIVE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Swim;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Swim)>();
+        for (name, sw) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sw.state as u32,
+                    sw.swim_speed,
+                    sw.dive_speed,
+                    sw.ascent_speed,
+                    sw.breath_remaining,
+                    sw.max_breath,
+                    sw.breath_drain_rate,
+                    sw.breath_regen_rate,
+                    sw.depth,
+                    sw.submerge_depth,
+                    sw.wants_dive,
+                    sw.wants_surface,
+                    sw.enabled,
+                ),
+            );
+        }
+        SWIM_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -18360,6 +18496,248 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut su) = world.get_mut::<bsengine_core::Stumble>(e) {
                         su.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::BeginSulk { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Sulk>(e) {
+                        sl.begin_sulk();
+                    }
+                }
+            }
+            ScriptCommand::EndSulk { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Sulk>(e) {
+                        sl.end_sulk();
+                    }
+                }
+            }
+            ScriptCommand::SetSulkEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Sulk>(e) {
+                        sl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplySunder { name, count } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sd) = world.get_mut::<bsengine_core::Sunder>(e) {
+                        sd.apply(count);
+                    }
+                }
+            }
+            ScriptCommand::RepairSunder { name, count } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sd) = world.get_mut::<bsengine_core::Sunder>(e) {
+                        sd.repair(count);
+                    }
+                }
+            }
+            ScriptCommand::RepairAllSunder { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sd) = world.get_mut::<bsengine_core::Sunder>(e) {
+                        sd.repair_all();
+                    }
+                }
+            }
+            ScriptCommand::SetSunderEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sd) = world.get_mut::<bsengine_core::Sunder>(e) {
+                        sd.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplySuppress { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sp) = world.get_mut::<bsengine_core::Suppress>(e) {
+                        sp.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::ClearSuppress { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sp) = world.get_mut::<bsengine_core::Suppress>(e) {
+                        sp.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetSuppressEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sp) = world.get_mut::<bsengine_core::Suppress>(e) {
+                        sp.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplySurge { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sg) = world.get_mut::<bsengine_core::Surge>(e) {
+                        sg.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::ClearSurge { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sg) = world.get_mut::<bsengine_core::Surge>(e) {
+                        sg.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetSurgeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sg) = world.get_mut::<bsengine_core::Surge>(e) {
+                        sg.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::UpdateSurround { name, count } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sr) = world.get_mut::<bsengine_core::Surround>(e) {
+                        sr.update(count);
+                    }
+                }
+            }
+            ScriptCommand::SetSurroundEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sr) = world.get_mut::<bsengine_core::Surround>(e) {
+                        sr.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AddSurviveCharge { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sv) = world.get_mut::<bsengine_core::Survive>(e) {
+                        sv.add_charge();
+                    }
+                }
+            }
+            ScriptCommand::SetSurviveEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sv) = world.get_mut::<bsengine_core::Survive>(e) {
+                        sv.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::EnterWater { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sw) = world.get_mut::<bsengine_core::Swim>(e) {
+                        sw.enter_water();
+                    }
+                }
+            }
+            ScriptCommand::ExitWater { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sw) = world.get_mut::<bsengine_core::Swim>(e) {
+                        sw.exit_water();
+                    }
+                }
+            }
+            ScriptCommand::SetWantsDive { name, wants } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sw) = world.get_mut::<bsengine_core::Swim>(e) {
+                        sw.wants_dive = wants;
+                    }
+                }
+            }
+            ScriptCommand::SetWantsSurface { name, wants } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sw) = world.get_mut::<bsengine_core::Swim>(e) {
+                        sw.wants_surface = wants;
+                    }
+                }
+            }
+            ScriptCommand::SetSwimEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sw) = world.get_mut::<bsengine_core::Swim>(e) {
+                        sw.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -67,11 +67,13 @@ use crate::ops::{
     SILENCE_SNAPSHOT, SIPHON_SNAPSHOT, SLAM_SNAPSHOT, SLAY_SNAPSHOT, SLEEP_SNAPSHOT,
     SLIDE_SNAPSHOT, SLIME_SNAPSHOT, SLINK_SNAPSHOT, SLOW_MO_SNAPSHOT, SLOW_SNAPSHOT,
     SMOKE_SNAPSHOT, SNARE_SNAPSHOT, SOAK_SNAPSHOT, SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT,
-    SPAWN_POINT_SNAPSHOT, SPRING_SNAPSHOT, SPRINT_SNAPSHOT, STAMINA_SNAPSHOT,
-    STATUS_EFFECT_SNAPSHOT, STUN_SNAPSHOT, TAG_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT,
-    TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT, TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT, TRIGGER_SNAPSHOT,
-    TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT, VIGNETTE_SNAPSHOT, VISIBLE_SNAPSHOT, WIND_SNAPSHOT,
-    WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    SPAWN_POINT_SNAPSHOT, SPIKE_SNAPSHOT, SPLINTER_SNAPSHOT, SPRING_SNAPSHOT, SPRINT_SNAPSHOT,
+    STAGGER_SNAPSHOT, STAKE_SNAPSHOT, STALK_SNAPSHOT, STAMINA_SNAPSHOT, STANCE_SNAPSHOT,
+    STATUS_EFFECT_SNAPSHOT, STAT_SNAPSHOT, STEALTH_SNAPSHOT, STOMP_SNAPSHOT, STRIDE_SNAPSHOT,
+    STRIFE_SNAPSHOT, STUMBLE_SNAPSHOT, STUN_SNAPSHOT, TAG_SNAPSHOT, TIMER_SNAPSHOT,
+    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT, TONE_MAP_SNAPSHOT,
+    TRANSFORM_SNAPSHOT, TRIGGER_SNAPSHOT, TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT, VIGNETTE_SNAPSHOT,
+    VISIBLE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -1181,6 +1183,241 @@ fn run_scripts(world: &mut World) {
             );
         }
         SOAK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Spike;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Spike)>();
+        for (name, sp) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sp.duration,
+                    sp.timer,
+                    sp.damage,
+                    sp.push_force,
+                    sp.just_extended,
+                    sp.just_retracted,
+                    sp.enabled,
+                ),
+            );
+        }
+        SPIKE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Splinter;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Splinter)>();
+        for (name, sp) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sp.threshold,
+                    sp.radius,
+                    sp.damage_fraction,
+                    sp.cooldown,
+                    sp.cooldown_timer,
+                    sp.just_splintered,
+                    sp.enabled,
+                ),
+            );
+        }
+        SPLINTER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stagger;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stagger)>();
+        for (name, sg) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sg.phase as u32,
+                    sg.stagger_threshold,
+                    sg.stagger_duration,
+                    sg.stagger_timer,
+                    sg.recovery_duration,
+                    sg.recovery_timer,
+                    sg.stagger_count,
+                    sg.resist,
+                    sg.just_staggered,
+                    sg.enabled,
+                ),
+            );
+        }
+        STAGGER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stake;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stake)>();
+        for (name, sk) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sk.active,
+                    sk.hold_timer,
+                    sk.min_hold,
+                    sk.damage_bonus,
+                    sk.just_staked,
+                    sk.just_broke,
+                    sk.enabled,
+                ),
+            );
+        }
+        STAKE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stalk;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stalk)>();
+        for (name, st) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    st.active,
+                    st.damage_multiplier,
+                    st.just_began,
+                    st.just_consumed,
+                    st.enabled,
+                ),
+            );
+        }
+        STALK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stance;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stance)>();
+        for (name, sa) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sa.current.clone() as u32,
+                    sa.offense_bonus,
+                    sa.defense_reduction,
+                    sa.just_changed,
+                    sa.enabled,
+                ),
+            );
+        }
+        STANCE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stat;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stat)>();
+        for (name, ss) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    ss.base,
+                    ss.bonus,
+                    ss.multiplier,
+                    ss.min.unwrap_or(0.0),
+                    ss.max.unwrap_or(0.0),
+                ),
+            );
+        }
+        STAT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stealth;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stealth)>();
+        for (name, se) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    se.base_visibility,
+                    se.visibility_modifier,
+                    se.noise_level,
+                    se.noise_decay_rate,
+                    se.sneaking,
+                    se.sneak_visibility_scale,
+                    se.enabled,
+                ),
+            );
+        }
+        STEALTH_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stomp;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stomp)>();
+        for (name, sm) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sm.magnitude,
+                    sm.impact_radius,
+                    sm.damage_per_unit,
+                    sm.just_stomped,
+                    sm.enabled,
+                ),
+            );
+        }
+        STOMP_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stride;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stride)>();
+        for (name, sd) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sd.stride_count,
+                    sd.max_strides,
+                    sd.speed_bonus,
+                    sd.just_peaked,
+                    sd.just_broke,
+                    sd.enabled,
+                ),
+            );
+        }
+        STRIDE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Strife;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Strife)>();
+        for (name, sf) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sf.strife,
+                    sf.max_strife,
+                    sf.gain_per_hit,
+                    sf.decay_rate,
+                    sf.just_peaked,
+                    sf.enabled,
+                ),
+            );
+        }
+        STRIFE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Stumble;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Stumble)>();
+        for (name, su) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    su.stumble_timer,
+                    su.stumble_duration,
+                    su.vulnerability_factor,
+                    su.move_penalty,
+                    su.stumble_count,
+                    su.stumbling,
+                    su.just_stumbled,
+                    su.just_recovered,
+                    su.enabled,
+                ),
+            );
+        }
+        STUMBLE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -17821,6 +18058,308 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut so) = world.get_mut::<bsengine_core::Soak>(e) {
                         so.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ExtendSpike { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sp) = world.get_mut::<bsengine_core::Spike>(e) {
+                        sp.extend(duration);
+                    }
+                }
+            }
+            ScriptCommand::RetractSpike { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sp) = world.get_mut::<bsengine_core::Spike>(e) {
+                        sp.retract();
+                    }
+                }
+            }
+            ScriptCommand::SetSpikeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sp) = world.get_mut::<bsengine_core::Spike>(e) {
+                        sp.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetSplinterEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sp) = world.get_mut::<bsengine_core::Splinter>(e) {
+                        sp.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyStagger { name, force } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sg) = world.get_mut::<bsengine_core::Stagger>(e) {
+                        sg.apply(force);
+                    }
+                }
+            }
+            ScriptCommand::ResetStagger { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sg) = world.get_mut::<bsengine_core::Stagger>(e) {
+                        sg.reset();
+                    }
+                }
+            }
+            ScriptCommand::SetStaggerEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sg) = world.get_mut::<bsengine_core::Stagger>(e) {
+                        sg.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetStakeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sk) = world.get_mut::<bsengine_core::Stake>(e) {
+                        sk.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::BeginStalk { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut st) = world.get_mut::<bsengine_core::Stalk>(e) {
+                        st.begin();
+                    }
+                }
+            }
+            ScriptCommand::SetStalkEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut st) = world.get_mut::<bsengine_core::Stalk>(e) {
+                        st.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetStance { name, kind } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sa) = world.get_mut::<bsengine_core::Stance>(e) {
+                        let stance_kind = match kind {
+                            1 => bsengine_core::StanceKind::Offensive,
+                            2 => bsengine_core::StanceKind::Defensive,
+                            _ => bsengine_core::StanceKind::Neutral,
+                        };
+                        sa.set_stance(stance_kind);
+                    }
+                }
+            }
+            ScriptCommand::SetStanceEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sa) = world.get_mut::<bsengine_core::Stance>(e) {
+                        sa.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AddStatBonus { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ss) = world.get_mut::<bsengine_core::Stat>(e) {
+                        ss.add_bonus(amount);
+                    }
+                }
+            }
+            ScriptCommand::RemoveStatBonus { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ss) = world.get_mut::<bsengine_core::Stat>(e) {
+                        ss.remove_bonus(amount);
+                    }
+                }
+            }
+            ScriptCommand::StartSneaking { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut se) = world.get_mut::<bsengine_core::Stealth>(e) {
+                        se.start_sneaking();
+                    }
+                }
+            }
+            ScriptCommand::StopSneaking { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut se) = world.get_mut::<bsengine_core::Stealth>(e) {
+                        se.stop_sneaking();
+                    }
+                }
+            }
+            ScriptCommand::AddNoise { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut se) = world.get_mut::<bsengine_core::Stealth>(e) {
+                        se.add_noise(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetStealthEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut se) = world.get_mut::<bsengine_core::Stealth>(e) {
+                        se.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::TriggerStomp { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sm) = world.get_mut::<bsengine_core::Stomp>(e) {
+                        sm.trigger();
+                    }
+                }
+            }
+            ScriptCommand::SetStompEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sm) = world.get_mut::<bsengine_core::Stomp>(e) {
+                        sm.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StepStride { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sd) = world.get_mut::<bsengine_core::Stride>(e) {
+                        sd.step();
+                    }
+                }
+            }
+            ScriptCommand::BreakStride { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sd) = world.get_mut::<bsengine_core::Stride>(e) {
+                        sd.break_stride();
+                    }
+                }
+            }
+            ScriptCommand::SetStrideEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sd) = world.get_mut::<bsengine_core::Stride>(e) {
+                        sd.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::HitStrife { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sf) = world.get_mut::<bsengine_core::Strife>(e) {
+                        sf.hit();
+                    }
+                }
+            }
+            ScriptCommand::SetStrifeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sf) = world.get_mut::<bsengine_core::Strife>(e) {
+                        sf.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::TriggerStumble { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut su) = world.get_mut::<bsengine_core::Stumble>(e) {
+                        su.trigger();
+                    }
+                }
+            }
+            ScriptCommand::SetStumbleEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut su) = world.get_mut::<bsengine_core::Stumble>(e) {
+                        su.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -74,8 +74,10 @@ use crate::ops::{
     SUPPRESS_SNAPSHOT, SURGE_SNAPSHOT, SURROUND_SNAPSHOT, SURVIVE_SNAPSHOT, SWIM_SNAPSHOT,
     TAG_SNAPSHOT, TAINT_SNAPSHOT, TALLY_SNAPSHOT, TALON_SNAPSHOT, TAPER_SNAPSHOT, TAUNT_SNAPSHOT,
     THAW_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT,
-    TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT, TRIGGER_SNAPSHOT, TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT,
-    VIGNETTE_SNAPSHOT, VISIBLE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    TONE_MAP_SNAPSHOT, TRAMPLE_SNAPSHOT, TRANCE_SNAPSHOT, TRANQUIL_SNAPSHOT, TRANSFIX_SNAPSHOT,
+    TRANSFORM_SNAPSHOT, TREMBLE_SNAPSHOT, TREMOR_SNAPSHOT, TRIGGER_SNAPSHOT, TROVE_SNAPSHOT,
+    TUSK_SNAPSHOT, TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT, VIGNETTE_SNAPSHOT, VISIBLE_SNAPSHOT,
+    WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -1671,6 +1673,160 @@ fn run_scripts(world: &mut World) {
             );
         }
         THAW_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Trample;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Trample)>();
+        for (name, tr) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tr.duration,
+                    tr.timer,
+                    tr.damage,
+                    tr.push_force,
+                    tr.radius,
+                    tr.just_started,
+                    tr.just_ended,
+                    tr.enabled,
+                ),
+            );
+        }
+        TRAMPLE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Trance;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Trance)>();
+        for (name, tr) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tr.duration,
+                    tr.timer,
+                    tr.regen_multiplier,
+                    tr.just_entered,
+                    tr.just_exited,
+                    tr.enabled,
+                ),
+            );
+        }
+        TRANCE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Tranquil;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Tranquil)>();
+        for (name, tq) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tq.duration,
+                    tq.timer,
+                    tq.regen_multiplier,
+                    tq.just_entered,
+                    tq.just_exited,
+                    tq.enabled,
+                ),
+            );
+        }
+        TRANQUIL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Transfix;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Transfix)>();
+        for (name, tf) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tf.active,
+                    tf.timer,
+                    tf.lock_range,
+                    tf.just_locked,
+                    tf.just_broken,
+                    tf.enabled,
+                ),
+            );
+        }
+        TRANSFIX_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Tremble;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Tremble)>();
+        for (name, tb) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tb.duration,
+                    tb.timer,
+                    tb.intensity,
+                    tb.just_trembling,
+                    tb.just_stopped,
+                    tb.enabled,
+                ),
+            );
+        }
+        TREMBLE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Tremor;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Tremor)>();
+        for (name, tm) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tm.pulse_interval,
+                    tm.pulse_timer,
+                    tm.radius,
+                    tm.stagger_strength,
+                    tm.active,
+                    tm.just_pulsed,
+                    tm.enabled,
+                ),
+            );
+        }
+        TREMOR_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Trove;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Trove)>();
+        for (name, tv) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tv.trove_value,
+                    tv.threshold,
+                    tv.reward_multiplier,
+                    tv.trove_count,
+                    tv.just_activated,
+                    tv.enabled,
+                ),
+            );
+        }
+        TROVE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Tusk;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Tusk)>();
+        for (name, tk) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tk.current_charge,
+                    tk.full_charge_dist,
+                    tk.max_bonus,
+                    tk.just_hit,
+                    tk.enabled,
+                ),
+            );
+        }
+        TUSK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -19031,6 +19187,281 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut th) = world.get_mut::<bsengine_core::Thaw>(e) {
                         th.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StartTrample { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tr) = world.get_mut::<bsengine_core::Trample>(e) {
+                        tr.start(duration);
+                    }
+                }
+            }
+            ScriptCommand::StopTrample { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tr) = world.get_mut::<bsengine_core::Trample>(e) {
+                        tr.stop();
+                    }
+                }
+            }
+            ScriptCommand::SetTrampleEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tr) = world.get_mut::<bsengine_core::Trample>(e) {
+                        tr.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyTrance { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tr) = world.get_mut::<bsengine_core::Trance>(e) {
+                        tr.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::ClearTrance { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tr) = world.get_mut::<bsengine_core::Trance>(e) {
+                        tr.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetTranceEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tr) = world.get_mut::<bsengine_core::Trance>(e) {
+                        tr.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::EnterTranquil { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tq) = world.get_mut::<bsengine_core::Tranquil>(e) {
+                        tq.enter(duration);
+                    }
+                }
+            }
+            ScriptCommand::InterruptTranquil { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tq) = world.get_mut::<bsengine_core::Tranquil>(e) {
+                        tq.interrupt();
+                    }
+                }
+            }
+            ScriptCommand::SetTranquilEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tq) = world.get_mut::<bsengine_core::Tranquil>(e) {
+                        tq.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::FixTransfix { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tf) = world.get_mut::<bsengine_core::Transfix>(e) {
+                        tf.fix(duration);
+                    }
+                }
+            }
+            ScriptCommand::BreakTransfix { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tf) = world.get_mut::<bsengine_core::Transfix>(e) {
+                        tf.break_lock();
+                    }
+                }
+            }
+            ScriptCommand::SetTransfixEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tf) = world.get_mut::<bsengine_core::Transfix>(e) {
+                        tf.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyTremble { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tb) = world.get_mut::<bsengine_core::Tremble>(e) {
+                        tb.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::ClearTremble { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tb) = world.get_mut::<bsengine_core::Tremble>(e) {
+                        tb.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetTrembleEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tb) = world.get_mut::<bsengine_core::Tremble>(e) {
+                        tb.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ActivateTremor { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tm) = world.get_mut::<bsengine_core::Tremor>(e) {
+                        tm.activate();
+                    }
+                }
+            }
+            ScriptCommand::DeactivateTremor { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tm) = world.get_mut::<bsengine_core::Tremor>(e) {
+                        tm.deactivate();
+                    }
+                }
+            }
+            ScriptCommand::SetTremorEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tm) = world.get_mut::<bsengine_core::Tremor>(e) {
+                        tm.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AddTroveValue { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tv) = world.get_mut::<bsengine_core::Trove>(e) {
+                        tv.add_value(amount);
+                    }
+                }
+            }
+            ScriptCommand::ConsumeTrove { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tv) = world.get_mut::<bsengine_core::Trove>(e) {
+                        tv.consume();
+                    }
+                }
+            }
+            ScriptCommand::SetTroveEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tv) = world.get_mut::<bsengine_core::Trove>(e) {
+                        tv.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ChargeTusk { name, dist } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tk) = world.get_mut::<bsengine_core::Tusk>(e) {
+                        tk.charge(dist);
+                    }
+                }
+            }
+            ScriptCommand::ImpactTusk { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tk) = world.get_mut::<bsengine_core::Tusk>(e) {
+                        tk.impact();
+                    }
+                }
+            }
+            ScriptCommand::ResetTusk { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tk) = world.get_mut::<bsengine_core::Tusk>(e) {
+                        tk.reset();
+                    }
+                }
+            }
+            ScriptCommand::SetTuskEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tk) = world.get_mut::<bsengine_core::Tusk>(e) {
+                        tk.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -83,7 +83,9 @@ use crate::ops::{
     VIEWPORT_SNAPSHOT, VIGNETTE_SNAPSHOT, VIGOR_SNAPSHOT, VILE_SNAPSHOT, VIM_SNAPSHOT,
     VIPER_SNAPSHOT, VIRAL_SNAPSHOT, VISIBLE_SNAPSHOT, VISION_SNAPSHOT, VISIT_SNAPSHOT,
     VISTA_SNAPSHOT, VOID_SNAPSHOT, VOLLEY_SNAPSHOT, VOLUMETRIC_LIGHT_SNAPSHOT, VORTEX_SNAPSHOT,
-    VOW_SNAPSHOT, VULNERABLE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    VOW_SNAPSHOT, VULNERABLE_SNAPSHOT, VULTURE_SNAPSHOT, WAGER_SNAPSHOT, WAGE_SNAPSHOT,
+    WAIL_SNAPSHOT, WAKE_SNAPSHOT, WALK_SNAPSHOT, WALL_SNAPSHOT, WALTZ_SNAPSHOT, WIND_SNAPSHOT,
+    WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -2437,6 +2439,165 @@ fn run_scripts(world: &mut World) {
             );
         }
         VULNERABLE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vulture;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vulture)>();
+        for (name, vul) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vul.patience,
+                    vul.max_patience,
+                    vul.wait_rate,
+                    vul.just_descended,
+                    vul.just_scattered,
+                    vul.enabled,
+                ),
+            );
+        }
+        VULTURE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wage;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wage)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.earnings,
+                    w.max_earnings,
+                    w.income_rate,
+                    w.just_paid,
+                    w.just_broke,
+                    w.enabled,
+                ),
+            );
+        }
+        WAGE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wager;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wager)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.stake,
+                    w.max_stake,
+                    w.risk_rate,
+                    w.just_won,
+                    w.just_lost,
+                    w.enabled,
+                ),
+            );
+        }
+        WAGER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wail;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wail)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.grief,
+                    w.max_grief,
+                    w.keen_rate,
+                    w.just_wailed,
+                    w.just_calmed,
+                    w.enabled,
+                ),
+            );
+        }
+        WAIL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wake;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wake)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.arousal,
+                    w.max_arousal,
+                    w.alert_rate,
+                    w.just_woken,
+                    w.just_slept,
+                    w.enabled,
+                ),
+            );
+        }
+        WAKE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Walk;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Walk)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.stride,
+                    w.max_stride,
+                    w.pace_rate,
+                    w.just_striding,
+                    w.just_halted,
+                    w.enabled,
+                ),
+            );
+        }
+        WALK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::{Wall, WallState};
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wall)>();
+        for (name, w) in q.iter(world) {
+            let state_u32 = match w.state {
+                WallState::None => 0u32,
+                WallState::Running => 1u32,
+                WallState::Sliding => 2u32,
+                WallState::Jumping => 3u32,
+            };
+            map.insert(
+                name.0.clone(),
+                (
+                    state_u32,
+                    w.run_speed,
+                    w.slide_speed,
+                    w.gravity_scale,
+                    w.run_timer,
+                    w.wall_jump_force,
+                    w.enabled,
+                ),
+            );
+        }
+        WALL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Waltz;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Waltz)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.rhythm,
+                    w.max_rhythm,
+                    w.grace_rate,
+                    w.just_dancing,
+                    w.just_still,
+                    w.enabled,
+                ),
+            );
+        }
+        WALTZ_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -21153,6 +21314,281 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut vul) = world.get_mut::<bsengine_core::Vulnerable>(e) {
                         vul.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::CircleVulture { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vul) = world.get_mut::<bsengine_core::Vulture>(e) {
+                        vul.circle(amount);
+                    }
+                }
+            }
+            ScriptCommand::ScatterVulture { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vul) = world.get_mut::<bsengine_core::Vulture>(e) {
+                        vul.scatter(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVultureEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vul) = world.get_mut::<bsengine_core::Vulture>(e) {
+                        vul.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::EarnWage { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wage>(e) {
+                        w.earn(amount);
+                    }
+                }
+            }
+            ScriptCommand::SpendWage { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wage>(e) {
+                        w.spend(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWageEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wage>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::BetWager { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wager>(e) {
+                        w.bet(amount);
+                    }
+                }
+            }
+            ScriptCommand::ForfeitWager { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wager>(e) {
+                        w.forfeit(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWagerEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wager>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::LamentWail { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wail>(e) {
+                        w.lament(amount);
+                    }
+                }
+            }
+            ScriptCommand::ConsoleWail { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wail>(e) {
+                        w.console(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWailEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wail>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::RouseWake { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wake>(e) {
+                        w.rouse(amount);
+                    }
+                }
+            }
+            ScriptCommand::LullWake { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wake>(e) {
+                        w.lull(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWakeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wake>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StepWalk { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Walk>(e) {
+                        w.step(amount);
+                    }
+                }
+            }
+            ScriptCommand::RestWalk { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Walk>(e) {
+                        w.rest(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWalkEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Walk>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetWallRunSpeed { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wall>(e) {
+                        w.run_speed = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWallSlideSpeed { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wall>(e) {
+                        w.slide_speed = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWallJumpForce { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wall>(e) {
+                        w.wall_jump_force = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWallEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wall>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StepWaltz { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waltz>(e) {
+                        w.step(amount);
+                    }
+                }
+            }
+            ScriptCommand::HaltWaltz { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waltz>(e) {
+                        w.halt(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWaltzEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Waltz>(e) {
+                        w.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -84,8 +84,9 @@ use crate::ops::{
     VIPER_SNAPSHOT, VIRAL_SNAPSHOT, VISIBLE_SNAPSHOT, VISION_SNAPSHOT, VISIT_SNAPSHOT,
     VISTA_SNAPSHOT, VOID_SNAPSHOT, VOLLEY_SNAPSHOT, VOLUMETRIC_LIGHT_SNAPSHOT, VORTEX_SNAPSHOT,
     VOW_SNAPSHOT, VULNERABLE_SNAPSHOT, VULTURE_SNAPSHOT, WAGER_SNAPSHOT, WAGE_SNAPSHOT,
-    WAIL_SNAPSHOT, WAKE_SNAPSHOT, WALK_SNAPSHOT, WALL_SNAPSHOT, WALTZ_SNAPSHOT, WIND_SNAPSHOT,
-    WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    WAIL_SNAPSHOT, WAKE_SNAPSHOT, WALK_SNAPSHOT, WALL_SNAPSHOT, WALTZ_SNAPSHOT, WAND_SNAPSHOT,
+    WANE_SNAPSHOT, WANGLE_SNAPSHOT, WANTON_SNAPSHOT, WANT_SNAPSHOT, WARD_SNAPSHOT, WARM_SNAPSHOT,
+    WARP_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -2598,6 +2599,157 @@ fn run_scripts(world: &mut World) {
             );
         }
         WALTZ_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wand;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wand)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.charge,
+                    w.max_charge,
+                    w.channel_rate,
+                    w.just_charged,
+                    w.just_spent,
+                    w.enabled,
+                ),
+            );
+        }
+        WAND_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wane;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wane)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.duration,
+                    w.timer,
+                    w.min_potency,
+                    w.just_waning,
+                    w.just_expired,
+                    w.enabled,
+                ),
+            );
+        }
+        WANE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wangle;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wangle)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.scheme,
+                    w.max_scheme,
+                    w.maneuver_rate,
+                    w.just_schemed,
+                    w.just_foiled,
+                    w.enabled,
+                ),
+            );
+        }
+        WANGLE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Want;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Want)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.desire,
+                    w.max_desire,
+                    w.craving_rate,
+                    w.just_wanted,
+                    w.just_sated,
+                    w.enabled,
+                ),
+            );
+        }
+        WANT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wanton;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wanton)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.excess,
+                    w.max_excess,
+                    w.indulge_rate,
+                    w.just_reckless,
+                    w.just_restrained,
+                    w.enabled,
+                ),
+            );
+        }
+        WANTON_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Ward;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Ward)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.ward_hp,
+                    w.max_ward_hp,
+                    w.just_broke,
+                    w.just_reinforced,
+                    w.enabled,
+                ),
+            );
+        }
+        WARD_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Warm;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Warm)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.heat,
+                    w.max_heat,
+                    w.kindle_rate,
+                    w.just_warm,
+                    w.just_cold,
+                    w.enabled,
+                ),
+            );
+        }
+        WARM_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Warp;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Warp)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.phase as u32,
+                    w.max_range,
+                    w.charge_duration,
+                    w.cooldown_duration,
+                    w.just_warped,
+                    w.enabled,
+                ),
+            );
+        }
+        WARP_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -21588,6 +21740,281 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut w) = world.get_mut::<bsengine_core::Waltz>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ChannelWand { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wand>(e) {
+                        w.channel(amount);
+                    }
+                }
+            }
+            ScriptCommand::DischargeWand { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wand>(e) {
+                        w.discharge(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWandEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wand>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StartWane { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wane>(e) {
+                        w.start(duration);
+                    }
+                }
+            }
+            ScriptCommand::StopWane { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wane>(e) {
+                        w.stop();
+                    }
+                }
+            }
+            ScriptCommand::SetWaneEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wane>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ManeuverWangle { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wangle>(e) {
+                        w.maneuver(amount);
+                    }
+                }
+            }
+            ScriptCommand::FoilWangle { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wangle>(e) {
+                        w.foil(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWangleEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wangle>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::CraveWant { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Want>(e) {
+                        w.crave(amount);
+                    }
+                }
+            }
+            ScriptCommand::SateWant { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Want>(e) {
+                        w.sate(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWantEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Want>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::IndulgeWanton { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wanton>(e) {
+                        w.indulge(amount);
+                    }
+                }
+            }
+            ScriptCommand::RestrainWanton { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wanton>(e) {
+                        w.restrain(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWantonEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wanton>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ReinforceWard { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Ward>(e) {
+                        w.reinforce(amount);
+                    }
+                }
+            }
+            ScriptCommand::AbsorbWard { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Ward>(e) {
+                        w.absorb(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWardEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Ward>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::KindleWarm { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warm>(e) {
+                        w.kindle(amount);
+                    }
+                }
+            }
+            ScriptCommand::ChillWarm { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warm>(e) {
+                        w.chill(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWarmEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warm>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetWarpMaxRange { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warp>(e) {
+                        w.max_range = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWarpChargeDuration { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warp>(e) {
+                        w.charge_duration = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWarpCooldownDuration { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warp>(e) {
+                        w.cooldown_duration = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWarpEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Warp>(e) {
                         w.enabled = enabled;
                     }
                 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -72,7 +72,8 @@ use crate::ops::{
     STATUS_EFFECT_SNAPSHOT, STAT_SNAPSHOT, STEALTH_SNAPSHOT, STOMP_SNAPSHOT, STRIDE_SNAPSHOT,
     STRIFE_SNAPSHOT, STUMBLE_SNAPSHOT, STUN_SNAPSHOT, SULK_SNAPSHOT, SUNDER_SNAPSHOT,
     SUPPRESS_SNAPSHOT, SURGE_SNAPSHOT, SURROUND_SNAPSHOT, SURVIVE_SNAPSHOT, SWIM_SNAPSHOT,
-    TAG_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT,
+    TAG_SNAPSHOT, TAINT_SNAPSHOT, TALLY_SNAPSHOT, TALON_SNAPSHOT, TAPER_SNAPSHOT, TAUNT_SNAPSHOT,
+    THAW_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT,
     TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT, TRIGGER_SNAPSHOT, TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT,
     VIGNETTE_SNAPSHOT, VISIBLE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
@@ -1554,6 +1555,122 @@ fn run_scripts(world: &mut World) {
             );
         }
         SWIM_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Taint;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Taint)>();
+        for (name, ta) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    ta.duration,
+                    ta.timer,
+                    ta.healing_reduction,
+                    ta.just_tainted,
+                    ta.just_cleansed,
+                    ta.enabled,
+                ),
+            );
+        }
+        TAINT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Tally;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Tally)>();
+        for (name, tl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tl.count,
+                    tl.goal,
+                    tl.just_incremented,
+                    tl.just_completed,
+                    tl.just_reset,
+                    tl.enabled,
+                ),
+            );
+        }
+        TALLY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Talon;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Talon)>();
+        for (name, tn) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tn.active,
+                    tn.grip_bonus,
+                    tn.slip_resistance,
+                    tn.just_gripped,
+                    tn.just_released,
+                    tn.enabled,
+                ),
+            );
+        }
+        TALON_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Taper;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Taper)>();
+        for (name, tp) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tp.elapsed_time,
+                    tp.max_reduction_time,
+                    tp.damage_reduction,
+                    tp.in_combat,
+                    tp.just_peaked,
+                    tp.enabled,
+                ),
+            );
+        }
+        TAPER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Taunt;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Taunt)>();
+        for (name, tt) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    tt.is_active,
+                    tt.radius,
+                    tt.threat_boost,
+                    tt.duration,
+                    tt.timer,
+                    tt.just_activated,
+                    tt.just_expired,
+                    tt.enabled,
+                ),
+            );
+        }
+        TAUNT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Thaw;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Thaw)>();
+        for (name, th) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    th.thaw_fraction,
+                    th.thaw_rate,
+                    th.freeze_penalty,
+                    th.just_thawed,
+                    th.just_frozen,
+                    th.enabled,
+                ),
+            );
+        }
+        THAW_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -18738,6 +18855,182 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut sw) = world.get_mut::<bsengine_core::Swim>(e) {
                         sw.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyTaint { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ta) = world.get_mut::<bsengine_core::Taint>(e) {
+                        ta.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::ClearTaint { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ta) = world.get_mut::<bsengine_core::Taint>(e) {
+                        ta.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetTaintEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ta) = world.get_mut::<bsengine_core::Taint>(e) {
+                        ta.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::IncrementTally { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tl) = world.get_mut::<bsengine_core::Tally>(e) {
+                        tl.increment(amount);
+                    }
+                }
+            }
+            ScriptCommand::ResetTally { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tl) = world.get_mut::<bsengine_core::Tally>(e) {
+                        tl.reset();
+                    }
+                }
+            }
+            ScriptCommand::SetTallyEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tl) = world.get_mut::<bsengine_core::Tally>(e) {
+                        tl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetGripping { name, gripping } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tn) = world.get_mut::<bsengine_core::Talon>(e) {
+                        tn.set_gripping(gripping);
+                    }
+                }
+            }
+            ScriptCommand::SetTalonEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tn) = world.get_mut::<bsengine_core::Talon>(e) {
+                        tn.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::EngageTaper { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tp) = world.get_mut::<bsengine_core::Taper>(e) {
+                        tp.engage();
+                    }
+                }
+            }
+            ScriptCommand::DisengageTaper { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tp) = world.get_mut::<bsengine_core::Taper>(e) {
+                        tp.disengage();
+                    }
+                }
+            }
+            ScriptCommand::SetTaperEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tp) = world.get_mut::<bsengine_core::Taper>(e) {
+                        tp.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ActivateTaunt { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tt) = world.get_mut::<bsengine_core::Taunt>(e) {
+                        tt.activate();
+                    }
+                }
+            }
+            ScriptCommand::DeactivateTaunt { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tt) = world.get_mut::<bsengine_core::Taunt>(e) {
+                        tt.deactivate();
+                    }
+                }
+            }
+            ScriptCommand::SetTauntEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut tt) = world.get_mut::<bsengine_core::Taunt>(e) {
+                        tt.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyFreeze { name, intensity } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut th) = world.get_mut::<bsengine_core::Thaw>(e) {
+                        th.apply_freeze(intensity);
+                    }
+                }
+            }
+            ScriptCommand::SetThawEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut th) = world.get_mut::<bsengine_core::Thaw>(e) {
+                        th.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -76,8 +76,10 @@ use crate::ops::{
     THAW_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT,
     TONE_MAP_SNAPSHOT, TRAMPLE_SNAPSHOT, TRANCE_SNAPSHOT, TRANQUIL_SNAPSHOT, TRANSFIX_SNAPSHOT,
     TRANSFORM_SNAPSHOT, TREMBLE_SNAPSHOT, TREMOR_SNAPSHOT, TRIGGER_SNAPSHOT, TROVE_SNAPSHOT,
-    TUSK_SNAPSHOT, TWEEN_SNAPSHOT, VELOCITY_SNAPSHOT, VIGNETTE_SNAPSHOT, VISIBLE_SNAPSHOT,
-    WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    TUSK_SNAPSHOT, TWEEN_SNAPSHOT, UNREST_SNAPSHOT, UPKEEP_SNAPSHOT, URGE_SNAPSHOT,
+    VELOCITY_SNAPSHOT, VENOM_SNAPSHOT, VEX_SNAPSHOT, VIGNETTE_SNAPSHOT, VIGOR_SNAPSHOT,
+    VILE_SNAPSHOT, VISIBLE_SNAPSHOT, VOID_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
+    Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -1827,6 +1829,165 @@ fn run_scripts(world: &mut World) {
             );
         }
         TUSK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Unrest;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Unrest)>();
+        for (name, ur) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    ur.unrest_level,
+                    ur.max_unrest,
+                    ur.threshold,
+                    ur.decay_rate,
+                    ur.penalty,
+                    ur.just_became_restless,
+                    ur.just_calmed,
+                    ur.enabled,
+                ),
+            );
+        }
+        UNREST_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Upkeep;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Upkeep)>();
+        for (name, up) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    up.deficit,
+                    up.max_deficit,
+                    up.cost_per_second,
+                    up.penalty,
+                    up.just_defaulted,
+                    up.just_cleared,
+                    up.enabled,
+                ),
+            );
+        }
+        UPKEEP_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Urge;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Urge)>();
+        for (name, ug) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    ug.urge_level,
+                    ug.max_urge,
+                    ug.build_rate,
+                    ug.decay_rate,
+                    ug.drive_bonus,
+                    ug.urged,
+                    ug.just_peaked,
+                    ug.enabled,
+                ),
+            );
+        }
+        URGE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Venom;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Venom)>();
+        for (name, vn) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vn.damage_per_stack,
+                    vn.stacks,
+                    vn.max_stacks,
+                    vn.duration,
+                    vn.timer,
+                    vn.just_applied,
+                    vn.just_expired,
+                    vn.enabled,
+                ),
+            );
+        }
+        VENOM_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vex;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vex)>();
+        for (name, vx) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vx.stacks,
+                    vx.max_stacks,
+                    vx.cc_duration_amplify_per_stack,
+                    vx.just_vexed,
+                    vx.just_cleared,
+                    vx.enabled,
+                ),
+            );
+        }
+        VEX_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vigor;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vigor)>();
+        for (name, vg) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vg.duration,
+                    vg.timer,
+                    vg.health_regen_per_second,
+                    vg.max_health_bonus,
+                    vg.just_invigorated,
+                    vg.just_faded,
+                    vg.enabled,
+                ),
+            );
+        }
+        VIGOR_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vile;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vile)>();
+        for (name, vi) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vi.duration,
+                    vi.timer,
+                    vi.heal_reduction,
+                    vi.just_applied,
+                    vi.just_cleared,
+                    vi.enabled,
+                ),
+            );
+        }
+        VILE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Void;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Void)>();
+        for (name, vo) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vo.void_charge,
+                    vo.max_charge,
+                    vo.drain_fraction,
+                    vo.just_peaked,
+                    vo.enabled,
+                ),
+            );
+        }
+        VOID_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -19462,6 +19623,270 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut tk) = world.get_mut::<bsengine_core::Tusk>(e) {
                         tk.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AgitateUnrest { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ur) = world.get_mut::<bsengine_core::Unrest>(e) {
+                        ur.agitate(amount);
+                    }
+                }
+            }
+            ScriptCommand::CalmUnrest { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ur) = world.get_mut::<bsengine_core::Unrest>(e) {
+                        ur.calm(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetUnrestEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ur) = world.get_mut::<bsengine_core::Unrest>(e) {
+                        ur.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::PayUpkeep { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut up) = world.get_mut::<bsengine_core::Upkeep>(e) {
+                        up.pay(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetUpkeepEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut up) = world.get_mut::<bsengine_core::Upkeep>(e) {
+                        up.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::UrgeOn { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ug) = world.get_mut::<bsengine_core::Urge>(e) {
+                        ug.urge_on();
+                    }
+                }
+            }
+            ScriptCommand::UrgeOff { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ug) = world.get_mut::<bsengine_core::Urge>(e) {
+                        ug.urge_off();
+                    }
+                }
+            }
+            ScriptCommand::SetUrgeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut ug) = world.get_mut::<bsengine_core::Urge>(e) {
+                        ug.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyVenom { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vn) = world.get_mut::<bsengine_core::Venom>(e) {
+                        vn.apply();
+                    }
+                }
+            }
+            ScriptCommand::ApplyVenomN { name, n } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vn) = world.get_mut::<bsengine_core::Venom>(e) {
+                        vn.apply_n(n);
+                    }
+                }
+            }
+            ScriptCommand::ClearVenom { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vn) = world.get_mut::<bsengine_core::Venom>(e) {
+                        vn.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetVenomEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vn) = world.get_mut::<bsengine_core::Venom>(e) {
+                        vn.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AddVexStack { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vx) = world.get_mut::<bsengine_core::Vex>(e) {
+                        vx.add_stack();
+                    }
+                }
+            }
+            ScriptCommand::RemoveVexStack { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vx) = world.get_mut::<bsengine_core::Vex>(e) {
+                        vx.remove_stack();
+                    }
+                }
+            }
+            ScriptCommand::ClearVex { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vx) = world.get_mut::<bsengine_core::Vex>(e) {
+                        vx.clear_all();
+                    }
+                }
+            }
+            ScriptCommand::SetVexEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vx) = world.get_mut::<bsengine_core::Vex>(e) {
+                        vx.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyVigor { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vg) = world.get_mut::<bsengine_core::Vigor>(e) {
+                        vg.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::SetVigorEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vg) = world.get_mut::<bsengine_core::Vigor>(e) {
+                        vg.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyVile { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vi) = world.get_mut::<bsengine_core::Vile>(e) {
+                        vi.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::CleanseVile { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vi) = world.get_mut::<bsengine_core::Vile>(e) {
+                        vi.cleanse();
+                    }
+                }
+            }
+            ScriptCommand::SetVileEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vi) = world.get_mut::<bsengine_core::Vile>(e) {
+                        vi.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::DrainVoid { name, damage } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vo) = world.get_mut::<bsengine_core::Void>(e) {
+                        vo.drain(damage);
+                    }
+                }
+            }
+            ScriptCommand::ReleaseVoid { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vo) = world.get_mut::<bsengine_core::Void>(e) {
+                        vo.release();
+                    }
+                }
+            }
+            ScriptCommand::SetVoidEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vo) = world.get_mut::<bsengine_core::Void>(e) {
+                        vo.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -87,8 +87,9 @@ use crate::ops::{
     WAIL_SNAPSHOT, WAKE_SNAPSHOT, WALK_SNAPSHOT, WALL_SNAPSHOT, WALTZ_SNAPSHOT, WAND_SNAPSHOT,
     WANE_SNAPSHOT, WANGLE_SNAPSHOT, WANTON_SNAPSHOT, WANT_SNAPSHOT, WARD_SNAPSHOT, WARM_SNAPSHOT,
     WARN_SNAPSHOT, WARP_SNAPSHOT, WARY_SNAPSHOT, WASH_SNAPSHOT, WASP_SNAPSHOT, WASTE_SNAPSHOT,
-    WATER_BODY_SNAPSHOT, WAVER_SNAPSHOT, WAVE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
-    Z_INDEX_SNAPSHOT,
+    WATER_BODY_SNAPSHOT, WAVER_SNAPSHOT, WAVE_SNAPSHOT, WAX_SNAPSHOT, WAY_SNAPSHOT, WEAL_SNAPSHOT,
+    WEARY_SNAPSHOT, WEASEL_SNAPSHOT, WEATHER_SNAPSHOT, WEAVE_SNAPSHOT, WEB_SNAPSHOT, WIND_SNAPSHOT,
+    WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -2896,6 +2897,157 @@ fn run_scripts(world: &mut World) {
             );
         }
         WAVER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wax;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wax)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.wax_level,
+                    w.max_wax,
+                    w.just_applied,
+                    w.just_stripped,
+                    w.enabled,
+                ),
+            );
+        }
+        WAX_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Way;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Way)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.progress,
+                    w.max_progress,
+                    w.traverse_rate,
+                    w.just_arrived,
+                    w.just_turned,
+                    w.enabled,
+                ),
+            );
+        }
+        WAY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weal;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weal)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.weal_level,
+                    w.max_weal,
+                    w.regen_rate,
+                    w.just_flourished,
+                    w.just_diminished,
+                    w.enabled,
+                ),
+            );
+        }
+        WEAL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weary;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weary)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.fatigue,
+                    w.max_fatigue,
+                    w.drain_rate,
+                    w.just_exhausted,
+                    w.just_refreshed,
+                    w.enabled,
+                ),
+            );
+        }
+        WEARY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weather;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weather)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.cloud_cover,
+                    w.precipitation_intensity,
+                    w.temperature,
+                    w.fog_density,
+                    w.lightning_probability,
+                    w.enabled,
+                ),
+            );
+        }
+        WEATHER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weave;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weave)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.weave_level,
+                    w.max_weave,
+                    w.buildup_rate,
+                    w.weaving,
+                    w.just_peaked,
+                    w.just_broken,
+                    w.enabled,
+                ),
+            );
+        }
+        WEAVE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Weasel;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Weasel)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.weasel_level,
+                    w.max_weasel,
+                    w.regen_rate,
+                    w.just_slipped,
+                    w.enabled,
+                ),
+            );
+        }
+        WEASEL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Web;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Web)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.web_strength,
+                    w.max_strength,
+                    w.movement_penalty,
+                    w.just_caught,
+                    w.just_broken,
+                    w.enabled,
+                ),
+            );
+        }
+        WEB_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -22458,6 +22610,281 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut w) = world.get_mut::<bsengine_core::Waver>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyWax { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wax>(e) {
+                        w.apply(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWaxMaxWax { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wax>(e) {
+                        w.max_wax = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWaxEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wax>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AdvanceWay { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Way>(e) {
+                        w.advance(amount);
+                    }
+                }
+            }
+            ScriptCommand::RetreatWay { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Way>(e) {
+                        w.retreat(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWayEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Way>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::NourishWeal { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weal>(e) {
+                        w.nourish(amount);
+                    }
+                }
+            }
+            ScriptCommand::DepleteWeal { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weal>(e) {
+                        w.deplete(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWealEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weal>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::TireWeary { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weary>(e) {
+                        w.tire(amount);
+                    }
+                }
+            }
+            ScriptCommand::RestWeary { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weary>(e) {
+                        w.rest(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWearyEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weary>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetWeatherCloudCover { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weather>(e) {
+                        w.cloud_cover = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWeatherPrecipitationIntensity { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weather>(e) {
+                        w.precipitation_intensity = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWeatherTemperature { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weather>(e) {
+                        w.temperature = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWeatherFogDensity { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weather>(e) {
+                        w.fog_density = value;
+                    }
+                }
+            }
+            ScriptCommand::SetWeatherEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weather>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::BeginWeave { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weave>(e) {
+                        w.begin();
+                    }
+                }
+            }
+            ScriptCommand::HaltWeave { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weave>(e) {
+                        w.halt();
+                    }
+                }
+            }
+            ScriptCommand::SetWeaveEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weave>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SlipWeasel { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weasel>(e) {
+                        w.slip();
+                    }
+                }
+            }
+            ScriptCommand::SetWeaselEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Weasel>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplyWeb { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Web>(e) {
+                        w.apply(amount);
+                    }
+                }
+            }
+            ScriptCommand::StruggleWeb { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Web>(e) {
+                        w.struggle(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWebEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Web>(e) {
                         w.enabled = enabled;
                     }
                 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -64,7 +64,9 @@ use crate::ops::{
     SCAN_SNAPSHOT, SCAR_SNAPSHOT, SCATTER_SNAPSHOT, SCOPE_SNAPSHOT, SCORCH_SNAPSHOT,
     SCREEN_SHAKE_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SHEAR_SNAPSHOT, SHIELD_BREAK_SNAPSHOT,
     SHIELD_SNAPSHOT, SHOCK_SNAPSHOT, SHRIVEL_SNAPSHOT, SHROUD_SNAPSHOT, SHUNT_SNAPSHOT,
-    SLEEP_SNAPSHOT, SLOW_SNAPSHOT, SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT,
+    SILENCE_SNAPSHOT, SIPHON_SNAPSHOT, SLAM_SNAPSHOT, SLAY_SNAPSHOT, SLEEP_SNAPSHOT,
+    SLIDE_SNAPSHOT, SLIME_SNAPSHOT, SLINK_SNAPSHOT, SLOW_MO_SNAPSHOT, SLOW_SNAPSHOT,
+    SMOKE_SNAPSHOT, SNARE_SNAPSHOT, SOAK_SNAPSHOT, SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT,
     SPAWN_POINT_SNAPSHOT, SPRING_SNAPSHOT, SPRINT_SNAPSHOT, STAMINA_SNAPSHOT,
     STATUS_EFFECT_SNAPSHOT, STUN_SNAPSHOT, TAG_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT,
     TIME_ELAPSED_SNAPSHOT, TINT_SNAPSHOT, TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT, TRIGGER_SNAPSHOT,
@@ -946,6 +948,239 @@ fn run_scripts(world: &mut World) {
             );
         }
         SHUNT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Silence;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Silence)>();
+        for (name, si) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    si.duration,
+                    si.timer,
+                    si.just_silenced,
+                    si.just_unsilenced,
+                    si.enabled,
+                ),
+            );
+        }
+        SILENCE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Siphon;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Siphon)>();
+        for (name, si) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    si.duration,
+                    si.timer,
+                    si.drain_per_second,
+                    si.return_fraction,
+                    si.just_started,
+                    si.just_ended,
+                    si.enabled,
+                ),
+            );
+        }
+        SIPHON_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Slam;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Slam)>();
+        for (name, sl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sl.phase as u32,
+                    sl.slam_speed,
+                    sl.impact_radius,
+                    sl.impact_force,
+                    sl.min_height,
+                    sl.launch_height,
+                    sl.recovery_time,
+                    sl.recovery_timer,
+                    sl.cooldown,
+                    sl.cooldown_timer,
+                    sl.wants_slam,
+                    sl.enabled,
+                ),
+            );
+        }
+        SLAM_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Slay;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Slay)>();
+        for (name, sl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sl.kill_count,
+                    sl.threshold,
+                    sl.trigger_count,
+                    sl.just_triggered,
+                    sl.enabled,
+                ),
+            );
+        }
+        SLAY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Slide;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Slide)>();
+        for (name, sl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sl.phase as u32,
+                    sl.direction.x,
+                    sl.direction.y,
+                    sl.direction.z,
+                    sl.duration,
+                    sl.brake_start,
+                    sl.elapsed,
+                    sl.slide_speed,
+                    sl.wants_slide,
+                    sl.crouch_scale,
+                    sl.enabled,
+                ),
+            );
+        }
+        SLIDE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Slime;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Slime)>();
+        for (name, sl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sl.slime_timer,
+                    sl.slow_factor,
+                    sl.slimed,
+                    sl.just_slimed,
+                    sl.just_cleansed,
+                    sl.enabled,
+                ),
+            );
+        }
+        SLIME_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Slink;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Slink)>();
+        for (name, sl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sl.active,
+                    sl.speed_reduction,
+                    sl.noise_reduction,
+                    sl.just_engaged,
+                    sl.just_disengaged,
+                    sl.enabled,
+                ),
+            );
+        }
+        SLINK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::SlowMo;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &SlowMo)>();
+        for (name, sm) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sm.target_scale,
+                    sm.current_scale,
+                    sm.blend_speed,
+                    sm.max_duration.unwrap_or(0.0),
+                    sm.elapsed,
+                    sm.charge,
+                    sm.drain_rate,
+                    sm.source as u32,
+                    sm.enabled,
+                ),
+            );
+        }
+        SLOW_MO_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Smoke;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Smoke)>();
+        for (name, sm) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sm.style as u32,
+                    sm.rate,
+                    sm.color[0],
+                    sm.color[1],
+                    sm.color[2],
+                    sm.color[3],
+                    sm.particle_speed,
+                    sm.spread_rate,
+                    sm.particle_lifetime,
+                    sm.offset.x,
+                    sm.offset.y,
+                    sm.offset.z,
+                    sm.burst_duration.unwrap_or(0.0),
+                    sm.elapsed,
+                    sm.enabled,
+                ),
+            );
+        }
+        SMOKE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Snare;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Snare)>();
+        for (name, sn) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    sn.duration,
+                    sn.timer,
+                    sn.slow_fraction,
+                    sn.escape_chance,
+                    sn.just_snared,
+                    sn.just_escaped,
+                    sn.enabled,
+                ),
+            );
+        }
+        SNARE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Soak;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Soak)>();
+        for (name, so) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    so.soak_level,
+                    so.decay_rate,
+                    so.fire_resistance,
+                    so.lightning_amplify,
+                    so.just_soaked,
+                    so.just_dried,
+                    so.enabled,
+                ),
+            );
+        }
+        SOAK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -17284,6 +17519,308 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut sh) = world.get_mut::<bsengine_core::Shunt>(e) {
                         sh.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplySilence { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut si) = world.get_mut::<bsengine_core::Silence>(e) {
+                        si.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::ClearSilence { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut si) = world.get_mut::<bsengine_core::Silence>(e) {
+                        si.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetSilenceEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut si) = world.get_mut::<bsengine_core::Silence>(e) {
+                        si.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StartSiphon { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut si) = world.get_mut::<bsengine_core::Siphon>(e) {
+                        si.start(duration);
+                    }
+                }
+            }
+            ScriptCommand::StopSiphon { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut si) = world.get_mut::<bsengine_core::Siphon>(e) {
+                        si.stop();
+                    }
+                }
+            }
+            ScriptCommand::SetSiphonEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut si) = world.get_mut::<bsengine_core::Siphon>(e) {
+                        si.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::BeginSlam { name, height } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slam>(e) {
+                        sl.begin(height);
+                    }
+                }
+            }
+            ScriptCommand::LandSlam { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slam>(e) {
+                        sl.land();
+                    }
+                }
+            }
+            ScriptCommand::SetSlamEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slam>(e) {
+                        sl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::RegisterKill { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slay>(e) {
+                        sl.register_kill();
+                    }
+                }
+            }
+            ScriptCommand::SetSlayEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slay>(e) {
+                        sl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StartSlide {
+                name,
+                dir_x,
+                dir_y,
+                dir_z,
+            } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slide>(e) {
+                        sl.start(glam::Vec3::new(dir_x, dir_y, dir_z));
+                    }
+                }
+            }
+            ScriptCommand::CancelSlide { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slide>(e) {
+                        sl.cancel();
+                    }
+                }
+            }
+            ScriptCommand::SetSlideEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slide>(e) {
+                        sl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplySlime { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slime>(e) {
+                        sl.apply_slime(duration);
+                    }
+                }
+            }
+            ScriptCommand::CleanseSlime { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slime>(e) {
+                        sl.cleanse();
+                    }
+                }
+            }
+            ScriptCommand::SetSlimeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slime>(e) {
+                        sl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::EngageSlink { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slink>(e) {
+                        sl.engage();
+                    }
+                }
+            }
+            ScriptCommand::DisengageSlink { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slink>(e) {
+                        sl.disengage();
+                    }
+                }
+            }
+            ScriptCommand::SetSlinkEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sl) = world.get_mut::<bsengine_core::Slink>(e) {
+                        sl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetSlowMoEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sm) = world.get_mut::<bsengine_core::SlowMo>(e) {
+                        sm.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetSmokeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sm) = world.get_mut::<bsengine_core::Smoke>(e) {
+                        sm.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ApplySnare { name, duration } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sn) = world.get_mut::<bsengine_core::Snare>(e) {
+                        sn.apply(duration);
+                    }
+                }
+            }
+            ScriptCommand::ClearSnare { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sn) = world.get_mut::<bsengine_core::Snare>(e) {
+                        sn.clear();
+                    }
+                }
+            }
+            ScriptCommand::SetSnareEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sn) = world.get_mut::<bsengine_core::Snare>(e) {
+                        sn.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AbsorbSoak { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut so) = world.get_mut::<bsengine_core::Soak>(e) {
+                        so.absorb(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetSoakEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut so) = world.get_mut::<bsengine_core::Soak>(e) {
+                        so.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -77,9 +77,10 @@ use crate::ops::{
     TONE_MAP_SNAPSHOT, TRAMPLE_SNAPSHOT, TRANCE_SNAPSHOT, TRANQUIL_SNAPSHOT, TRANSFIX_SNAPSHOT,
     TRANSFORM_SNAPSHOT, TREMBLE_SNAPSHOT, TREMOR_SNAPSHOT, TRIGGER_SNAPSHOT, TROVE_SNAPSHOT,
     TUSK_SNAPSHOT, TWEEN_SNAPSHOT, UNREST_SNAPSHOT, UPKEEP_SNAPSHOT, URGE_SNAPSHOT,
-    VELOCITY_SNAPSHOT, VENOM_SNAPSHOT, VEX_SNAPSHOT, VIGNETTE_SNAPSHOT, VIGOR_SNAPSHOT,
-    VILE_SNAPSHOT, VISIBLE_SNAPSHOT, VOID_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
-    Z_INDEX_SNAPSHOT,
+    VELOCITY_SNAPSHOT, VENOM_SNAPSHOT, VENTURE_SNAPSHOT, VERGE_SNAPSHOT, VERIFY_SNAPSHOT,
+    VERILY_SNAPSHOT, VERMIN_SNAPSHOT, VERNAL_SNAPSHOT, VERSE_SNAPSHOT, VERTEX_SNAPSHOT,
+    VEX_SNAPSHOT, VIGNETTE_SNAPSHOT, VIGOR_SNAPSHOT, VILE_SNAPSHOT, VISIBLE_SNAPSHOT,
+    VOID_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -1988,6 +1989,153 @@ fn run_scripts(world: &mut World) {
             );
         }
         VOID_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Venture;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Venture)>();
+        for (name, vt) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vt.venture_level,
+                    vt.max_venture,
+                    vt.venture_rate,
+                    vt.recovery_rate,
+                    vt.damage_bonus,
+                    vt.in_venture,
+                    vt.just_peaked,
+                    vt.enabled,
+                ),
+            );
+        }
+        VENTURE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Verge;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Verge)>();
+        for (name, vg) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (vg.charge, vg.charge_rate, vg.just_peaked, vg.enabled),
+            );
+        }
+        VERGE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Verify;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Verify)>();
+        for (name, vy) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vy.confidence,
+                    vy.max_confidence,
+                    vy.probe_rate,
+                    vy.just_verified,
+                    vy.just_refuted,
+                    vy.enabled,
+                ),
+            );
+        }
+        VERIFY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Verily;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Verily)>();
+        for (name, vl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vl.conviction,
+                    vl.max_conviction,
+                    vl.oath_rate,
+                    vl.just_sworn,
+                    vl.just_recanted,
+                    vl.enabled,
+                ),
+            );
+        }
+        VERILY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vermin;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vermin)>();
+        for (name, vm) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vm.infestation,
+                    vm.max_infestation,
+                    vm.swarm_rate,
+                    vm.just_swarmed,
+                    vm.just_exterminated,
+                    vm.enabled,
+                ),
+            );
+        }
+        VERMIN_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vernal;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vernal)>();
+        for (name, vn) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vn.bloom,
+                    vn.max_bloom,
+                    vn.thaw_rate,
+                    vn.just_bloomed,
+                    vn.just_dormant,
+                    vn.enabled,
+                ),
+            );
+        }
+        VERNAL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Verse;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Verse)>();
+        for (name, vs) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vs.meter,
+                    vs.max_meter,
+                    vs.cadence_rate,
+                    vs.just_composed,
+                    vs.just_silenced,
+                    vs.enabled,
+                ),
+            );
+        }
+        VERSE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vertex;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vertex)>();
+        for (name, vx) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vx.apex,
+                    vx.max_apex,
+                    vx.ascent_rate,
+                    vx.just_peaked,
+                    vx.just_grounded,
+                    vx.enabled,
+                ),
+            );
+        }
+        VERTEX_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -19887,6 +20035,270 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut vo) = world.get_mut::<bsengine_core::Void>(e) {
                         vo.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::BeginVenture { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vt) = world.get_mut::<bsengine_core::Venture>(e) {
+                        vt.begin_venture();
+                    }
+                }
+            }
+            ScriptCommand::EndVenture { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vt) = world.get_mut::<bsengine_core::Venture>(e) {
+                        vt.end_venture();
+                    }
+                }
+            }
+            ScriptCommand::SetVentureEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vt) = world.get_mut::<bsengine_core::Venture>(e) {
+                        vt.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::FeedVerge { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vg) = world.get_mut::<bsengine_core::Verge>(e) {
+                        vg.feed(amount);
+                    }
+                }
+            }
+            ScriptCommand::ConsumeVerge { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vg) = world.get_mut::<bsengine_core::Verge>(e) {
+                        vg.consume();
+                    }
+                }
+            }
+            ScriptCommand::SetVergeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vg) = world.get_mut::<bsengine_core::Verge>(e) {
+                        vg.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ConfirmVerify { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vy) = world.get_mut::<bsengine_core::Verify>(e) {
+                        vy.confirm(amount);
+                    }
+                }
+            }
+            ScriptCommand::RefuteVerify { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vy) = world.get_mut::<bsengine_core::Verify>(e) {
+                        vy.refute(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVerifyEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vy) = world.get_mut::<bsengine_core::Verify>(e) {
+                        vy.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AffirmVerily { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::Verily>(e) {
+                        vl.affirm(amount);
+                    }
+                }
+            }
+            ScriptCommand::RecantVerily { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::Verily>(e) {
+                        vl.recant(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVerilyEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::Verily>(e) {
+                        vl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::InfestVermin { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vm) = world.get_mut::<bsengine_core::Vermin>(e) {
+                        vm.infest(amount);
+                    }
+                }
+            }
+            ScriptCommand::ExterminateVermin { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vm) = world.get_mut::<bsengine_core::Vermin>(e) {
+                        vm.exterminate(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVerminEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vm) = world.get_mut::<bsengine_core::Vermin>(e) {
+                        vm.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::RenewVernal { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vn) = world.get_mut::<bsengine_core::Vernal>(e) {
+                        vn.renew(amount);
+                    }
+                }
+            }
+            ScriptCommand::WitherVernal { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vn) = world.get_mut::<bsengine_core::Vernal>(e) {
+                        vn.wither(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVernalEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vn) = world.get_mut::<bsengine_core::Vernal>(e) {
+                        vn.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ComposeVerse { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vs) = world.get_mut::<bsengine_core::Verse>(e) {
+                        vs.compose(amount);
+                    }
+                }
+            }
+            ScriptCommand::SilenceVerse { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vs) = world.get_mut::<bsengine_core::Verse>(e) {
+                        vs.silence(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVerseEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vs) = world.get_mut::<bsengine_core::Verse>(e) {
+                        vs.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AscendVertex { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vx) = world.get_mut::<bsengine_core::Vertex>(e) {
+                        vx.ascend(amount);
+                    }
+                }
+            }
+            ScriptCommand::DescendVertex { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vx) = world.get_mut::<bsengine_core::Vertex>(e) {
+                        vx.descend(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVertexEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vx) = world.get_mut::<bsengine_core::Vertex>(e) {
+                        vx.enabled = enabled;
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -79,9 +79,11 @@ use crate::ops::{
     TUSK_SNAPSHOT, TWEEN_SNAPSHOT, UNREST_SNAPSHOT, UPKEEP_SNAPSHOT, URGE_SNAPSHOT,
     VELOCITY_SNAPSHOT, VENOM_SNAPSHOT, VENTURE_SNAPSHOT, VERGE_SNAPSHOT, VERIFY_SNAPSHOT,
     VERILY_SNAPSHOT, VERMIN_SNAPSHOT, VERNAL_SNAPSHOT, VERSE_SNAPSHOT, VERTEX_SNAPSHOT,
-    VERVE_SNAPSHOT, VEST_SNAPSHOT, VEX_SNAPSHOT, VICE_SNAPSHOT, VIGNETTE_SNAPSHOT, VIGOR_SNAPSHOT,
-    VILE_SNAPSHOT, VIM_SNAPSHOT, VIPER_SNAPSHOT, VIRAL_SNAPSHOT, VISIBLE_SNAPSHOT, VISIT_SNAPSHOT,
-    VISTA_SNAPSHOT, VOID_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    VERVE_SNAPSHOT, VEST_SNAPSHOT, VEX_SNAPSHOT, VIBRATE_SNAPSHOT, VICE_SNAPSHOT,
+    VIEWPORT_SNAPSHOT, VIGNETTE_SNAPSHOT, VIGOR_SNAPSHOT, VILE_SNAPSHOT, VIM_SNAPSHOT,
+    VIPER_SNAPSHOT, VIRAL_SNAPSHOT, VISIBLE_SNAPSHOT, VISION_SNAPSHOT, VISIT_SNAPSHOT,
+    VISTA_SNAPSHOT, VOID_SNAPSHOT, VOLLEY_SNAPSHOT, VOLUMETRIC_LIGHT_SNAPSHOT, VORTEX_SNAPSHOT,
+    VOW_SNAPSHOT, VULNERABLE_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -2289,6 +2291,152 @@ fn run_scripts(world: &mut World) {
             );
         }
         VISTA_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vibrate;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vibrate)>();
+        for (name, vib) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vib.amplitude,
+                    vib.frequency,
+                    vib.duration,
+                    vib.elapsed,
+                    vib.decay_rate,
+                    vib.just_started,
+                    vib.just_stopped,
+                    vib.enabled,
+                ),
+            );
+        }
+        VIBRATE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Viewport;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Viewport)>();
+        for (name, vp) in q.iter(world) {
+            map.insert(name.0.clone(), (vp.x, vp.y, vp.width, vp.height));
+        }
+        VIEWPORT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vision;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vision)>();
+        for (name, vis) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vis.range,
+                    vis.fov_half_angle,
+                    vis.detection_mask,
+                    vis.in_view_duration,
+                    vis.detection_delay,
+                    vis.los_blocked,
+                    vis.last_seen.is_some(),
+                    vis.enabled,
+                ),
+            );
+        }
+        VISION_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::VolumetricLight;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &VolumetricLight)>();
+        for (name, vl) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vl.scattering,
+                    vl.absorption,
+                    vl.anisotropy,
+                    vl.step_count,
+                    vl.max_distance,
+                    vl.enabled,
+                ),
+            );
+        }
+        VOLUMETRIC_LIGHT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Volley;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Volley)>();
+        for (name, vol) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vol.charge,
+                    vol.max_charge,
+                    vol.draw_rate,
+                    vol.just_vollied,
+                    vol.just_spent,
+                    vol.enabled,
+                ),
+            );
+        }
+        VOLLEY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vortex;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vortex)>();
+        for (name, vtx) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vtx.spin,
+                    vtx.max_spin,
+                    vtx.spiral_rate,
+                    vtx.just_formed,
+                    vtx.just_calm,
+                    vtx.enabled,
+                ),
+            );
+        }
+        VORTEX_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vow;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vow)>();
+        for (name, vow) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vow.pledge,
+                    vow.max_pledge,
+                    vow.devotion_rate,
+                    vow.just_bound,
+                    vow.just_broken,
+                    vow.enabled,
+                ),
+            );
+        }
+        VOW_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Vulnerable;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Vulnerable)>();
+        for (name, vul) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    vul.exposure,
+                    vul.max_exposure,
+                    vul.breach_rate,
+                    vul.just_exposed,
+                    vul.just_hardened,
+                    vul.enabled,
+                ),
+            );
+        }
+        VULNERABLE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -20694,6 +20842,317 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut vta) = world.get_mut::<bsengine_core::Vista>(e) {
                         vta.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::TriggerVibrate {
+                name,
+                amplitude,
+                frequency,
+                duration,
+            } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vib) = world.get_mut::<bsengine_core::Vibrate>(e) {
+                        vib.trigger(amplitude, frequency, duration);
+                    }
+                }
+            }
+            ScriptCommand::StopVibrate { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vib) = world.get_mut::<bsengine_core::Vibrate>(e) {
+                        vib.stop();
+                    }
+                }
+            }
+            ScriptCommand::SetVibrateEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vib) = world.get_mut::<bsengine_core::Vibrate>(e) {
+                        vib.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetViewportRect {
+                name,
+                x,
+                y,
+                width,
+                height,
+            } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vp) = world.get_mut::<bsengine_core::Viewport>(e) {
+                        vp.x = x;
+                        vp.y = y;
+                        vp.width = width;
+                        vp.height = height;
+                    }
+                }
+            }
+            ScriptCommand::SetVisionRange { name, range } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vis) = world.get_mut::<bsengine_core::Vision>(e) {
+                        vis.range = range;
+                    }
+                }
+            }
+            ScriptCommand::SetVisionFov { name, fov } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vis) = world.get_mut::<bsengine_core::Vision>(e) {
+                        vis.fov_half_angle = fov;
+                    }
+                }
+            }
+            ScriptCommand::SetVisionMask { name, mask } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vis) = world.get_mut::<bsengine_core::Vision>(e) {
+                        vis.detection_mask = mask;
+                    }
+                }
+            }
+            ScriptCommand::ResetVisionTimer { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vis) = world.get_mut::<bsengine_core::Vision>(e) {
+                        vis.reset_view_timer();
+                    }
+                }
+            }
+            ScriptCommand::SetVisionEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vis) = world.get_mut::<bsengine_core::Vision>(e) {
+                        vis.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetVolumetricScattering { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::VolumetricLight>(e) {
+                        vl.scattering = value;
+                    }
+                }
+            }
+            ScriptCommand::SetVolumetricAbsorption { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::VolumetricLight>(e) {
+                        vl.absorption = value;
+                    }
+                }
+            }
+            ScriptCommand::SetVolumetricAnisotropy { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::VolumetricLight>(e) {
+                        vl.anisotropy = value;
+                    }
+                }
+            }
+            ScriptCommand::SetVolumetricStepCount { name, count } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::VolumetricLight>(e) {
+                        vl.step_count = count;
+                    }
+                }
+            }
+            ScriptCommand::SetVolumetricMaxDistance { name, value } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::VolumetricLight>(e) {
+                        vl.max_distance = value;
+                    }
+                }
+            }
+            ScriptCommand::SetVolumetricLightEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vl) = world.get_mut::<bsengine_core::VolumetricLight>(e) {
+                        vl.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::LoadVolley { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vol) = world.get_mut::<bsengine_core::Volley>(e) {
+                        vol.load(amount);
+                    }
+                }
+            }
+            ScriptCommand::ReleaseVolley { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vol) = world.get_mut::<bsengine_core::Volley>(e) {
+                        vol.release(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVolleyEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vol) = world.get_mut::<bsengine_core::Volley>(e) {
+                        vol.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::WindVortex { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vtx) = world.get_mut::<bsengine_core::Vortex>(e) {
+                        vtx.wind(amount);
+                    }
+                }
+            }
+            ScriptCommand::DissipateVortex { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vtx) = world.get_mut::<bsengine_core::Vortex>(e) {
+                        vtx.dissipate(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVortexEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vtx) = world.get_mut::<bsengine_core::Vortex>(e) {
+                        vtx.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SwearVow { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vow) = world.get_mut::<bsengine_core::Vow>(e) {
+                        vow.swear(amount);
+                    }
+                }
+            }
+            ScriptCommand::RenounceVow { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vow) = world.get_mut::<bsengine_core::Vow>(e) {
+                        vow.renounce(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVowEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vow) = world.get_mut::<bsengine_core::Vow>(e) {
+                        vow.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::WeakenVulnerable { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vul) = world.get_mut::<bsengine_core::Vulnerable>(e) {
+                        vul.weaken(amount);
+                    }
+                }
+            }
+            ScriptCommand::FortifyVulnerable { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vul) = world.get_mut::<bsengine_core::Vulnerable>(e) {
+                        vul.fortify(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetVulnerableEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut vul) = world.get_mut::<bsengine_core::Vulnerable>(e) {
+                        vul.enabled = enabled;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Adds 72 scripting ops for Wax, Way, Weal, Weary, Weather, Weave, Weasel, Web components
- Read ops via thread_local snapshots; write ops via ScriptCommand queue
- Replaces auto-closed PR #1604