### PR TITLE
feat(editor): add Undo/Redo via snapshot checkpoint reconciliation

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -130,6 +130,11 @@ pub struct InspectorState {
     pub gizmo_drag_axis: Option<u8>,
     pub gizmo_drag_start_world: [f32; 3],
     pub gizmo_drag_start_mouse: [f32; 2],
+
+    // Set by the toolbar/keyboard to request an undo/redo; consumed and
+    // cleared by EditorPlugin's history system the same frame.
+    pub request_undo: bool,
+    pub request_redo: bool,
 }
 
 impl Default for InspectorState {
@@ -165,6 +170,8 @@ impl Default for InspectorState {
             gizmo_drag_axis: None,
             gizmo_drag_start_world: [0.0; 3],
             gizmo_drag_start_mouse: [0.0; 2],
+            request_undo: false,
+            request_redo: false,
         }
     }
 }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1,10 +1,10 @@
 use crate::snapshot::{
-    EditorCommand, EditorCommandQueueResource, EditorSelectionResource, EditorSnapshot,
-    EditorSnapshotResource, EntityInfo, SharedCommandQueue, SharedSelection, SharedSnapshot, Tags,
-    Visible,
+    EditorCommand, EditorCommandQueueResource, EditorHistory, EditorHistoryResource,
+    EditorSelectionResource, EditorSnapshot, EditorSnapshotResource, EntityInfo,
+    SharedCommandQueue, SharedHistory, SharedSelection, SharedSnapshot, Tags, Visible,
 };
 use bevy_app::{App, Plugin, Update};
-use bevy_ecs::prelude::{Commands, Entity, IntoSystemConfigs, ParamSet, Query, ResMut};
+use bevy_ecs::prelude::{Commands, Entity, IntoSystemConfigs, ParamSet, Query, ResMut, World};
 use bsengine_core::{
     Camera, DirectionalLight, GlobalTransform, InspectorCmd, InspectorEntityInfo, InspectorState,
     Material, Parent, PointLight, SpotLight, Transform,
@@ -86,9 +86,12 @@ fn update_editor_snapshot(
         .collect();
 }
 
+const MAX_UNDO_HISTORY: usize = 100;
+
 fn process_editor_commands(
     queue_res: Res<EditorCommandQueueResource>,
     snapshot_res: Res<EditorSnapshotResource>,
+    history_res: Res<EditorHistoryResource>,
     mut params: ParamSet<(
         Query<Entity>,
         Query<(Entity, &mut Transform)>,
@@ -105,6 +108,16 @@ fn process_editor_commands(
         let mut queue = queue_res.0.lock().unwrap();
         queue.drain(..).collect()
     };
+
+    if !cmds.is_empty() {
+        let checkpoint = snapshot_res.0.lock().unwrap().clone();
+        let mut history = history_res.0.lock().unwrap();
+        history.undo_stack.push(checkpoint);
+        history.redo_stack.clear();
+        if history.undo_stack.len() > MAX_UNDO_HISTORY {
+            history.undo_stack.remove(0);
+        }
+    }
 
     for cmd in cmds {
         match cmd {
@@ -573,6 +586,304 @@ fn process_editor_commands(
     }
 }
 
+/// Restores world state to match `target`, diffing against `current` to
+/// know which entities to despawn (existed now, not in target) versus spawn
+/// fresh (existed in target, not now). Entities present in both are updated
+/// in place.
+///
+/// Only fields fully captured by `EntityInfo` are ever replaced wholesale
+/// (Transform, MeshRenderer, PointLight, Name, Visible, Tags, Parent).
+/// Camera/DirectionalLight/SpotLight/Material carry fields `EntityInfo`
+/// doesn't track (aspect/near/far, direction/ambient, cone angles,
+/// texture_id) — for those, only the tracked sub-fields are patched in
+/// place on an already-existing component, and a missing component is never
+/// fabricated from partial data, to avoid silently losing untracked state.
+fn reconcile_to_snapshot(world: &mut World, current: &EditorSnapshot, target: &EditorSnapshot) {
+    let mut live_by_id: std::collections::HashMap<u64, Entity> = std::collections::HashMap::new();
+    {
+        let mut q = world.query::<Entity>();
+        for e in q.iter(world) {
+            live_by_id.insert(e.index() as u64, e);
+        }
+    }
+
+    let target_ids: std::collections::HashSet<u64> =
+        target.entities.iter().map(|e| e.id).collect();
+    for info in &current.entities {
+        if !target_ids.contains(&info.id) {
+            if let Some(e) = live_by_id.remove(&info.id) {
+                world.despawn(e);
+            }
+        }
+    }
+
+    for info in &target.entities {
+        if let Some(&e) = live_by_id.get(&info.id) {
+            sync_entity_to_info(world, e, info);
+        } else {
+            let e = spawn_entity_from_info(world, info);
+            live_by_id.insert(info.id, e);
+        }
+    }
+
+    // Parent links are resolved last, once every target entity (updated or
+    // freshly respawned) has a live Entity handle.
+    for info in &target.entities {
+        let Some(&child) = live_by_id.get(&info.id) else {
+            continue;
+        };
+        match info.parent_id.and_then(|pid| live_by_id.get(&pid).copied()) {
+            Some(parent) => {
+                world.entity_mut(child).insert(Parent(parent));
+            }
+            None => {
+                world.entity_mut(child).remove::<Parent>();
+            }
+        }
+    }
+}
+
+fn sync_entity_to_info(world: &mut World, entity: Entity, info: &EntityInfo) {
+    let mut e = world.entity_mut(entity);
+
+    match &info.name {
+        Some(name) => {
+            e.insert(Name(name.clone()));
+        }
+        None => {
+            e.remove::<Name>();
+        }
+    }
+
+    if let (Some(pos), Some(rot), Some(scale)) = (info.position, info.rotation, info.scale) {
+        e.insert((
+            Transform {
+                translation: glam::Vec3::from(pos),
+                rotation: glam::Quat::from_euler(
+                    glam::EulerRot::XYZ,
+                    rot[0].to_radians(),
+                    rot[1].to_radians(),
+                    rot[2].to_radians(),
+                ),
+                scale: glam::Vec3::from(scale),
+            },
+            GlobalTransform::default(),
+        ));
+    } else {
+        e.remove::<Transform>();
+        e.remove::<GlobalTransform>();
+    }
+
+    match info.mesh_id {
+        Some(mesh_id) => {
+            e.insert(MeshRenderer { mesh_id });
+        }
+        None => {
+            e.remove::<MeshRenderer>();
+        }
+    }
+
+    e.insert(Visible(info.visible));
+
+    if info.tags.is_empty() {
+        e.remove::<Tags>();
+    } else {
+        e.insert(Tags(info.tags.clone()));
+    }
+
+    match info.light_type.as_deref() {
+        Some("point") => {
+            e.remove::<DirectionalLight>();
+            e.remove::<SpotLight>();
+            e.insert(PointLight {
+                color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])),
+                intensity: info.light_intensity.unwrap_or(1.0),
+                range: info.light_range.unwrap_or(10.0),
+            });
+        }
+        Some("directional") => {
+            e.remove::<PointLight>();
+            e.remove::<SpotLight>();
+            if let Some(mut dl) = e.get_mut::<DirectionalLight>() {
+                if let Some(c) = info.light_color {
+                    dl.color = glam::Vec3::from(c);
+                }
+            }
+        }
+        Some("spot") => {
+            e.remove::<PointLight>();
+            e.remove::<DirectionalLight>();
+            if let Some(mut sl) = e.get_mut::<SpotLight>() {
+                if let Some(c) = info.light_color {
+                    sl.color = glam::Vec3::from(c);
+                }
+                if let Some(i) = info.light_intensity {
+                    sl.intensity = i;
+                }
+                if let Some(r) = info.light_range {
+                    sl.range = r;
+                }
+            }
+        }
+        _ => {
+            e.remove::<PointLight>();
+            e.remove::<DirectionalLight>();
+            e.remove::<SpotLight>();
+        }
+    }
+
+    match info.camera_fov {
+        Some(fov_deg) => {
+            if let Some(mut cam) = e.get_mut::<Camera>() {
+                cam.fov_y_radians = fov_deg.to_radians();
+            }
+        }
+        None => {
+            e.remove::<Camera>();
+        }
+    }
+
+    match info.material_base_color {
+        Some(base_color) => {
+            if let Some(mut mat) = e.get_mut::<Material>() {
+                mat.base_color = glam::Vec3::from(base_color);
+                if let Some(m) = info.material_metallic {
+                    mat.metallic = m;
+                }
+                if let Some(r) = info.material_roughness {
+                    mat.roughness = r;
+                }
+                if let Some(em) = info.material_emissive {
+                    mat.emissive = glam::Vec3::from(em);
+                }
+            }
+        }
+        None => {
+            e.remove::<Material>();
+        }
+    }
+}
+
+fn spawn_entity_from_info(world: &mut World, info: &EntityInfo) -> Entity {
+    let mut e = world.spawn_empty();
+    if let Some(name) = &info.name {
+        e.insert(Name(name.clone()));
+    }
+    if let (Some(pos), Some(rot), Some(scale)) = (info.position, info.rotation, info.scale) {
+        e.insert((
+            Transform {
+                translation: glam::Vec3::from(pos),
+                rotation: glam::Quat::from_euler(
+                    glam::EulerRot::XYZ,
+                    rot[0].to_radians(),
+                    rot[1].to_radians(),
+                    rot[2].to_radians(),
+                ),
+                scale: glam::Vec3::from(scale),
+            },
+            GlobalTransform::default(),
+        ));
+    }
+    if let Some(mesh_id) = info.mesh_id {
+        e.insert(MeshRenderer { mesh_id });
+    }
+    if !info.visible {
+        e.insert(Visible(false));
+    }
+    if !info.tags.is_empty() {
+        e.insert(Tags(info.tags.clone()));
+    }
+    match info.light_type.as_deref() {
+        Some("point") => {
+            e.insert(PointLight {
+                color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])),
+                intensity: info.light_intensity.unwrap_or(1.0),
+                range: info.light_range.unwrap_or(10.0),
+                ..PointLight::default()
+            });
+        }
+        Some("directional") => {
+            e.insert(DirectionalLight {
+                color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])),
+                ..DirectionalLight::default()
+            });
+        }
+        Some("spot") => {
+            e.insert(SpotLight {
+                color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])),
+                intensity: info.light_intensity.unwrap_or(1.0),
+                range: info.light_range.unwrap_or(10.0),
+                ..SpotLight::default()
+            });
+        }
+        _ => {}
+    }
+    if let Some(fov_deg) = info.camera_fov {
+        e.insert(Camera::perspective(fov_deg, 16.0 / 9.0));
+    }
+    if let Some(base_color) = info.material_base_color {
+        e.insert(Material {
+            base_color: glam::Vec3::from(base_color),
+            metallic: info.material_metallic.unwrap_or(0.0),
+            roughness: info.material_roughness.unwrap_or(0.5),
+            emissive: info.material_emissive.map(glam::Vec3::from).unwrap_or(glam::Vec3::ZERO),
+            ..Material::default()
+        });
+    }
+    e.id()
+}
+
+fn apply_history_action(world: &mut World) {
+    let is_undo = {
+        let Some(mut insp) = world.get_resource_mut::<InspectorState>() else {
+            return;
+        };
+        if insp.request_undo {
+            insp.request_undo = false;
+            true
+        } else if insp.request_redo {
+            insp.request_redo = false;
+            false
+        } else {
+            return;
+        }
+    };
+
+    let current = {
+        let snap_res = world.resource::<EditorSnapshotResource>();
+        let s = snap_res.0.lock().unwrap().clone();
+        s
+    };
+
+    let target = {
+        let hist_res = world.resource::<EditorHistoryResource>();
+        let mut history = hist_res.0.lock().unwrap();
+        let popped = if is_undo {
+            history.undo_stack.pop()
+        } else {
+            history.redo_stack.pop()
+        };
+        let Some(target) = popped else {
+            return;
+        };
+        if is_undo {
+            history.redo_stack.push(current.clone());
+        } else {
+            history.undo_stack.push(current.clone());
+        }
+        target
+    };
+
+    reconcile_to_snapshot(world, &current, &target);
+
+    if let Some(mut insp) = world.get_resource_mut::<InspectorState>() {
+        insp.selected_id = None;
+    }
+    if let Some(sel_res) = world.get_resource::<EditorSelectionResource>() {
+        sel_res.0.lock().unwrap().clear();
+    }
+}
+
 fn update_editor_camera(
     inspector: Option<ResMut<InspectorState>>,
     mouse: Option<bsengine_ecs::Res<bsengine_input::MouseState>>,
@@ -749,16 +1060,19 @@ impl Plugin for EditorPlugin {
         let snapshot: SharedSnapshot = Arc::new(Mutex::new(EditorSnapshot::default()));
         let cmd_queue: SharedCommandQueue = Arc::new(Mutex::new(Vec::new()));
         let selection: SharedSelection = Arc::new(Mutex::new(std::collections::HashSet::new()));
+        let history: SharedHistory = Arc::new(Mutex::new(EditorHistory::default()));
 
         app.insert_resource(EditorSnapshotResource(snapshot.clone()));
         app.insert_resource(EditorCommandQueueResource(cmd_queue.clone()));
         app.insert_resource(EditorSelectionResource(selection.clone()));
+        app.insert_resource(EditorHistoryResource(history.clone()));
         app.insert_resource(InspectorState::editor());
         app.add_systems(Update, update_editor_snapshot);
         app.add_systems(Update, update_editor_camera);
         app.add_systems(Update, populate_inspector.after(update_editor_snapshot));
         app.add_systems(Update, apply_inspector_cmds.before(process_editor_commands));
         app.add_systems(Update, process_editor_commands);
+        app.add_systems(Update, apply_history_action.after(process_editor_commands));
 
         if let Some(mcp) = app.world_mut().get_resource_mut::<McpRegistryResource>() {
             // list_entities
@@ -28202,7 +28516,9 @@ mod tests {
     use glam::Vec3;
     use serde_json::json;
 
-    use crate::snapshot::{EditorSelectionResource, EditorSnapshotResource};
+    use crate::snapshot::{
+        EditorCommand, EditorCommandQueueResource, EditorSelectionResource, EditorSnapshotResource,
+    };
 
     #[test]
     fn editor_plugin_builds_without_panic() {
@@ -28352,6 +28668,190 @@ mod tests {
         assert!(!selection.contains(&id_a));
         assert!(selection.contains(&id_b));
         assert_eq!(selection.len(), 1);
+    }
+
+    #[test]
+    fn undo_restores_despawned_entity() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let id = app
+            .world_mut()
+            .spawn((
+                Name("Box".to_string()),
+                Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
+            ))
+            .id()
+            .index() as u64;
+        app.update();
+
+        {
+            let queue_res = app.world().resource::<EditorCommandQueueResource>();
+            queue_res
+                .0
+                .lock()
+                .unwrap()
+                .push(EditorCommand::Despawn { entity_id: id });
+        }
+        app.update();
+        app.update();
+
+        {
+            let snapshot = app
+                .world()
+                .resource::<EditorSnapshotResource>()
+                .0
+                .lock()
+                .unwrap();
+            assert!(!snapshot.entities.iter().any(|e| e.name.as_deref() == Some("Box")));
+        }
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .request_undo = true;
+        app.update();
+        app.update();
+
+        let snapshot = app
+            .world()
+            .resource::<EditorSnapshotResource>()
+            .0
+            .lock()
+            .unwrap();
+        let restored = snapshot
+            .entities
+            .iter()
+            .find(|e| e.name.as_deref() == Some("Box"))
+            .expect("Box should be restored by undo");
+        let pos = restored.position.expect("restored Box has a transform");
+        assert!((pos[0] - 1.0).abs() < 1e-5);
+        assert!((pos[1] - 2.0).abs() < 1e-5);
+        assert!((pos[2] - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn redo_reapplies_despawn_after_undo() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let id = app
+            .world_mut()
+            .spawn(Name("Box".to_string()))
+            .id()
+            .index() as u64;
+        app.update();
+
+        {
+            let queue_res = app.world().resource::<EditorCommandQueueResource>();
+            queue_res
+                .0
+                .lock()
+                .unwrap()
+                .push(EditorCommand::Despawn { entity_id: id });
+        }
+        app.update();
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .request_undo = true;
+        app.update();
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .request_redo = true;
+        app.update();
+        app.update();
+
+        let snapshot = app
+            .world()
+            .resource::<EditorSnapshotResource>()
+            .0
+            .lock()
+            .unwrap();
+        assert!(
+            !snapshot.entities.iter().any(|e| e.name.as_deref() == Some("Box")),
+            "redo should reapply the despawn"
+        );
+    }
+
+    #[test]
+    fn undo_reverts_position_change() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let id = app
+            .world_mut()
+            .spawn((
+                Name("Box".to_string()),
+                Transform::from_translation(Vec3::new(1.0, 0.0, 0.0)),
+            ))
+            .id()
+            .index() as u64;
+        app.update();
+
+        {
+            let queue_res = app.world().resource::<EditorCommandQueueResource>();
+            queue_res.0.lock().unwrap().push(EditorCommand::SetPosition {
+                entity_id: id,
+                x: 9.0,
+                y: 9.0,
+                z: 9.0,
+            });
+        }
+        app.update();
+        app.update();
+
+        {
+            let snapshot = app
+                .world()
+                .resource::<EditorSnapshotResource>()
+                .0
+                .lock()
+                .unwrap();
+            let pos = snapshot
+                .entities
+                .iter()
+                .find(|e| e.id == id)
+                .and_then(|e| e.position)
+                .expect("Box has a transform");
+            assert!((pos[0] - 9.0).abs() < 1e-5);
+        }
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .request_undo = true;
+        app.update();
+        app.update();
+
+        let snapshot = app
+            .world()
+            .resource::<EditorSnapshotResource>()
+            .0
+            .lock()
+            .unwrap();
+        let pos = snapshot
+            .entities
+            .iter()
+            .find(|e| e.id == id)
+            .and_then(|e| e.position)
+            .expect("Box still has a transform after undo");
+        assert!((pos[0] - 1.0).abs() < 1e-5, "expected x reverted to 1.0, got {}", pos[0]);
+    }
+
+    #[test]
+    fn undo_with_empty_history_does_not_panic() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .request_undo = true;
+        app.update();
+        app.update();
     }
 
     #[test]

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -185,9 +185,20 @@ pub enum EditorCommand {
     },
 }
 
+/// Undo/redo checkpoint stacks. Each entry is a full `EditorSnapshot` taken
+/// just before an `EditorCommand` batch was applied, so undo/redo restores
+/// state by diffing+reconciling against a target snapshot rather than
+/// replaying inverse commands.
+#[derive(Default)]
+pub struct EditorHistory {
+    pub undo_stack: Vec<EditorSnapshot>,
+    pub redo_stack: Vec<EditorSnapshot>,
+}
+
 pub type SharedSnapshot = Arc<Mutex<EditorSnapshot>>;
 pub type SharedCommandQueue = Arc<Mutex<Vec<EditorCommand>>>;
 pub type SharedSelection = Arc<Mutex<HashSet<u64>>>;
+pub type SharedHistory = Arc<Mutex<EditorHistory>>;
 
 #[derive(Resource)]
 pub struct EditorSnapshotResource(pub SharedSnapshot);
@@ -197,6 +208,9 @@ pub struct EditorCommandQueueResource(pub SharedCommandQueue);
 
 #[derive(Resource)]
 pub struct EditorSelectionResource(pub SharedSelection);
+
+#[derive(Resource)]
+pub struct EditorHistoryResource(pub SharedHistory);
 
 #[cfg(test)]
 mod tests {

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1600,6 +1600,13 @@ impl WgpuSurface {
                                         "◆ Editor"
                                     };
                                 ui.label(mode_label);
+                                ui.separator();
+                                if ui.button("↩ Undo").clicked() {
+                                    insp.request_undo = true;
+                                }
+                                if ui.button("↪ Redo").clicked() {
+                                    insp.request_redo = true;
+                                }
                             });
                         });
 


### PR DESCRIPTION
## Summary

Part of "뷰포트 조작성" editor improvements (item 10 in ENGINE_ROADMAP.md). The editor had no way to revert an accidental edit or delete.

Rather than writing per-`EditorCommand` inverse operations (~30 variants, several destructive like `Despawn`/`ClearScene` that can't be trivially inverted), undo/redo captures a full `EditorSnapshot` checkpoint before each applied command batch and restores state by diffing the current snapshot against a target checkpoint.

- `EditorHistoryResource` holds undo/redo `Vec<EditorSnapshot>` stacks (capped at 100 entries). `process_editor_commands` pushes a checkpoint (and clears the redo stack) whenever it's about to apply a non-empty command batch
- `InspectorState.request_undo`/`request_redo` are set by new toolbar buttons (↩ Undo / ↪ Redo); a new exclusive `apply_history_action` system consumes them, pops the target checkpoint, and calls `reconcile_to_snapshot`
- `reconcile_to_snapshot` diffs entity ids between the current and target snapshots: despawns entities missing from the target, spawns fresh ones for entities the target has but the world doesn't, and in-place-updates entities present in both

**Data-loss safety**: only fields `EntityInfo` fully captures (Transform, MeshRenderer, PointLight, Name, Visible, Tags, Parent) are ever replaced wholesale during in-place update. `Camera`/`DirectionalLight`/`SpotLight`/`Material` carry fields `EntityInfo` doesn't track (aspect/near/far, direction/ambient, cone angles, texture_id) — for those, only the tracked sub-fields are patched onto an *already-existing* component, and a missing component is never fabricated from partial data, so undo/redo can't silently discard untracked state. Freshly-respawned entities fall back to each component's `Default` for untracked fields — the same limitation the existing `DuplicateEntity` command already has.

**Caught during review**: an initial version added `.after(update_editor_snapshot)` to `process_editor_commands` to guarantee checkpoints were captured pre-mutation. This broke ~1 existing MCP test (`mcp_set_transform_moves_entity`) that relied on a single `app.update()` reflecting a queued command in the snapshot — turns out the *existing* (undocumented) system ordering already runs `process_editor_commands` before `update_editor_snapshot`, so checkpoints were already correctly pre-mutation without the extra constraint. Reverted that ordering change; kept only the new `apply_history_action.after(process_editor_commands)`.

Keyboard shortcuts (Ctrl+Z/Ctrl+Y) are a follow-up, not in this PR — item 10's remaining checklist item.

## Test plan

- [x] `cargo test -p bsengine-editor` — 4 new tests (`undo_restores_despawned_entity`, `redo_reapplies_despawn_after_undo`, `undo_reverts_position_change`, `undo_with_empty_history_does_not_panic`) plus all 781 existing tests passing (including the previously-broken `mcp_set_transform_moves_entity`, now fixed)
- [x] `cargo test -p bsengine-core -p bsengine-rhi-wgpu` — no regressions (17850 + 34 passing)
- [x] `cargo build --workspace` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] Manually drove `SetPosition -> undo -> redo -> undo -> redo` every frame for 15s against the default scene — no panic
- [x] CI (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)