### PR TITLE
feat(post-processing): HDR pipeline with Bloom, SSAO, and ACES tone-mapping

### DIFF
--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1,8 +1,8 @@
 use bevy_app::{App, Plugin, PostUpdate, Update};
 use bevy_ecs::prelude::{Entity, EventReader, IntoSystemConfigs, ParamSet, Query, ResMut, Without};
 use bsengine_core::{
-    Camera, CustomShader, DirectionalLight, GlobalTransform, HudTexts, Material, Parent,
-    PointLight, SkyboxPath, SpotLight, Transform, UiState, Visible,
+    AmbientOcclusion, Bloom, Camera, CustomShader, DirectionalLight, GlobalTransform, HudTexts,
+    Material, Parent, PointLight, SkyboxPath, SpotLight, ToneMap, Transform, UiState, Visible,
 };
 use bsengine_ecs::Res;
 use bsengine_input::{Input, MouseButton, MouseState};
@@ -89,7 +89,13 @@ fn render_frame(
     mut ui_state: Option<ResMut<UiState>>,
     mouse_state: Option<Res<MouseState>>,
     mouse_buttons: Option<Res<Input<MouseButton>>>,
-    camera_query: Query<(&Camera, &Transform)>,
+    camera_query: Query<(
+        &Camera,
+        &Transform,
+        Option<&Bloom>,
+        Option<&ToneMap>,
+        Option<&AmbientOcclusion>,
+    )>,
     mesh_query: Query<(
         &MeshRenderer,
         &Transform,
@@ -138,15 +144,25 @@ fn render_frame(
         }
     }
 
-    let (view_proj, cam_pos) = camera_query
+    let (view_proj, cam_pos, cam_proj, bloom, tone_map, ambient_occlusion) = camera_query
         .iter()
         .next()
-        .map(|(cam, t)| (cam.projection_matrix() * t.view_matrix(), t.translation))
-        .unwrap_or((Mat4::IDENTITY, Vec3::ZERO));
+        .map(|(cam, t, b, tm, ao)| {
+            let proj = cam.projection_matrix();
+            (
+                proj * t.view_matrix(),
+                t.translation,
+                proj,
+                b.copied(),
+                tm.copied(),
+                ao.copied(),
+            )
+        })
+        .unwrap_or((Mat4::IDENTITY, Vec3::ZERO, Mat4::IDENTITY, None, None, None));
 
     // Rotation-only VP inverse for skybox (no translation → direction-only)
     let sky_vp_inv: Option<Mat4> = if surface.0.has_skybox() {
-        camera_query.iter().next().map(|(cam, t)| {
+        camera_query.iter().next().map(|(cam, t, _, _, _)| {
             let proj = cam.projection_matrix();
             let view = t.view_matrix();
             let view_rot = Mat4::from_cols(view.x_axis, view.y_axis, view.z_axis, Vec4::W);
@@ -277,6 +293,10 @@ fn render_frame(
         cursor_y,
         left_just_pressed,
         left_just_released,
+        cam_proj,
+        bloom,
+        tone_map,
+        ambient_occlusion,
     ) {
         Ok(clicked) => {
             if let Some(ref mut state) = ui_state {

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod mesh;
 pub mod plugin;
+pub mod post_process;
 pub mod rhi;
 pub mod surface;
 pub mod texture;

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -1,0 +1,791 @@
+pub const HDR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
+const BLOOM_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
+const AO_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+const CONFIG_SIZE: u64 = 64;
+const SSAO_CAM_SIZE: u64 = 128;
+
+const BLOOM_WGSL: &str = r#"
+struct FullscreenOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+struct PostProcessConfig {
+    bloom_threshold: f32, bloom_softness: f32, bloom_intensity: f32, bloom_radius: f32,
+    bloom_enabled: u32, tonemap_mode: u32, tonemap_exposure: f32, tonemap_enabled: u32,
+    ssao_radius: f32, ssao_bias: f32, ssao_intensity: f32, ssao_sample_count: u32,
+    ssao_enabled: u32, _pad0: f32, _pad1: f32, _pad2: f32,
+}
+@group(0) @binding(0) var hdr_tex: texture_2d<f32>;
+@group(0) @binding(1) var tex_sampler: sampler;
+@group(1) @binding(0) var<uniform> config: PostProcessConfig;
+
+@vertex
+fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0), vec2<f32>(-1.0, 1.0), vec2<f32>(3.0, 1.0),
+    );
+    let p = positions[vi];
+    var out: FullscreenOut;
+    out.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+    out.uv = vec2<f32>(p.x * 0.5 + 0.5, -p.y * 0.5 + 0.5);
+    return out;
+}
+
+@fragment
+fn fs_bloom(in: FullscreenOut) -> @location(0) vec4<f32> {
+    if config.bloom_enabled == 0u {
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    let dims = vec2<f32>(textureDimensions(hdr_tex, 0));
+    let texel = vec2<f32>(1.0 / dims.x, 1.0 / dims.y);
+    let radius_px = config.bloom_radius;
+    var accum = vec3<f32>(0.0);
+    var weight_sum = 0.0;
+    let steps = 4;
+    for (var dy = -steps; dy <= steps; dy++) {
+        for (var dx = -steps; dx <= steps; dx++) {
+            let offset = vec2<f32>(f32(dx), f32(dy)) * texel * (radius_px / f32(steps));
+            let sample_uv = clamp(in.uv + offset, vec2<f32>(0.0), vec2<f32>(1.0));
+            let color = textureSample(hdr_tex, tex_sampler, sample_uv).rgb;
+            let lum = dot(color, vec3<f32>(0.2126, 0.7152, 0.0722));
+            let t = config.bloom_threshold;
+            let soft = config.bloom_softness * t;
+            let knee_low = t - soft;
+            let knee_high = t + soft;
+            let blend = clamp((lum - knee_low) / max(knee_high - knee_low, 0.0001), 0.0, 1.0);
+            let bright = color * blend;
+            let w = exp(-0.5 * f32(dx * dx + dy * dy) / f32(steps * steps));
+            accum += bright * w;
+            weight_sum += w;
+        }
+    }
+    return vec4<f32>(accum / weight_sum * config.bloom_intensity, 1.0);
+}
+"#;
+
+const SSAO_WGSL: &str = r#"
+struct FullscreenOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+struct PostProcessConfig {
+    bloom_threshold: f32, bloom_softness: f32, bloom_intensity: f32, bloom_radius: f32,
+    bloom_enabled: u32, tonemap_mode: u32, tonemap_exposure: f32, tonemap_enabled: u32,
+    ssao_radius: f32, ssao_bias: f32, ssao_intensity: f32, ssao_sample_count: u32,
+    ssao_enabled: u32, _pad0: f32, _pad1: f32, _pad2: f32,
+}
+struct SsaoCamera {
+    proj: mat4x4<f32>,
+    inv_proj: mat4x4<f32>,
+}
+@group(0) @binding(0) var depth_tex: texture_depth_2d;
+@group(1) @binding(0) var<uniform> config: PostProcessConfig;
+@group(2) @binding(0) var<uniform> cam: SsaoCamera;
+
+@vertex
+fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0), vec2<f32>(-1.0, 1.0), vec2<f32>(3.0, 1.0),
+    );
+    let p = positions[vi];
+    var out: FullscreenOut;
+    out.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+    out.uv = vec2<f32>(p.x * 0.5 + 0.5, -p.y * 0.5 + 0.5);
+    return out;
+}
+
+fn load_depth(uv: vec2<f32>) -> f32 {
+    let dims = vec2<i32>(textureDimensions(depth_tex, 0));
+    let coord = clamp(vec2<i32>(uv * vec2<f32>(dims)), vec2<i32>(0), dims - vec2<i32>(1));
+    return textureLoad(depth_tex, coord, 0);
+}
+
+fn reconstruct_view_pos(uv: vec2<f32>, depth: f32) -> vec3<f32> {
+    let ndc = vec4<f32>(uv.x * 2.0 - 1.0, -(uv.y * 2.0 - 1.0), depth, 1.0);
+    let view_pos = cam.inv_proj * ndc;
+    return view_pos.xyz / view_pos.w;
+}
+
+@fragment
+fn fs_ssao(in: FullscreenOut) -> @location(0) vec4<f32> {
+    if config.ssao_enabled == 0u {
+        return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+    }
+    let depth = load_depth(in.uv);
+    if depth >= 1.0 {
+        return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+    }
+    let pos = reconstruct_view_pos(in.uv, depth);
+    let dims = vec2<f32>(textureDimensions(depth_tex, 0));
+    let texel = vec2<f32>(1.0 / dims.x, 1.0 / dims.y);
+    let pos_r = reconstruct_view_pos(in.uv + vec2<f32>(texel.x, 0.0), load_depth(in.uv + vec2<f32>(texel.x, 0.0)));
+    let pos_u = reconstruct_view_pos(in.uv + vec2<f32>(0.0, texel.y), load_depth(in.uv + vec2<f32>(0.0, texel.y)));
+    let normal = normalize(cross(pos_r - pos, pos_u - pos));
+    var hemisphere: array<vec3<f32>, 8> = array<vec3<f32>, 8>(
+        vec3<f32>( 0.5411,  0.5,     0.5),
+        vec3<f32>(-0.5411,  0.5,     0.5),
+        vec3<f32>( 0.5,    -0.5411,  0.5),
+        vec3<f32>(-0.5,    -0.5411,  0.5),
+        vec3<f32>( 0.7071,  0.0,     0.3),
+        vec3<f32>(-0.7071,  0.0,     0.3),
+        vec3<f32>( 0.0,     0.7071,  0.3),
+        vec3<f32>( 0.0,    -0.7071,  0.3),
+    );
+    var occlusion = 0.0;
+    let max_samples = min(config.ssao_sample_count, 8u);
+    for (var i: u32 = 0u; i < max_samples; i++) {
+        let s = normalize(hemisphere[i] + normal * 0.5);
+        let sample_pos = pos + s * config.ssao_radius;
+        let clip = cam.proj * vec4<f32>(sample_pos, 1.0);
+        if clip.w <= 0.0 { continue; }
+        let ndc = clip.xyz / clip.w;
+        let sample_uv = vec2<f32>(ndc.x * 0.5 + 0.5, -ndc.y * 0.5 + 0.5);
+        if sample_uv.x < 0.0 || sample_uv.x > 1.0 || sample_uv.y < 0.0 || sample_uv.y > 1.0 {
+            continue;
+        }
+        let actual_pos = reconstruct_view_pos(sample_uv, load_depth(sample_uv));
+        let range_check = smoothstep(0.0, 1.0, config.ssao_radius / max(abs(pos.z - actual_pos.z), 0.0001));
+        if actual_pos.z >= sample_pos.z + config.ssao_bias {
+            occlusion += range_check;
+        }
+    }
+    let ao = 1.0 - (occlusion / f32(max_samples)) * config.ssao_intensity;
+    return vec4<f32>(ao, ao, ao, 1.0);
+}
+"#;
+
+const COMPOSITE_WGSL: &str = r#"
+struct FullscreenOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+struct PostProcessConfig {
+    bloom_threshold: f32, bloom_softness: f32, bloom_intensity: f32, bloom_radius: f32,
+    bloom_enabled: u32, tonemap_mode: u32, tonemap_exposure: f32, tonemap_enabled: u32,
+    ssao_radius: f32, ssao_bias: f32, ssao_intensity: f32, ssao_sample_count: u32,
+    ssao_enabled: u32, _pad0: f32, _pad1: f32, _pad2: f32,
+}
+@group(0) @binding(0) var hdr_tex: texture_2d<f32>;
+@group(0) @binding(1) var hdr_sampler: sampler;
+@group(1) @binding(0) var bloom_tex: texture_2d<f32>;
+@group(1) @binding(1) var bloom_sampler: sampler;
+@group(2) @binding(0) var ao_tex: texture_2d<f32>;
+@group(2) @binding(1) var ao_sampler: sampler;
+@group(3) @binding(0) var<uniform> config: PostProcessConfig;
+
+@vertex
+fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0), vec2<f32>(-1.0, 1.0), vec2<f32>(3.0, 1.0),
+    );
+    let p = positions[vi];
+    var out: FullscreenOut;
+    out.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+    out.uv = vec2<f32>(p.x * 0.5 + 0.5, -p.y * 0.5 + 0.5);
+    return out;
+}
+
+fn aces(x: vec3<f32>) -> vec3<f32> {
+    let a = 2.51; let b = 0.03; let c = 2.43; let d = 0.59; let e = 0.14;
+    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), vec3<f32>(0.0), vec3<f32>(1.0));
+}
+fn reinhard(x: vec3<f32>) -> vec3<f32> {
+    return x / (x + vec3<f32>(1.0));
+}
+fn reinhard_lum(x: vec3<f32>) -> vec3<f32> {
+    let lum = dot(x, vec3<f32>(0.2126, 0.7152, 0.0722));
+    let mapped = lum / (lum + 1.0);
+    return x * (mapped / max(lum, 0.0001));
+}
+fn filmic(x: vec3<f32>) -> vec3<f32> {
+    let tmp = max(vec3<f32>(0.0), x - vec3<f32>(0.004));
+    return (tmp * (6.2 * tmp + vec3<f32>(0.5))) / (tmp * (6.2 * tmp + vec3<f32>(1.7)) + vec3<f32>(0.06));
+}
+
+fn apply_tonemap(color: vec3<f32>) -> vec3<f32> {
+    let scaled = color * pow(2.0, config.tonemap_exposure);
+    if config.tonemap_enabled == 0u { return clamp(scaled, vec3<f32>(0.0), vec3<f32>(1.0)); }
+    if config.tonemap_mode == 0u { return clamp(scaled, vec3<f32>(0.0), vec3<f32>(1.0)); }
+    if config.tonemap_mode == 1u { return reinhard(scaled); }
+    if config.tonemap_mode == 2u { return reinhard_lum(scaled); }
+    if config.tonemap_mode == 4u { return filmic(scaled); }
+    return aces(scaled);
+}
+
+@fragment
+fn fs_composite(in: FullscreenOut) -> @location(0) vec4<f32> {
+    let hdr   = textureSample(hdr_tex,   hdr_sampler,   in.uv).rgb;
+    let bloom = textureSample(bloom_tex, bloom_sampler, in.uv).rgb;
+    let ao    = textureSample(ao_tex,    ao_sampler,    in.uv).r;
+    let combined = hdr * ao + bloom;
+    return vec4<f32>(apply_tonemap(combined), 1.0);
+}
+"#;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct PostProcessConfigGpu {
+    pub bloom_threshold: f32,
+    pub bloom_softness: f32,
+    pub bloom_intensity: f32,
+    pub bloom_radius: f32,
+    pub bloom_enabled: u32,
+    pub tonemap_mode: u32,
+    pub tonemap_exposure: f32,
+    pub tonemap_enabled: u32,
+    pub ssao_radius: f32,
+    pub ssao_bias: f32,
+    pub ssao_intensity: f32,
+    pub ssao_sample_count: u32,
+    pub ssao_enabled: u32,
+    pub _pad0: f32,
+    pub _pad1: f32,
+    pub _pad2: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct SsaoCameraGpu {
+    pub proj: [[f32; 4]; 4],
+    pub inv_proj: [[f32; 4]; 4],
+}
+
+struct PostProcessTargets {
+    hdr_texture: wgpu::Texture,
+    hdr_view: wgpu::TextureView,
+    hdr_bg: wgpu::BindGroup,
+    bloom_texture: wgpu::Texture,
+    bloom_view: wgpu::TextureView,
+    bloom_bg: wgpu::BindGroup,
+    ao_texture: wgpu::Texture,
+    ao_view: wgpu::TextureView,
+    ao_bg: wgpu::BindGroup,
+    depth_bg: wgpu::BindGroup,
+}
+
+pub struct PostProcessState {
+    pub hdr_view: wgpu::TextureView,
+    _hdr_texture: wgpu::Texture,
+    bloom_view: wgpu::TextureView,
+    _bloom_texture: wgpu::Texture,
+    ao_view: wgpu::TextureView,
+    _ao_texture: wgpu::Texture,
+    hdr_bg: wgpu::BindGroup,
+    bloom_bg: wgpu::BindGroup,
+    ao_bg: wgpu::BindGroup,
+    depth_bg: wgpu::BindGroup,
+    sampler: wgpu::Sampler,
+    config_buffer: wgpu::Buffer,
+    config_bg: wgpu::BindGroup,
+    ssao_cam_buffer: wgpu::Buffer,
+    ssao_cam_bg: wgpu::BindGroup,
+    pub bloom_pipeline: wgpu::RenderPipeline,
+    pub ssao_pipeline: wgpu::RenderPipeline,
+    pub composite_pipeline: wgpu::RenderPipeline,
+    tex2d_bgl: wgpu::BindGroupLayout,
+    depth_bgl: wgpu::BindGroupLayout,
+}
+
+impl PostProcessState {
+    pub fn new(
+        device: &wgpu::Device,
+        width: u32,
+        height: u32,
+        depth_view: &wgpu::TextureView,
+        surface_format: wgpu::TextureFormat,
+    ) -> Self {
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("pp sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let tex2d_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp tex2d bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let depth_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp depth bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Depth,
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            }],
+        });
+
+        let config_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp config bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(CONFIG_SIZE),
+                },
+                count: None,
+            }],
+        });
+
+        let ssao_cam_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp ssao cam bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(SSAO_CAM_SIZE),
+                },
+                count: None,
+            }],
+        });
+
+        let config_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pp config buffer"),
+            size: CONFIG_SIZE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let config_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pp config bg"),
+            layout: &config_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: config_buffer.as_entire_binding(),
+            }],
+        });
+
+        let ssao_cam_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pp ssao cam buffer"),
+            size: SSAO_CAM_SIZE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let ssao_cam_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pp ssao cam bg"),
+            layout: &ssao_cam_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: ssao_cam_buffer.as_entire_binding(),
+            }],
+        });
+
+        let bloom_pipeline = Self::make_bloom_pipeline(device, &tex2d_bgl, &config_bgl);
+        let ssao_pipeline =
+            Self::make_ssao_pipeline(device, &depth_bgl, &config_bgl, &ssao_cam_bgl);
+        let composite_pipeline =
+            Self::make_composite_pipeline(device, &tex2d_bgl, &config_bgl, surface_format);
+
+        let targets = Self::create_targets(
+            device, width, height, depth_view, &sampler, &tex2d_bgl, &depth_bgl,
+        );
+
+        Self {
+            hdr_view: targets.hdr_view,
+            _hdr_texture: targets.hdr_texture,
+            bloom_view: targets.bloom_view,
+            _bloom_texture: targets.bloom_texture,
+            ao_view: targets.ao_view,
+            _ao_texture: targets.ao_texture,
+            hdr_bg: targets.hdr_bg,
+            bloom_bg: targets.bloom_bg,
+            ao_bg: targets.ao_bg,
+            depth_bg: targets.depth_bg,
+            sampler,
+            config_buffer,
+            config_bg,
+            ssao_cam_buffer,
+            ssao_cam_bg,
+            bloom_pipeline,
+            ssao_pipeline,
+            composite_pipeline,
+            tex2d_bgl,
+            depth_bgl,
+        }
+    }
+
+    fn create_targets(
+        device: &wgpu::Device,
+        width: u32,
+        height: u32,
+        depth_view: &wgpu::TextureView,
+        sampler: &wgpu::Sampler,
+        tex2d_bgl: &wgpu::BindGroupLayout,
+        depth_bgl: &wgpu::BindGroupLayout,
+    ) -> PostProcessTargets {
+        let make_tex = |label: &str, fmt: wgpu::TextureFormat| {
+            device.create_texture(&wgpu::TextureDescriptor {
+                label: Some(label),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: fmt,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            })
+        };
+
+        let hdr_texture = make_tex("pp hdr", HDR_FORMAT);
+        let hdr_view = hdr_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let bloom_texture = make_tex("pp bloom", BLOOM_FORMAT);
+        let bloom_view = bloom_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let ao_texture = make_tex("pp ao", AO_FORMAT);
+        let ao_view = ao_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let make_tex2d_bg = |label: &str, view: &wgpu::TextureView| {
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some(label),
+                layout: tex2d_bgl,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(sampler),
+                    },
+                ],
+            })
+        };
+
+        let hdr_bg = make_tex2d_bg("pp hdr bg", &hdr_view);
+        let bloom_bg = make_tex2d_bg("pp bloom bg", &bloom_view);
+        let ao_bg = make_tex2d_bg("pp ao bg", &ao_view);
+
+        let depth_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pp depth bg"),
+            layout: depth_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(depth_view),
+            }],
+        });
+
+        PostProcessTargets {
+            hdr_texture,
+            hdr_view,
+            hdr_bg,
+            bloom_texture,
+            bloom_view,
+            bloom_bg,
+            ao_texture,
+            ao_view,
+            ao_bg,
+            depth_bg,
+        }
+    }
+
+    fn make_bloom_pipeline(
+        device: &wgpu::Device,
+        tex2d_bgl: &wgpu::BindGroupLayout,
+        config_bgl: &wgpu::BindGroupLayout,
+    ) -> wgpu::RenderPipeline {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("bloom shader"),
+            source: wgpu::ShaderSource::Wgsl(BLOOM_WGSL.into()),
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("bloom pll"),
+            bind_group_layouts: &[tex2d_bgl, config_bgl],
+            push_constant_ranges: &[],
+        });
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("bloom pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_fullscreen",
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_bloom",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: BLOOM_FORMAT,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        })
+    }
+
+    fn make_ssao_pipeline(
+        device: &wgpu::Device,
+        depth_bgl: &wgpu::BindGroupLayout,
+        config_bgl: &wgpu::BindGroupLayout,
+        ssao_cam_bgl: &wgpu::BindGroupLayout,
+    ) -> wgpu::RenderPipeline {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("ssao shader"),
+            source: wgpu::ShaderSource::Wgsl(SSAO_WGSL.into()),
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("ssao pll"),
+            bind_group_layouts: &[depth_bgl, config_bgl, ssao_cam_bgl],
+            push_constant_ranges: &[],
+        });
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("ssao pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_fullscreen",
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_ssao",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: AO_FORMAT,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        })
+    }
+
+    fn make_composite_pipeline(
+        device: &wgpu::Device,
+        tex2d_bgl: &wgpu::BindGroupLayout,
+        config_bgl: &wgpu::BindGroupLayout,
+        surface_format: wgpu::TextureFormat,
+    ) -> wgpu::RenderPipeline {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("composite shader"),
+            source: wgpu::ShaderSource::Wgsl(COMPOSITE_WGSL.into()),
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("composite pll"),
+            bind_group_layouts: &[tex2d_bgl, tex2d_bgl, tex2d_bgl, config_bgl],
+            push_constant_ranges: &[],
+        });
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("composite pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_fullscreen",
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_composite",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        })
+    }
+
+    pub fn resize_targets(
+        &mut self,
+        device: &wgpu::Device,
+        depth_view: &wgpu::TextureView,
+        width: u32,
+        height: u32,
+    ) {
+        let t = Self::create_targets(
+            device,
+            width,
+            height,
+            depth_view,
+            &self.sampler,
+            &self.tex2d_bgl,
+            &self.depth_bgl,
+        );
+        self.hdr_view = t.hdr_view;
+        self._hdr_texture = t.hdr_texture;
+        self.bloom_view = t.bloom_view;
+        self._bloom_texture = t.bloom_texture;
+        self.ao_view = t.ao_view;
+        self._ao_texture = t.ao_texture;
+        self.hdr_bg = t.hdr_bg;
+        self.bloom_bg = t.bloom_bg;
+        self.ao_bg = t.ao_bg;
+        self.depth_bg = t.depth_bg;
+    }
+
+    pub fn update_config(&self, queue: &wgpu::Queue, config: PostProcessConfigGpu) {
+        queue.write_buffer(&self.config_buffer, 0, bytemuck::cast_slice(&[config]));
+    }
+
+    pub fn update_ssao_camera(&self, queue: &wgpu::Queue, cam: SsaoCameraGpu) {
+        queue.write_buffer(&self.ssao_cam_buffer, 0, bytemuck::cast_slice(&[cam]));
+    }
+
+    pub fn apply(&self, encoder: &mut wgpu::CommandEncoder, surface_view: &wgpu::TextureView) {
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("bloom pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.bloom_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(&self.bloom_pipeline);
+            pass.set_bind_group(0, &self.hdr_bg, &[]);
+            pass.set_bind_group(1, &self.config_bg, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("ssao pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.ao_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(&self.ssao_pipeline);
+            pass.set_bind_group(0, &self.depth_bg, &[]);
+            pass.set_bind_group(1, &self.config_bg, &[]);
+            pass.set_bind_group(2, &self.ssao_cam_bg, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("composite pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: surface_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(&self.composite_pipeline);
+            pass.set_bind_group(0, &self.hdr_bg, &[]);
+            pass.set_bind_group(1, &self.bloom_bg, &[]);
+            pass.set_bind_group(2, &self.ao_bg, &[]);
+            pass.set_bind_group(3, &self.config_bg, &[]);
+            pass.draw(0..3, 0..1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rhi::WgpuRHI;
+
+    #[test]
+    fn config_gpu_size() {
+        assert_eq!(std::mem::size_of::<PostProcessConfigGpu>(), 64);
+    }
+
+    #[test]
+    fn ssao_cam_gpu_size() {
+        assert_eq!(std::mem::size_of::<SsaoCameraGpu>(), 128);
+    }
+
+    #[test]
+    fn hdr_format_is_rgba16float() {
+        assert_eq!(HDR_FORMAT, wgpu::TextureFormat::Rgba16Float);
+    }
+
+    #[test]
+    fn bloom_shader_compiles() {
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
+        let _m = rhi
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: None,
+                source: wgpu::ShaderSource::Wgsl(BLOOM_WGSL.into()),
+            });
+    }
+
+    #[test]
+    fn ssao_shader_compiles() {
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
+        let _m = rhi
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: None,
+                source: wgpu::ShaderSource::Wgsl(SSAO_WGSL.into()),
+            });
+    }
+
+    #[test]
+    fn composite_shader_compiles() {
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
+        let _m = rhi
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: None,
+                source: wgpu::ShaderSource::Wgsl(COMPOSITE_WGSL.into()),
+            });
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -449,6 +449,7 @@ pub struct WgpuSurface {
     loaded_skybox_path: Option<String>,
     pipeline_layout: wgpu::PipelineLayout,
     custom_pipelines: std::collections::HashMap<String, wgpu::RenderPipeline>,
+    post_process: crate::post_process::PostProcessState,
 }
 
 impl WgpuSurface {
@@ -752,7 +753,7 @@ impl WgpuSurface {
                 module: &shader,
                 entry_point: "fs_main",
                 targets: &[Some(wgpu::ColorTargetState {
-                    format,
+                    format: crate::post_process::HDR_FORMAT,
                     blend: Some(wgpu::BlendState::REPLACE),
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
@@ -778,6 +779,14 @@ impl WgpuSurface {
 
         let egui_ctx = egui::Context::default();
         let egui_renderer = egui_wgpu::Renderer::new(&device, format, None, 1, false);
+
+        let post_process = crate::post_process::PostProcessState::new(
+            &device,
+            config.width,
+            config.height,
+            &depth_view,
+            format,
+        );
 
         Ok(Self {
             _window: window,
@@ -807,6 +816,7 @@ impl WgpuSurface {
             loaded_skybox_path: None,
             pipeline_layout,
             custom_pipelines: std::collections::HashMap::new(),
+            post_process,
         })
     }
 
@@ -826,7 +836,7 @@ impl WgpuSurface {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: DEPTH_FORMAT,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -1123,6 +1133,10 @@ impl WgpuSurface {
         cursor_y: f32,
         left_just_pressed: bool,
         left_just_released: bool,
+        cam_proj: Mat4,
+        bloom: Option<bsengine_core::Bloom>,
+        tone_map: Option<bsengine_core::ToneMap>,
+        ambient_occlusion: Option<bsengine_core::AmbientOcclusion>,
     ) -> Result<std::collections::HashSet<String>, String> {
         let camera_data = CameraUniformData {
             view_proj: view_proj.to_cols_array_2d(),
@@ -1235,6 +1249,47 @@ impl WgpuSurface {
                 label: Some("render encoder"),
             });
 
+        // --- post-process config upload ---
+        {
+            let b = bloom.unwrap_or_default();
+            let tm = tone_map.unwrap_or_default();
+            let ao = ambient_occlusion.unwrap_or_default();
+            let tonemap_mode = match tm.mode {
+                bsengine_core::ToneMappingMode::None => 0u32,
+                bsengine_core::ToneMappingMode::Reinhard => 1,
+                bsengine_core::ToneMappingMode::ReinhardLuminance => 2,
+                bsengine_core::ToneMappingMode::Aces => 3,
+                bsengine_core::ToneMappingMode::Filmic => 4,
+            };
+            let pp_config = crate::post_process::PostProcessConfigGpu {
+                bloom_threshold: b.threshold,
+                bloom_softness: b.softness,
+                bloom_intensity: b.intensity,
+                bloom_radius: b.radius,
+                bloom_enabled: b.enabled as u32,
+                tonemap_mode,
+                tonemap_exposure: tm.exposure,
+                tonemap_enabled: tm.enabled as u32,
+                ssao_radius: ao.radius,
+                ssao_bias: ao.bias,
+                ssao_intensity: ao.intensity,
+                ssao_sample_count: ao.sample_count,
+                ssao_enabled: ao.enabled as u32,
+                _pad0: 0.0,
+                _pad1: 0.0,
+                _pad2: 0.0,
+            };
+            self.post_process.update_config(&self.queue, pp_config);
+            let inv_proj = cam_proj.inverse();
+            self.post_process.update_ssao_camera(
+                &self.queue,
+                crate::post_process::SsaoCameraGpu {
+                    proj: cam_proj.to_cols_array_2d(),
+                    inv_proj: inv_proj.to_cols_array_2d(),
+                },
+            );
+        }
+
         // --- shadow pass ---
         {
             let mut shadow_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -1269,12 +1324,12 @@ impl WgpuSurface {
             }
         }
 
-        // --- main pass ---
+        // --- main pass (into HDR buffer) ---
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("render pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: &view,
+                    view: &self.post_process.hdr_view,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color {
@@ -1335,7 +1390,7 @@ impl WgpuSurface {
             let mut sky_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("skybox pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: &view,
+                    view: &self.post_process.hdr_view,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Load,
@@ -1358,6 +1413,9 @@ impl WgpuSurface {
             sky_pass.set_bind_group(1, &sky.texture_bg, &[]);
             sky_pass.draw(0..3, 0..1);
         }
+
+        // --- post-process passes: bloom → SSAO → composite → surface ---
+        self.post_process.apply(&mut encoder, &view);
 
         // UI + HUD overlay via egui
         let has_ui = !hud_texts.is_empty() || !ui_state.widgets.is_empty();
@@ -1566,6 +1624,8 @@ impl WgpuSurface {
         let (depth_texture, depth_view) = Self::create_depth_texture(&self.device, width, height);
         self.depth_texture = depth_texture;
         self.depth_view = depth_view;
+        self.post_process
+            .resize_targets(&self.device, &self.depth_view, width, height);
     }
 
     pub fn compile_and_store_shader(&mut self, path: &str, wgsl: &str) {
@@ -1617,7 +1677,7 @@ impl WgpuSurface {
                     module: &shader,
                     entry_point: "fs_main",
                     targets: &[Some(wgpu::ColorTargetState {
-                        format: self.config.format,
+                        format: crate::post_process::HDR_FORMAT,
                         blend: Some(wgpu::BlendState::REPLACE),
                         write_mask: wgpu::ColorWrites::ALL,
                     })],


### PR DESCRIPTION
## Summary

- Adds `post_process.rs` with three GPU render passes: bloom (threshold + gaussian blur), SSAO (screen-space AO via `textureLoad` on depth), and composite (tone-mapping + combine)
- Redirects all mesh/skybox/custom-shader passes to an HDR (`Rgba16Float`) intermediate render target; composite pass applies tone-mapping and writes to the sRGB surface
- Depth texture gains `TEXTURE_BINDING` so SSAO can read raw depth values without a comparison sampler
- `PostProcessState` holds pipelines and size-dependent resources with `resize_targets()` on window resize
- `render/plugin.rs` camera query now extracts `Bloom`, `ToneMap`, and `AmbientOcclusion` components and passes them into `render_frame`
- Scripting API (`Bsengine.postprocess.*`) was already wired up in a prior PR

## Test plan

- [x] `cargo check --workspace` - no errors, no warnings
- [x] `cargo test -p bsengine-rhi-wgpu -p bsengine-render` - 25 + 12 tests pass, including shader compile tests for bloom, SSAO, and composite
- [x] GPU struct sizes validated: `PostProcessConfigGpu` = 64 bytes, `SsaoCameraGpu` = 128 bytes
- [x] HDR format constant verified as `Rgba16Float`

Closes ENGINE_ROADMAP item #6.

Generated with Claude Code