### PR TITLE
feat(editor-app): standalone editor binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bsengine-editor-app"
+version = "0.1.0"
+dependencies = [
+ "bevy_ecs",
+ "bsengine-app",
+ "bsengine-core",
+ "bsengine-ecs",
+ "bsengine-editor",
+ "bsengine-gltf",
+ "bsengine-input",
+ "bsengine-render",
+ "bsengine-rhi-wgpu",
+ "bsengine-scene",
+ "bsengine-window",
+ "glam 0.29.3",
+]
+
+[[package]]
 name = "bsengine-gltf"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "games/cube-roller",
     "games/cube-evader",
     "crates/bsengine-network",
+    "apps/bsengine-editor-app",
 ]
 
 [workspace.package]

--- a/apps/bsengine-editor-app/Cargo.toml
+++ b/apps/bsengine-editor-app/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bsengine-editor-app"
+description = "Standalone BSEngine editor — Unity/Unreal-style viewport"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "bsengine-editor"
+path = "src/main.rs"
+
+[dependencies]
+bsengine-app    = { workspace = true }
+bsengine-core   = { workspace = true }
+bsengine-ecs    = { workspace = true }
+bsengine-editor = { workspace = true }
+bsengine-gltf   = { workspace = true }
+bsengine-input  = { workspace = true }
+bsengine-render = { workspace = true }
+bsengine-rhi-wgpu = { workspace = true }
+bsengine-scene  = { workspace = true }
+bsengine-window = { workspace = true }
+bevy_ecs        = { workspace = true }
+glam            = { workspace = true }

--- a/apps/bsengine-editor-app/src/main.rs
+++ b/apps/bsengine-editor-app/src/main.rs
@@ -1,0 +1,67 @@
+use bsengine_app::{new_app, Startup};
+use bsengine_core::{Camera, DirectionalLight, GlobalTransform, InspectorState, Transform};
+use bsengine_ecs::{Commands, ResMut};
+use bsengine_editor::EditorPlugin;
+use bsengine_gltf::GltfPlugin;
+use bsengine_input::InputPlugin;
+use bsengine_render::{MeshRenderer, RenderPlugin};
+use bsengine_rhi_wgpu::{GpuMeshRegistry, WgpuRHIPlugin};
+use bsengine_scene::ScenePlugin;
+use bsengine_window::{WindowDescriptor, WindowPlugin};
+use glam::{Quat, Vec3};
+use std::env;
+
+fn main() {
+    let scene_path = env::args().nth(1);
+
+    let mut app = new_app();
+    app.add_plugins(WgpuRHIPlugin)
+        .add_plugins(WindowPlugin {
+            descriptor: WindowDescriptor {
+                title: "BSEngine Editor".to_string(),
+                width: 1600,
+                height: 900,
+                resizable: true,
+            },
+        })
+        .add_plugins(InputPlugin)
+        .add_plugins(GltfPlugin)
+        .add_plugins(RenderPlugin)
+        .add_plugins(EditorPlugin)
+        .insert_resource(InspectorState::editor());
+
+    match scene_path {
+        Some(path) => {
+            app.add_plugins(ScenePlugin::from_file(&path));
+        }
+        None => {
+            app.add_systems(Startup, setup_empty_scene);
+        }
+    }
+
+    app.run();
+}
+
+fn setup_empty_scene(mut commands: Commands, mut registry: Option<ResMut<GpuMeshRegistry>>) {
+    commands.spawn((
+        Camera::perspective(60.0, 16.0 / 9.0),
+        Transform::from_translation(Vec3::new(0.0, 3.0, 10.0)),
+    ));
+
+    commands.spawn(DirectionalLight::default());
+
+    // Default ground plane so the viewport is not completely empty
+    if let Some(ref mut reg) = registry {
+        let (verts, indices) = bsengine_rhi_wgpu::cube_vertices();
+        let mesh_id = reg.register(&verts, &indices);
+        commands.spawn((
+            MeshRenderer { mesh_id },
+            Transform {
+                translation: Vec3::new(0.0, -0.1, 0.0),
+                rotation: Quat::IDENTITY,
+                scale: Vec3::new(20.0, 0.2, 20.0),
+            },
+            GlobalTransform::default(),
+        ));
+    }
+}

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -78,6 +78,13 @@ impl Default for InspectorState {
 }
 
 impl InspectorState {
+    pub fn editor() -> Self {
+        Self {
+            editor_mode: true,
+            ..Default::default()
+        }
+    }
+
     pub fn sync_selection(&mut self) {
         if self.selected_id != self.prev_selected_id {
             self.prev_selected_id = self.selected_id;


### PR DESCRIPTION
## Summary

- New `apps/bsengine-editor-app` crate — `bsengine-editor` binary
- Boots directly in editor mode (no game-code toggle required)
- `InspectorState::editor()` constructor added to `bsengine-core`

## Usage

```sh
# Empty scene
cargo run -p bsengine-editor-app

# Load existing scene
cargo run -p bsengine-editor-app -- games/cube-roller/assets/scene.ron
```

## Test plan

- [ ] `cargo check -p bsengine-editor-app` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)