### PR TITLE
fix(scripting): raise V8's internal stack-size limit to fix IsOnCentralStack crash

### DIFF
--- a/crates/bsengine-scripting/src/runtime.rs
+++ b/crates/bsengine-scripting/src/runtime.rs
@@ -1,4 +1,23 @@
 use deno_core::{JsRuntime, RuntimeOptions};
+use std::sync::Once;
+
+// V8 auto-detects its internal JS-stack limit from the current thread's OS
+// stack at isolate-creation time, but on Windows this detection can fall back
+// to a tiny default (~984 KB) regardless of the actual reserved thread stack
+// (see .cargo/config.toml's /STACK:67108864), causing V8 to abort with
+// "Check failed: IsOnCentralStack()" while compiling even trivial scripts.
+// Set --stack-size explicitly (in KB) so V8's own limit is generous, well
+// within the real 64 MB OS-reserved stack.
+static INIT_V8_FLAGS: Once = Once::new();
+
+fn ensure_v8_flags() {
+    INIT_V8_FLAGS.call_once(|| {
+        deno_core::v8_set_flags(vec![
+            "bsengine".to_string(),
+            "--stack-size=16384".to_string(),
+        ]);
+    });
+}
 
 pub struct ScriptRuntime {
     runtime: JsRuntime,
@@ -6,6 +25,7 @@ pub struct ScriptRuntime {
 
 impl ScriptRuntime {
     pub fn new() -> Self {
+        ensure_v8_flags();
         let runtime = JsRuntime::new(RuntimeOptions {
             ..Default::default()
         });
@@ -13,6 +33,7 @@ impl ScriptRuntime {
     }
 
     pub fn new_with_ops() -> Self {
+        ensure_v8_flags();
         let runtime = JsRuntime::new(RuntimeOptions {
             extensions: vec![crate::ops::bsengine_ops::init()],
             ..Default::default()


### PR DESCRIPTION
## Summary

Despite PR #1682 (64 MB main-thread stack via linker flag + `run_scripts` refactor into `collect_world_snapshots`), the editor still crashed with `Check failed: IsOnCentralStack()` the instant Play ran any script — reproduced by manually testing `cargo run -p bsengine-editor-app`.

- Crash trace: `Isolate::StackOverflow` → `PendingCompilationErrorHandler::ReportErrors` while V8 compiles a single trivial call expression (`Bsengine._runAll(...)`) — far too shallow to exhaust a real 64 MB OS stack
- Root cause: V8 auto-detects its own internal JS-stack limit from the current thread's stack at isolate-creation time. On Windows this auto-detection can fall back to a tiny hardcoded default (~984 KB) *regardless* of the actual OS-reserved thread stack — so the `/STACK:67108864` linker flag from #1682 never actually raised the limit V8 itself enforces

## Fix

`crates/bsengine-scripting/src/runtime.rs`: call `deno_core::v8_set_flags(vec!["--stack-size=16384"])` once (guarded by `std::sync::Once`) before the first `JsRuntime`/`Isolate` is created, so V8's self-imposed stack limit is explicit and generous (16 MB), well within the real 64 MB OS-reserved stack — independent of V8's unreliable Windows auto-detection.

## Test plan

- [x] `cargo test -p bsengine-scripting` — 1725 passed, 0 failed
- [x] Manually forced `InspectorState::editor().play_state = EditorPlayState::Playing` and ran `cargo run -p bsengine-editor-app -- games/cube-roller/assets/scenes/main.ron` for 15s (~900 frames of `run_scripts`/`exec_source`) — no crash, versus an immediate `IsOnCentralStack` crash before this fix
- [x] `cargo +nightly fmt --all -- --check`
- [x] CI (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)