### PR TITLE
fix(editor): transparent CentralPanel fixes blank viewport

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -450,9 +450,6 @@ pub struct WgpuSurface {
     pipeline_layout: wgpu::PipelineLayout,
     custom_pipelines: std::collections::HashMap<String, wgpu::RenderPipeline>,
     post_process: crate::post_process::PostProcessState,
-    scene_view_texture: wgpu::Texture,
-    scene_view_view: wgpu::TextureView,
-    scene_view_egui_id: egui::TextureId,
 }
 
 impl WgpuSurface {
@@ -783,7 +780,7 @@ impl WgpuSurface {
         });
 
         let egui_ctx = egui::Context::default();
-        let mut egui_renderer = egui_wgpu::Renderer::new(&device, format, None, 1, false);
+        let egui_renderer = egui_wgpu::Renderer::new(&device, format, None, 1, false);
 
         let post_process = crate::post_process::PostProcessState::new(
             &device,
@@ -791,14 +788,6 @@ impl WgpuSurface {
             config.height,
             &depth_view,
             format,
-        );
-
-        let (scene_view_texture, scene_view_view) =
-            Self::create_scene_view_texture(&device, config.width, config.height, format);
-        let scene_view_egui_id = egui_renderer.register_native_texture(
-            &device,
-            &scene_view_view,
-            wgpu::FilterMode::Linear,
         );
 
         Ok(Self {
@@ -830,34 +819,7 @@ impl WgpuSurface {
             pipeline_layout,
             custom_pipelines: std::collections::HashMap::new(),
             post_process,
-            scene_view_texture,
-            scene_view_view,
-            scene_view_egui_id,
         })
-    }
-
-    fn create_scene_view_texture(
-        device: &wgpu::Device,
-        width: u32,
-        height: u32,
-        format: wgpu::TextureFormat,
-    ) -> (wgpu::Texture, wgpu::TextureView) {
-        let texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("scene view texture"),
-            size: wgpu::Extent3d {
-                width: width.max(1),
-                height: height.max(1),
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
-            view_formats: &[],
-        });
-        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-        (texture, view)
     }
 
     fn create_depth_texture(
@@ -1455,17 +1417,9 @@ impl WgpuSurface {
             sky_pass.draw(0..3, 0..1);
         }
 
-        // --- post-process passes: bloom → SSAO → composite → surface or scene_view ---
+        // --- post-process passes: bloom → SSAO → composite → swapchain ---
         let is_editor = inspector.as_ref().map(|i| i.editor_mode).unwrap_or(false);
-        if is_editor {
-            crate::post_process::PostProcessState::apply(
-                &self.post_process,
-                &mut encoder,
-                &self.scene_view_view,
-            );
-        } else {
-            self.post_process.apply(&mut encoder, &view);
-        }
+        self.post_process.apply(&mut encoder, &view);
 
         // UI + HUD overlay via egui (always on in editor mode)
         let has_ui = is_editor
@@ -1503,7 +1457,6 @@ impl WgpuSurface {
             };
 
             let mut new_text_values = ui_state.text_values.clone();
-            let scene_view_egui_id = self.scene_view_egui_id;
             let full_output = self.egui_ctx.run(raw_input, |ctx| {
                 // HUD texts — text-only overlay at top-left
                 if !hud_texts.is_empty() {
@@ -1784,17 +1737,15 @@ impl WgpuSurface {
                             }
                         }
 
-                        egui::CentralPanel::default().show(ctx, |ui| {
-                            let avail = ui.available_size();
-                            insp.viewport_size = [avail.x, avail.y];
-                            let panel_rect = ui.max_rect();
-                            insp.viewport_contains_cursor =
-                                panel_rect.contains(egui::Pos2::new(cursor_x, cursor_y));
-                            ui.add(egui::Image::new(egui::load::SizedTexture::new(
-                                scene_view_egui_id,
-                                avail,
-                            )));
-                        });
+                        egui::CentralPanel::default()
+                            .frame(egui::Frame::none())
+                            .show(ctx, |ui| {
+                                let panel_rect = ui.max_rect();
+                                insp.viewport_size = [panel_rect.width(), panel_rect.height()];
+                                insp.viewport_contains_cursor =
+                                    panel_rect.contains(egui::Pos2::new(cursor_x, cursor_y));
+                                ui.allocate_rect(panel_rect, egui::Sense::hover());
+                            });
                     } else {
                         // Overlay mode: side panels rendered over the running game
                         let entities_snapshot = insp.entities.clone();
@@ -2000,16 +1951,6 @@ impl WgpuSurface {
         self.depth_view = depth_view;
         self.post_process
             .resize_targets(&self.device, &self.depth_view, width, height);
-        let (sv_texture, sv_view) =
-            Self::create_scene_view_texture(&self.device, width, height, self.config.format);
-        self.egui_renderer.update_egui_texture_from_wgpu_texture(
-            &self.device,
-            &sv_view,
-            wgpu::FilterMode::Linear,
-            self.scene_view_egui_id,
-        );
-        self.scene_view_texture = sv_texture;
-        self.scene_view_view = sv_view;
     }
 
     pub fn compile_and_store_shader(&mut self, path: &str, wgsl: &str) {


### PR DESCRIPTION
## Summary
- Removes broken render-to-texture approach (`scene_view_texture` / `scene_view_egui_id`)
- Root cause: wgpu texture barrier issue when writing (composite pass) and sampling (egui pass) the same texture within one command encoder
- Fix: scene renders to swapchain normally; CentralPanel uses `Frame::none()` so the scene shows through; egui side/top panels have opaque backgrounds and overlay correctly

## Test plan
- [ ] Run `cargo build -p bsengine-editor-app` — zero errors, zero warnings
- [ ] Launch `bsengine-editor games/cube-roller/assets/scenes/main.ron` — scene visible in viewport
- [ ] Hierarchy, Inspector, Toolbar panels render with opaque backgrounds over the scene
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)