### PR TITLE
feat(animation): add AnimationStateMachine with crossfade and scripting API

### DIFF
--- a/crates/bsengine-app/src/animation_state_machine.rs
+++ b/crates/bsengine-app/src/animation_state_machine.rs
@@ -1,0 +1,339 @@
+use bevy_app::{App, Plugin, PostUpdate};
+use bsengine_core::{AnimationPlayer, AnimationStateMachine, Time, TransitionCondition};
+use bsengine_ecs::{Query, Res};
+
+pub struct AnimationStateMachinePlugin;
+
+impl Plugin for AnimationStateMachinePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(PostUpdate, advance_state_machines);
+    }
+}
+
+fn advance_state_machines(
+    mut query: Query<(&mut AnimationStateMachine, &mut AnimationPlayer)>,
+    time: Res<Time>,
+) {
+    let dt = time.delta_seconds;
+    for (mut asm, mut player) in query.iter_mut() {
+        // Advance crossfade blend weight.
+        if asm.blend_from.is_some() {
+            asm.blend_elapsed += dt;
+            let w = (asm.blend_elapsed / asm.blend_duration.max(f32::EPSILON)).clamp(0.0, 1.0);
+            asm.blend_weight = w;
+            if w >= 1.0 {
+                asm.blend_from = None;
+            }
+        }
+
+        // Snapshot values needed before borrowing asm mutably.
+        let current = asm.current_state.clone();
+        let player_finished = player.is_finished();
+
+        // Find the first transition whose condition is satisfied.
+        let fired = asm
+            .transitions
+            .iter()
+            .find(|t| {
+                let from_ok = t.from == "*" || t.from == current;
+                if !from_ok {
+                    return false;
+                }
+                match &t.condition {
+                    TransitionCondition::Trigger(name) => asm.triggers.contains(name.as_str()),
+                    TransitionCondition::FloatGreater { param, threshold } => {
+                        asm.params_float.get(param.as_str()).copied().unwrap_or(0.0) > *threshold
+                    }
+                    TransitionCondition::FloatLess { param, threshold } => {
+                        asm.params_float.get(param.as_str()).copied().unwrap_or(0.0) < *threshold
+                    }
+                    TransitionCondition::BoolTrue(name) => {
+                        asm.params_bool.get(name.as_str()).copied().unwrap_or(false)
+                    }
+                    TransitionCondition::BoolFalse(name) => {
+                        !asm.params_bool.get(name.as_str()).copied().unwrap_or(false)
+                    }
+                    TransitionCondition::Finished => player_finished,
+                }
+            })
+            .cloned();
+
+        if let Some(t) = fired {
+            // Consume trigger so it doesn't re-fire next frame.
+            if let TransitionCondition::Trigger(name) = &t.condition {
+                asm.triggers.remove(name.as_str());
+            }
+
+            // Start crossfade.
+            asm.blend_from = Some(current);
+            asm.blend_weight = 0.0;
+            asm.blend_duration = t.blend_duration.max(f32::EPSILON);
+            asm.blend_elapsed = 0.0;
+            asm.current_state = t.to.clone();
+
+            // Drive AnimationPlayer to the new state's clip.
+            if let Some(state) = asm.states.get(&t.to) {
+                player.clip = state.clip.clone();
+                player.looping = state.looping;
+                player.speed = state.speed;
+                player.time = 0.0;
+                player.playing = true;
+                if state.duration > 0.0 {
+                    player.duration = state.duration;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_core::{AsmState, Time, TransitionCondition};
+
+    fn make_app() -> bevy_app::App {
+        let mut app = crate::new_app();
+        app.add_plugins(AnimationStateMachinePlugin);
+        let mut t = Time::default();
+        t.set_delta_for_test(0.1);
+        app.insert_resource(t);
+        app
+    }
+
+    #[test]
+    fn trigger_causes_state_transition() {
+        let mut app = make_app();
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        asm.add_state("walk", AsmState::new("walk_clip").with_duration(0.8));
+        asm.add_transition(
+            "idle",
+            "walk",
+            TransitionCondition::Trigger("move".into()),
+            0.2,
+        );
+        asm.set_trigger("move");
+        let player = AnimationPlayer::new("idle_clip").with_duration(1.0);
+        app.world_mut().spawn((asm, player));
+        app.update();
+
+        let state = app
+            .world_mut()
+            .query::<&AnimationStateMachine>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .current_state
+            .clone();
+        assert_eq!(state, "walk");
+    }
+
+    #[test]
+    fn float_greater_causes_transition() {
+        let mut app = make_app();
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        asm.add_state("run", AsmState::new("run_clip").with_duration(0.5));
+        asm.add_transition(
+            "idle",
+            "run",
+            TransitionCondition::FloatGreater {
+                param: "speed".into(),
+                threshold: 0.5,
+            },
+            0.1,
+        );
+        asm.set_float("speed", 1.0);
+        let player = AnimationPlayer::new("idle_clip").with_duration(1.0);
+        app.world_mut().spawn((asm, player));
+        app.update();
+
+        let state = app
+            .world_mut()
+            .query::<&AnimationStateMachine>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .current_state
+            .clone();
+        assert_eq!(state, "run");
+    }
+
+    #[test]
+    fn no_transition_without_trigger() {
+        let mut app = make_app();
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        asm.add_state("walk", AsmState::new("walk_clip").with_duration(0.8));
+        asm.add_transition(
+            "idle",
+            "walk",
+            TransitionCondition::Trigger("move".into()),
+            0.2,
+        );
+        let player = AnimationPlayer::new("idle_clip").with_duration(1.0);
+        app.world_mut().spawn((asm, player));
+        app.update();
+
+        let state = app
+            .world_mut()
+            .query::<&AnimationStateMachine>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .current_state
+            .clone();
+        assert_eq!(state, "idle");
+    }
+
+    #[test]
+    fn trigger_consumed_after_transition() {
+        let mut app = make_app();
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        asm.add_state("walk", AsmState::new("walk_clip").with_duration(0.8));
+        asm.add_transition(
+            "idle",
+            "walk",
+            TransitionCondition::Trigger("move".into()),
+            0.2,
+        );
+        asm.set_trigger("move");
+        let player = AnimationPlayer::new("idle_clip").with_duration(1.0);
+        app.world_mut().spawn((asm, player));
+        app.update();
+
+        let asm = app
+            .world_mut()
+            .query::<&AnimationStateMachine>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .clone();
+        assert!(!asm.triggers.contains("move"));
+    }
+
+    #[test]
+    fn crossfade_blend_advances_over_frames() {
+        let mut app = make_app();
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        asm.add_state("walk", AsmState::new("walk_clip").with_duration(0.8));
+        asm.add_transition(
+            "idle",
+            "walk",
+            TransitionCondition::Trigger("move".into()),
+            0.5,
+        );
+        asm.set_trigger("move");
+        let player = AnimationPlayer::new("idle_clip").with_duration(1.0);
+        app.world_mut().spawn((asm, player));
+        app.update(); // transition fires, blend starts at weight=0.0
+        app.update(); // blend_elapsed=0.1, duration=0.5 → weight=0.2
+
+        let asm = app
+            .world_mut()
+            .query::<&AnimationStateMachine>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .clone();
+        assert!(asm.blend_from.is_some());
+        assert!(asm.blend_weight > 0.0 && asm.blend_weight < 1.0);
+    }
+
+    #[test]
+    fn finished_condition_triggers_transition() {
+        // This test also needs AnimationPlugin (Update) to tick the player before
+        // the ASM (PostUpdate) evaluates the Finished condition.
+        let mut app = crate::new_app();
+        app.add_plugins(crate::AnimationPlugin);
+        app.add_plugins(AnimationStateMachinePlugin);
+        let mut t = Time::default();
+        t.set_delta_for_test(0.1);
+        app.insert_resource(t);
+
+        let mut asm = AnimationStateMachine::new("attack");
+        asm.add_state(
+            "attack",
+            AsmState::new("attack_clip")
+                .with_duration(0.05)
+                .with_looping(false),
+        );
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        asm.add_transition("attack", "idle", TransitionCondition::Finished, 0.1);
+        let player = AnimationPlayer::new("attack_clip")
+            .with_duration(0.05)
+            .with_looping(false);
+        app.world_mut().spawn((asm, player));
+        // Update: AnimationPlugin ticks player (dt=0.1 > duration=0.05 → finished).
+        //         ASM (PostUpdate) sees finished → transitions to "idle".
+        app.update();
+
+        let state = app
+            .world_mut()
+            .query::<&AnimationStateMachine>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .current_state
+            .clone();
+        assert_eq!(state, "idle");
+    }
+
+    #[test]
+    fn player_clip_updates_on_transition() {
+        let mut app = make_app();
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        asm.add_state("run", AsmState::new("run_clip").with_duration(0.6));
+        asm.add_transition(
+            "idle",
+            "run",
+            TransitionCondition::Trigger("go".into()),
+            0.0,
+        );
+        asm.set_trigger("go");
+        let player = AnimationPlayer::new("idle_clip").with_duration(1.0);
+        app.world_mut().spawn((asm, player));
+        app.update();
+
+        let clip = app
+            .world_mut()
+            .query::<&AnimationPlayer>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .clip
+            .clone();
+        assert_eq!(clip, "run_clip");
+    }
+
+    #[test]
+    fn wildcard_from_matches_any_state() {
+        let mut app = make_app();
+        let mut asm = AnimationStateMachine::new("run");
+        asm.add_state("run", AsmState::new("run_clip").with_duration(0.5));
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        asm.add_transition(
+            "*",
+            "idle",
+            TransitionCondition::BoolTrue("stop".into()),
+            0.1,
+        );
+        asm.set_bool("stop", true);
+        let player = AnimationPlayer::new("run_clip").with_duration(0.5);
+        app.world_mut().spawn((asm, player));
+        app.update();
+
+        let state = app
+            .world_mut()
+            .query::<&AnimationStateMachine>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .current_state
+            .clone();
+        assert_eq!(state, "idle");
+    }
+}

--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod angular_velocity;
 pub mod animation_player;
+pub mod animation_state_machine;
 pub mod app;
 pub mod damping;
 pub mod external_impulse;
@@ -14,6 +15,7 @@ pub mod velocity;
 
 pub use angular_velocity::AngularVelocityPlugin;
 pub use animation_player::AnimationPlugin;
+pub use animation_state_machine::AnimationStateMachinePlugin;
 pub use app::{new_app, App, BsPlugin, Last, PostUpdate, PreUpdate, Startup, Update};
 pub use damping::DampingPlugin;
 pub use external_impulse::ExternalImpulsePlugin;

--- a/crates/bsengine-core/src/animation_state_machine.rs
+++ b/crates/bsengine-core/src/animation_state_machine.rs
@@ -1,0 +1,189 @@
+use std::collections::{HashMap, HashSet};
+
+use bevy_ecs::prelude::Component;
+
+#[derive(Debug, Clone)]
+pub struct AsmState {
+    pub clip: String,
+    pub looping: bool,
+    pub speed: f32,
+    pub duration: f32,
+}
+
+impl AsmState {
+    pub fn new(clip: impl Into<String>) -> Self {
+        Self {
+            clip: clip.into(),
+            looping: true,
+            speed: 1.0,
+            duration: 0.0,
+        }
+    }
+
+    pub fn with_looping(mut self, looping: bool) -> Self {
+        self.looping = looping;
+        self
+    }
+
+    pub fn with_speed(mut self, speed: f32) -> Self {
+        self.speed = speed;
+        self
+    }
+
+    pub fn with_duration(mut self, duration: f32) -> Self {
+        self.duration = duration.max(0.0);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransitionCondition {
+    Trigger(String),
+    FloatGreater { param: String, threshold: f32 },
+    FloatLess { param: String, threshold: f32 },
+    BoolTrue(String),
+    BoolFalse(String),
+    Finished,
+}
+
+#[derive(Debug, Clone)]
+pub struct AsmTransition {
+    /// Source state name, or `"*"` to match any state.
+    pub from: String,
+    pub to: String,
+    pub condition: TransitionCondition,
+    pub blend_duration: f32,
+}
+
+/// Component that drives an `AnimationPlayer` through a named-state graph.
+///
+/// Each frame the ECS system evaluates transitions in order and fires the first
+/// matching one, consuming Trigger parameters in the process.  Crossfade blend
+/// weight is exposed via `blend_weight` so renderers can lerp bone poses.
+#[derive(Component, Debug, Clone)]
+pub struct AnimationStateMachine {
+    pub states: HashMap<String, AsmState>,
+    pub transitions: Vec<AsmTransition>,
+    pub current_state: String,
+    pub params_float: HashMap<String, f32>,
+    pub params_bool: HashMap<String, bool>,
+    pub triggers: HashSet<String>,
+    /// The state being blended *out* during a crossfade (None when not blending).
+    pub blend_from: Option<String>,
+    /// 0.0 = fully `blend_from`, 1.0 = fully `current_state`.
+    pub blend_weight: f32,
+    pub blend_duration: f32,
+    pub blend_elapsed: f32,
+}
+
+impl AnimationStateMachine {
+    pub fn new(initial_state: impl Into<String>) -> Self {
+        Self {
+            states: HashMap::new(),
+            transitions: Vec::new(),
+            current_state: initial_state.into(),
+            params_float: HashMap::new(),
+            params_bool: HashMap::new(),
+            triggers: HashSet::new(),
+            blend_from: None,
+            blend_weight: 1.0,
+            blend_duration: 0.0,
+            blend_elapsed: 0.0,
+        }
+    }
+
+    pub fn add_state(&mut self, name: impl Into<String>, state: AsmState) -> &mut Self {
+        self.states.insert(name.into(), state);
+        self
+    }
+
+    pub fn add_transition(
+        &mut self,
+        from: impl Into<String>,
+        to: impl Into<String>,
+        condition: TransitionCondition,
+        blend_duration: f32,
+    ) -> &mut Self {
+        self.transitions.push(AsmTransition {
+            from: from.into(),
+            to: to.into(),
+            condition,
+            blend_duration: blend_duration.max(0.0),
+        });
+        self
+    }
+
+    pub fn set_trigger(&mut self, name: impl Into<String>) {
+        self.triggers.insert(name.into());
+    }
+
+    pub fn set_float(&mut self, name: impl Into<String>, value: f32) {
+        self.params_float.insert(name.into(), value);
+    }
+
+    pub fn set_bool(&mut self, name: impl Into<String>, value: bool) {
+        self.params_bool.insert(name.into(), value);
+    }
+
+    pub fn is_blending(&self) -> bool {
+        self.blend_from.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_asm_starts_in_initial_state() {
+        let asm = AnimationStateMachine::new("idle");
+        assert_eq!(asm.current_state, "idle");
+        assert!(!asm.is_blending());
+        assert_eq!(asm.blend_weight, 1.0);
+    }
+
+    #[test]
+    fn add_state_stores_state() {
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.add_state("idle", AsmState::new("idle_clip").with_duration(1.0));
+        assert!(asm.states.contains_key("idle"));
+        assert_eq!(asm.states["idle"].clip, "idle_clip");
+    }
+
+    #[test]
+    fn set_trigger_inserts() {
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.set_trigger("move");
+        assert!(asm.triggers.contains("move"));
+    }
+
+    #[test]
+    fn set_float_and_bool() {
+        let mut asm = AnimationStateMachine::new("idle");
+        asm.set_float("speed", 1.5);
+        asm.set_bool("grounded", true);
+        assert!((asm.params_float["speed"] - 1.5).abs() < 1e-6);
+        assert!(asm.params_bool["grounded"]);
+    }
+
+    #[test]
+    fn asm_state_builder() {
+        let s = AsmState::new("run")
+            .with_looping(false)
+            .with_speed(2.0)
+            .with_duration(0.8);
+        assert_eq!(s.clip, "run");
+        assert!(!s.looping);
+        assert!((s.speed - 2.0).abs() < 1e-6);
+        assert!((s.duration - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn transition_condition_eq() {
+        assert_eq!(TransitionCondition::Finished, TransitionCondition::Finished);
+        assert_ne!(
+            TransitionCondition::Trigger("a".into()),
+            TransitionCondition::Trigger("b".into())
+        );
+    }
+}

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod amplify;
 pub mod anchor;
 pub mod angular_velocity;
 pub mod animation_player;
+pub mod animation_state_machine;
 pub mod armor;
 pub mod attach_point;
 pub mod audio_emitter;
@@ -938,6 +939,9 @@ pub use amplify::Amplify;
 pub use anchor::{Anchor, AnchorPreset};
 pub use angular_velocity::AngularVelocity;
 pub use animation_player::AnimationPlayer;
+pub use animation_state_machine::{
+    AnimationStateMachine, AsmState, AsmTransition, TransitionCondition,
+};
 pub use armor::{Armor, ArmorType};
 pub use attach_point::AttachPoint;
 pub use audio_emitter::{AudioEmitter, AudioListener};

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -17,9 +17,9 @@ use crate::ops::{
     ScriptCommand, SpawnParams, ABILITY_SNAPSHOT, ABSORPTION_SNAPSHOT, ALARM_SNAPSHOT,
     AMBIENT_OCCLUSION_SNAPSHOT, AMMO_SNAPSHOT, AMPLIFY_SNAPSHOT, ANCHOR_SNAPSHOT,
     ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT, ANIMATION_SNAPSHOT, ARMOR_SNAPSHOT,
-    BARRIER_SNAPSHOT, BEACON_SNAPSHOT, BILLBOARD_SNAPSHOT, BLEED_SNAPSHOT, BLIND_SNAPSHOT,
-    BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, BUOYANCY_SNAPSHOT, BURN_SNAPSHOT,
-    CHARGE_SNAPSHOT, CHARM_SNAPSHOT, CHILDREN_SNAPSHOT, CHROM_AB_SNAPSHOT,
+    ASM_STATE_SNAPSHOT, BARRIER_SNAPSHOT, BEACON_SNAPSHOT, BILLBOARD_SNAPSHOT, BLEED_SNAPSHOT,
+    BLIND_SNAPSHOT, BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, BUOYANCY_SNAPSHOT,
+    BURN_SNAPSHOT, CHARGE_SNAPSHOT, CHARM_SNAPSHOT, CHILDREN_SNAPSHOT, CHROM_AB_SNAPSHOT,
     COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT, COLOR_GRADING_SNAPSHOT, COMMAND_BUFFER,
     CONCUSS_SNAPSHOT, CONFUSE_SNAPSHOT, COOLDOWN_SNAPSHOT, CORROSION_SNAPSHOT, CRIPPLE_SNAPSHOT,
     CROSSHAIR_SNAPSHOT, CURSE_SNAPSHOT, DAMAGE_SNAPSHOT, DASH_SNAPSHOT, DAZE_SNAPSHOT,
@@ -800,6 +800,15 @@ fn run_scripts(world: &mut World) {
             );
         }
         ANIMATION_SNAPSHOT.with(|s| *s.borrow_mut() = anim_map);
+    }
+    {
+        use bsengine_core::AnimationStateMachine;
+        let mut asm_map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &AnimationStateMachine)>();
+        for (name, asm) in q.iter(world) {
+            asm_map.insert(name.0.clone(), asm.current_state.clone());
+        }
+        ASM_STATE_SNAPSHOT.with(|s| *s.borrow_mut() = asm_map);
     }
     {
         use bsengine_core::Lifetime;
@@ -14211,6 +14220,42 @@ fn run_scripts(world: &mut World) {
                 if let Some(e) = entity {
                     if let Some(mut ap) = world.get_mut::<AnimationPlayer>(e) {
                         ap.looping = looping;
+                    }
+                }
+            }
+            ScriptCommand::AsmSetTrigger { name, trigger } => {
+                use bsengine_core::AnimationStateMachine;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut asm) = world.get_mut::<AnimationStateMachine>(e) {
+                        asm.set_trigger(trigger);
+                    }
+                }
+            }
+            ScriptCommand::AsmSetFloat { name, param, value } => {
+                use bsengine_core::AnimationStateMachine;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut asm) = world.get_mut::<AnimationStateMachine>(e) {
+                        asm.set_float(param, value);
+                    }
+                }
+            }
+            ScriptCommand::AsmSetBool { name, param, value } => {
+                use bsengine_core::AnimationStateMachine;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut asm) = world.get_mut::<AnimationStateMachine>(e) {
+                        asm.set_bool(param, value);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Add `AnimationStateMachine` component to `bsengine-core`: named states, transition conditions (Trigger / FloatGreater / FloatLess / BoolTrue / BoolFalse / Finished), wildcard `*` from-state, crossfade blend weight tracking
- Add `AnimationStateMachinePlugin` to `bsengine-app` (PostUpdate): evaluates transitions after `AnimationPlugin` ticks playback, drives `AnimationPlayer` to new clip, advances blend weight over `blend_duration`
- Add scripting ops `bsengine_anim_set_trigger/set_float/set_bool/get_state` + `Bsengine.asmSetTrigger/asmSetFloat/asmSetBool/asmGetState`
- Snapshot `ASM_STATE_SNAPSHOT` (entity name → current state) each frame before V8 runs
- 18 new unit tests across the three crates

Closes ENGINE_ROADMAP item #2 — Animation State Machine.

## Test plan

- [ ] `cargo test -p bsengine-core -p bsengine-app -p bsengine-scripting` — all pass
- [ ] `cargo +nightly fmt` — no diff
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)