### PR TITLE
fix(editor-app): add ScriptingPlugin so Play button runs game scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ dependencies = [
  "bsengine-render",
  "bsengine-rhi-wgpu",
  "bsengine-scene",
+ "bsengine-scripting",
  "bsengine-window",
  "glam 0.29.3",
 ]

--- a/apps/bsengine-editor-app/Cargo.toml
+++ b/apps/bsengine-editor-app/Cargo.toml
@@ -19,7 +19,8 @@ bsengine-gltf   = { workspace = true }
 bsengine-input  = { workspace = true }
 bsengine-render = { workspace = true }
 bsengine-rhi-wgpu = { workspace = true }
-bsengine-scene  = { workspace = true }
-bsengine-window = { workspace = true }
+bsengine-scene     = { workspace = true }
+bsengine-scripting = { workspace = true }
+bsengine-window    = { workspace = true }
 bevy_ecs        = { workspace = true }
 glam            = { workspace = true }

--- a/apps/bsengine-editor-app/src/main.rs
+++ b/apps/bsengine-editor-app/src/main.rs
@@ -10,6 +10,7 @@ use bsengine_rhi_wgpu::{
     WgpuRHIPlugin,
 };
 use bsengine_scene::{Primitive, PrimitiveMesh, ScenePlugin};
+use bsengine_scripting::ScriptingPlugin;
 use bsengine_window::{WindowDescriptor, WindowPlugin};
 use glam::{Quat, Vec3};
 use std::env;
@@ -31,6 +32,7 @@ fn main() {
         .add_plugins(GltfPlugin)
         .add_plugins(RenderPlugin)
         .add_plugins(EditorPlugin)
+        .add_plugins(ScriptingPlugin::default())
         .add_systems(Update, resolve_primitives)
         .insert_resource(InspectorState::editor());
 


### PR DESCRIPTION
## Summary

- Scene entities with `script:` fields (e.g. `Player → player.js`) were never executed because `ScriptingPlugin` was missing from the editor binary
- `run_scripts()` in `bsengine-scripting` already gates correctly on `insp.play_state == Playing`, but the plugin was never added so the system never registered
- Added `ScriptingPlugin::default()` to `bsengine-editor-app` and `bsengine-scripting` to its `Cargo.toml`

## Test plan

- [x] `cargo build -p bsengine-editor-app` compiles clean (exe locked error was because editor was still running)
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)