### PR TITLE
feat(editor): add viewport translate gizmo for the selected entity

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -120,6 +120,12 @@ pub struct InspectorState {
     pub editor_view_proj: Option<[[f32; 4]; 4]>,
     pub editor_proj: [[f32; 4]; 4],
     pub editor_cam_pos: [f32; 3],
+
+    // Translate-gizmo drag state (viewport panel). `gizmo_drag_axis` is
+    // 0=X, 1=Y, 2=Z while a handle is being dragged.
+    pub gizmo_drag_axis: Option<u8>,
+    pub gizmo_drag_start_world: [f32; 3],
+    pub gizmo_drag_start_mouse: [f32; 2],
 }
 
 impl Default for InspectorState {
@@ -152,6 +158,9 @@ impl Default for InspectorState {
             editor_view_proj: None,
             editor_proj: [[0.0; 4]; 4],
             editor_cam_pos: [0.0; 3],
+            gizmo_drag_axis: None,
+            gizmo_drag_start_world: [0.0; 3],
+            gizmo_drag_start_mouse: [0.0; 2],
         }
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/gizmo.rs
+++ b/crates/bsengine-rhi-wgpu/src/gizmo.rs
@@ -1,0 +1,234 @@
+//! Screen-space translate gizmo: pure projection/hit-test math plus an egui
+//! painter routine. Kept separate from `surface.rs` so the math is
+//! unit-testable without a live wgpu/winit context.
+
+use egui::{Color32, Painter, Pos2, Rect, Stroke, Vec2};
+use glam::{Mat4, Vec3};
+
+pub const AXIS_X: u8 = 0;
+pub const AXIS_Y: u8 = 1;
+pub const AXIS_Z: u8 = 2;
+
+const HANDLE_HIT_RADIUS: f32 = 8.0;
+const HANDLE_LENGTH_FRACTION: f32 = 0.15;
+
+pub fn axis_dir(axis: u8) -> Vec3 {
+    match axis {
+        AXIS_X => Vec3::X,
+        AXIS_Y => Vec3::Y,
+        _ => Vec3::Z,
+    }
+}
+
+fn axis_color(axis: u8) -> Color32 {
+    match axis {
+        AXIS_X => Color32::from_rgb(220, 60, 60),
+        AXIS_Y => Color32::from_rgb(60, 200, 80),
+        _ => Color32::from_rgb(70, 120, 230),
+    }
+}
+
+/// Projects a world-space point into screen-space pixel coordinates within
+/// `rect`, using a combined view-projection matrix. Returns `None` if the
+/// point is behind the camera (w <= 0), where projection is undefined.
+pub fn world_to_screen(pos: Vec3, view_proj: &[[f32; 4]; 4], rect: Rect) -> Option<Pos2> {
+    let m = Mat4::from_cols_array_2d(view_proj);
+    let clip = m * pos.extend(1.0);
+    if clip.w <= 1e-4 {
+        return None;
+    }
+    let ndc_x = clip.x / clip.w;
+    let ndc_y = clip.y / clip.w;
+    let sx = rect.min.x + (ndc_x * 0.5 + 0.5) * rect.width();
+    let sy = rect.min.y + (1.0 - (ndc_y * 0.5 + 0.5)) * rect.height();
+    Some(Pos2::new(sx, sy))
+}
+
+/// Distance from `p` to the segment `a`-`b`, in screen pixels.
+pub fn dist_to_segment(p: Pos2, a: Pos2, b: Pos2) -> f32 {
+    let ab = b - a;
+    let len_sq = ab.length_sq();
+    let t = if len_sq > 1e-8 {
+        ((p - a).dot(ab) / len_sq).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let closest = a + ab * t;
+    (p - closest).length()
+}
+
+/// World-space handle length for a gizmo centered at `pos`, scaled so its
+/// on-screen size stays roughly constant regardless of camera distance.
+pub fn handle_length(pos: Vec3, cam_pos: Vec3) -> f32 {
+    (pos - cam_pos).length() * HANDLE_LENGTH_FRACTION
+}
+
+/// Screen-space unit direction and pixels-per-world-unit scale for one axis,
+/// used to convert a 2D mouse drag delta into a 1D world-space offset along
+/// that axis. Returns `None` if the axis is degenerate on screen (e.g.
+/// pointing directly at/away from the camera).
+pub fn axis_screen_dir_and_scale(
+    pos: Vec3,
+    axis: u8,
+    probe_len: f32,
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+) -> Option<(Vec2, f32)> {
+    let origin = world_to_screen(pos, view_proj, rect)?;
+    let tip = world_to_screen(pos + axis_dir(axis) * probe_len, view_proj, rect)?;
+    let delta = tip - origin;
+    let pixel_len = delta.length();
+    if pixel_len < 1e-3 {
+        return None;
+    }
+    Some((delta / pixel_len, pixel_len / probe_len))
+}
+
+/// Finds which axis handle (if any) is under `mouse_pos`, closest first.
+pub fn hit_test(
+    pos: Vec3,
+    handle_len: f32,
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+    mouse_pos: Pos2,
+) -> Option<u8> {
+    let origin = world_to_screen(pos, view_proj, rect)?;
+    [AXIS_X, AXIS_Y, AXIS_Z]
+        .into_iter()
+        .filter_map(|axis| {
+            let tip = world_to_screen(pos + axis_dir(axis) * handle_len, view_proj, rect)?;
+            let d = dist_to_segment(mouse_pos, origin, tip);
+            (d <= HANDLE_HIT_RADIUS).then_some((axis, d))
+        })
+        .min_by(|a, b| a.1.total_cmp(&b.1))
+        .map(|(axis, _)| axis)
+}
+
+/// Draws the three translate handles, highlighting `hovered`/`dragging`.
+pub fn draw(
+    painter: &Painter,
+    pos: Vec3,
+    handle_len: f32,
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+    hovered: Option<u8>,
+    dragging: Option<u8>,
+) {
+    let Some(origin) = world_to_screen(pos, view_proj, rect) else {
+        return;
+    };
+    for axis in [AXIS_X, AXIS_Y, AXIS_Z] {
+        let Some(tip) = world_to_screen(pos + axis_dir(axis) * handle_len, view_proj, rect) else {
+            continue;
+        };
+        let active = dragging == Some(axis) || (dragging.is_none() && hovered == Some(axis));
+        let color = if active {
+            Color32::WHITE
+        } else {
+            axis_color(axis)
+        };
+        let width = if active { 4.0 } else { 2.5 };
+        painter.line_segment([origin, tip], Stroke::new(width, color));
+        painter.circle_filled(tip, 4.0, color);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_view_proj() -> [[f32; 4]; 4] {
+        let eye = Vec3::new(0.0, 0.0, 10.0);
+        let view = Mat4::look_at_rh(eye, Vec3::ZERO, Vec3::Y);
+        let proj = Mat4::perspective_rh(std::f32::consts::FRAC_PI_4, 800.0 / 600.0, 0.1, 1000.0);
+        (proj * view).to_cols_array_2d()
+    }
+
+    fn test_rect() -> Rect {
+        Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0))
+    }
+
+    #[test]
+    fn origin_projects_near_screen_center() {
+        let vp = test_view_proj();
+        let screen = world_to_screen(Vec3::ZERO, &vp, test_rect()).expect("in front of camera");
+        assert!((screen.x - 400.0).abs() < 1.0);
+        assert!((screen.y - 300.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn point_behind_camera_returns_none() {
+        let vp = test_view_proj();
+        // Camera sits at z=10 looking toward -Z; z=20 is behind it.
+        let screen = world_to_screen(Vec3::new(0.0, 0.0, 20.0), &vp, test_rect());
+        assert!(screen.is_none());
+    }
+
+    #[test]
+    fn x_axis_moves_screen_point_horizontally() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        let origin = world_to_screen(Vec3::ZERO, &vp, rect).unwrap();
+        let tip = world_to_screen(Vec3::new(2.0, 0.0, 0.0), &vp, rect).unwrap();
+        assert!((tip.x - origin.x).abs() > 5.0);
+        assert!((tip.y - origin.y).abs() < 1.0);
+    }
+
+    #[test]
+    fn y_axis_moves_screen_point_vertically() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        let origin = world_to_screen(Vec3::ZERO, &vp, rect).unwrap();
+        let tip = world_to_screen(Vec3::new(0.0, 2.0, 0.0), &vp, rect).unwrap();
+        assert!((tip.y - origin.y).abs() > 5.0);
+        assert!((tip.x - origin.x).abs() < 1.0);
+    }
+
+    #[test]
+    fn dist_to_segment_endpoint_and_perpendicular() {
+        let a = Pos2::new(0.0, 0.0);
+        let b = Pos2::new(10.0, 0.0);
+        assert!((dist_to_segment(Pos2::new(5.0, 3.0), a, b) - 3.0).abs() < 1e-4);
+        assert!((dist_to_segment(Pos2::new(-2.0, 0.0), a, b) - 2.0).abs() < 1e-4);
+        assert!((dist_to_segment(Pos2::new(0.0, 0.0), a, b)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn handle_length_scales_with_camera_distance() {
+        let near = handle_length(Vec3::ZERO, Vec3::new(0.0, 0.0, 5.0));
+        let far = handle_length(Vec3::ZERO, Vec3::new(0.0, 0.0, 50.0));
+        assert!(far > near);
+    }
+
+    #[test]
+    fn axis_screen_dir_and_scale_is_unit_and_positive() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        let (dir, scale) =
+            axis_screen_dir_and_scale(Vec3::ZERO, AXIS_X, 1.0, &vp, rect).expect("not degenerate");
+        assert!((dir.length() - 1.0).abs() < 1e-3);
+        assert!(scale > 0.0);
+    }
+
+    #[test]
+    fn hit_test_finds_closest_handle_tip() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        let handle_len = 2.0;
+        let x_tip = world_to_screen(Vec3::new(handle_len, 0.0, 0.0), &vp, rect).unwrap();
+        assert_eq!(
+            hit_test(Vec3::ZERO, handle_len, &vp, rect, x_tip),
+            Some(AXIS_X)
+        );
+    }
+
+    #[test]
+    fn hit_test_misses_far_away_point() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        assert_eq!(
+            hit_test(Vec3::ZERO, 2.0, &vp, rect, Pos2::new(10.0, 10.0)),
+            None
+        );
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod gizmo;
 pub mod mesh;
 pub mod plugin;
 pub mod post_process;

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1953,7 +1953,93 @@ impl WgpuSurface {
                                 insp.viewport_size = [panel_rect.width(), panel_rect.height()];
                                 insp.viewport_contains_cursor =
                                     panel_rect.contains(egui::Pos2::new(cursor_x, cursor_y));
-                                ui.allocate_rect(panel_rect, egui::Sense::hover());
+                                let response =
+                                    ui.allocate_rect(panel_rect, egui::Sense::click_and_drag());
+
+                                if let (Some(sel_id), Some(view_proj)) =
+                                    (insp.selected_id, insp.editor_view_proj)
+                                {
+                                    let has_transform = entities_snapshot
+                                        .iter()
+                                        .find(|e| e.id == sel_id)
+                                        .is_some_and(|e| e.position.is_some());
+                                    if has_transform {
+                                        let pos = glam::Vec3::from(insp.edit_pos);
+                                        let cam_pos = glam::Vec3::from(insp.editor_cam_pos);
+                                        let handle_len = crate::gizmo::handle_length(pos, cam_pos);
+
+                                        if response.drag_started() {
+                                            if let Some(mp) = response.interact_pointer_pos() {
+                                                if let Some(axis) = crate::gizmo::hit_test(
+                                                    pos, handle_len, &view_proj, panel_rect, mp,
+                                                ) {
+                                                    insp.gizmo_drag_axis = Some(axis);
+                                                    insp.gizmo_drag_start_world = insp.edit_pos;
+                                                    insp.gizmo_drag_start_mouse = [mp.x, mp.y];
+                                                }
+                                            }
+                                        }
+
+                                        let mut pos_changed = false;
+                                        if let Some(axis) = insp.gizmo_drag_axis {
+                                            if response.dragged() {
+                                                if let (Some((dir2d, px_per_unit)), Some(mp)) = (
+                                                    crate::gizmo::axis_screen_dir_and_scale(
+                                                        glam::Vec3::from(
+                                                            insp.gizmo_drag_start_world,
+                                                        ),
+                                                        axis,
+                                                        handle_len.max(0.01),
+                                                        &view_proj,
+                                                        panel_rect,
+                                                    ),
+                                                    response.interact_pointer_pos(),
+                                                ) {
+                                                    let start = egui::Pos2::new(
+                                                        insp.gizmo_drag_start_mouse[0],
+                                                        insp.gizmo_drag_start_mouse[1],
+                                                    );
+                                                    let screen_delta = mp - start;
+                                                    let world_delta =
+                                                        screen_delta.dot(dir2d) / px_per_unit;
+                                                    let new_pos = glam::Vec3::from(
+                                                        insp.gizmo_drag_start_world,
+                                                    ) + crate::gizmo::axis_dir(axis)
+                                                        * world_delta;
+                                                    insp.edit_pos = new_pos.to_array();
+                                                    pos_changed = true;
+                                                }
+                                            } else if response.drag_stopped() {
+                                                insp.gizmo_drag_axis = None;
+                                            }
+                                        }
+                                        if pos_changed {
+                                            insp.cmd_queue.push(
+                                                bsengine_core::InspectorCmd::SetPosition {
+                                                    id: sel_id,
+                                                    x: insp.edit_pos[0],
+                                                    y: insp.edit_pos[1],
+                                                    z: insp.edit_pos[2],
+                                                },
+                                            );
+                                        }
+
+                                        let hovered = response.hover_pos().and_then(|mp| {
+                                            crate::gizmo::hit_test(
+                                                pos, handle_len, &view_proj, panel_rect, mp,
+                                            )
+                                        });
+                                        crate::gizmo::draw(
+                                            ui.painter(),
+                                            pos,
+                                            handle_len,
+                                            &view_proj,
+                                            panel_rect,
+                                            hovered,
+                                            insp.gizmo_drag_axis,
+                                        );
+                                    }
+                                }
                             });
                     } else {
                         // Overlay mode: side panels rendered over the running game


### PR DESCRIPTION
## Summary

Part of "뷰포트 조작성" editor improvements. Until now the only way to move an entity was typing numbers into the Inspector's Transform DragValue fields — no way to drag it directly in the 3D viewport, unlike Unity/Unreal's move handles.

- New `bsengine-rhi-wgpu::gizmo` module: pure projection/hit-test math (`world_to_screen`, `dist_to_segment`, `axis_screen_dir_and_scale`, `handle_length`, `hit_test`) plus an egui `Painter`-based `draw()` routine
- When a selected entity has a `Transform`, three colored axis handles (X=red, Y=green, Z=blue) are drawn from its world position, projected via the editor camera's view-projection matrix. Handle length scales with camera distance so on-screen size stays roughly constant
- Dragging a handle projects the 2D mouse delta onto the handle's screen-space direction, converts it to a world-space offset along that axis, and pushes the existing `InspectorCmd::SetPosition` — reusing the same command path the DragValue fields already use, so no new ECS-side handling was needed
- `InspectorState` gained `gizmo_drag_axis` / `gizmo_drag_start_world` / `gizmo_drag_start_mouse` to track drag state across frames

## Test plan

- [x] `cargo test -p bsengine-rhi-wgpu gizmo` — 9 new unit tests covering projection, hit-testing, and axis math against a realistic `look_at_rh`/`perspective_rh` camera
- [x] `cargo test -p bsengine-core -p bsengine-rhi-wgpu -p bsengine-editor` — all passing, no regressions
- [x] `cargo build --workspace` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] Manually forced entity selection every frame and ran `cargo run -p bsengine-editor-app` for 15s (~900 frames) — gizmo draw/hit-test executed every frame with no panic
- [x] CI (ubuntu + windows)

## Follow-ups (not in this PR)

- Rotate/scale gizmo handles
- Multi-select
- Undo/redo
- Keyboard shortcuts (Delete, Ctrl+D, W/E/R gizmo mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)