### PR TITLE
fix(editor-app): add resolve_primitives — ScenePlugin entities were not rendering

### DIFF
--- a/apps/bsengine-editor-app/src/main.rs
+++ b/apps/bsengine-editor-app/src/main.rs
@@ -1,12 +1,15 @@
-use bsengine_app::{new_app, Startup};
+use bsengine_app::{new_app, Startup, Update};
 use bsengine_core::{Camera, DirectionalLight, GlobalTransform, InspectorState, Transform};
-use bsengine_ecs::{Commands, ResMut};
+use bsengine_ecs::{Added, Commands, Entity, Query, ResMut};
 use bsengine_editor::EditorPlugin;
 use bsengine_gltf::GltfPlugin;
 use bsengine_input::InputPlugin;
 use bsengine_render::{MeshRenderer, RenderPlugin};
-use bsengine_rhi_wgpu::{GpuMeshRegistry, WgpuRHIPlugin};
-use bsengine_scene::ScenePlugin;
+use bsengine_rhi_wgpu::{
+    capsule_vertices, cube_vertices, plane_vertices, sphere_vertices, GpuMeshRegistry,
+    WgpuRHIPlugin,
+};
+use bsengine_scene::{Primitive, PrimitiveMesh, ScenePlugin};
 use bsengine_window::{WindowDescriptor, WindowPlugin};
 use glam::{Quat, Vec3};
 use std::env;
@@ -28,6 +31,7 @@ fn main() {
         .add_plugins(GltfPlugin)
         .add_plugins(RenderPlugin)
         .add_plugins(EditorPlugin)
+        .add_systems(Update, resolve_primitives)
         .insert_resource(InspectorState::editor());
 
     match scene_path {
@@ -42,6 +46,41 @@ fn main() {
     app.run();
 }
 
+fn resolve_primitives(
+    query: Query<(Entity, &PrimitiveMesh), Added<PrimitiveMesh>>,
+    mut commands: Commands,
+    registry: Option<ResMut<GpuMeshRegistry>>,
+) {
+    let Some(mut registry) = registry else {
+        return;
+    };
+    let mut cube_id: Option<u64> = None;
+    let mut sphere_id: Option<u64> = None;
+    let mut plane_id: Option<u64> = None;
+    let mut capsule_id: Option<u64> = None;
+    for (entity, prim) in query.iter() {
+        let mesh_id = match &prim.0 {
+            Primitive::Cube => *cube_id.get_or_insert_with(|| {
+                let (v, i) = cube_vertices();
+                registry.register(&v, &i)
+            }),
+            Primitive::Sphere => *sphere_id.get_or_insert_with(|| {
+                let (v, i) = sphere_vertices();
+                registry.register(&v, &i)
+            }),
+            Primitive::Plane => *plane_id.get_or_insert_with(|| {
+                let (v, i) = plane_vertices();
+                registry.register(&v, &i)
+            }),
+            Primitive::Capsule => *capsule_id.get_or_insert_with(|| {
+                let (v, i) = capsule_vertices();
+                registry.register(&v, &i)
+            }),
+        };
+        commands.entity(entity).insert(MeshRenderer { mesh_id });
+    }
+}
+
 fn setup_empty_scene(mut commands: Commands, mut registry: Option<ResMut<GpuMeshRegistry>>) {
     commands.spawn((
         Camera::perspective(60.0, 16.0 / 9.0),
@@ -52,7 +91,7 @@ fn setup_empty_scene(mut commands: Commands, mut registry: Option<ResMut<GpuMesh
 
     // Default ground plane so the viewport is not completely empty
     if let Some(ref mut reg) = registry {
-        let (verts, indices) = bsengine_rhi_wgpu::cube_vertices();
+        let (verts, indices) = cube_vertices();
         let mesh_id = reg.register(&verts, &indices);
         commands.spawn((
             MeshRenderer { mesh_id },


### PR DESCRIPTION
## Summary

- `bsengine-editor-app` uses `ScenePlugin::from_file` which spawns entities with `PrimitiveMesh` but no system converted them to `MeshRenderer`
- Added `resolve_primitives` system (identical to the one in `bsengine-app/src/main.rs`) to the editor binary's `Update` schedule
- This is the root cause of the gray viewport: primitives from the scene file were loaded but never turned into GPU draw calls

## Test plan

- [x] `cargo build -p bsengine-editor-app` compiles clean
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)