### PR TITLE
fix(editor): use game camera during Play; add camera frustum + rotate gizmos

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -90,6 +90,13 @@ pub enum EditorPlayState {
     Playing,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
+pub enum GizmoMode {
+    #[default]
+    Translate,
+    Rotate,
+}
+
 #[derive(Resource)]
 pub struct InspectorState {
     pub entities: Vec<InspectorEntityInfo>,
@@ -128,11 +135,21 @@ pub struct InspectorState {
     pub editor_proj: [[f32; 4]; 4],
     pub editor_cam_pos: [f32; 3],
 
+    // Which viewport gizmo is active for the selected entity.
+    pub gizmo_mode: GizmoMode,
+
     // Translate-gizmo drag state (viewport panel). `gizmo_drag_axis` is
     // 0=X, 1=Y, 2=Z while a handle is being dragged.
     pub gizmo_drag_axis: Option<u8>,
     pub gizmo_drag_start_world: [f32; 3],
     pub gizmo_drag_start_mouse: [f32; 2],
+
+    // Rotate-gizmo drag state. `gizmo_rotate_axis` is 0=X, 1=Y, 2=Z (world
+    // axis) while a ring is being dragged; the angle fields are radians of
+    // the mouse's angle around the gizmo's screen-space center.
+    pub gizmo_rotate_axis: Option<u8>,
+    pub gizmo_rotate_start_deg: [f32; 3],
+    pub gizmo_rotate_start_angle: f32,
 
     // Set by the toolbar/keyboard to request an undo/redo; consumed and
     // cleared by EditorPlugin's history system the same frame.
@@ -170,9 +187,13 @@ impl Default for InspectorState {
             editor_view_proj: None,
             editor_proj: [[0.0; 4]; 4],
             editor_cam_pos: [0.0; 3],
+            gizmo_mode: GizmoMode::Translate,
             gizmo_drag_axis: None,
             gizmo_drag_start_world: [0.0; 3],
             gizmo_drag_start_mouse: [0.0; 2],
+            gizmo_rotate_axis: None,
+            gizmo_rotate_start_deg: [0.0; 3],
+            gizmo_rotate_start_angle: 0.0,
             request_undo: false,
             request_redo: false,
         }

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1108,7 +1108,9 @@ pub use imbue::Imbue;
 pub use immune::Immune;
 pub use impact::Impact;
 pub use input_map::{Binding, InputCode, InputMap};
-pub use inspector::{EditorPlayState, InspectorCmd, InspectorEntityInfo, InspectorState};
+pub use inspector::{
+    EditorPlayState, GizmoMode, InspectorCmd, InspectorEntityInfo, InspectorState,
+};
 pub use interactable::{InteractTrigger, Interactable};
 pub use intercept::Intercept;
 pub use interrupt::Interrupt;

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -28904,6 +28904,52 @@ mod tests {
     }
 
     #[test]
+    fn inspector_set_rotation_updates_transform() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let id = app
+            .world_mut()
+            .spawn((
+                Name("Box".to_string()),
+                Transform::from_translation(Vec3::ZERO),
+            ))
+            .id()
+            .index() as u64;
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .cmd_queue
+            .push(InspectorCmd::SetRotation {
+                id,
+                rx: 0.0,
+                ry: 90.0,
+                rz: 0.0,
+            });
+        app.update();
+        app.update();
+
+        let snapshot = app
+            .world()
+            .resource::<EditorSnapshotResource>()
+            .0
+            .lock()
+            .unwrap();
+        let rot = snapshot
+            .entities
+            .iter()
+            .find(|e| e.id == id)
+            .and_then(|e| e.rotation)
+            .expect("Box has a rotation");
+        assert!(
+            (rot[1] - 90.0).abs() < 1e-3,
+            "expected y rotation ~90deg, got {:?}",
+            rot
+        );
+    }
+
+    #[test]
     fn mcp_list_entities_tool_registered() {
         let mut app = new_app();
         app.add_plugins(McpPlugin);

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1,9 +1,9 @@
 use bevy_app::{App, Plugin, PostUpdate, Update};
 use bevy_ecs::prelude::{Entity, EventReader, IntoSystemConfigs, ParamSet, Query, ResMut, Without};
 use bsengine_core::{
-    AmbientOcclusion, Bloom, Camera, CustomShader, DirectionalLight, GlobalTransform, HudTexts,
-    InspectorState, Material, Parent, PointLight, SkyboxPath, SpotLight, ToneMap, Transform,
-    UiState, Visible,
+    AmbientOcclusion, Bloom, Camera, CustomShader, DirectionalLight, EditorPlayState,
+    GlobalTransform, HudTexts, InspectorState, Material, Parent, PointLight, SkyboxPath, SpotLight,
+    ToneMap, Transform, UiState, Visible,
 };
 use bsengine_ecs::Res;
 use bsengine_input::{Input, MouseButton, MouseState};
@@ -163,9 +163,11 @@ fn render_frame(
             })
             .unwrap_or((Mat4::IDENTITY, Vec3::ZERO, Mat4::IDENTITY, None, None, None));
 
-    // In editor mode, override camera matrices from orbit camera computed by EditorPlugin
+    // While editing (not Playing), override camera matrices from the orbit
+    // camera computed by EditorPlugin. Once Play starts, the viewport should
+    // show what the game's own Camera entity sees, same as a build would.
     if let Some(insp) = inspector.as_deref() {
-        if insp.editor_mode {
+        if insp.editor_mode && insp.play_state == EditorPlayState::Stopped {
             if let Some(vp) = insp.editor_view_proj {
                 view_proj = Mat4::from_cols_array_2d(&vp);
             }

--- a/crates/bsengine-rhi-wgpu/src/gizmo.rs
+++ b/crates/bsengine-rhi-wgpu/src/gizmo.rs
@@ -196,6 +196,90 @@ pub fn draw_camera_frustum(
     }
 }
 
+const ROTATE_RING_SEGMENTS: usize = 32;
+
+/// World-space points approximating a circle of `radius` centered at `pos`,
+/// lying in the plane perpendicular to the given world axis (so the X-axis
+/// ring lies in the YZ plane, etc.) — this is a world-aligned gizmo, not
+/// relative to the entity's own rotation.
+pub fn ring_points(pos: Vec3, axis: u8, radius: f32) -> [Vec3; ROTATE_RING_SEGMENTS] {
+    let (u, v) = match axis {
+        AXIS_X => (Vec3::Y, Vec3::Z),
+        AXIS_Y => (Vec3::Z, Vec3::X),
+        _ => (Vec3::X, Vec3::Y),
+    };
+    let mut pts = [Vec3::ZERO; ROTATE_RING_SEGMENTS];
+    for (i, p) in pts.iter_mut().enumerate() {
+        let t = i as f32 / ROTATE_RING_SEGMENTS as f32 * std::f32::consts::TAU;
+        *p = pos + (u * t.cos() + v * t.sin()) * radius;
+    }
+    pts
+}
+
+/// Angle (radians) of `p` around `center` in screen space.
+pub fn screen_angle(center: Pos2, p: Pos2) -> f32 {
+    (p.y - center.y).atan2(p.x - center.x)
+}
+
+/// Finds which rotate ring (if any) is under `mouse_pos`, closest first.
+pub fn hit_test_rotate(
+    pos: Vec3,
+    radius: f32,
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+    mouse_pos: Pos2,
+) -> Option<u8> {
+    [AXIS_X, AXIS_Y, AXIS_Z]
+        .into_iter()
+        .filter_map(|axis| {
+            let pts = ring_points(pos, axis, radius);
+            let mut min_d = f32::MAX;
+            for i in 0..ROTATE_RING_SEGMENTS {
+                let j = (i + 1) % ROTATE_RING_SEGMENTS;
+                if let (Some(a), Some(b)) = (
+                    world_to_screen(pts[i], view_proj, rect),
+                    world_to_screen(pts[j], view_proj, rect),
+                ) {
+                    min_d = min_d.min(dist_to_segment(mouse_pos, a, b));
+                }
+            }
+            (min_d <= HANDLE_HIT_RADIUS).then_some((axis, min_d))
+        })
+        .min_by(|a, b| a.1.total_cmp(&b.1))
+        .map(|(axis, _)| axis)
+}
+
+/// Draws the three rotate rings, highlighting `hovered`/`dragging`.
+pub fn draw_rotate_gizmo(
+    painter: &Painter,
+    pos: Vec3,
+    radius: f32,
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+    hovered: Option<u8>,
+    dragging: Option<u8>,
+) {
+    for axis in [AXIS_X, AXIS_Y, AXIS_Z] {
+        let pts = ring_points(pos, axis, radius);
+        let active = dragging == Some(axis) || (dragging.is_none() && hovered == Some(axis));
+        let color = if active {
+            Color32::WHITE
+        } else {
+            axis_color(axis)
+        };
+        let stroke = Stroke::new(if active { 3.0 } else { 2.0 }, color);
+        for i in 0..ROTATE_RING_SEGMENTS {
+            let j = (i + 1) % ROTATE_RING_SEGMENTS;
+            if let (Some(a), Some(b)) = (
+                world_to_screen(pts[i], view_proj, rect),
+                world_to_screen(pts[j], view_proj, rect),
+            ) {
+                painter.line_segment([a, b], stroke);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -330,6 +414,71 @@ mod tests {
         assert!(
             wide_width > narrow_width,
             "wider fov should produce a wider far plane"
+        );
+    }
+
+    #[test]
+    fn ring_points_lie_on_a_circle_of_given_radius() {
+        for axis in [AXIS_X, AXIS_Y, AXIS_Z] {
+            let pts = ring_points(Vec3::ZERO, axis, 2.0);
+            for p in pts {
+                assert!(
+                    (p.length() - 2.0).abs() < 1e-3,
+                    "point {:?} should be at radius 2.0 on axis {}",
+                    p,
+                    axis
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ring_points_perpendicular_to_axis() {
+        let x_ring = ring_points(Vec3::ZERO, AXIS_X, 1.0);
+        for p in x_ring {
+            assert!(p.x.abs() < 1e-4, "X-axis ring should lie in the YZ plane");
+        }
+        let y_ring = ring_points(Vec3::ZERO, AXIS_Y, 1.0);
+        for p in y_ring {
+            assert!(p.y.abs() < 1e-4, "Y-axis ring should lie in the XZ plane");
+        }
+        let z_ring = ring_points(Vec3::ZERO, AXIS_Z, 1.0);
+        for p in z_ring {
+            assert!(p.z.abs() < 1e-4, "Z-axis ring should lie in the XY plane");
+        }
+    }
+
+    #[test]
+    fn screen_angle_matches_known_directions() {
+        let center = Pos2::new(0.0, 0.0);
+        assert!((screen_angle(center, Pos2::new(1.0, 0.0))).abs() < 1e-4);
+        assert!(
+            (screen_angle(center, Pos2::new(0.0, 1.0)) - std::f32::consts::FRAC_PI_2).abs() < 1e-4
+        );
+    }
+
+    #[test]
+    fn hit_test_rotate_finds_ring_under_cursor() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        let radius = 1.5;
+        let pts = ring_points(Vec3::ZERO, AXIS_Z, radius);
+        // Pick a point off any axis (rings intersect exactly on the other
+        // two axes, which would make the hit-test result ambiguous).
+        let on_ring = world_to_screen(pts[ROTATE_RING_SEGMENTS / 8], &vp, rect).unwrap();
+        assert_eq!(
+            hit_test_rotate(Vec3::ZERO, radius, &vp, rect, on_ring),
+            Some(AXIS_Z)
+        );
+    }
+
+    #[test]
+    fn hit_test_rotate_misses_far_away_point() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        assert_eq!(
+            hit_test_rotate(Vec3::ZERO, 1.0, &vp, rect, Pos2::new(-500.0, -500.0)),
+            None
         );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/gizmo.rs
+++ b/crates/bsengine-rhi-wgpu/src/gizmo.rs
@@ -3,7 +3,7 @@
 //! unit-testable without a live wgpu/winit context.
 
 use egui::{Color32, Painter, Pos2, Rect, Stroke, Vec2};
-use glam::{Mat4, Vec3};
+use glam::{Mat4, Quat, Vec3};
 
 pub const AXIS_X: u8 = 0;
 pub const AXIS_Y: u8 = 1;
@@ -11,6 +11,12 @@ pub const AXIS_Z: u8 = 2;
 
 const HANDLE_HIT_RADIUS: f32 = 8.0;
 const HANDLE_LENGTH_FRACTION: f32 = 0.15;
+
+// Camera entities don't carry their real aspect ratio in EntityInfo (only
+// fov_y is tracked), so the frustum gizmo uses a fixed 16:9 stand-in — this
+// is a visual indicator of position/orientation, not a pixel-accurate preview.
+const FRUSTUM_VIZ_DISTANCE: f32 = 1.2;
+const FRUSTUM_DEFAULT_ASPECT: f32 = 16.0 / 9.0;
 
 pub fn axis_dir(axis: u8) -> Vec3 {
     match axis {
@@ -133,6 +139,63 @@ pub fn draw(
     }
 }
 
+/// The 4 far-plane corners of a camera's frustum wireframe, in world space,
+/// for a fixed small visualization distance (not the camera's actual near/far).
+pub fn frustum_far_corners(pos: Vec3, rotation: Quat, fov_y_radians: f32) -> [Vec3; 4] {
+    let forward = rotation * Vec3::NEG_Z;
+    let up = rotation * Vec3::Y;
+    let right = rotation * Vec3::X;
+
+    let half_h = FRUSTUM_VIZ_DISTANCE * (fov_y_radians * 0.5).tan();
+    let half_w = half_h * FRUSTUM_DEFAULT_ASPECT;
+    let center = pos + forward * FRUSTUM_VIZ_DISTANCE;
+
+    [
+        center + up * half_h - right * half_w,
+        center + up * half_h + right * half_w,
+        center - up * half_h + right * half_w,
+        center - up * half_h - right * half_w,
+    ]
+}
+
+/// Draws a camera's frustum as a wireframe pyramid from `pos` (the apex) to
+/// its four far-plane corners, so Camera entities are visible/orientable in
+/// the editor viewport even though they render nothing themselves.
+pub fn draw_camera_frustum(
+    painter: &Painter,
+    pos: Vec3,
+    rotation: Quat,
+    fov_y_radians: f32,
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+    highlighted: bool,
+) {
+    let Some(apex) = world_to_screen(pos, view_proj, rect) else {
+        return;
+    };
+    let corners = frustum_far_corners(pos, rotation, fov_y_radians);
+    let screen: Vec<Option<Pos2>> = corners
+        .iter()
+        .map(|&c| world_to_screen(c, view_proj, rect))
+        .collect();
+
+    let color = if highlighted {
+        Color32::WHITE
+    } else {
+        Color32::from_rgb(230, 200, 90)
+    };
+    let stroke = Stroke::new(1.5, color);
+
+    for sc in screen.iter().flatten() {
+        painter.line_segment([apex, *sc], stroke);
+    }
+    for i in 0..4 {
+        if let (Some(a), Some(b)) = (screen[i], screen[(i + 1) % 4]) {
+            painter.line_segment([a, b], stroke);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,6 +292,44 @@ mod tests {
         assert_eq!(
             hit_test(Vec3::ZERO, 2.0, &vp, rect, Pos2::new(10.0, 10.0)),
             None
+        );
+    }
+
+    #[test]
+    fn frustum_far_corners_are_in_front_of_identity_rotation() {
+        let corners = frustum_far_corners(Vec3::ZERO, Quat::IDENTITY, std::f32::consts::FRAC_PI_4);
+        for c in corners {
+            // Identity rotation looks down -Z, so all corners should be
+            // behind the origin along -Z.
+            assert!(c.z < 0.0, "expected corner {:?} to have negative z", c);
+        }
+    }
+
+    #[test]
+    fn frustum_far_corners_are_symmetric_around_center() {
+        let corners = frustum_far_corners(Vec3::ZERO, Quat::IDENTITY, std::f32::consts::FRAC_PI_4);
+        let center: Vec3 = corners.iter().copied().fold(Vec3::ZERO, |a, b| a + b) / 4.0;
+        assert!(
+            center.x.abs() < 1e-4,
+            "center.x should be ~0, got {}",
+            center.x
+        );
+        assert!(
+            center.y.abs() < 1e-4,
+            "center.y should be ~0, got {}",
+            center.y
+        );
+    }
+
+    #[test]
+    fn frustum_far_corners_scale_with_fov() {
+        let narrow = frustum_far_corners(Vec3::ZERO, Quat::IDENTITY, 0.2);
+        let wide = frustum_far_corners(Vec3::ZERO, Quat::IDENTITY, 1.5);
+        let narrow_width = (narrow[1] - narrow[0]).length();
+        let wide_width = (wide[1] - wide[0]).length();
+        assert!(
+            wide_width > narrow_width,
+            "wider fov should produce a wider far plane"
         );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1607,6 +1607,25 @@ impl WgpuSurface {
                                 if ui.button("↪ Redo").clicked() {
                                     insp.request_redo = true;
                                 }
+                                ui.separator();
+                                if ui
+                                    .selectable_label(
+                                        insp.gizmo_mode == bsengine_core::GizmoMode::Translate,
+                                        "Move (W)",
+                                    )
+                                    .clicked()
+                                {
+                                    insp.gizmo_mode = bsengine_core::GizmoMode::Translate;
+                                }
+                                if ui
+                                    .selectable_label(
+                                        insp.gizmo_mode == bsengine_core::GizmoMode::Rotate,
+                                        "Rotate (E)",
+                                    )
+                                    .clicked()
+                                {
+                                    insp.gizmo_mode = bsengine_core::GizmoMode::Rotate;
+                                }
                             });
                         });
 
@@ -1622,7 +1641,7 @@ impl WgpuSurface {
                         // DragValue or text field) has focus, so Ctrl+Z etc. don't
                         // get stolen from in-progress text editing.
                         if ctx.memory(|m| m.focused()).is_none() {
-                            let (del, dup, undo, redo) = ctx.input(|i| {
+                            let (del, dup, undo, redo, move_mode, rotate_mode) = ctx.input(|i| {
                                 (
                                     i.key_pressed(egui::Key::Delete),
                                     i.modifiers.ctrl && i.key_pressed(egui::Key::D),
@@ -1633,6 +1652,8 @@ impl WgpuSurface {
                                         && i.modifiers.shift
                                         && i.key_pressed(egui::Key::Z))
                                         || (i.modifiers.ctrl && i.key_pressed(egui::Key::Y)),
+                                    i.key_pressed(egui::Key::W),
+                                    i.key_pressed(egui::Key::E),
                                 )
                             });
                             if del {
@@ -1646,6 +1667,12 @@ impl WgpuSurface {
                             }
                             if redo {
                                 insp.request_redo = true;
+                            }
+                            if move_mode {
+                                insp.gizmo_mode = bsengine_core::GizmoMode::Translate;
+                            }
+                            if rotate_mode {
+                                insp.gizmo_mode = bsengine_core::GizmoMode::Rotate;
                             }
                         }
 
@@ -2066,8 +2093,8 @@ impl WgpuSurface {
                                 // starts, the viewport shows the game's own Camera entity
                                 // feed (see bsengine-render's render_frame), which the
                                 // editor-orbit-relative view_proj no longer matches.
-                                let is_stopped = insp.play_state
-                                    == bsengine_core::EditorPlayState::Stopped;
+                                let is_stopped =
+                                    insp.play_state == bsengine_core::EditorPlayState::Stopped;
 
                                 if is_stopped {
                                     if let Some(view_proj) = insp.editor_view_proj {
@@ -2096,90 +2123,212 @@ impl WgpuSurface {
                                 }
 
                                 if is_stopped {
-                                if let (Some(sel_id), Some(view_proj)) =
-                                    (insp.selected_id, insp.editor_view_proj)
-                                {
-                                    let has_transform = entities_snapshot
-                                        .iter()
-                                        .find(|e| e.id == sel_id)
-                                        .is_some_and(|e| e.position.is_some());
-                                    if has_transform {
-                                        let pos = glam::Vec3::from(insp.edit_pos);
-                                        let cam_pos = glam::Vec3::from(insp.editor_cam_pos);
-                                        let handle_len = crate::gizmo::handle_length(pos, cam_pos);
+                                    if let (Some(sel_id), Some(view_proj)) =
+                                        (insp.selected_id, insp.editor_view_proj)
+                                    {
+                                        let has_transform = entities_snapshot
+                                            .iter()
+                                            .find(|e| e.id == sel_id)
+                                            .is_some_and(|e| e.position.is_some());
+                                        if has_transform {
+                                            let pos = glam::Vec3::from(insp.edit_pos);
+                                            let cam_pos = glam::Vec3::from(insp.editor_cam_pos);
+                                            let handle_len =
+                                                crate::gizmo::handle_length(pos, cam_pos);
 
-                                        if response.drag_started() {
-                                            if let Some(mp) = response.interact_pointer_pos() {
-                                                if let Some(axis) = crate::gizmo::hit_test(
-                                                    pos, handle_len, &view_proj, panel_rect, mp,
-                                                ) {
-                                                    insp.gizmo_drag_axis = Some(axis);
-                                                    insp.gizmo_drag_start_world = insp.edit_pos;
-                                                    insp.gizmo_drag_start_mouse = [mp.x, mp.y];
-                                                }
-                                            }
-                                        }
+                                            match insp.gizmo_mode {
+                                                bsengine_core::GizmoMode::Translate => {
+                                                    if response.drag_started() {
+                                                        if let Some(mp) =
+                                                            response.interact_pointer_pos()
+                                                        {
+                                                            if let Some(axis) =
+                                                                crate::gizmo::hit_test(
+                                                                    pos, handle_len, &view_proj,
+                                                                    panel_rect, mp,
+                                                                )
+                                                            {
+                                                                insp.gizmo_drag_axis = Some(axis);
+                                                                insp.gizmo_drag_start_world =
+                                                                    insp.edit_pos;
+                                                                insp.gizmo_drag_start_mouse =
+                                                                    [mp.x, mp.y];
+                                                            }
+                                                        }
+                                                    }
 
-                                        let mut pos_changed = false;
-                                        if let Some(axis) = insp.gizmo_drag_axis {
-                                            if response.dragged() {
-                                                if let (Some((dir2d, px_per_unit)), Some(mp)) = (
-                                                    crate::gizmo::axis_screen_dir_and_scale(
-                                                        glam::Vec3::from(
-                                                            insp.gizmo_drag_start_world,
-                                                        ),
-                                                        axis,
-                                                        handle_len.max(0.01),
+                                                    let mut pos_changed = false;
+                                                    if let Some(axis) = insp.gizmo_drag_axis {
+                                                        if response.dragged() {
+                                                            if let (
+                                                            Some((dir2d, px_per_unit)),
+                                                            Some(mp),
+                                                        ) = (
+                                                            crate::gizmo::axis_screen_dir_and_scale(
+                                                                glam::Vec3::from(
+                                                                    insp.gizmo_drag_start_world,
+                                                                ),
+                                                                axis,
+                                                                handle_len.max(0.01),
+                                                                &view_proj,
+                                                                panel_rect,
+                                                            ),
+                                                            response.interact_pointer_pos(),
+                                                        ) {
+                                                            let start = egui::Pos2::new(
+                                                                insp.gizmo_drag_start_mouse[0],
+                                                                insp.gizmo_drag_start_mouse[1],
+                                                            );
+                                                            let screen_delta = mp - start;
+                                                            let world_delta =
+                                                                screen_delta.dot(dir2d)
+                                                                    / px_per_unit;
+                                                            let new_pos = glam::Vec3::from(
+                                                                insp.gizmo_drag_start_world,
+                                                            ) + crate::gizmo::axis_dir(axis)
+                                                                * world_delta;
+                                                            insp.edit_pos = new_pos.to_array();
+                                                            pos_changed = true;
+                                                        }
+                                                        } else if response.drag_stopped() {
+                                                            insp.gizmo_drag_axis = None;
+                                                        }
+                                                    }
+                                                    if pos_changed {
+                                                        insp.cmd_queue.push(
+                                                        bsengine_core::InspectorCmd::SetPosition {
+                                                            id: sel_id,
+                                                            x: insp.edit_pos[0],
+                                                            y: insp.edit_pos[1],
+                                                            z: insp.edit_pos[2],
+                                                        },
+                                                    );
+                                                    }
+
+                                                    let hovered =
+                                                        response.hover_pos().and_then(|mp| {
+                                                            crate::gizmo::hit_test(
+                                                                pos, handle_len, &view_proj,
+                                                                panel_rect, mp,
+                                                            )
+                                                        });
+                                                    crate::gizmo::draw(
+                                                        ui.painter(),
+                                                        pos,
+                                                        handle_len,
                                                         &view_proj,
                                                         panel_rect,
-                                                    ),
-                                                    response.interact_pointer_pos(),
-                                                ) {
-                                                    let start = egui::Pos2::new(
-                                                        insp.gizmo_drag_start_mouse[0],
-                                                        insp.gizmo_drag_start_mouse[1],
+                                                        hovered,
+                                                        insp.gizmo_drag_axis,
                                                     );
-                                                    let screen_delta = mp - start;
-                                                    let world_delta =
-                                                        screen_delta.dot(dir2d) / px_per_unit;
-                                                    let new_pos = glam::Vec3::from(
-                                                        insp.gizmo_drag_start_world,
-                                                    ) + crate::gizmo::axis_dir(axis)
-                                                        * world_delta;
-                                                    insp.edit_pos = new_pos.to_array();
-                                                    pos_changed = true;
                                                 }
-                                            } else if response.drag_stopped() {
-                                                insp.gizmo_drag_axis = None;
+                                                bsengine_core::GizmoMode::Rotate => {
+                                                    let radius = handle_len;
+
+                                                    if response.drag_started() {
+                                                        if let Some(mp) =
+                                                            response.interact_pointer_pos()
+                                                        {
+                                                            if let Some(axis) =
+                                                                crate::gizmo::hit_test_rotate(
+                                                                    pos, radius, &view_proj,
+                                                                    panel_rect, mp,
+                                                                )
+                                                            {
+                                                                if let Some(center) =
+                                                                    crate::gizmo::world_to_screen(
+                                                                        pos, &view_proj, panel_rect,
+                                                                    )
+                                                                {
+                                                                    insp.gizmo_rotate_axis =
+                                                                        Some(axis);
+                                                                    insp.gizmo_rotate_start_deg =
+                                                                        insp.edit_rot;
+                                                                    insp.gizmo_rotate_start_angle =
+                                                                        crate::gizmo::screen_angle(
+                                                                            center, mp,
+                                                                        );
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+
+                                                    let mut rot_changed = false;
+                                                    if let Some(axis) = insp.gizmo_rotate_axis {
+                                                        if response.dragged() {
+                                                            if let (Some(center), Some(mp)) = (
+                                                                crate::gizmo::world_to_screen(
+                                                                    pos, &view_proj, panel_rect,
+                                                                ),
+                                                                response.interact_pointer_pos(),
+                                                            ) {
+                                                                let current_angle =
+                                                                    crate::gizmo::screen_angle(
+                                                                        center, mp,
+                                                                    );
+                                                                let delta = current_angle
+                                                                    - insp.gizmo_rotate_start_angle;
+                                                                let deg =
+                                                                    insp.gizmo_rotate_start_deg;
+                                                                let start_rot =
+                                                                    glam::Quat::from_euler(
+                                                                        glam::EulerRot::XYZ,
+                                                                        deg[0].to_radians(),
+                                                                        deg[1].to_radians(),
+                                                                        deg[2].to_radians(),
+                                                                    );
+                                                                let delta_rot =
+                                                                    glam::Quat::from_axis_angle(
+                                                                        crate::gizmo::axis_dir(
+                                                                            axis,
+                                                                        ),
+                                                                        delta,
+                                                                    );
+                                                                let (rx, ry, rz) = (delta_rot
+                                                                    * start_rot)
+                                                                    .to_euler(glam::EulerRot::XYZ);
+                                                                insp.edit_rot = [
+                                                                    rx.to_degrees(),
+                                                                    ry.to_degrees(),
+                                                                    rz.to_degrees(),
+                                                                ];
+                                                                rot_changed = true;
+                                                            }
+                                                        } else if response.drag_stopped() {
+                                                            insp.gizmo_rotate_axis = None;
+                                                        }
+                                                    }
+                                                    if rot_changed {
+                                                        insp.cmd_queue.push(
+                                                        bsengine_core::InspectorCmd::SetRotation {
+                                                            id: sel_id,
+                                                            rx: insp.edit_rot[0],
+                                                            ry: insp.edit_rot[1],
+                                                            rz: insp.edit_rot[2],
+                                                        },
+                                                    );
+                                                    }
+
+                                                    let hovered =
+                                                        response.hover_pos().and_then(|mp| {
+                                                            crate::gizmo::hit_test_rotate(
+                                                                pos, radius, &view_proj,
+                                                                panel_rect, mp,
+                                                            )
+                                                        });
+                                                    crate::gizmo::draw_rotate_gizmo(
+                                                        ui.painter(),
+                                                        pos,
+                                                        radius,
+                                                        &view_proj,
+                                                        panel_rect,
+                                                        hovered,
+                                                        insp.gizmo_rotate_axis,
+                                                    );
+                                                }
                                             }
                                         }
-                                        if pos_changed {
-                                            insp.cmd_queue.push(
-                                                bsengine_core::InspectorCmd::SetPosition {
-                                                    id: sel_id,
-                                                    x: insp.edit_pos[0],
-                                                    y: insp.edit_pos[1],
-                                                    z: insp.edit_pos[2],
-                                                },
-                                            );
-                                        }
-
-                                        let hovered = response.hover_pos().and_then(|mp| {
-                                            crate::gizmo::hit_test(
-                                                pos, handle_len, &view_proj, panel_rect, mp,
-                                            )
-                                        });
-                                        crate::gizmo::draw(
-                                            ui.painter(),
-                                            pos,
-                                            handle_len,
-                                            &view_proj,
-                                            panel_rect,
-                                            hovered,
-                                            insp.gizmo_drag_axis,
-                                        );
                                     }
-                                }
                                 }
                             });
                     } else {

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2062,6 +2062,40 @@ impl WgpuSurface {
                                 let response =
                                     ui.allocate_rect(panel_rect, egui::Sense::click_and_drag());
 
+                                // Gizmo overlays only make sense while editing: once Play
+                                // starts, the viewport shows the game's own Camera entity
+                                // feed (see bsengine-render's render_frame), which the
+                                // editor-orbit-relative view_proj no longer matches.
+                                let is_stopped = insp.play_state
+                                    == bsengine_core::EditorPlayState::Stopped;
+
+                                if is_stopped {
+                                    if let Some(view_proj) = insp.editor_view_proj {
+                                        for info in &entities_snapshot {
+                                            if let (Some(fov_deg), Some(pos), Some(rot)) =
+                                                (info.camera_fov, info.position, info.rotation)
+                                            {
+                                                let rotation = glam::Quat::from_euler(
+                                                    glam::EulerRot::XYZ,
+                                                    rot[0].to_radians(),
+                                                    rot[1].to_radians(),
+                                                    rot[2].to_radians(),
+                                                );
+                                                crate::gizmo::draw_camera_frustum(
+                                                    ui.painter(),
+                                                    glam::Vec3::from(pos),
+                                                    rotation,
+                                                    fov_deg.to_radians(),
+                                                    &view_proj,
+                                                    panel_rect,
+                                                    info.selected,
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if is_stopped {
                                 if let (Some(sel_id), Some(view_proj)) =
                                     (insp.selected_id, insp.editor_view_proj)
                                 {
@@ -2145,6 +2179,7 @@ impl WgpuSurface {
                                             insp.gizmo_drag_axis,
                                         );
                                     }
+                                }
                                 }
                             });
                     } else {


### PR DESCRIPTION
## Summary

Three related gaps reported in the editor viewport:

1. **Play didn't switch cameras**: `render_frame` only checked `insp.editor_mode` (which stays `true` for the whole life of the standalone editor app), not `insp.play_state` — so the orbit camera kept overriding the game's actual `Camera` entity even while Playing. The viewport now falls back to the game's own `Camera` + `Transform` once `play_state == Playing`, matching what a real build would show.
2. **No way to see camera position/orientation in the editor**: unlike Unreal's camera frustum gizmo, there was no visual indicator at all. Added `gizmo::draw_camera_frustum`: a wireframe pyramid from the camera's position to its four far-plane corners (computed from `fov_y`; aspect is a fixed 16:9 stand-in since `EntityInfo` doesn't track the camera's real aspect ratio). Drawn for every `Camera` entity in the scene, highlighted white when selected.
3. **Rotation could only be typed, never dragged**: the viewport gizmo only ever supported translation. Added a rotate gizmo — three world-aligned rings (X in the YZ plane, etc.), hit-tested/drawn the same screen-space-projection way the translate handles already are. Dragging a ring computes the mouse's angle around the gizmo's screen-space center and applies that delta as a world-axis rotation (`Quat::from_axis_angle(axis, delta) * start_rotation`), converted back to XYZ-euler-degrees and pushed through the existing `InspectorCmd::SetRotation` path. `InspectorState.gizmo_mode` picks Translate vs Rotate, toggled via toolbar buttons or **W**/**E** keys.

All viewport gizmos (translate, rotate, camera frustum) are gated on `play_state == Stopped`: once Playing, the viewport is driven by the game camera's own `view_proj`, which the editor-orbit-relative gizmo math no longer matches.

Also added `inspector_set_rotation_updates_transform`, a regression test confirming `SetRotation`'s ECS-side plumbing works end-to-end — this PR was prompted by a report that rotation editing seemed broken entirely; the backend turned out fine, the actual gap was the missing rotate gizmo this PR adds.

## Test plan

- [x] `cargo test -p bsengine-rhi-wgpu` — 8 new tests (3 frustum, 5 rotate-ring) plus all existing tests passing (42 total)
- [x] `cargo test -p bsengine-render -p bsengine-editor -p bsengine-core` — no regressions, including the new `inspector_set_rotation_updates_transform`
- [x] `cargo build --workspace` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] Manually toggled Play/Stop every 20 frames for 15s with a Camera entity selected — no panic across repeated camera-source switches and frustum draws
- [x] Manually toggled Translate/Rotate gizmo mode every 10 frames while continuously pushing SetRotation for 15s — no panic across repeated mode switches and rotation updates
- [x] CI (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)