### PR TITLE
feat(editor): multi-select in Hierarchy panel (Ctrl/Shift-click)

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -20,6 +20,7 @@ pub struct InspectorEntityInfo {
     pub material_roughness: Option<f32>,
     pub material_emissive: Option<[f32; 3]>,
     pub visible: bool,
+    pub selected: bool,
 }
 
 pub enum InspectorCmd {
@@ -73,6 +74,9 @@ pub enum InspectorCmd {
         metallic: Option<f32>,
         roughness: Option<f32>,
         emissive: Option<[f32; 3]>,
+    },
+    SetSelection {
+        ids: Vec<u64>,
     },
 }
 

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -660,6 +660,7 @@ fn populate_inspector(
             material_roughness: e.material_roughness,
             material_emissive: e.material_emissive,
             visible: e.visible,
+            selected: e.selected,
         })
         .collect();
 }
@@ -667,6 +668,7 @@ fn populate_inspector(
 fn apply_inspector_cmds(
     inspector: Option<ResMut<InspectorState>>,
     queue_res: Res<EditorCommandQueueResource>,
+    selection_res: Res<EditorSelectionResource>,
 ) {
     let Some(mut inspector) = inspector else {
         return;
@@ -678,6 +680,12 @@ fn apply_inspector_cmds(
     let mut queue = queue_res.0.lock().unwrap();
     for cmd in cmds {
         match cmd {
+            InspectorCmd::SetSelection { ids } => {
+                let mut sel = selection_res.0.lock().unwrap();
+                sel.clear();
+                sel.extend(ids);
+                continue;
+            }
             InspectorCmd::SetPosition { id, x, y, z } => {
                 queue.push(EditorCommand::SetPosition { entity_id: id, x, y, z });
             }
@@ -28188,13 +28196,13 @@ fn parse_vec3_input(v: &serde_json::Value) -> Option<[f32; 3]> {
 mod tests {
     use super::EditorPlugin;
     use bsengine_app::new_app;
-    use bsengine_core::Transform;
+    use bsengine_core::{InspectorCmd, InspectorState, Transform};
     use bsengine_mcp::McpPlugin;
     use bsengine_scene::Name;
     use glam::Vec3;
     use serde_json::json;
 
-    use crate::snapshot::EditorSnapshotResource;
+    use crate::snapshot::{EditorSelectionResource, EditorSnapshotResource};
 
     #[test]
     fn editor_plugin_builds_without_panic() {
@@ -28254,6 +28262,96 @@ mod tests {
         assert!((pos[0] - 1.0).abs() < 1e-5);
         assert!((pos[1] - 2.0).abs() < 1e-5);
         assert!((pos[2] - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn inspector_set_selection_updates_selection_resource() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let id_a = app.world_mut().spawn(Name("A".to_string())).id().index() as u64;
+        let id_b = app.world_mut().spawn(Name("B".to_string())).id().index() as u64;
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .cmd_queue
+            .push(InspectorCmd::SetSelection {
+                ids: vec![id_a, id_b],
+            });
+        app.update();
+
+        let selection = app
+            .world()
+            .resource::<EditorSelectionResource>()
+            .0
+            .lock()
+            .unwrap();
+        assert!(selection.contains(&id_a));
+        assert!(selection.contains(&id_b));
+        assert_eq!(selection.len(), 2);
+    }
+
+    #[test]
+    fn editor_snapshot_reflects_multi_selection() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let id_a = app.world_mut().spawn(Name("A".to_string())).id().index() as u64;
+        let id_b = app.world_mut().spawn(Name("B".to_string())).id().index() as u64;
+        let id_c = app.world_mut().spawn(Name("C".to_string())).id().index() as u64;
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .cmd_queue
+            .push(InspectorCmd::SetSelection {
+                ids: vec![id_a, id_b],
+            });
+        app.update();
+        app.update();
+
+        let snapshot = app
+            .world()
+            .resource::<EditorSnapshotResource>()
+            .0
+            .lock()
+            .unwrap();
+        let selected = |id: u64| snapshot.entities.iter().find(|e| e.id == id).unwrap().selected;
+        assert!(selected(id_a));
+        assert!(selected(id_b));
+        assert!(!selected(id_c));
+    }
+
+    #[test]
+    fn inspector_set_selection_replaces_previous_selection() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let id_a = app.world_mut().spawn(Name("A".to_string())).id().index() as u64;
+        let id_b = app.world_mut().spawn(Name("B".to_string())).id().index() as u64;
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .cmd_queue
+            .push(InspectorCmd::SetSelection { ids: vec![id_a] });
+        app.update();
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .cmd_queue
+            .push(InspectorCmd::SetSelection { ids: vec![id_b] });
+        app.update();
+
+        let selection = app
+            .world()
+            .resource::<EditorSelectionResource>()
+            .0
+            .lock()
+            .unwrap();
+        assert!(!selection.contains(&id_a));
+        assert!(selection.contains(&id_b));
+        assert_eq!(selection.len(), 1);
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1606,6 +1606,7 @@ impl WgpuSurface {
                         let entities_snapshot = insp.entities.clone();
                         let current_sel = insp.selected_id;
                         let mut new_sel = insp.selected_id;
+                        let mut new_selection: Option<Vec<u64>> = None;
                         let mut spawn_entity = false;
                         let mut despawn_entity = false;
                         egui::SidePanel::left("bse_hierarchy")
@@ -1624,15 +1625,48 @@ impl WgpuSurface {
                                         despawn_entity = true;
                                     }
                                 });
+                                ui.label("Ctrl+click: toggle · Shift+click: range");
                                 ui.separator();
                                 egui::ScrollArea::vertical().show(ui, |ui| {
-                                    for info in &entities_snapshot {
+                                    for (idx, info) in entities_snapshot.iter().enumerate() {
                                         let label = info.name.as_deref().unwrap_or("(unnamed)");
                                         let text = format!("[{}] {}", info.id, label);
-                                        if ui
-                                            .selectable_label(current_sel == Some(info.id), text)
-                                            .clicked()
-                                        {
+                                        let resp = ui.selectable_label(info.selected, text);
+                                        if resp.clicked() {
+                                            let mods = ui.ctx().input(|i| i.modifiers);
+                                            if mods.shift {
+                                                let anchor_idx = current_sel
+                                                    .and_then(|id| {
+                                                        entities_snapshot
+                                                            .iter()
+                                                            .position(|e| e.id == id)
+                                                    })
+                                                    .unwrap_or(idx);
+                                                let (lo, hi) =
+                                                    (anchor_idx.min(idx), anchor_idx.max(idx));
+                                                new_selection = Some(
+                                                    entities_snapshot[lo..=hi]
+                                                        .iter()
+                                                        .map(|e| e.id)
+                                                        .collect(),
+                                                );
+                                            } else if mods.ctrl {
+                                                let mut ids: Vec<u64> = entities_snapshot
+                                                    .iter()
+                                                    .filter(|e| e.selected)
+                                                    .map(|e| e.id)
+                                                    .collect();
+                                                if let Some(pos) =
+                                                    ids.iter().position(|&id| id == info.id)
+                                                {
+                                                    ids.remove(pos);
+                                                } else {
+                                                    ids.push(info.id);
+                                                }
+                                                new_selection = Some(ids);
+                                            } else {
+                                                new_selection = Some(vec![info.id]);
+                                            }
                                             new_sel = Some(info.id);
                                         }
                                     }
@@ -1645,11 +1679,27 @@ impl WgpuSurface {
                                 });
                         }
                         if despawn_entity {
-                            if let Some(id) = current_sel {
+                            let ids: Vec<u64> = entities_snapshot
+                                .iter()
+                                .filter(|e| e.selected)
+                                .map(|e| e.id)
+                                .collect();
+                            let ids: Vec<u64> = if ids.is_empty() {
+                                current_sel.into_iter().collect()
+                            } else {
+                                ids
+                            };
+                            for id in ids {
                                 insp.cmd_queue
                                     .push(bsengine_core::InspectorCmd::Despawn { id });
-                                insp.selected_id = None;
                             }
+                            insp.selected_id = None;
+                            insp.cmd_queue
+                                .push(bsengine_core::InspectorCmd::SetSelection { ids: vec![] });
+                        }
+                        if let Some(ids) = new_selection {
+                            insp.cmd_queue
+                                .push(bsengine_core::InspectorCmd::SetSelection { ids });
                         }
                         if new_sel != insp.selected_id {
                             insp.selected_id = new_sel;


### PR DESCRIPTION
## Summary

Part of "뷰포트 조작성" editor improvements (item 10 in ENGINE_ROADMAP.md). The Hierarchy panel only supported single selection, even though a multi-entity selection set (`EditorSelectionResource`, an `Arc<Mutex<HashSet<u64>>>` already used by MCP tools like `select_entities_with_duplicate_name`) already existed on the ECS side — it just wasn't wired up to mouse clicks.

- Add `InspectorCmd::SetSelection { ids }` as the UI → ECS bridge, processed in `apply_inspector_cmds` by replacing `EditorSelectionResource`'s `HashSet`
- Add `InspectorEntityInfo.selected`, populated in `populate_inspector` from the snapshot's already-computed per-entity `selected` flag (itself derived from `EditorSelectionResource` in `update_editor_snapshot`)
- Hierarchy panel: plain click replaces the selection (unchanged behavior); **Ctrl+click** toggles the clicked entity in/out of the selection; **Shift+click** range-selects from the primary selection to the clicked row
- The "－" delete button now despawns every selected entity, not just the primary one

Gizmo dragging and the Inspector's property panel still act on the primary `selected_id` only — multi-entity transform editing is a follow-up, not in this PR.

## Test plan

- [x] `cargo test -p bsengine-editor` — 3 new tests (`inspector_set_selection_updates_selection_resource`, `editor_snapshot_reflects_multi_selection`, `inspector_set_selection_replaces_previous_selection`) plus all 777 existing tests passing
- [x] `cargo test -p bsengine-core -p bsengine-rhi-wgpu` — no regressions (17850 + 34 passing)
- [x] `cargo build --workspace` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] Manually ran `cargo run -p bsengine-editor-app` — boots and runs without panic
- [x] CI (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)