### PR TITLE
fix(rhi-wgpu): correct model uniform min_binding_size 96→112

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -557,7 +557,9 @@ impl WgpuSurface {
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: true,
-                    min_binding_size: wgpu::BufferSize::new(96),
+                    min_binding_size: wgpu::BufferSize::new(
+                        std::mem::size_of::<ModelUniformData>() as u64,
+                    ),
                 },
                 count: None,
             }],


### PR DESCRIPTION
## Summary

Pre-existing bug: `ModelUniformData` is 112 bytes but `min_binding_size` was set to 96, causing wgpu pipeline validation to panic when a real GPU surface is created.

**Byte layout:**
| Field | Bytes |
|-------|-------|
| `model: mat4x4` | 64 |
| `metallic + roughness + _pad0 + _pad1` | 16 |
| `emissive: vec3 + _pad2` | 16 |
| `base_color: vec3 + _pad3` | 16 |
| **Total** | **112** |

Fix: `min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<ModelUniformData>() as u64)` — self-documents and stays correct if the struct changes.

Found when running `cargo run -p bsengine-editor-app` for the first time (CI is headless and never creates a real GPU surface).

## Test plan

- [ ] CI green
- [ ] `cargo run -p bsengine-editor-app -- games/cube-roller/assets/scenes/main.ron` launches without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)