### PR TITLE
feat(editor): keyboard shortcuts (Delete, Ctrl+D, Ctrl+Z/Y)

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -78,6 +78,9 @@ pub enum InspectorCmd {
     SetSelection {
         ids: Vec<u64>,
     },
+    Duplicate {
+        id: u64,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -997,6 +997,9 @@ fn apply_inspector_cmds(
                 sel.extend(ids);
                 continue;
             }
+            InspectorCmd::Duplicate { id } => {
+                queue.push(EditorCommand::DuplicateEntity { entity_id: id });
+            }
             InspectorCmd::SetPosition { id, x, y, z } => {
                 queue.push(EditorCommand::SetPosition { entity_id: id, x, y, z });
             }
@@ -28852,6 +28855,52 @@ mod tests {
             .request_undo = true;
         app.update();
         app.update();
+    }
+
+    #[test]
+    fn inspector_duplicate_cmd_spawns_a_copy() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let id = app
+            .world_mut()
+            .spawn((
+                Name("Box".to_string()),
+                Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
+            ))
+            .id()
+            .index() as u64;
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .cmd_queue
+            .push(InspectorCmd::Duplicate { id });
+        app.update();
+        app.update();
+
+        let snapshot = app
+            .world()
+            .resource::<EditorSnapshotResource>()
+            .0
+            .lock()
+            .unwrap();
+        assert!(
+            snapshot
+                .entities
+                .iter()
+                .any(|e| e.name.as_deref() == Some("Box (copy)")),
+            "expected a duplicated entity named 'Box (copy)'"
+        );
+        assert_eq!(
+            snapshot
+                .entities
+                .iter()
+                .filter(|e| e.name.as_deref() == Some("Box"))
+                .count(),
+            1,
+            "original Box should still exist exactly once"
+        );
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1616,6 +1616,39 @@ impl WgpuSurface {
                         let mut new_selection: Option<Vec<u64>> = None;
                         let mut spawn_entity = false;
                         let mut despawn_entity = false;
+                        let mut duplicate_selected = false;
+
+                        // Keyboard shortcuts. Ignored while an egui widget (e.g. a
+                        // DragValue or text field) has focus, so Ctrl+Z etc. don't
+                        // get stolen from in-progress text editing.
+                        if ctx.memory(|m| m.focused()).is_none() {
+                            let (del, dup, undo, redo) = ctx.input(|i| {
+                                (
+                                    i.key_pressed(egui::Key::Delete),
+                                    i.modifiers.ctrl && i.key_pressed(egui::Key::D),
+                                    i.modifiers.ctrl
+                                        && !i.modifiers.shift
+                                        && i.key_pressed(egui::Key::Z),
+                                    (i.modifiers.ctrl
+                                        && i.modifiers.shift
+                                        && i.key_pressed(egui::Key::Z))
+                                        || (i.modifiers.ctrl && i.key_pressed(egui::Key::Y)),
+                                )
+                            });
+                            if del {
+                                despawn_entity = true;
+                            }
+                            if dup {
+                                duplicate_selected = true;
+                            }
+                            if undo {
+                                insp.request_undo = true;
+                            }
+                            if redo {
+                                insp.request_redo = true;
+                            }
+                        }
+
                         egui::SidePanel::left("bse_hierarchy")
                             .default_width(220.0)
                             .show(ctx, |ui| {
@@ -1703,6 +1736,22 @@ impl WgpuSurface {
                             insp.selected_id = None;
                             insp.cmd_queue
                                 .push(bsengine_core::InspectorCmd::SetSelection { ids: vec![] });
+                        }
+                        if duplicate_selected {
+                            let ids: Vec<u64> = entities_snapshot
+                                .iter()
+                                .filter(|e| e.selected)
+                                .map(|e| e.id)
+                                .collect();
+                            let ids: Vec<u64> = if ids.is_empty() {
+                                current_sel.into_iter().collect()
+                            } else {
+                                ids
+                            };
+                            for id in ids {
+                                insp.cmd_queue
+                                    .push(bsengine_core::InspectorCmd::Duplicate { id });
+                            }
                         }
                         if let Some(ids) = new_selection {
                             insp.cmd_queue


### PR DESCRIPTION
## Summary

Final checklist item for item 10 (Editor Viewport Interactivity) in ENGINE_ROADMAP.md. All editor actions (delete, duplicate, undo, redo) previously required clicking a specific button.

- **Delete**: despawns every selected entity (falls back to the primary selection if none are multi-selected), reusing the same `InspectorCmd` path as the Hierarchy "－" button
- **Ctrl+D**: duplicates every selected entity via a new `InspectorCmd::Duplicate { id }`, which `apply_inspector_cmds` forwards to the existing `EditorCommand::DuplicateEntity` handler
- **Ctrl+Z**: undo. **Ctrl+Y** or **Ctrl+Shift+Z**: redo (both bindings accepted since editors are split roughly evenly between the two conventions)

All four are gated on `ctx.memory(|m| m.focused()).is_none()` so they don't fire while the user is typing in a DragValue or text field (e.g. Ctrl+Z while editing a name field types 'z' instead of undoing).

This closes out item 10's checklist (gizmo, multi-select, undo/redo, keyboard shortcuts all done).

## Test plan

- [x] `cargo test -p bsengine-editor` — 1 new test (`inspector_duplicate_cmd_spawns_a_copy`) plus all 782 existing tests passing
- [x] `cargo test -p bsengine-core -p bsengine-rhi-wgpu` — no regressions (17850 + 34 passing)
- [x] `cargo build --workspace` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] Manually ran `cargo run -p bsengine-editor-app` — boots and runs without panic
- [x] CI (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)