### PR TITLE
fix(rhi-wgpu): correct model BufferBinding size 96→112

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -572,7 +572,7 @@ impl WgpuSurface {
                 resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
                     buffer: &model_buffer,
                     offset: 0,
-                    size: wgpu::BufferSize::new(96),
+                    size: wgpu::BufferSize::new(std::mem::size_of::<ModelUniformData>() as u64),
                 }),
             }],
         });


### PR DESCRIPTION
## Summary

Follow-up to #1672. The `min_binding_size` was corrected in that PR, but the `BufferBinding::size` in the bind group entry was also hardcoded to 96, causing a second validation error:

```
Binding size 96 of Buffer with 'model uniform' label is less than minimum 112
```

Fix: use `std::mem::size_of::<ModelUniformData>() as u64` so both sites stay consistent with the struct size.

## Test plan

- [ ] CI green
- [ ] `cargo run -p bsengine-editor-app -- games/cube-roller/assets/scenes/main.ron` launches without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)