### PR TITLE
feat(scripting): add Windfall/Windup/Wine/Wing/Wink/Wino/Winsome/Wintry scripting API

### DIFF
--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -5214,6 +5214,106 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Wilt ─────────────────────────────────────────────────────────────────
+    StrainOnWilt {
+        name: String,
+    },
+    StrainOffWilt {
+        name: String,
+    },
+    SetWiltEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wily ─────────────────────────────────────────────────────────────────
+    PlotWily {
+        name: String,
+        amount: f32,
+    },
+    NaiveWily {
+        name: String,
+        amount: f32,
+    },
+    SetWilyEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wimp ─────────────────────────────────────────────────────────────────
+    FlinchWimp {
+        name: String,
+        amount: f32,
+    },
+    DefyWimp {
+        name: String,
+    },
+    SetWimpEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wimple ───────────────────────────────────────────────────────────────
+    DrapeWimple {
+        name: String,
+        amount: f32,
+    },
+    UnfoldWimple {
+        name: String,
+        amount: f32,
+    },
+    SetWimpleEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Win ──────────────────────────────────────────────────────────────────
+    GainWin {
+        name: String,
+        amount: f32,
+    },
+    ForfeitWin {
+        name: String,
+        amount: f32,
+    },
+    SetWinEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wince ────────────────────────────────────────────────────────────────
+    FlinchWince {
+        name: String,
+        amount: f32,
+    },
+    RecoverWince {
+        name: String,
+    },
+    SetWinceEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Winch ────────────────────────────────────────────────────────────────
+    CrankWinch {
+        name: String,
+        amount: f32,
+    },
+    ReleaseWinch {
+        name: String,
+        amount: f32,
+    },
+    SetWinchEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Winder ───────────────────────────────────────────────────────────────
+    CrankWinder {
+        name: String,
+        amount: f32,
+    },
+    ReleaseWinder {
+        name: String,
+        amount: f32,
+    },
+    SetWinderEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -6505,6 +6605,22 @@ thread_local! {
     pub(crate) static WILL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static WILLOW_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WILT_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WILY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WIMP_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WIMPLE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WIN_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINCE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINCH_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINDER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -14826,6 +14942,359 @@ pub fn bsengine_set_willow_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetWillowEnabled { name, enabled })
+    });
+}
+// ── Wilt ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wilt_level(#[string] name: String) -> f32 {
+    WILT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wilt_max_wilt(#[string] name: String) -> f32 {
+    WILT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wilt_strain_rate(#[string] name: String) -> f32 {
+    WILT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wilt_just_wilted(#[string] name: String) -> bool {
+    WILT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wilt_just_recovered(#[string] name: String) -> bool {
+    WILT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wilt_enabled(#[string] name: String) -> bool {
+    WILT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_strain_on_wilt(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StrainOnWilt { name }));
+}
+#[op2(fast)]
+pub fn bsengine_strain_off_wilt(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StrainOffWilt { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wilt_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWiltEnabled { name, enabled })
+    });
+}
+// ── Wily ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wily_cunning(#[string] name: String) -> f32 {
+    WILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wily_max_cunning(#[string] name: String) -> f32 {
+    WILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wily_plot_rate(#[string] name: String) -> f32 {
+    WILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wily_just_sly(#[string] name: String) -> bool {
+    WILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wily_just_naive(#[string] name: String) -> bool {
+    WILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wily_enabled(#[string] name: String) -> bool {
+    WILY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_plot_wily(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::PlotWily { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_naive_wily(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::NaiveWily { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wily_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWilyEnabled { name, enabled })
+    });
+}
+// ── Wimp ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wimp_level(#[string] name: String) -> f32 {
+    WIMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wimp_max_wimp(#[string] name: String) -> f32 {
+    WIMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wimp_recover_rate(#[string] name: String) -> f32 {
+    WIMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wimp_just_flinched(#[string] name: String) -> bool {
+    WIMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wimp_just_overcame(#[string] name: String) -> bool {
+    WIMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wimp_enabled(#[string] name: String) -> bool {
+    WIMP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_flinch_wimp(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::FlinchWimp { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_defy_wimp(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::DefyWimp { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wimp_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWimpEnabled { name, enabled })
+    });
+}
+// ── Wimple ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wimple_folds(#[string] name: String) -> f32 {
+    WIMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wimple_max_folds(#[string] name: String) -> f32 {
+    WIMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wimple_drape_rate(#[string] name: String) -> f32 {
+    WIMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wimple_just_draped(#[string] name: String) -> bool {
+    WIMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wimple_just_plain(#[string] name: String) -> bool {
+    WIMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wimple_enabled(#[string] name: String) -> bool {
+    WIMPLE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_drape_wimple(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DrapeWimple { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_unfold_wimple(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::UnfoldWimple { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wimple_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWimpleEnabled { name, enabled })
+    });
+}
+// ── Win ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_win_score(#[string] name: String) -> f32 {
+    WIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_win_max_score(#[string] name: String) -> f32 {
+    WIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_win_win_rate(#[string] name: String) -> f32 {
+    WIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_win_just_won(#[string] name: String) -> bool {
+    WIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_win_just_lost(#[string] name: String) -> bool {
+    WIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_win_enabled(#[string] name: String) -> bool {
+    WIN_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_gain_win(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::GainWin { name, amount }));
+}
+#[op2(fast)]
+pub fn bsengine_forfeit_win(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ForfeitWin { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_win_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWinEnabled { name, enabled })
+    });
+}
+// ── Wince ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wince_level(#[string] name: String) -> f32 {
+    WINCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wince_max_wince(#[string] name: String) -> f32 {
+    WINCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wince_decay_rate(#[string] name: String) -> f32 {
+    WINCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wince_just_winced(#[string] name: String) -> bool {
+    WINCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wince_just_recovered(#[string] name: String) -> bool {
+    WINCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wince_enabled(#[string] name: String) -> bool {
+    WINCE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_flinch_wince(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::FlinchWince { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_recover_wince(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::RecoverWince { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wince_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWinceEnabled { name, enabled })
+    });
+}
+// ── Winch ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_winch_tension(#[string] name: String) -> f32 {
+    WINCH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_winch_max_tension(#[string] name: String) -> f32 {
+    WINCH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_winch_crank_rate(#[string] name: String) -> f32 {
+    WINCH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_winch_just_taut(#[string] name: String) -> bool {
+    WINCH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_winch_just_slack(#[string] name: String) -> bool {
+    WINCH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_winch_enabled(#[string] name: String) -> bool {
+    WINCH_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_crank_winch(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CrankWinch { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_release_winch(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ReleaseWinch { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_winch_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWinchEnabled { name, enabled })
+    });
+}
+// ── Winder ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_winder_tension(#[string] name: String) -> f32 {
+    WINDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_winder_max_tension(#[string] name: String) -> f32 {
+    WINDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_winder_crank_rate(#[string] name: String) -> f32 {
+    WINDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_winder_just_taut(#[string] name: String) -> bool {
+    WINDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_winder_just_slack(#[string] name: String) -> bool {
+    WINDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_winder_enabled(#[string] name: String) -> bool {
+    WINDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_crank_winder(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CrankWinder { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_release_winder(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ReleaseWinder { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_winder_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWinderEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -35413,6 +35882,78 @@ deno_core::extension!(
         bsengine_bend_willow,
         bsengine_settle_willow,
         bsengine_set_willow_enabled,
+        bsengine_get_wilt_level,
+        bsengine_get_wilt_max_wilt,
+        bsengine_get_wilt_strain_rate,
+        bsengine_is_wilt_just_wilted,
+        bsengine_is_wilt_just_recovered,
+        bsengine_is_wilt_enabled,
+        bsengine_strain_on_wilt,
+        bsengine_strain_off_wilt,
+        bsengine_set_wilt_enabled,
+        bsengine_get_wily_cunning,
+        bsengine_get_wily_max_cunning,
+        bsengine_get_wily_plot_rate,
+        bsengine_is_wily_just_sly,
+        bsengine_is_wily_just_naive,
+        bsengine_is_wily_enabled,
+        bsengine_plot_wily,
+        bsengine_naive_wily,
+        bsengine_set_wily_enabled,
+        bsengine_get_wimp_level,
+        bsengine_get_wimp_max_wimp,
+        bsengine_get_wimp_recover_rate,
+        bsengine_is_wimp_just_flinched,
+        bsengine_is_wimp_just_overcame,
+        bsengine_is_wimp_enabled,
+        bsengine_flinch_wimp,
+        bsengine_defy_wimp,
+        bsengine_set_wimp_enabled,
+        bsengine_get_wimple_folds,
+        bsengine_get_wimple_max_folds,
+        bsengine_get_wimple_drape_rate,
+        bsengine_is_wimple_just_draped,
+        bsengine_is_wimple_just_plain,
+        bsengine_is_wimple_enabled,
+        bsengine_drape_wimple,
+        bsengine_unfold_wimple,
+        bsengine_set_wimple_enabled,
+        bsengine_get_win_score,
+        bsengine_get_win_max_score,
+        bsengine_get_win_win_rate,
+        bsengine_is_win_just_won,
+        bsengine_is_win_just_lost,
+        bsengine_is_win_enabled,
+        bsengine_gain_win,
+        bsengine_forfeit_win,
+        bsengine_set_win_enabled,
+        bsengine_get_wince_level,
+        bsengine_get_wince_max_wince,
+        bsengine_get_wince_decay_rate,
+        bsengine_is_wince_just_winced,
+        bsengine_is_wince_just_recovered,
+        bsengine_is_wince_enabled,
+        bsengine_flinch_wince,
+        bsengine_recover_wince,
+        bsengine_set_wince_enabled,
+        bsengine_get_winch_tension,
+        bsengine_get_winch_max_tension,
+        bsengine_get_winch_crank_rate,
+        bsengine_is_winch_just_taut,
+        bsengine_is_winch_just_slack,
+        bsengine_is_winch_enabled,
+        bsengine_crank_winch,
+        bsengine_release_winch,
+        bsengine_set_winch_enabled,
+        bsengine_get_winder_tension,
+        bsengine_get_winder_max_tension,
+        bsengine_get_winder_crank_rate,
+        bsengine_is_winder_just_taut,
+        bsengine_is_winder_just_slack,
+        bsengine_is_winder_enabled,
+        bsengine_crank_winder,
+        bsengine_release_winder,
+        bsengine_set_winder_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -39412,6 +39953,78 @@ const Bsengine = {
     bendWillow:                 (name, amount)      => Deno.core.ops.bsengine_bend_willow(name, amount),
     settleWillow:               (name, amount)      => Deno.core.ops.bsengine_settle_willow(name, amount),
     setWillowEnabled:           (name, v)           => Deno.core.ops.bsengine_set_willow_enabled(name, v),
+    getWiltLevel:               (name)              => Deno.core.ops.bsengine_get_wilt_level(name),
+    getWiltMaxWilt:             (name)              => Deno.core.ops.bsengine_get_wilt_max_wilt(name),
+    getWiltStrainRate:          (name)              => Deno.core.ops.bsengine_get_wilt_strain_rate(name),
+    isWiltJustWilted:           (name)              => Deno.core.ops.bsengine_is_wilt_just_wilted(name),
+    isWiltJustRecovered:        (name)              => Deno.core.ops.bsengine_is_wilt_just_recovered(name),
+    isWiltEnabled:              (name)              => Deno.core.ops.bsengine_is_wilt_enabled(name),
+    strainOnWilt:               (name)              => Deno.core.ops.bsengine_strain_on_wilt(name),
+    strainOffWilt:              (name)              => Deno.core.ops.bsengine_strain_off_wilt(name),
+    setWiltEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wilt_enabled(name, v),
+    getWilyCunning:             (name)              => Deno.core.ops.bsengine_get_wily_cunning(name),
+    getWilyMaxCunning:          (name)              => Deno.core.ops.bsengine_get_wily_max_cunning(name),
+    getWilyPlotRate:            (name)              => Deno.core.ops.bsengine_get_wily_plot_rate(name),
+    isWilyJustSly:              (name)              => Deno.core.ops.bsengine_is_wily_just_sly(name),
+    isWilyJustNaive:            (name)              => Deno.core.ops.bsengine_is_wily_just_naive(name),
+    isWilyEnabled:              (name)              => Deno.core.ops.bsengine_is_wily_enabled(name),
+    plotWily:                   (name, amount)      => Deno.core.ops.bsengine_plot_wily(name, amount),
+    naiveWily:                  (name, amount)      => Deno.core.ops.bsengine_naive_wily(name, amount),
+    setWilyEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wily_enabled(name, v),
+    getWimpLevel:               (name)              => Deno.core.ops.bsengine_get_wimp_level(name),
+    getWimpMaxWimp:             (name)              => Deno.core.ops.bsengine_get_wimp_max_wimp(name),
+    getWimpRecoverRate:         (name)              => Deno.core.ops.bsengine_get_wimp_recover_rate(name),
+    isWimpJustFlinched:         (name)              => Deno.core.ops.bsengine_is_wimp_just_flinched(name),
+    isWimpJustOvercame:         (name)              => Deno.core.ops.bsengine_is_wimp_just_overcame(name),
+    isWimpEnabled:              (name)              => Deno.core.ops.bsengine_is_wimp_enabled(name),
+    flinchWimp:                 (name, amount)      => Deno.core.ops.bsengine_flinch_wimp(name, amount),
+    defyWimp:                   (name)              => Deno.core.ops.bsengine_defy_wimp(name),
+    setWimpEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wimp_enabled(name, v),
+    getWimpleFolds:             (name)              => Deno.core.ops.bsengine_get_wimple_folds(name),
+    getWimpleMaxFolds:          (name)              => Deno.core.ops.bsengine_get_wimple_max_folds(name),
+    getWimpleDrapeRate:         (name)              => Deno.core.ops.bsengine_get_wimple_drape_rate(name),
+    isWimpleJustDraped:         (name)              => Deno.core.ops.bsengine_is_wimple_just_draped(name),
+    isWimpleJustPlain:          (name)              => Deno.core.ops.bsengine_is_wimple_just_plain(name),
+    isWimpleEnabled:            (name)              => Deno.core.ops.bsengine_is_wimple_enabled(name),
+    drapeWimple:                (name, amount)      => Deno.core.ops.bsengine_drape_wimple(name, amount),
+    unfoldWimple:               (name, amount)      => Deno.core.ops.bsengine_unfold_wimple(name, amount),
+    setWimpleEnabled:           (name, v)           => Deno.core.ops.bsengine_set_wimple_enabled(name, v),
+    getWinScore:                (name)              => Deno.core.ops.bsengine_get_win_score(name),
+    getWinMaxScore:             (name)              => Deno.core.ops.bsengine_get_win_max_score(name),
+    getWinWinRate:              (name)              => Deno.core.ops.bsengine_get_win_win_rate(name),
+    isWinJustWon:               (name)              => Deno.core.ops.bsengine_is_win_just_won(name),
+    isWinJustLost:              (name)              => Deno.core.ops.bsengine_is_win_just_lost(name),
+    isWinEnabled:               (name)              => Deno.core.ops.bsengine_is_win_enabled(name),
+    gainWin:                    (name, amount)      => Deno.core.ops.bsengine_gain_win(name, amount),
+    forfeitWin:                 (name, amount)      => Deno.core.ops.bsengine_forfeit_win(name, amount),
+    setWinEnabled:              (name, v)           => Deno.core.ops.bsengine_set_win_enabled(name, v),
+    getWinceLevel:              (name)              => Deno.core.ops.bsengine_get_wince_level(name),
+    getWinceMaxWince:           (name)              => Deno.core.ops.bsengine_get_wince_max_wince(name),
+    getWinceDecayRate:          (name)              => Deno.core.ops.bsengine_get_wince_decay_rate(name),
+    isWinceJustWinced:          (name)              => Deno.core.ops.bsengine_is_wince_just_winced(name),
+    isWinceJustRecovered:       (name)              => Deno.core.ops.bsengine_is_wince_just_recovered(name),
+    isWinceEnabled:             (name)              => Deno.core.ops.bsengine_is_wince_enabled(name),
+    flinchWince:                (name, amount)      => Deno.core.ops.bsengine_flinch_wince(name, amount),
+    recoverWince:               (name)              => Deno.core.ops.bsengine_recover_wince(name),
+    setWinceEnabled:            (name, v)           => Deno.core.ops.bsengine_set_wince_enabled(name, v),
+    getWinchTension:            (name)              => Deno.core.ops.bsengine_get_winch_tension(name),
+    getWinchMaxTension:         (name)              => Deno.core.ops.bsengine_get_winch_max_tension(name),
+    getWinchCrankRate:          (name)              => Deno.core.ops.bsengine_get_winch_crank_rate(name),
+    isWinchJustTaut:            (name)              => Deno.core.ops.bsengine_is_winch_just_taut(name),
+    isWinchJustSlack:           (name)              => Deno.core.ops.bsengine_is_winch_just_slack(name),
+    isWinchEnabled:             (name)              => Deno.core.ops.bsengine_is_winch_enabled(name),
+    crankWinch:                 (name, amount)      => Deno.core.ops.bsengine_crank_winch(name, amount),
+    releaseWinch:               (name, amount)      => Deno.core.ops.bsengine_release_winch(name, amount),
+    setWinchEnabled:            (name, v)           => Deno.core.ops.bsengine_set_winch_enabled(name, v),
+    getWinderTension:           (name)              => Deno.core.ops.bsengine_get_winder_tension(name),
+    getWinderMaxTension:        (name)              => Deno.core.ops.bsengine_get_winder_max_tension(name),
+    getWinderCrankRate:         (name)              => Deno.core.ops.bsengine_get_winder_crank_rate(name),
+    isWinderJustTaut:           (name)              => Deno.core.ops.bsengine_is_winder_just_taut(name),
+    isWinderJustSlack:          (name)              => Deno.core.ops.bsengine_is_winder_just_slack(name),
+    isWinderEnabled:            (name)              => Deno.core.ops.bsengine_is_winder_enabled(name),
+    crankWinder:                (name, amount)      => Deno.core.ops.bsengine_crank_winder(name, amount),
+    releaseWinder:              (name, amount)      => Deno.core.ops.bsengine_release_winder(name, amount),
+    setWinderEnabled:           (name, v)           => Deno.core.ops.bsengine_set_winder_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -65751,6 +66364,434 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BendWillow { name, amount } if name == "Reed" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SettleWillow { name, amount } if name == "Reed" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWillowEnabled { name, enabled } if name == "Reed" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wilt_read_ops() {
+        super::WILT_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Candle".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWiltLevel("Candle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWiltMaxWilt("Candle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWiltStrainRate("Candle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWiltJustWilted("Candle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWiltJustRecovered("Candle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWiltEnabled("Candle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WILT_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wilt_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.strainOnWilt("Candle");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.strainOffWilt("Candle");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWiltEnabled("Candle", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StrainOnWilt { name } if name == "Candle")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StrainOffWilt { name } if name == "Candle")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWiltEnabled { name, enabled } if name == "Candle" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wily_read_ops() {
+        super::WILY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Fox".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWilyCunning("Fox"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWilyMaxCunning("Fox"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWilyPlotRate("Fox"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt.eval(r#"String(Bsengine.isWilyJustSly("Fox"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWilyJustNaive("Fox"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isWilyEnabled("Fox"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WILY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wily_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.plotWily("Fox", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.naiveWily("Fox", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWilyEnabled("Fox", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::PlotWily { name, amount } if name == "Fox" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::NaiveWily { name, amount } if name == "Fox" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWilyEnabled { name, enabled } if name == "Fox" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wimp_read_ops() {
+        super::WIMP_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Coward".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWimpLevel("Coward"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWimpMaxWimp("Coward"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWimpRecoverRate("Coward"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWimpJustFlinched("Coward"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWimpJustOvercame("Coward"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWimpEnabled("Coward"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WIMP_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wimp_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.flinchWimp("Coward", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.defyWimp("Coward");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWimpEnabled("Coward", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::FlinchWimp { name, amount } if name == "Coward" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DefyWimp { name } if name == "Coward")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWimpEnabled { name, enabled } if name == "Coward" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wimple_read_ops() {
+        super::WIMPLE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Veil".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWimpleFolds("Veil"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWimpleMaxFolds("Veil"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWimpleDrapeRate("Veil"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWimpleJustDraped("Veil"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWimpleJustPlain("Veil"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWimpleEnabled("Veil"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WIMPLE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wimple_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.drapeWimple("Veil", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.unfoldWimple("Veil", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWimpleEnabled("Veil", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DrapeWimple { name, amount } if name == "Veil" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::UnfoldWimple { name, amount } if name == "Veil" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWimpleEnabled { name, enabled } if name == "Veil" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_win_read_ops() {
+        super::WIN_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Trophy".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWinScore("Trophy"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinMaxScore("Trophy"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinWinRate("Trophy"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinJustWon("Trophy"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinJustLost("Trophy"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinEnabled("Trophy"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WIN_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_win_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.gainWin("Trophy", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.forfeitWin("Trophy", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWinEnabled("Trophy", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::GainWin { name, amount } if name == "Trophy" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ForfeitWin { name, amount } if name == "Trophy" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWinEnabled { name, enabled } if name == "Trophy" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wince_read_ops() {
+        super::WINCE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Ouch".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWinceLevel("Ouch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinceMaxWince("Ouch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinceDecayRate("Ouch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinceJustWinced("Ouch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinceJustRecovered("Ouch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinceEnabled("Ouch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINCE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wince_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.flinchWince("Ouch", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.recoverWince("Ouch");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWinceEnabled("Ouch", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::FlinchWince { name, amount } if name == "Ouch" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RecoverWince { name } if name == "Ouch")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWinceEnabled { name, enabled } if name == "Ouch" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_winch_read_ops() {
+        super::WINCH_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Pulley".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWinchTension("Pulley"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinchMaxTension("Pulley"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinchCrankRate("Pulley"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinchJustTaut("Pulley"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinchJustSlack("Pulley"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinchEnabled("Pulley"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINCH_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_winch_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.crankWinch("Pulley", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.releaseWinch("Pulley", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWinchEnabled("Pulley", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CrankWinch { name, amount } if name == "Pulley" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ReleaseWinch { name, amount } if name == "Pulley" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWinchEnabled { name, enabled } if name == "Pulley" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_winder_read_ops() {
+        super::WINDER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Spool".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWinderTension("Spool"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinderMaxTension("Spool"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinderCrankRate("Spool"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinderJustTaut("Spool"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinderJustSlack("Spool"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinderEnabled("Spool"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINDER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_winder_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.crankWinder("Spool", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.releaseWinder("Spool", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWinderEnabled("Spool", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CrankWinder { name, amount } if name == "Spool" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ReleaseWinder { name, amount } if name == "Spool" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWinderEnabled { name, enabled } if name == "Spool" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -5314,6 +5314,106 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    // ── Windfall ─────────────────────────────────────────────────────────────
+    AccrueWindfall {
+        name: String,
+        amount: f32,
+    },
+    SpendWindfall {
+        name: String,
+        amount: f32,
+    },
+    SetWindfallEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Windup ───────────────────────────────────────────────────────────────
+    BeginWindup {
+        name: String,
+        amount: f32,
+    },
+    ReleaseWindup {
+        name: String,
+    },
+    SetWindupEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wine ─────────────────────────────────────────────────────────────────
+    UncorkWine {
+        name: String,
+    },
+    AgeWine {
+        name: String,
+        amount: f32,
+    },
+    SetWineEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wing ─────────────────────────────────────────────────────────────────
+    SoarWing {
+        name: String,
+        amount: f32,
+    },
+    StallWing {
+        name: String,
+        amount: f32,
+    },
+    SetWingEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wink ─────────────────────────────────────────────────────────────────
+    OpenWink {
+        name: String,
+    },
+    CloseWink {
+        name: String,
+    },
+    SetWinkEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wino ─────────────────────────────────────────────────────────────────
+    TippleWino {
+        name: String,
+        amount: f32,
+    },
+    SoberWino {
+        name: String,
+        amount: f32,
+    },
+    SetWinoEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Winsome ──────────────────────────────────────────────────────────────
+    DelightWinsome {
+        name: String,
+        amount: f32,
+    },
+    DullWinsome {
+        name: String,
+        amount: f32,
+    },
+    SetWinsomeEnabled {
+        name: String,
+        enabled: bool,
+    },
+    // ── Wintry ───────────────────────────────────────────────────────────────
+    ChillWintry {
+        name: String,
+        amount: f32,
+    },
+    ThawWintry {
+        name: String,
+        amount: f32,
+    },
+    SetWintryEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -6621,6 +6721,22 @@ thread_local! {
     pub(crate) static WINCH_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static WINDER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINDFALL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINDUP_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WING_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINO_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINSOME_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WINTRY_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -15295,6 +15411,359 @@ pub fn bsengine_set_winder_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetWinderEnabled { name, enabled })
+    });
+}
+// ── Windfall ─────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_windfall_fortune(#[string] name: String) -> f32 {
+    WINDFALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_windfall_max_fortune(#[string] name: String) -> f32 {
+    WINDFALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_windfall_accrue_rate(#[string] name: String) -> f32 {
+    WINDFALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_windfall_just_fortunate(#[string] name: String) -> bool {
+    WINDFALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_windfall_just_penniless(#[string] name: String) -> bool {
+    WINDFALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_windfall_enabled(#[string] name: String) -> bool {
+    WINDFALL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_accrue_windfall(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::AccrueWindfall { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_spend_windfall(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SpendWindfall { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_windfall_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWindfallEnabled { name, enabled })
+    });
+}
+// ── Windup ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_windup_duration(#[string] name: String) -> f32 {
+    WINDUP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_windup_timer(#[string] name: String) -> f32 {
+    WINDUP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_windup_damage_multiplier(#[string] name: String) -> f32 {
+    WINDUP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_windup_just_started(#[string] name: String) -> bool {
+    WINDUP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_windup_just_released(#[string] name: String) -> bool {
+    WINDUP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_windup_enabled(#[string] name: String) -> bool {
+    WINDUP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_begin_windup(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::BeginWindup { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_release_windup(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ReleaseWindup { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_windup_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWindupEnabled { name, enabled })
+    });
+}
+// ── Wine ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wine_age(#[string] name: String) -> f32 {
+    WINE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wine_peak_vintage(#[string] name: String) -> f32 {
+    WINE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wine_age_rate(#[string] name: String) -> f32 {
+    WINE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wine_just_peaked(#[string] name: String) -> bool {
+    WINE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wine_just_spoiled(#[string] name: String) -> bool {
+    WINE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wine_enabled(#[string] name: String) -> bool {
+    WINE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_uncork_wine(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::UncorkWine { name }));
+}
+#[op2(fast)]
+pub fn bsengine_age_wine(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::AgeWine { name, amount }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wine_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWineEnabled { name, enabled })
+    });
+}
+// ── Wing ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wing_lift(#[string] name: String) -> f32 {
+    WING_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wing_max_lift(#[string] name: String) -> f32 {
+    WING_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wing_glide_rate(#[string] name: String) -> f32 {
+    WING_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wing_just_airborne(#[string] name: String) -> bool {
+    WING_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wing_just_grounded(#[string] name: String) -> bool {
+    WING_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wing_enabled(#[string] name: String) -> bool {
+    WING_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_soar_wing(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SoarWing { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_stall_wing(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::StallWing { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wing_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWingEnabled { name, enabled })
+    });
+}
+// ── Wink ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wink_timer(#[string] name: String) -> f32 {
+    WINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wink_duration(#[string] name: String) -> f32 {
+    WINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wink_power(#[string] name: String) -> f32 {
+    WINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wink_active(#[string] name: String) -> bool {
+    WINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wink_just_closed(#[string] name: String) -> bool {
+    WINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wink_enabled(#[string] name: String) -> bool {
+    WINK_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_open_wink(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::OpenWink { name }));
+}
+#[op2(fast)]
+pub fn bsengine_close_wink(#[string] name: String) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::CloseWink { name }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wink_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWinkEnabled { name, enabled })
+    });
+}
+// ── Wino ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wino_indulgence(#[string] name: String) -> f32 {
+    WINO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wino_max_indulgence(#[string] name: String) -> f32 {
+    WINO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wino_tipple_rate(#[string] name: String) -> f32 {
+    WINO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wino_just_tipsy(#[string] name: String) -> bool {
+    WINO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wino_just_sober(#[string] name: String) -> bool {
+    WINO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wino_enabled(#[string] name: String) -> bool {
+    WINO_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_tipple_wino(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::TippleWino { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_sober_wino(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SoberWino { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wino_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWinoEnabled { name, enabled })
+    });
+}
+// ── Winsome ──────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_winsome_charm(#[string] name: String) -> f32 {
+    WINSOME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_winsome_max_charm(#[string] name: String) -> f32 {
+    WINSOME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_winsome_delight_rate(#[string] name: String) -> f32 {
+    WINSOME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_winsome_just_delightful(#[string] name: String) -> bool {
+    WINSOME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_winsome_just_dull(#[string] name: String) -> bool {
+    WINSOME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_winsome_enabled(#[string] name: String) -> bool {
+    WINSOME_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_delight_winsome(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DelightWinsome { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_dull_winsome(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DullWinsome { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_winsome_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWinsomeEnabled { name, enabled })
+    });
+}
+// ── Wintry ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wintry_cold(#[string] name: String) -> f32 {
+    WINTRY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wintry_max_cold(#[string] name: String) -> f32 {
+    WINTRY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wintry_chill_rate(#[string] name: String) -> f32 {
+    WINTRY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wintry_just_frozen(#[string] name: String) -> bool {
+    WINTRY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wintry_just_thawed(#[string] name: String) -> bool {
+    WINTRY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wintry_enabled(#[string] name: String) -> bool {
+    WINTRY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_chill_wintry(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ChillWintry { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_thaw_wintry(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ThawWintry { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wintry_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWintryEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -35954,6 +36423,78 @@ deno_core::extension!(
         bsengine_crank_winder,
         bsengine_release_winder,
         bsengine_set_winder_enabled,
+        bsengine_get_windfall_fortune,
+        bsengine_get_windfall_max_fortune,
+        bsengine_get_windfall_accrue_rate,
+        bsengine_is_windfall_just_fortunate,
+        bsengine_is_windfall_just_penniless,
+        bsengine_is_windfall_enabled,
+        bsengine_accrue_windfall,
+        bsengine_spend_windfall,
+        bsengine_set_windfall_enabled,
+        bsengine_get_windup_duration,
+        bsengine_get_windup_timer,
+        bsengine_get_windup_damage_multiplier,
+        bsengine_is_windup_just_started,
+        bsengine_is_windup_just_released,
+        bsengine_is_windup_enabled,
+        bsengine_begin_windup,
+        bsengine_release_windup,
+        bsengine_set_windup_enabled,
+        bsengine_get_wine_age,
+        bsengine_get_wine_peak_vintage,
+        bsengine_get_wine_age_rate,
+        bsengine_is_wine_just_peaked,
+        bsengine_is_wine_just_spoiled,
+        bsengine_is_wine_enabled,
+        bsengine_uncork_wine,
+        bsengine_age_wine,
+        bsengine_set_wine_enabled,
+        bsengine_get_wing_lift,
+        bsengine_get_wing_max_lift,
+        bsengine_get_wing_glide_rate,
+        bsengine_is_wing_just_airborne,
+        bsengine_is_wing_just_grounded,
+        bsengine_is_wing_enabled,
+        bsengine_soar_wing,
+        bsengine_stall_wing,
+        bsengine_set_wing_enabled,
+        bsengine_get_wink_timer,
+        bsengine_get_wink_duration,
+        bsengine_get_wink_power,
+        bsengine_is_wink_active,
+        bsengine_is_wink_just_closed,
+        bsengine_is_wink_enabled,
+        bsengine_open_wink,
+        bsengine_close_wink,
+        bsengine_set_wink_enabled,
+        bsengine_get_wino_indulgence,
+        bsengine_get_wino_max_indulgence,
+        bsengine_get_wino_tipple_rate,
+        bsengine_is_wino_just_tipsy,
+        bsengine_is_wino_just_sober,
+        bsengine_is_wino_enabled,
+        bsengine_tipple_wino,
+        bsengine_sober_wino,
+        bsengine_set_wino_enabled,
+        bsengine_get_winsome_charm,
+        bsengine_get_winsome_max_charm,
+        bsengine_get_winsome_delight_rate,
+        bsengine_is_winsome_just_delightful,
+        bsengine_is_winsome_just_dull,
+        bsengine_is_winsome_enabled,
+        bsengine_delight_winsome,
+        bsengine_dull_winsome,
+        bsengine_set_winsome_enabled,
+        bsengine_get_wintry_cold,
+        bsengine_get_wintry_max_cold,
+        bsengine_get_wintry_chill_rate,
+        bsengine_is_wintry_just_frozen,
+        bsengine_is_wintry_just_thawed,
+        bsengine_is_wintry_enabled,
+        bsengine_chill_wintry,
+        bsengine_thaw_wintry,
+        bsengine_set_wintry_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -40025,6 +40566,78 @@ const Bsengine = {
     crankWinder:                (name, amount)      => Deno.core.ops.bsengine_crank_winder(name, amount),
     releaseWinder:              (name, amount)      => Deno.core.ops.bsengine_release_winder(name, amount),
     setWinderEnabled:           (name, v)           => Deno.core.ops.bsengine_set_winder_enabled(name, v),
+    getWindfallFortune:         (name)              => Deno.core.ops.bsengine_get_windfall_fortune(name),
+    getWindfallMaxFortune:      (name)              => Deno.core.ops.bsengine_get_windfall_max_fortune(name),
+    getWindfallAccrueRate:      (name)              => Deno.core.ops.bsengine_get_windfall_accrue_rate(name),
+    isWindfallJustFortunate:    (name)              => Deno.core.ops.bsengine_is_windfall_just_fortunate(name),
+    isWindfallJustPenniless:    (name)              => Deno.core.ops.bsengine_is_windfall_just_penniless(name),
+    isWindfallEnabled:          (name)              => Deno.core.ops.bsengine_is_windfall_enabled(name),
+    accrueWindfall:             (name, amount)      => Deno.core.ops.bsengine_accrue_windfall(name, amount),
+    spendWindfall:              (name, amount)      => Deno.core.ops.bsengine_spend_windfall(name, amount),
+    setWindfallEnabled:         (name, v)           => Deno.core.ops.bsengine_set_windfall_enabled(name, v),
+    getWindupDuration:          (name)              => Deno.core.ops.bsengine_get_windup_duration(name),
+    getWindupTimer:             (name)              => Deno.core.ops.bsengine_get_windup_timer(name),
+    getWindupDamageMultiplier:  (name)              => Deno.core.ops.bsengine_get_windup_damage_multiplier(name),
+    isWindupJustStarted:        (name)              => Deno.core.ops.bsengine_is_windup_just_started(name),
+    isWindupJustReleased:       (name)              => Deno.core.ops.bsengine_is_windup_just_released(name),
+    isWindupEnabled:            (name)              => Deno.core.ops.bsengine_is_windup_enabled(name),
+    beginWindup:                (name, amount)      => Deno.core.ops.bsengine_begin_windup(name, amount),
+    releaseWindup:              (name)              => Deno.core.ops.bsengine_release_windup(name),
+    setWindupEnabled:           (name, v)           => Deno.core.ops.bsengine_set_windup_enabled(name, v),
+    getWineAge:                 (name)              => Deno.core.ops.bsengine_get_wine_age(name),
+    getWinePeakVintage:         (name)              => Deno.core.ops.bsengine_get_wine_peak_vintage(name),
+    getWineAgeRate:             (name)              => Deno.core.ops.bsengine_get_wine_age_rate(name),
+    isWineJustPeaked:           (name)              => Deno.core.ops.bsengine_is_wine_just_peaked(name),
+    isWineJustSpoiled:          (name)              => Deno.core.ops.bsengine_is_wine_just_spoiled(name),
+    isWineEnabled:              (name)              => Deno.core.ops.bsengine_is_wine_enabled(name),
+    uncorkWine:                 (name)              => Deno.core.ops.bsengine_uncork_wine(name),
+    ageWine:                    (name, amount)      => Deno.core.ops.bsengine_age_wine(name, amount),
+    setWineEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wine_enabled(name, v),
+    getWingLift:                (name)              => Deno.core.ops.bsengine_get_wing_lift(name),
+    getWingMaxLift:             (name)              => Deno.core.ops.bsengine_get_wing_max_lift(name),
+    getWingGlideRate:           (name)              => Deno.core.ops.bsengine_get_wing_glide_rate(name),
+    isWingJustAirborne:         (name)              => Deno.core.ops.bsengine_is_wing_just_airborne(name),
+    isWingJustGrounded:         (name)              => Deno.core.ops.bsengine_is_wing_just_grounded(name),
+    isWingEnabled:              (name)              => Deno.core.ops.bsengine_is_wing_enabled(name),
+    soarWing:                   (name, amount)      => Deno.core.ops.bsengine_soar_wing(name, amount),
+    stallWing:                  (name, amount)      => Deno.core.ops.bsengine_stall_wing(name, amount),
+    setWingEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wing_enabled(name, v),
+    getWinkTimer:               (name)              => Deno.core.ops.bsengine_get_wink_timer(name),
+    getWinkDuration:            (name)              => Deno.core.ops.bsengine_get_wink_duration(name),
+    getWinkPower:               (name)              => Deno.core.ops.bsengine_get_wink_power(name),
+    isWinkActive:               (name)              => Deno.core.ops.bsengine_is_wink_active(name),
+    isWinkJustClosed:           (name)              => Deno.core.ops.bsengine_is_wink_just_closed(name),
+    isWinkEnabled:              (name)              => Deno.core.ops.bsengine_is_wink_enabled(name),
+    openWink:                   (name)              => Deno.core.ops.bsengine_open_wink(name),
+    closeWink:                  (name)              => Deno.core.ops.bsengine_close_wink(name),
+    setWinkEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wink_enabled(name, v),
+    getWinoIndulgence:          (name)              => Deno.core.ops.bsengine_get_wino_indulgence(name),
+    getWinoMaxIndulgence:       (name)              => Deno.core.ops.bsengine_get_wino_max_indulgence(name),
+    getWinoTippleRate:          (name)              => Deno.core.ops.bsengine_get_wino_tipple_rate(name),
+    isWinoJustTipsy:            (name)              => Deno.core.ops.bsengine_is_wino_just_tipsy(name),
+    isWinoJustSober:            (name)              => Deno.core.ops.bsengine_is_wino_just_sober(name),
+    isWinoEnabled:              (name)              => Deno.core.ops.bsengine_is_wino_enabled(name),
+    tippleWino:                 (name, amount)      => Deno.core.ops.bsengine_tipple_wino(name, amount),
+    soberWino:                  (name, amount)      => Deno.core.ops.bsengine_sober_wino(name, amount),
+    setWinoEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wino_enabled(name, v),
+    getWinsomeCharm:            (name)              => Deno.core.ops.bsengine_get_winsome_charm(name),
+    getWinsomeMaxCharm:         (name)              => Deno.core.ops.bsengine_get_winsome_max_charm(name),
+    getWinsomeDelightRate:      (name)              => Deno.core.ops.bsengine_get_winsome_delight_rate(name),
+    isWinsomeJustDelightful:    (name)              => Deno.core.ops.bsengine_is_winsome_just_delightful(name),
+    isWinsomeJustDull:          (name)              => Deno.core.ops.bsengine_is_winsome_just_dull(name),
+    isWinsomeEnabled:           (name)              => Deno.core.ops.bsengine_is_winsome_enabled(name),
+    delightWinsome:             (name, amount)      => Deno.core.ops.bsengine_delight_winsome(name, amount),
+    dullWinsome:                (name, amount)      => Deno.core.ops.bsengine_dull_winsome(name, amount),
+    setWinsomeEnabled:          (name, v)           => Deno.core.ops.bsengine_set_winsome_enabled(name, v),
+    getWintryCold:              (name)              => Deno.core.ops.bsengine_get_wintry_cold(name),
+    getWintryMaxCold:           (name)              => Deno.core.ops.bsengine_get_wintry_max_cold(name),
+    getWintryChillRate:         (name)              => Deno.core.ops.bsengine_get_wintry_chill_rate(name),
+    isWintryJustFrozen:         (name)              => Deno.core.ops.bsengine_is_wintry_just_frozen(name),
+    isWintryJustThawed:         (name)              => Deno.core.ops.bsengine_is_wintry_just_thawed(name),
+    isWintryEnabled:            (name)              => Deno.core.ops.bsengine_is_wintry_enabled(name),
+    chillWintry:                (name, amount)      => Deno.core.ops.bsengine_chill_wintry(name, amount),
+    thawWintry:                 (name, amount)      => Deno.core.ops.bsengine_thaw_wintry(name, amount),
+    setWintryEnabled:           (name, v)           => Deno.core.ops.bsengine_set_wintry_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -66792,6 +67405,426 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CrankWinder { name, amount } if name == "Spool" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ReleaseWinder { name, amount } if name == "Spool" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWinderEnabled { name, enabled } if name == "Spool" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_windfall_read_ops() {
+        super::WINDFALL_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Luck".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWindfallFortune("Luck"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWindfallMaxFortune("Luck"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWindfallAccrueRate("Luck"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWindfallJustFortunate("Luck"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWindfallJustPenniless("Luck"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWindfallEnabled("Luck"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINDFALL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_windfall_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.accrueWindfall("Luck", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.spendWindfall("Luck", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWindfallEnabled("Luck", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AccrueWindfall { name, amount } if name == "Luck" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SpendWindfall { name, amount } if name == "Luck" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWindfallEnabled { name, enabled } if name == "Luck" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_windup_read_ops() {
+        super::WINDUP_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Punch".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWindupDuration("Punch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWindupTimer("Punch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWindupDamageMultiplier("Punch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWindupJustStarted("Punch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWindupJustReleased("Punch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWindupEnabled("Punch"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINDUP_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_windup_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.beginWindup("Punch", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.releaseWindup("Punch");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWindupEnabled("Punch", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BeginWindup { name, amount } if name == "Punch" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ReleaseWindup { name } if name == "Punch")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWindupEnabled { name, enabled } if name == "Punch" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wine_read_ops() {
+        super::WINE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Grape".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWineAge("Grape"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinePeakVintage("Grape"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWineAgeRate("Grape"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWineJustPeaked("Grape"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWineJustSpoiled("Grape"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWineEnabled("Grape"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wine_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.uncorkWine("Grape");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.ageWine("Grape", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWineEnabled("Grape", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::UncorkWine { name } if name == "Grape")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::AgeWine { name, amount } if name == "Grape" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWineEnabled { name, enabled } if name == "Grape" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wing_read_ops() {
+        super::WING_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Eagle".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWingLift("Eagle"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWingMaxLift("Eagle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWingGlideRate("Eagle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWingJustAirborne("Eagle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWingJustGrounded("Eagle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWingEnabled("Eagle"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WING_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wing_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.soarWing("Eagle", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.stallWing("Eagle", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWingEnabled("Eagle", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SoarWing { name, amount } if name == "Eagle" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StallWing { name, amount } if name == "Eagle" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWingEnabled { name, enabled } if name == "Eagle" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wink_read_ops() {
+        super::WINK_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Eye".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt.eval(r#"String(Bsengine.getWinkTimer("Eye"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinkDuration("Eye"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt.eval(r#"String(Bsengine.getWinkPower("Eye"))"#).unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt.eval(r#"String(Bsengine.isWinkActive("Eye"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinkJustClosed("Eye"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt.eval(r#"String(Bsengine.isWinkEnabled("Eye"))"#).unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINK_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wink_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.openWink("Eye");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.closeWink("Eye");"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWinkEnabled("Eye", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::OpenWink { name } if name == "Eye")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CloseWink { name } if name == "Eye")));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWinkEnabled { name, enabled } if name == "Eye" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wino_read_ops() {
+        super::WINO_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Drunkard".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWinoIndulgence("Drunkard"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinoMaxIndulgence("Drunkard"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinoTippleRate("Drunkard"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinoJustTipsy("Drunkard"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinoJustSober("Drunkard"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinoEnabled("Drunkard"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINO_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wino_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.tippleWino("Drunkard", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.soberWino("Drunkard", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWinoEnabled("Drunkard", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::TippleWino { name, amount } if name == "Drunkard" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SoberWino { name, amount } if name == "Drunkard" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWinoEnabled { name, enabled } if name == "Drunkard" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_winsome_read_ops() {
+        super::WINSOME_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Charmer".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWinsomeCharm("Charmer"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinsomeMaxCharm("Charmer"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWinsomeDelightRate("Charmer"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinsomeJustDelightful("Charmer"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinsomeJustDull("Charmer"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWinsomeEnabled("Charmer"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINSOME_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_winsome_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.delightWinsome("Charmer", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.dullWinsome("Charmer", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWinsomeEnabled("Charmer", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DelightWinsome { name, amount } if name == "Charmer" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DullWinsome { name, amount } if name == "Charmer" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWinsomeEnabled { name, enabled } if name == "Charmer" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wintry_read_ops() {
+        super::WINTRY_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Frost".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWintryCold("Frost"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWintryMaxCold("Frost"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWintryChillRate("Frost"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWintryJustFrozen("Frost"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWintryJustThawed("Frost"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWintryEnabled("Frost"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WINTRY_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wintry_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.chillWintry("Frost", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.thawWintry("Frost", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWintryEnabled("Frost", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ChillWintry { name, amount } if name == "Frost" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ThawWintry { name, amount } if name == "Frost" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWintryEnabled { name, enabled } if name == "Frost" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -5118,6 +5118,102 @@ pub enum ScriptCommand {
         name: String,
         enabled: bool,
     },
+    PlaitWicker {
+        name: String,
+        amount: f32,
+    },
+    UnravelWicker {
+        name: String,
+        amount: f32,
+    },
+    SetWickerEnabled {
+        name: String,
+        enabled: bool,
+    },
+    StyleWig {
+        name: String,
+        amount: f32,
+    },
+    ShedWig {
+        name: String,
+        amount: f32,
+    },
+    SetWigEnabled {
+        name: String,
+        enabled: bool,
+    },
+    UnleashWild {
+        name: String,
+        amount: f32,
+    },
+    TameWild {
+        name: String,
+        amount: f32,
+    },
+    SetWildEnabled {
+        name: String,
+        enabled: bool,
+    },
+    RampWilder {
+        name: String,
+        amount: f32,
+    },
+    CalmWilder {
+        name: String,
+        amount: f32,
+    },
+    SetWilderEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SchemeWile {
+        name: String,
+        amount: f32,
+    },
+    ExposeWile {
+        name: String,
+        amount: f32,
+    },
+    SetWileEnabled {
+        name: String,
+        enabled: bool,
+    },
+    SchemeWiles {
+        name: String,
+        amount: f32,
+    },
+    DisarmWiles {
+        name: String,
+        amount: f32,
+    },
+    SetWilesEnabled {
+        name: String,
+        enabled: bool,
+    },
+    FocusWill {
+        name: String,
+        amount: f32,
+    },
+    WaverWill {
+        name: String,
+        amount: f32,
+    },
+    SetWillEnabled {
+        name: String,
+        enabled: bool,
+    },
+    BendWillow {
+        name: String,
+        amount: f32,
+    },
+    SettleWillow {
+        name: String,
+        amount: f32,
+    },
+    SetWillowEnabled {
+        name: String,
+        enabled: bool,
+    },
     // ── Quest ────────────────────────────────────────────────────────────────
     SetQuestXpReward {
         name: String,
@@ -6393,6 +6489,22 @@ thread_local! {
     pub(crate) static WHISK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     pub(crate) static WICK_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WICKER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WIG_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WILD_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WILDER_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WILE_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WILES_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WILL_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
+        RefCell::new(HashMap::new());
+    pub(crate) static WILLOW_SNAPSHOT: RefCell<HashMap<String, (f32, f32, f32, bool, bool, bool)>> =
         RefCell::new(HashMap::new());
     // entity name → (current, max)
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
@@ -14349,6 +14461,371 @@ pub fn bsengine_set_wick_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
         c.borrow_mut()
             .push(ScriptCommand::SetWickEnabled { name, enabled })
+    });
+}
+// ── Wicker ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wicker_weave(#[string] name: String) -> f32 {
+    WICKER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wicker_max_weave(#[string] name: String) -> f32 {
+    WICKER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wicker_plait_rate(#[string] name: String) -> f32 {
+    WICKER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wicker_just_plaited(#[string] name: String) -> bool {
+    WICKER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wicker_just_unraveled(#[string] name: String) -> bool {
+    WICKER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wicker_enabled(#[string] name: String) -> bool {
+    WICKER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_plait_wicker(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::PlaitWicker { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_unravel_wicker(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::UnravelWicker { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wicker_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWickerEnabled { name, enabled })
+    });
+}
+// ── Wig ──────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wig_coverage(#[string] name: String) -> f32 {
+    WIG_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wig_max_coverage(#[string] name: String) -> f32 {
+    WIG_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wig_style_rate(#[string] name: String) -> f32 {
+    WIG_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wig_just_coiffed(#[string] name: String) -> bool {
+    WIG_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wig_just_bare(#[string] name: String) -> bool {
+    WIG_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wig_enabled(#[string] name: String) -> bool {
+    WIG_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_style_wig(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::StyleWig { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_shed_wig(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ShedWig { name, amount }));
+}
+#[op2(fast)]
+pub fn bsengine_set_wig_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWigEnabled { name, enabled })
+    });
+}
+// ── Wild ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wild_feral(#[string] name: String) -> f32 {
+    WILD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wild_max_feral(#[string] name: String) -> f32 {
+    WILD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wild_instinct_rate(#[string] name: String) -> f32 {
+    WILD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wild_just_wild(#[string] name: String) -> bool {
+    WILD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wild_just_tame(#[string] name: String) -> bool {
+    WILD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wild_enabled(#[string] name: String) -> bool {
+    WILD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_unleash_wild(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::UnleashWild { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_tame_wild(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::TameWild { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wild_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWildEnabled { name, enabled })
+    });
+}
+// ── Wilder ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wilder_frenzy(#[string] name: String) -> f32 {
+    WILDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wilder_max_frenzy(#[string] name: String) -> f32 {
+    WILDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wilder_ramp_rate(#[string] name: String) -> f32 {
+    WILDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wilder_just_frenzied(#[string] name: String) -> bool {
+    WILDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wilder_just_calmed(#[string] name: String) -> bool {
+    WILDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wilder_enabled(#[string] name: String) -> bool {
+    WILDER_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_ramp_wilder(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::RampWilder { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_calm_wilder(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::CalmWilder { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wilder_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWilderEnabled { name, enabled })
+    });
+}
+// ── Wile ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wile_cunning(#[string] name: String) -> f32 {
+    WILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wile_max_cunning(#[string] name: String) -> f32 {
+    WILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wile_scheme_rate(#[string] name: String) -> f32 {
+    WILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wile_just_crafty(#[string] name: String) -> bool {
+    WILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wile_just_naive(#[string] name: String) -> bool {
+    WILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wile_enabled(#[string] name: String) -> bool {
+    WILE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_scheme_wile(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SchemeWile { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_expose_wile(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::ExposeWile { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wile_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWileEnabled { name, enabled })
+    });
+}
+// ── Wiles ────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_wiles_guile(#[string] name: String) -> f32 {
+    WILES_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wiles_max_guile(#[string] name: String) -> f32 {
+    WILES_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_wiles_scheme_rate(#[string] name: String) -> f32 {
+    WILES_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_wiles_just_cunning(#[string] name: String) -> bool {
+    WILES_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wiles_just_guileless(#[string] name: String) -> bool {
+    WILES_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_wiles_enabled(#[string] name: String) -> bool {
+    WILES_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_scheme_wiles(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SchemeWiles { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_disarm_wiles(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::DisarmWiles { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_wiles_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWilesEnabled { name, enabled })
+    });
+}
+// ── Will ─────────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_will_resolve(#[string] name: String) -> f32 {
+    WILL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_will_max_resolve(#[string] name: String) -> f32 {
+    WILL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_will_resolve_rate(#[string] name: String) -> f32 {
+    WILL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_will_just_resolved(#[string] name: String) -> bool {
+    WILL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_will_just_broken(#[string] name: String) -> bool {
+    WILL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_will_enabled(#[string] name: String) -> bool {
+    WILL_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_focus_will(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::FocusWill { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_waver_will(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::WaverWill { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_will_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWillEnabled { name, enabled })
+    });
+}
+// ── Willow ───────────────────────────────────────────────────────────────────
+#[op2(fast)]
+pub fn bsengine_get_willow_sway(#[string] name: String) -> f32 {
+    WILLOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.0).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_willow_max_sway(#[string] name: String) -> f32 {
+    WILLOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.1).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_get_willow_bend_rate(#[string] name: String) -> f32 {
+    WILLOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.2).unwrap_or(0.0))
+}
+#[op2(fast)]
+pub fn bsengine_is_willow_just_swaying(#[string] name: String) -> bool {
+    WILLOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.3).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_willow_just_still(#[string] name: String) -> bool {
+    WILLOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.4).unwrap_or(false))
+}
+#[op2(fast)]
+pub fn bsengine_is_willow_enabled(#[string] name: String) -> bool {
+    WILLOW_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| v.5).unwrap_or(true))
+}
+#[op2(fast)]
+pub fn bsengine_bend_willow(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::BendWillow { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_settle_willow(#[string] name: String, amount: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SettleWillow { name, amount })
+    });
+}
+#[op2(fast)]
+pub fn bsengine_set_willow_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetWillowEnabled { name, enabled })
     });
 }
 // ── Silence ──────────────────────────────────────────────────────────────────
@@ -34864,6 +35341,78 @@ deno_core::extension!(
         bsengine_soak_wick,
         bsengine_spend_wick,
         bsengine_set_wick_enabled,
+        bsengine_get_wicker_weave,
+        bsengine_get_wicker_max_weave,
+        bsengine_get_wicker_plait_rate,
+        bsengine_is_wicker_just_plaited,
+        bsengine_is_wicker_just_unraveled,
+        bsengine_is_wicker_enabled,
+        bsengine_plait_wicker,
+        bsengine_unravel_wicker,
+        bsengine_set_wicker_enabled,
+        bsengine_get_wig_coverage,
+        bsengine_get_wig_max_coverage,
+        bsengine_get_wig_style_rate,
+        bsengine_is_wig_just_coiffed,
+        bsengine_is_wig_just_bare,
+        bsengine_is_wig_enabled,
+        bsengine_style_wig,
+        bsengine_shed_wig,
+        bsengine_set_wig_enabled,
+        bsengine_get_wild_feral,
+        bsengine_get_wild_max_feral,
+        bsengine_get_wild_instinct_rate,
+        bsengine_is_wild_just_wild,
+        bsengine_is_wild_just_tame,
+        bsengine_is_wild_enabled,
+        bsengine_unleash_wild,
+        bsengine_tame_wild,
+        bsengine_set_wild_enabled,
+        bsengine_get_wilder_frenzy,
+        bsengine_get_wilder_max_frenzy,
+        bsengine_get_wilder_ramp_rate,
+        bsengine_is_wilder_just_frenzied,
+        bsengine_is_wilder_just_calmed,
+        bsengine_is_wilder_enabled,
+        bsengine_ramp_wilder,
+        bsengine_calm_wilder,
+        bsengine_set_wilder_enabled,
+        bsengine_get_wile_cunning,
+        bsengine_get_wile_max_cunning,
+        bsengine_get_wile_scheme_rate,
+        bsengine_is_wile_just_crafty,
+        bsengine_is_wile_just_naive,
+        bsengine_is_wile_enabled,
+        bsengine_scheme_wile,
+        bsengine_expose_wile,
+        bsengine_set_wile_enabled,
+        bsengine_get_wiles_guile,
+        bsengine_get_wiles_max_guile,
+        bsengine_get_wiles_scheme_rate,
+        bsengine_is_wiles_just_cunning,
+        bsengine_is_wiles_just_guileless,
+        bsengine_is_wiles_enabled,
+        bsengine_scheme_wiles,
+        bsengine_disarm_wiles,
+        bsengine_set_wiles_enabled,
+        bsengine_get_will_resolve,
+        bsengine_get_will_max_resolve,
+        bsengine_get_will_resolve_rate,
+        bsengine_is_will_just_resolved,
+        bsengine_is_will_just_broken,
+        bsengine_is_will_enabled,
+        bsengine_focus_will,
+        bsengine_waver_will,
+        bsengine_set_will_enabled,
+        bsengine_get_willow_sway,
+        bsengine_get_willow_max_sway,
+        bsengine_get_willow_bend_rate,
+        bsengine_is_willow_just_swaying,
+        bsengine_is_willow_just_still,
+        bsengine_is_willow_enabled,
+        bsengine_bend_willow,
+        bsengine_settle_willow,
+        bsengine_set_willow_enabled,
         bsengine_damage_shield,
         bsengine_restore_shield,
         bsengine_set_max_shield,
@@ -38791,6 +39340,78 @@ const Bsengine = {
     soakWick:                   (name, amount)      => Deno.core.ops.bsengine_soak_wick(name, amount),
     spendWick:                  (name, amount)      => Deno.core.ops.bsengine_spend_wick(name, amount),
     setWickEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wick_enabled(name, v),
+    getWickerWeave:             (name)              => Deno.core.ops.bsengine_get_wicker_weave(name),
+    getWickerMaxWeave:          (name)              => Deno.core.ops.bsengine_get_wicker_max_weave(name),
+    getWickerPlaitRate:         (name)              => Deno.core.ops.bsengine_get_wicker_plait_rate(name),
+    isWickerJustPlaited:        (name)              => Deno.core.ops.bsengine_is_wicker_just_plaited(name),
+    isWickerJustUnraveled:      (name)              => Deno.core.ops.bsengine_is_wicker_just_unraveled(name),
+    isWickerEnabled:            (name)              => Deno.core.ops.bsengine_is_wicker_enabled(name),
+    plaitWicker:                (name, amount)      => Deno.core.ops.bsengine_plait_wicker(name, amount),
+    unravelWicker:              (name, amount)      => Deno.core.ops.bsengine_unravel_wicker(name, amount),
+    setWickerEnabled:           (name, v)           => Deno.core.ops.bsengine_set_wicker_enabled(name, v),
+    getWigCoverage:             (name)              => Deno.core.ops.bsengine_get_wig_coverage(name),
+    getWigMaxCoverage:          (name)              => Deno.core.ops.bsengine_get_wig_max_coverage(name),
+    getWigStyleRate:            (name)              => Deno.core.ops.bsengine_get_wig_style_rate(name),
+    isWigJustCoiffed:           (name)              => Deno.core.ops.bsengine_is_wig_just_coiffed(name),
+    isWigJustBare:              (name)              => Deno.core.ops.bsengine_is_wig_just_bare(name),
+    isWigEnabled:               (name)              => Deno.core.ops.bsengine_is_wig_enabled(name),
+    styleWig:                   (name, amount)      => Deno.core.ops.bsengine_style_wig(name, amount),
+    shedWig:                    (name, amount)      => Deno.core.ops.bsengine_shed_wig(name, amount),
+    setWigEnabled:              (name, v)           => Deno.core.ops.bsengine_set_wig_enabled(name, v),
+    getWildFeral:               (name)              => Deno.core.ops.bsengine_get_wild_feral(name),
+    getWildMaxFeral:            (name)              => Deno.core.ops.bsengine_get_wild_max_feral(name),
+    getWildInstinctRate:        (name)              => Deno.core.ops.bsengine_get_wild_instinct_rate(name),
+    isWildJustWild:             (name)              => Deno.core.ops.bsengine_is_wild_just_wild(name),
+    isWildJustTame:             (name)              => Deno.core.ops.bsengine_is_wild_just_tame(name),
+    isWildEnabled:              (name)              => Deno.core.ops.bsengine_is_wild_enabled(name),
+    unleashWild:                (name, amount)      => Deno.core.ops.bsengine_unleash_wild(name, amount),
+    tameWild:                   (name, amount)      => Deno.core.ops.bsengine_tame_wild(name, amount),
+    setWildEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wild_enabled(name, v),
+    getWilderFrenzy:            (name)              => Deno.core.ops.bsengine_get_wilder_frenzy(name),
+    getWilderMaxFrenzy:         (name)              => Deno.core.ops.bsengine_get_wilder_max_frenzy(name),
+    getWilderRampRate:          (name)              => Deno.core.ops.bsengine_get_wilder_ramp_rate(name),
+    isWilderJustFrenzied:       (name)              => Deno.core.ops.bsengine_is_wilder_just_frenzied(name),
+    isWilderJustCalmed:         (name)              => Deno.core.ops.bsengine_is_wilder_just_calmed(name),
+    isWilderEnabled:            (name)              => Deno.core.ops.bsengine_is_wilder_enabled(name),
+    rampWilder:                 (name, amount)      => Deno.core.ops.bsengine_ramp_wilder(name, amount),
+    calmWilder:                 (name, amount)      => Deno.core.ops.bsengine_calm_wilder(name, amount),
+    setWilderEnabled:           (name, v)           => Deno.core.ops.bsengine_set_wilder_enabled(name, v),
+    getWileCunning:             (name)              => Deno.core.ops.bsengine_get_wile_cunning(name),
+    getWileMaxCunning:          (name)              => Deno.core.ops.bsengine_get_wile_max_cunning(name),
+    getWileSchemeRate:          (name)              => Deno.core.ops.bsengine_get_wile_scheme_rate(name),
+    isWileJustCrafty:           (name)              => Deno.core.ops.bsengine_is_wile_just_crafty(name),
+    isWileJustNaive:            (name)              => Deno.core.ops.bsengine_is_wile_just_naive(name),
+    isWileEnabled:              (name)              => Deno.core.ops.bsengine_is_wile_enabled(name),
+    schemeWile:                 (name, amount)      => Deno.core.ops.bsengine_scheme_wile(name, amount),
+    exposeWile:                 (name, amount)      => Deno.core.ops.bsengine_expose_wile(name, amount),
+    setWileEnabled:             (name, v)           => Deno.core.ops.bsengine_set_wile_enabled(name, v),
+    getWilesGuile:              (name)              => Deno.core.ops.bsengine_get_wiles_guile(name),
+    getWilesMaxGuile:           (name)              => Deno.core.ops.bsengine_get_wiles_max_guile(name),
+    getWilesSchemeRate:         (name)              => Deno.core.ops.bsengine_get_wiles_scheme_rate(name),
+    isWilesJustCunning:         (name)              => Deno.core.ops.bsengine_is_wiles_just_cunning(name),
+    isWilesJustGuileless:       (name)              => Deno.core.ops.bsengine_is_wiles_just_guileless(name),
+    isWilesEnabled:             (name)              => Deno.core.ops.bsengine_is_wiles_enabled(name),
+    schemeWiles:                (name, amount)      => Deno.core.ops.bsengine_scheme_wiles(name, amount),
+    disarmWiles:                (name, amount)      => Deno.core.ops.bsengine_disarm_wiles(name, amount),
+    setWilesEnabled:            (name, v)           => Deno.core.ops.bsengine_set_wiles_enabled(name, v),
+    getWillResolve:             (name)              => Deno.core.ops.bsengine_get_will_resolve(name),
+    getWillMaxResolve:          (name)              => Deno.core.ops.bsengine_get_will_max_resolve(name),
+    getWillResolveRate:         (name)              => Deno.core.ops.bsengine_get_will_resolve_rate(name),
+    isWillJustResolved:         (name)              => Deno.core.ops.bsengine_is_will_just_resolved(name),
+    isWillJustBroken:           (name)              => Deno.core.ops.bsengine_is_will_just_broken(name),
+    isWillEnabled:              (name)              => Deno.core.ops.bsengine_is_will_enabled(name),
+    focusWill:                  (name, amount)      => Deno.core.ops.bsengine_focus_will(name, amount),
+    waverWill:                  (name, amount)      => Deno.core.ops.bsengine_waver_will(name, amount),
+    setWillEnabled:             (name, v)           => Deno.core.ops.bsengine_set_will_enabled(name, v),
+    getWillowSway:              (name)              => Deno.core.ops.bsengine_get_willow_sway(name),
+    getWillowMaxSway:           (name)              => Deno.core.ops.bsengine_get_willow_max_sway(name),
+    getWillowBendRate:          (name)              => Deno.core.ops.bsengine_get_willow_bend_rate(name),
+    isWillowJustSwaying:        (name)              => Deno.core.ops.bsengine_is_willow_just_swaying(name),
+    isWillowJustStill:          (name)              => Deno.core.ops.bsengine_is_willow_just_still(name),
+    isWillowEnabled:            (name)              => Deno.core.ops.bsengine_is_willow_enabled(name),
+    bendWillow:                 (name, amount)      => Deno.core.ops.bsengine_bend_willow(name, amount),
+    settleWillow:               (name, amount)      => Deno.core.ops.bsengine_settle_willow(name, amount),
+    setWillowEnabled:           (name, v)           => Deno.core.ops.bsengine_set_willow_enabled(name, v),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
@@ -64698,6 +65319,438 @@ JSON.stringify(received)
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SoakWick { name, amount } if name == "Lamp" && *amount == 0.5)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SpendWick { name, amount } if name == "Lamp" && *amount == 0.25)));
             assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWickEnabled { name, enabled } if name == "Lamp" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wicker_read_ops() {
+        super::WICKER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Basket".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWickerWeave("Basket"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWickerMaxWeave("Basket"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWickerPlaitRate("Basket"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWickerJustPlaited("Basket"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWickerJustUnraveled("Basket"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWickerEnabled("Basket"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WICKER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wicker_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.plaitWicker("Basket", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.unravelWicker("Basket", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWickerEnabled("Basket", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::PlaitWicker { name, amount } if name == "Basket" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::UnravelWicker { name, amount } if name == "Basket" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWickerEnabled { name, enabled } if name == "Basket" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wig_read_ops() {
+        super::WIG_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Toupee".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWigCoverage("Toupee"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWigMaxCoverage("Toupee"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWigStyleRate("Toupee"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWigJustCoiffed("Toupee"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWigJustBare("Toupee"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWigEnabled("Toupee"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WIG_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wig_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.styleWig("Toupee", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.shedWig("Toupee", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWigEnabled("Toupee", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::StyleWig { name, amount } if name == "Toupee" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ShedWig { name, amount } if name == "Toupee" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWigEnabled { name, enabled } if name == "Toupee" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wild_read_ops() {
+        super::WILD_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Beast".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWildFeral("Beast"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWildMaxFeral("Beast"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWildInstinctRate("Beast"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWildJustWild("Beast"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWildJustTame("Beast"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWildEnabled("Beast"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WILD_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wild_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.unleashWild("Beast", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.tameWild("Beast", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWildEnabled("Beast", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::UnleashWild { name, amount } if name == "Beast" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::TameWild { name, amount } if name == "Beast" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWildEnabled { name, enabled } if name == "Beast" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wilder_read_ops() {
+        super::WILDER_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Fury".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWilderFrenzy("Fury"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWilderMaxFrenzy("Fury"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWilderRampRate("Fury"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWilderJustFrenzied("Fury"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWilderJustCalmed("Fury"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWilderEnabled("Fury"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WILDER_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wilder_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.rampWilder("Fury", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.calmWilder("Fury", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWilderEnabled("Fury", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::RampWilder { name, amount } if name == "Fury" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::CalmWilder { name, amount } if name == "Fury" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWilderEnabled { name, enabled } if name == "Fury" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wile_read_ops() {
+        super::WILE_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Trick".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWileCunning("Trick"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWileMaxCunning("Trick"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWileSchemeRate("Trick"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWileJustCrafty("Trick"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWileJustNaive("Trick"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWileEnabled("Trick"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WILE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wile_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.schemeWile("Trick", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.exposeWile("Trick", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWileEnabled("Trick", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SchemeWile { name, amount } if name == "Trick" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::ExposeWile { name, amount } if name == "Trick" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWileEnabled { name, enabled } if name == "Trick" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wiles_read_ops() {
+        super::WILES_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Ruse".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWilesGuile("Ruse"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWilesMaxGuile("Ruse"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWilesSchemeRate("Ruse"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWilesJustCunning("Ruse"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWilesJustGuileless("Ruse"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWilesEnabled("Ruse"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WILES_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_wiles_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.schemeWiles("Ruse", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.disarmWiles("Ruse", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWilesEnabled("Ruse", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SchemeWiles { name, amount } if name == "Ruse" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::DisarmWiles { name, amount } if name == "Ruse" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWilesEnabled { name, enabled } if name == "Ruse" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_will_read_ops() {
+        super::WILL_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Iron".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWillResolve("Iron"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWillMaxResolve("Iron"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWillResolveRate("Iron"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWillJustResolved("Iron"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWillJustBroken("Iron"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWillEnabled("Iron"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WILL_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_will_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.focusWill("Iron", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.waverWill("Iron", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWillEnabled("Iron", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::FocusWill { name, amount } if name == "Iron" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::WaverWill { name, amount } if name == "Iron" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWillEnabled { name, enabled } if name == "Iron" && !enabled)));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+    #[test]
+    fn test_willow_read_ops() {
+        super::WILLOW_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(
+                "Reed".to_string(),
+                (0.5f32, 1.0f32, 0.25f32, true, false, true),
+            );
+        });
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"String(Bsengine.getWillowSway("Reed"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.5");
+        let r = rt
+            .eval(r#"String(Bsengine.getWillowMaxSway("Reed"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "1");
+        let r = rt
+            .eval(r#"String(Bsengine.getWillowBendRate("Reed"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "0.25");
+        let r = rt
+            .eval(r#"String(Bsengine.isWillowJustSwaying("Reed"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        let r = rt
+            .eval(r#"String(Bsengine.isWillowJustStill("Reed"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "false");
+        let r = rt
+            .eval(r#"String(Bsengine.isWillowEnabled("Reed"))"#)
+            .unwrap();
+        assert_eq!(r.as_str(), "true");
+        super::WILLOW_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+    #[test]
+    fn test_willow_write_ops_queue_commands() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(r#"Bsengine.bendWillow("Reed", 0.5);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.settleWillow("Reed", 0.25);"#, "<test>")
+            .unwrap();
+        rt.exec_source(r#"Bsengine.setWillowEnabled("Reed", false);"#, "<test>")
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::BendWillow { name, amount } if name == "Reed" && *amount == 0.5)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SettleWillow { name, amount } if name == "Reed" && *amount == 0.25)));
+            assert!(buf.iter().any(|cmd| matches!(cmd, super::ScriptCommand::SetWillowEnabled { name, enabled } if name == "Reed" && !enabled)));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -95,8 +95,9 @@ use crate::ops::{
     WHIFF_SNAPSHOT, WHIM_SNAPSHOT, WHIP_SNAPSHOT, WHIRL_SNAPSHOT, WHISK_SNAPSHOT, WICKER_SNAPSHOT,
     WICK_SNAPSHOT, WIG_SNAPSHOT, WILDER_SNAPSHOT, WILD_SNAPSHOT, WILES_SNAPSHOT, WILE_SNAPSHOT,
     WILLOW_SNAPSHOT, WILL_SNAPSHOT, WILT_SNAPSHOT, WILY_SNAPSHOT, WIMPLE_SNAPSHOT, WIMP_SNAPSHOT,
-    WINCE_SNAPSHOT, WINCH_SNAPSHOT, WINDER_SNAPSHOT, WIND_SNAPSHOT, WIN_SNAPSHOT,
-    WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    WINCE_SNAPSHOT, WINCH_SNAPSHOT, WINDER_SNAPSHOT, WINDFALL_SNAPSHOT, WINDUP_SNAPSHOT,
+    WIND_SNAPSHOT, WINE_SNAPSHOT, WING_SNAPSHOT, WINK_SNAPSHOT, WINO_SNAPSHOT, WINSOME_SNAPSHOT,
+    WINTRY_SNAPSHOT, WIN_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -3816,6 +3817,158 @@ fn run_scripts(world: &mut World) {
             );
         }
         WINDER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Windfall;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Windfall)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.fortune,
+                    w.max_fortune,
+                    w.accrue_rate,
+                    w.just_fortunate,
+                    w.just_penniless,
+                    w.enabled,
+                ),
+            );
+        }
+        WINDFALL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Windup;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Windup)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.duration,
+                    w.timer,
+                    w.damage_multiplier,
+                    w.just_started,
+                    w.just_released,
+                    w.enabled,
+                ),
+            );
+        }
+        WINDUP_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wine;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wine)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.wine_age,
+                    w.peak_vintage,
+                    w.age_rate,
+                    w.just_peaked,
+                    w.just_spoiled,
+                    w.enabled,
+                ),
+            );
+        }
+        WINE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wing;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wing)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.lift,
+                    w.max_lift,
+                    w.glide_rate,
+                    w.just_airborne,
+                    w.just_grounded,
+                    w.enabled,
+                ),
+            );
+        }
+        WING_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wink;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wink)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.wink_timer,
+                    w.wink_duration,
+                    w.wink_power,
+                    w.active,
+                    w.just_closed,
+                    w.enabled,
+                ),
+            );
+        }
+        WINK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wino;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wino)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.indulgence,
+                    w.max_indulgence,
+                    w.tipple_rate,
+                    w.just_tipsy,
+                    w.just_sober,
+                    w.enabled,
+                ),
+            );
+        }
+        WINO_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Winsome;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Winsome)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.charm,
+                    w.max_charm,
+                    w.delight_rate,
+                    w.just_delightful,
+                    w.just_dull,
+                    w.enabled,
+                ),
+            );
+        }
+        WINSOME_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wintry;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wintry)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.cold,
+                    w.max_cold,
+                    w.chill_rate,
+                    w.just_frozen,
+                    w.just_thawed,
+                    w.enabled,
+                ),
+            );
+        }
+        WINTRY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -24962,6 +25115,271 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut w) = world.get_mut::<bsengine_core::Winder>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::AccrueWindfall { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Windfall>(e) {
+                        w.accrue(amount);
+                    }
+                }
+            }
+            ScriptCommand::SpendWindfall { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Windfall>(e) {
+                        w.spend(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWindfallEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Windfall>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::BeginWindup { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Windup>(e) {
+                        w.begin(amount);
+                    }
+                }
+            }
+            ScriptCommand::ReleaseWindup { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Windup>(e) {
+                        let _ = w.release();
+                    }
+                }
+            }
+            ScriptCommand::SetWindupEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Windup>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::UncorkWine { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wine>(e) {
+                        w.uncork();
+                    }
+                }
+            }
+            ScriptCommand::AgeWine { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wine>(e) {
+                        w.wine_age += amount;
+                    }
+                }
+            }
+            ScriptCommand::SetWineEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wine>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SoarWing { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wing>(e) {
+                        w.soar(amount);
+                    }
+                }
+            }
+            ScriptCommand::StallWing { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wing>(e) {
+                        w.stall(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWingEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wing>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::OpenWink { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wink>(e) {
+                        w.open();
+                    }
+                }
+            }
+            ScriptCommand::CloseWink { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wink>(e) {
+                        w.active = false;
+                        w.wink_timer = 0.0;
+                    }
+                }
+            }
+            ScriptCommand::SetWinkEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wink>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::TippleWino { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wino>(e) {
+                        w.tipple(amount);
+                    }
+                }
+            }
+            ScriptCommand::SoberWino { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wino>(e) {
+                        w.sober(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWinoEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wino>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::DelightWinsome { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winsome>(e) {
+                        w.delight(amount);
+                    }
+                }
+            }
+            ScriptCommand::DullWinsome { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winsome>(e) {
+                        w.dull(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWinsomeEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winsome>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::ChillWintry { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wintry>(e) {
+                        w.chill(amount);
+                    }
+                }
+            }
+            ScriptCommand::ThawWintry { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wintry>(e) {
+                        w.thaw(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWintryEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wintry>(e) {
                         w.enabled = enabled;
                     }
                 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -92,8 +92,9 @@ use crate::ops::{
     WEDGE_SNAPSHOT, WED_SNAPSHOT, WEEDY_SNAPSHOT, WEED_SNAPSHOT, WEEP_SNAPSHOT, WEE_SNAPSHOT,
     WEFT_SNAPSHOT, WEIGHT_SNAPSHOT, WEIGH_SNAPSHOT, WEIRD_SNAPSHOT, WELDER_SNAPSHOT, WELD_SNAPSHOT,
     WELKIN_SNAPSHOT, WELLY_SNAPSHOT, WELL_SNAPSHOT, WELP_SNAPSHOT, WELT_SNAPSHOT, WEND_SNAPSHOT,
-    WHIFF_SNAPSHOT, WHIM_SNAPSHOT, WHIP_SNAPSHOT, WHIRL_SNAPSHOT, WHISK_SNAPSHOT, WICK_SNAPSHOT,
-    WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    WHIFF_SNAPSHOT, WHIM_SNAPSHOT, WHIP_SNAPSHOT, WHIRL_SNAPSHOT, WHISK_SNAPSHOT, WICKER_SNAPSHOT,
+    WICK_SNAPSHOT, WIG_SNAPSHOT, WILDER_SNAPSHOT, WILD_SNAPSHOT, WILES_SNAPSHOT, WILE_SNAPSHOT,
+    WILLOW_SNAPSHOT, WILL_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -3509,6 +3510,158 @@ fn run_scripts(world: &mut World) {
             );
         }
         WICK_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wicker;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wicker)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.weave,
+                    w.max_weave,
+                    w.plait_rate,
+                    w.just_plaited,
+                    w.just_unraveled,
+                    w.enabled,
+                ),
+            );
+        }
+        WICKER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wig;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wig)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.coverage,
+                    w.max_coverage,
+                    w.style_rate,
+                    w.just_coiffed,
+                    w.just_bare,
+                    w.enabled,
+                ),
+            );
+        }
+        WIG_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wild;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wild)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.feral,
+                    w.max_feral,
+                    w.instinct_rate,
+                    w.just_wild,
+                    w.just_tame,
+                    w.enabled,
+                ),
+            );
+        }
+        WILD_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wilder;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wilder)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.frenzy,
+                    w.max_frenzy,
+                    w.ramp_rate,
+                    w.just_frenzied,
+                    w.just_calmed,
+                    w.enabled,
+                ),
+            );
+        }
+        WILDER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wile;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wile)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.cunning,
+                    w.max_cunning,
+                    w.scheme_rate,
+                    w.just_crafty,
+                    w.just_naive,
+                    w.enabled,
+                ),
+            );
+        }
+        WILE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wiles;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wiles)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.guile,
+                    w.max_guile,
+                    w.scheme_rate,
+                    w.just_cunning,
+                    w.just_guileless,
+                    w.enabled,
+                ),
+            );
+        }
+        WILES_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Will;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Will)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.resolve,
+                    w.max_resolve,
+                    w.resolve_rate,
+                    w.just_resolved,
+                    w.just_broken,
+                    w.enabled,
+                ),
+            );
+        }
+        WILL_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Willow;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Willow)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.sway,
+                    w.max_sway,
+                    w.bend_rate,
+                    w.just_swaying,
+                    w.just_still,
+                    w.enabled,
+                ),
+            );
+        }
+        WILLOW_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -24127,6 +24280,270 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut w) = world.get_mut::<bsengine_core::Wick>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::PlaitWicker { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wicker>(e) {
+                        w.plait(amount);
+                    }
+                }
+            }
+            ScriptCommand::UnravelWicker { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wicker>(e) {
+                        w.unravel(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWickerEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wicker>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StyleWig { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wig>(e) {
+                        w.style(amount);
+                    }
+                }
+            }
+            ScriptCommand::ShedWig { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wig>(e) {
+                        w.shed(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWigEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wig>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::UnleashWild { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wild>(e) {
+                        w.unleash(amount);
+                    }
+                }
+            }
+            ScriptCommand::TameWild { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wild>(e) {
+                        w.tame(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWildEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wild>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::RampWilder { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wilder>(e) {
+                        w.ramp(amount);
+                    }
+                }
+            }
+            ScriptCommand::CalmWilder { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wilder>(e) {
+                        w.calm(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWilderEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wilder>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SchemeWile { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wile>(e) {
+                        w.scheme(amount);
+                    }
+                }
+            }
+            ScriptCommand::ExposeWile { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wile>(e) {
+                        w.expose(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWileEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wile>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SchemeWiles { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wiles>(e) {
+                        w.scheme(amount);
+                    }
+                }
+            }
+            ScriptCommand::DisarmWiles { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wiles>(e) {
+                        w.disarm(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWilesEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wiles>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::FocusWill { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Will>(e) {
+                        w.focus(amount);
+                    }
+                }
+            }
+            ScriptCommand::WaverWill { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Will>(e) {
+                        w.waver(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWillEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Will>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::BendWillow { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Willow>(e) {
+                        w.bend(amount);
+                    }
+                }
+            }
+            ScriptCommand::SettleWillow { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Willow>(e) {
+                        w.settle(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWillowEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Willow>(e) {
                         w.enabled = enabled;
                     }
                 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -94,7 +94,9 @@ use crate::ops::{
     WELKIN_SNAPSHOT, WELLY_SNAPSHOT, WELL_SNAPSHOT, WELP_SNAPSHOT, WELT_SNAPSHOT, WEND_SNAPSHOT,
     WHIFF_SNAPSHOT, WHIM_SNAPSHOT, WHIP_SNAPSHOT, WHIRL_SNAPSHOT, WHISK_SNAPSHOT, WICKER_SNAPSHOT,
     WICK_SNAPSHOT, WIG_SNAPSHOT, WILDER_SNAPSHOT, WILD_SNAPSHOT, WILES_SNAPSHOT, WILE_SNAPSHOT,
-    WILLOW_SNAPSHOT, WILL_SNAPSHOT, WIND_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
+    WILLOW_SNAPSHOT, WILL_SNAPSHOT, WILT_SNAPSHOT, WILY_SNAPSHOT, WIMPLE_SNAPSHOT, WIMP_SNAPSHOT,
+    WINCE_SNAPSHOT, WINCH_SNAPSHOT, WINDER_SNAPSHOT, WIND_SNAPSHOT, WIN_SNAPSHOT,
+    WORLD_TRANSFORM_SNAPSHOT, Z_INDEX_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -3662,6 +3664,158 @@ fn run_scripts(world: &mut World) {
             );
         }
         WILLOW_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wilt;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wilt)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.wilt_level,
+                    w.max_wilt,
+                    w.strain_rate,
+                    w.just_wilted,
+                    w.just_recovered,
+                    w.enabled,
+                ),
+            );
+        }
+        WILT_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wily;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wily)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.cunning,
+                    w.max_cunning,
+                    w.plot_rate,
+                    w.just_sly,
+                    w.just_naive,
+                    w.enabled,
+                ),
+            );
+        }
+        WILY_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wimp;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wimp)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.wimp_level,
+                    w.max_wimp,
+                    w.recover_rate,
+                    w.just_flinched,
+                    w.just_overcame,
+                    w.enabled,
+                ),
+            );
+        }
+        WIMP_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wimple;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wimple)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.folds,
+                    w.max_folds,
+                    w.drape_rate,
+                    w.just_draped,
+                    w.just_plain,
+                    w.enabled,
+                ),
+            );
+        }
+        WIMPLE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Win;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Win)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.score,
+                    w.max_score,
+                    w.win_rate,
+                    w.just_won,
+                    w.just_lost,
+                    w.enabled,
+                ),
+            );
+        }
+        WIN_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Wince;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Wince)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.wince_level,
+                    w.max_wince,
+                    w.decay_rate,
+                    w.just_winced,
+                    w.just_recovered,
+                    w.enabled,
+                ),
+            );
+        }
+        WINCE_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Winch;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Winch)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.tension,
+                    w.max_tension,
+                    w.crank_rate,
+                    w.just_taut,
+                    w.just_slack,
+                    w.enabled,
+                ),
+            );
+        }
+        WINCH_SNAPSHOT.with(|s| *s.borrow_mut() = map);
+    }
+    {
+        use bsengine_core::Winder;
+        let mut map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &Winder)>();
+        for (name, w) in q.iter(world) {
+            map.insert(
+                name.0.clone(),
+                (
+                    w.tension,
+                    w.max_tension,
+                    w.crank_rate,
+                    w.just_taut,
+                    w.just_slack,
+                    w.enabled,
+                ),
+            );
+        }
+        WINDER_SNAPSHOT.with(|s| *s.borrow_mut() = map);
     }
     {
         use bsengine_core::Shield;
@@ -24544,6 +24698,270 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut w) = world.get_mut::<bsengine_core::Willow>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::StrainOnWilt { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wilt>(e) {
+                        w.strain_on();
+                    }
+                }
+            }
+            ScriptCommand::StrainOffWilt { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wilt>(e) {
+                        w.strain_off();
+                    }
+                }
+            }
+            ScriptCommand::SetWiltEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wilt>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::PlotWily { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wily>(e) {
+                        w.plot(amount);
+                    }
+                }
+            }
+            ScriptCommand::NaiveWily { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wily>(e) {
+                        w.naive(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWilyEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wily>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::FlinchWimp { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wimp>(e) {
+                        w.flinch(amount);
+                    }
+                }
+            }
+            ScriptCommand::DefyWimp { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wimp>(e) {
+                        w.defy();
+                    }
+                }
+            }
+            ScriptCommand::SetWimpEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wimp>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::DrapeWimple { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wimple>(e) {
+                        w.drape(amount);
+                    }
+                }
+            }
+            ScriptCommand::UnfoldWimple { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wimple>(e) {
+                        w.unfold(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWimpleEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wimple>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::GainWin { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Win>(e) {
+                        w.gain(amount);
+                    }
+                }
+            }
+            ScriptCommand::ForfeitWin { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Win>(e) {
+                        w.forfeit(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWinEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Win>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::FlinchWince { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wince>(e) {
+                        w.flinch(amount);
+                    }
+                }
+            }
+            ScriptCommand::RecoverWince { name } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wince>(e) {
+                        w.wince_level = 0.0;
+                    }
+                }
+            }
+            ScriptCommand::SetWinceEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Wince>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::CrankWinch { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winch>(e) {
+                        w.crank(amount);
+                    }
+                }
+            }
+            ScriptCommand::ReleaseWinch { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winch>(e) {
+                        w.release(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWinchEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winch>(e) {
+                        w.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::CrankWinder { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winder>(e) {
+                        w.crank(amount);
+                    }
+                }
+            }
+            ScriptCommand::ReleaseWinder { name, amount } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winder>(e) {
+                        w.release(amount);
+                    }
+                }
+            }
+            ScriptCommand::SetWinderEnabled { name, enabled } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut w) = world.get_mut::<bsengine_core::Winder>(e) {
                         w.enabled = enabled;
                     }
                 }


### PR DESCRIPTION
Adds scripting API for 8 components: Windfall, Windup, Wine, Wing, Wink, Wino, Winsome, Wintry.

- 8 snapshot thread-locals + plugin population
- 72 ops (6 read + 3 write per component)
- 72 BOOTSTRAP_JS bindings
- 16 tests (1093 total)