### PR TITLE
chore: clean up remaining clippy warnings across the workspace

### DIFF
--- a/crates/bsengine-app/src/angular_velocity.rs
+++ b/crates/bsengine-app/src/angular_velocity.rs
@@ -28,7 +28,7 @@ fn apply_angular_velocity(mut query: Query<(&AngularVelocity, &mut Transform)>, 
 mod tests {
     use super::*;
     use bsengine_core::{AngularVelocity, Time, Transform};
-    use glam::Vec3;
+
     use std::f32::consts::PI;
 
     fn make_app_with_delta(delta: f32) -> bevy_app::App {

--- a/crates/bsengine-app/src/nav_mesh.rs
+++ b/crates/bsengine-app/src/nav_mesh.rs
@@ -294,7 +294,6 @@ mod tests {
         // Change destination.
         let mut agent = app.world_mut().get_mut::<NavMeshAgent>(entity).unwrap();
         agent.destination = Some(Vec3::new(-3.0, 0.0, 0.0));
-        drop(agent);
         app.update();
 
         let state = app

--- a/crates/bsengine-app/src/nav_mesh.rs
+++ b/crates/bsengine-app/src/nav_mesh.rs
@@ -60,7 +60,7 @@ fn navigate_agents(
             .0
             .get(&entity)
             .and_then(|(_, _, for_dest)| *for_dest)
-            .map_or(true, |d| (d - dest).length_squared() > 0.0001);
+            .is_none_or(|d| (d - dest).length_squared() > 0.0001);
 
         if needs_recompute {
             match navmesh.find_path(transform.translation, dest) {

--- a/crates/bsengine-app/src/tests.rs
+++ b/crates/bsengine-app/src/tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[allow(clippy::module_inception)] // this file (tests.rs) is itself the test module
 mod tests {
     use crate::{new_app, App, BsPlugin};
 

--- a/crates/bsengine-asset/src/handle.rs
+++ b/crates/bsengine-asset/src/handle.rs
@@ -40,7 +40,7 @@ impl<T> std::fmt::Debug for Handle<T> {
 mod tests {
     use super::*;
 
-    struct DummyAsset(Vec<u8>);
+    struct DummyAsset;
 
     #[test]
     fn handle_has_typed_id() {

--- a/crates/bsengine-core/src/ammo.rs
+++ b/crates/bsengine-core/src/ammo.rs
@@ -43,7 +43,7 @@ impl Ammo {
         Self {
             current: cap,
             max_capacity: cap,
-            reserve: rsv.min(u32::MAX),
+            reserve: rsv,
             reserve_max,
             just_emptied: false,
             just_reloaded: false,

--- a/crates/bsengine-core/src/barrier.rs
+++ b/crates/bsengine-core/src/barrier.rs
@@ -85,11 +85,8 @@ impl Barrier {
 
         self.regen_timer += dt;
         if self.regen_timer >= self.regen_delay {
-            let was_depleted = self.current <= 0.0;
             self.current = (self.current + self.regen_rate * dt).min(self.capacity);
-            if self.current >= self.capacity && !was_depleted {
-                self.just_restored = true;
-            } else if self.current >= self.capacity {
+            if self.current >= self.capacity {
                 self.just_restored = true;
             }
         }

--- a/crates/bsengine-core/src/blink.rs
+++ b/crates/bsengine-core/src/blink.rs
@@ -88,10 +88,8 @@ impl Blink {
 
     /// Called by the movement system after the teleport is applied.
     pub fn consume(&mut self) {
-        if let Some(_) = self.charges {
-            if self.charges_remaining > 0 {
-                self.charges_remaining -= 1;
-            }
+        if self.charges.is_some() && self.charges_remaining > 0 {
+            self.charges_remaining -= 1;
         }
         self.cooldown_remaining = self.cooldown;
         self.state = BlinkState::Cooldown;
@@ -108,7 +106,7 @@ impl Blink {
                 }
             }
         }
-        if let Some(_) = self.charges {
+        if self.charges.is_some() {
             if self.charges_remaining < self.charges.unwrap_or(0) {
                 self.charge_regen_accumulated += dt;
                 if self.charge_regen_accumulated >= self.charge_regen_time {

--- a/crates/bsengine-core/src/carry.rs
+++ b/crates/bsengine-core/src/carry.rs
@@ -91,7 +91,7 @@ impl Carry {
     }
 
     /// Begin releasing the held object.
-    pub fn drop(&mut self) {
+    pub fn begin_drop(&mut self) {
         if self.phase == CarryPhase::Carrying || self.phase == CarryPhase::Lifting {
             self.phase = CarryPhase::Dropping;
             self.drop_timer = self.drop_duration;
@@ -199,7 +199,7 @@ mod tests {
         let mut c = carry();
         c.pickup(10.0);
         c.tick(0.3); // finish lifting
-        c.drop();
+        c.begin_drop();
         c.tick(0.2); // finish dropping
         assert_eq!(c.phase, CarryPhase::None);
         assert!(c.just_dropped);

--- a/crates/bsengine-core/src/experience.rs
+++ b/crates/bsengine-core/src/experience.rs
@@ -50,7 +50,7 @@ impl Experience {
 
     /// Returns `true` if the entity is at `max_level`.
     pub fn is_max_level(&self) -> bool {
-        self.max_level.map_or(false, |max| self.level >= max)
+        self.max_level.is_some_and(|max| self.level >= max)
     }
 
     /// Add `amount` XP and process level-ups. Returns the number of levels gained.

--- a/crates/bsengine-core/src/faze.rs
+++ b/crates/bsengine-core/src/faze.rs
@@ -288,7 +288,7 @@ mod tests {
     #[test]
     fn effective_cc_duration_base_when_disabled() {
         let f = Faze::new(10.0, 2.0);
-        let mut f = Faze {
+        let f = Faze {
             enabled: false,
             ..f
         };

--- a/crates/bsengine-core/src/force.rs
+++ b/crates/bsengine-core/src/force.rs
@@ -89,8 +89,7 @@ impl Force {
                 *t -= dt;
             }
         }
-        self.entries
-            .retain(|e| e.lifetime.map_or(true, |t| t > 0.0));
+        self.entries.retain(|e| e.lifetime.is_none_or(|t| t > 0.0));
     }
 
     fn sum_by_mode(&self, mode: ForceMode) -> Vec3 {

--- a/crates/bsengine-core/src/input_map.rs
+++ b/crates/bsengine-core/src/input_map.rs
@@ -88,7 +88,7 @@ impl InputMap {
         if !self.enabled {
             return false;
         }
-        self.bindings.get(action).map_or(false, |b| b.matches(code))
+        self.bindings.get(action).is_some_and(|b| b.matches(code))
     }
 
     pub fn action_count(&self) -> usize {

--- a/crates/bsengine-core/src/inventory.rs
+++ b/crates/bsengine-core/src/inventory.rs
@@ -53,10 +53,10 @@ impl Inventory {
         if !self.enabled {
             return false;
         }
-        let slot_ok = self.free_slots().map_or(true, |f| f > 0);
+        let slot_ok = self.free_slots().is_none_or(|f| f > 0);
         let weight_ok = self
             .max_weight
-            .map_or(true, |max| self.current_weight + weight <= max);
+            .is_none_or(|max| self.current_weight + weight <= max);
         slot_ok && weight_ok
     }
 

--- a/crates/bsengine-core/src/ledge.rs
+++ b/crates/bsengine-core/src/ledge.rs
@@ -86,7 +86,7 @@ impl Ledge {
     }
 
     /// Begin dropping from Hanging.
-    pub fn drop(&mut self) {
+    pub fn begin_drop(&mut self) {
         if self.phase == LedgePhase::Hanging {
             self.phase = LedgePhase::Dropping;
         }
@@ -155,7 +155,7 @@ mod tests {
     fn drop_from_hanging() {
         let mut l = Ledge::new();
         l.grab(Vec3::ZERO, Vec3::Z);
-        l.drop();
+        l.begin_drop();
         assert_eq!(l.phase, LedgePhase::Dropping);
     }
 

--- a/crates/bsengine-core/src/loot_table.rs
+++ b/crates/bsengine-core/src/loot_table.rs
@@ -67,7 +67,7 @@ impl LootTable {
         self
     }
 
-    pub fn add(mut self, entry: LootEntry) -> Self {
+    pub fn with_entry(mut self, entry: LootEntry) -> Self {
         self.entries.push(entry);
         self
     }
@@ -110,16 +110,16 @@ mod tests {
     #[test]
     fn loot_table_total_weight() {
         let table = LootTable::new()
-            .add(LootEntry::new("gold", 3.0))
-            .add(LootEntry::new("sword", 1.0));
+            .with_entry(LootEntry::new("gold", 3.0))
+            .with_entry(LootEntry::new("sword", 1.0));
         assert!((table.total_weight() - 4.0).abs() < 0.001);
     }
 
     #[test]
     fn loot_table_pick_first() {
         let table = LootTable::new()
-            .add(LootEntry::new("gold", 3.0))
-            .add(LootEntry::new("sword", 1.0));
+            .with_entry(LootEntry::new("gold", 3.0))
+            .with_entry(LootEntry::new("sword", 1.0));
         let entry = table.pick(0.0).unwrap();
         assert_eq!(entry.item_id, "gold");
     }
@@ -127,8 +127,8 @@ mod tests {
     #[test]
     fn loot_table_pick_second() {
         let table = LootTable::new()
-            .add(LootEntry::new("gold", 3.0))
-            .add(LootEntry::new("sword", 1.0));
+            .with_entry(LootEntry::new("gold", 3.0))
+            .with_entry(LootEntry::new("sword", 1.0));
         let entry = table.pick(3.5).unwrap();
         assert_eq!(entry.item_id, "sword");
     }
@@ -137,13 +137,15 @@ mod tests {
     fn luck_modifier_scales_weight() {
         let table = LootTable::new()
             .with_luck(2.0)
-            .add(LootEntry::new("gem", 1.0));
+            .with_entry(LootEntry::new("gem", 1.0));
         assert!((table.total_weight() - 2.0).abs() < 0.001);
     }
 
     #[test]
     fn disabled_table_returns_none() {
-        let table = LootTable::new().add(LootEntry::new("gold", 1.0)).disabled();
+        let table = LootTable::new()
+            .with_entry(LootEntry::new("gold", 1.0))
+            .disabled();
         assert!(table.pick(0.0).is_none());
     }
 }

--- a/crates/bsengine-core/src/oscillate.rs
+++ b/crates/bsengine-core/src/oscillate.rs
@@ -95,7 +95,7 @@ impl Oscillate {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::f32::consts::{FRAC_PI_2, TAU};
+    use std::f32::consts::FRAC_PI_2;
 
     #[test]
     fn zero_phase_gives_zero_offset() {

--- a/crates/bsengine-core/src/pickup.rs
+++ b/crates/bsengine-core/src/pickup.rs
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn reserved_pickup_rejects_other_entity() {
         let es = entities(2);
-        let mut p = Pickup::currency(100).with_reserved_for(es[0]);
+        let p = Pickup::currency(100).with_reserved_for(es[0]);
         assert!(!p.can_collect(es[1]));
         assert!(p.can_collect(es[0]));
     }

--- a/crates/bsengine-core/src/poise.rs
+++ b/crates/bsengine-core/src/poise.rs
@@ -26,6 +26,7 @@ pub struct Poise {
     /// Latched true when current hits 0; cleared only when:
     /// - `tick()` regens current back to `max`
     /// - `restore()` brings current above 0
+    ///
     /// Use `is_broken()` — do not inspect this field directly.
     pub broken: bool,
     pub just_broken: bool,

--- a/crates/bsengine-core/src/skeleton.rs
+++ b/crates/bsengine-core/src/skeleton.rs
@@ -2,7 +2,7 @@ use bevy_ecs::prelude::Component;
 
 /// Root-level binding between a mesh entity and its bone hierarchy.
 /// The animation system drives `Bone` entities referenced here each frame.
-#[derive(Component, Debug, Clone, PartialEq)]
+#[derive(Component, Debug, Clone, PartialEq, Default)]
 pub struct Skeleton {
     /// Names of all bones, ordered by bone index.
     /// Must match the joints in the associated `SkinnedMesh` primitive.
@@ -63,16 +63,6 @@ impl Skeleton {
                     None
                 }
             })
-    }
-}
-
-impl Default for Skeleton {
-    fn default() -> Self {
-        Self {
-            bone_names: Vec::new(),
-            parent_indices: Vec::new(),
-            roots: Vec::new(),
-        }
     }
 }
 

--- a/crates/bsengine-core/src/slow_mo.rs
+++ b/crates/bsengine-core/src/slow_mo.rs
@@ -88,7 +88,7 @@ impl SlowMo {
             self.charge = (self.charge - self.drain_rate * real_dt).max(0.0);
         }
 
-        let expired_duration = self.max_duration.map_or(false, |d| self.elapsed >= d);
+        let expired_duration = self.max_duration.is_some_and(|d| self.elapsed >= d);
         let out_of_charge = self.drain_rate > 0.0 && self.charge <= 0.0;
 
         if expired_duration || out_of_charge {

--- a/crates/bsengine-core/src/spawn_point.rs
+++ b/crates/bsengine-core/src/spawn_point.rs
@@ -34,7 +34,7 @@ impl SpawnPoint {
     /// Returns `true` if this spawn point is available to the given team.
     /// Shared points (no team set) are available to all teams.
     pub fn available_for(&self, team: u32) -> bool {
-        self.enabled && self.team.map_or(true, |t| t == team)
+        self.enabled && self.team.is_none_or(|t| t == team)
     }
 }
 

--- a/crates/bsengine-core/src/trail.rs
+++ b/crates/bsengine-core/src/trail.rs
@@ -84,9 +84,10 @@ impl Trail {
 
         // Emit a new point if far enough from the last one.
         if self.emitting {
-            let should_emit = self.points.last().map_or(true, |last| {
-                last.position.distance(position) >= self.min_distance
-            });
+            let should_emit = self
+                .points
+                .last()
+                .is_none_or(|last| last.position.distance(position) >= self.min_distance);
             if should_emit {
                 self.points.push(TrailPoint { position, age: 0.0 });
                 if self.points.len() > self.max_points {

--- a/crates/bsengine-core/src/turret.rs
+++ b/crates/bsengine-core/src/turret.rs
@@ -116,11 +116,7 @@ impl Turret {
         if self.fire_cooldown > 0.0 {
             self.fire_cooldown -= dt;
         }
-        if self.fire_cooldown <= 0.0 && self.current_target.is_some() {
-            self.wants_to_fire = true;
-        } else {
-            self.wants_to_fire = false;
-        }
+        self.wants_to_fire = self.fire_cooldown <= 0.0 && self.current_target.is_some();
     }
 
     /// Called by the weapon system after a shot is fired.

--- a/crates/bsengine-core/src/weave.rs
+++ b/crates/bsengine-core/src/weave.rs
@@ -15,6 +15,7 @@ use bevy_ecs::prelude::Component;
 ///   at `max_weave`), firing `just_peaked` on first reach of `max_weave`;
 /// - when `!weaving`: decreases `weave_level` by `falloff_rate * dt` (floored
 ///   0), firing `just_broken` on first drop to 0 from positive.
+///
 /// No-op when disabled.
 ///
 /// `is_evading()` returns `weave_level >= max_weave && enabled`.

--- a/crates/bsengine-core/src/weld.rs
+++ b/crates/bsengine-core/src/weld.rs
@@ -15,6 +15,7 @@ use bevy_ecs::prelude::Component;
 ///   `max_strength`), firing `just_bonded` on first reach of `max_strength`;
 /// - when `!welding`: decreases `strength` by `fracture_rate * dt` (floored
 ///   0), firing `just_fractured` on first drop to 0 from positive.
+///
 /// No-op when disabled.
 ///
 /// `is_bonded()` returns `strength >= max_strength && enabled`.

--- a/crates/bsengine-core/src/worry.rs
+++ b/crates/bsengine-core/src/worry.rs
@@ -98,53 +98,53 @@ mod tests {
         assert!(Worry::default().enabled);
     }
     #[test]
-    fn ADD_increases() {
+    fn add_increases() {
         let mut w = inst();
         w.fret(30.0);
         assert_eq!(w.anxiety, 30.0);
     }
     #[test]
-    fn ADD_clamps_at_max() {
+    fn add_clamps_at_max() {
         let mut w = inst();
         w.fret(200.0);
         assert_eq!(w.anxiety, 100.0);
     }
     #[test]
-    fn ADD_no_op_when_disabled() {
+    fn add_no_op_when_disabled() {
         let mut w = inst();
         w.enabled = false;
         w.fret(50.0);
         assert_eq!(w.anxiety, 0.0);
     }
     #[test]
-    fn ADD_sets_just_anxious_at_max() {
+    fn add_sets_just_anxious_at_max() {
         let mut w = inst();
         w.fret(100.0);
         assert!(w.just_anxious);
     }
     #[test]
-    fn ADD_no_just_anxious_if_already_max() {
+    fn add_no_just_anxious_if_already_max() {
         let mut w = inst();
         w.anxiety = 100.0;
         w.fret(1.0);
         assert!(!w.just_anxious);
     }
     #[test]
-    fn REMOVE_decreases() {
+    fn remove_decreases() {
         let mut w = inst();
         w.anxiety = 60.0;
         w.calm(20.0);
         assert_eq!(w.anxiety, 40.0);
     }
     #[test]
-    fn REMOVE_clamps_at_zero() {
+    fn remove_clamps_at_zero() {
         let mut w = inst();
         w.anxiety = 30.0;
         w.calm(200.0);
         assert_eq!(w.anxiety, 0.0);
     }
     #[test]
-    fn REMOVE_no_op_when_disabled() {
+    fn remove_no_op_when_disabled() {
         let mut w = inst();
         w.anxiety = 50.0;
         w.enabled = false;
@@ -152,20 +152,20 @@ mod tests {
         assert_eq!(w.anxiety, 50.0);
     }
     #[test]
-    fn REMOVE_no_op_when_already_zero() {
+    fn remove_no_op_when_already_zero() {
         let mut w = inst();
         w.calm(10.0);
         assert_eq!(w.anxiety, 0.0);
     }
     #[test]
-    fn REMOVE_sets_just_calm_at_zero() {
+    fn remove_sets_just_calm_at_zero() {
         let mut w = inst();
         w.anxiety = 10.0;
         w.calm(10.0);
         assert!(w.just_calm);
     }
     #[test]
-    fn REMOVE_no_just_calm_if_already_zero() {
+    fn remove_no_just_calm_if_already_zero() {
         let mut w = inst();
         w.calm(1.0);
         assert!(!w.just_calm);
@@ -268,7 +268,7 @@ mod tests {
         assert_eq!(w.effective_dread(10.0), 0.0);
     }
     #[test]
-    fn just_anxious_cleared_on_next_ADD() {
+    fn just_anxious_cleared_on_next_add() {
         let mut w = inst();
         w.fret(100.0);
         assert!(w.just_anxious);
@@ -276,7 +276,7 @@ mod tests {
         assert!(!w.just_anxious);
     }
     #[test]
-    fn just_calm_cleared_on_next_REMOVE() {
+    fn just_calm_cleared_on_next_remove() {
         let mut w = inst();
         w.anxiety = 10.0;
         w.calm(10.0);

--- a/crates/bsengine-core/src/worse.rs
+++ b/crates/bsengine-core/src/worse.rs
@@ -98,53 +98,53 @@ mod tests {
         assert!(Worse::default().enabled);
     }
     #[test]
-    fn ADD_increases() {
+    fn add_increases() {
         let mut w = inst();
         w.decline(30.0);
         assert_eq!(w.deterioration, 30.0);
     }
     #[test]
-    fn ADD_clamps_at_max() {
+    fn add_clamps_at_max() {
         let mut w = inst();
         w.decline(200.0);
         assert_eq!(w.deterioration, 100.0);
     }
     #[test]
-    fn ADD_no_op_when_disabled() {
+    fn add_no_op_when_disabled() {
         let mut w = inst();
         w.enabled = false;
         w.decline(50.0);
         assert_eq!(w.deterioration, 0.0);
     }
     #[test]
-    fn ADD_sets_just_ruined_at_max() {
+    fn add_sets_just_ruined_at_max() {
         let mut w = inst();
         w.decline(100.0);
         assert!(w.just_ruined);
     }
     #[test]
-    fn ADD_no_just_ruined_if_already_max() {
+    fn add_no_just_ruined_if_already_max() {
         let mut w = inst();
         w.deterioration = 100.0;
         w.decline(1.0);
         assert!(!w.just_ruined);
     }
     #[test]
-    fn REMOVE_decreases() {
+    fn remove_decreases() {
         let mut w = inst();
         w.deterioration = 60.0;
         w.restore(20.0);
         assert_eq!(w.deterioration, 40.0);
     }
     #[test]
-    fn REMOVE_clamps_at_zero() {
+    fn remove_clamps_at_zero() {
         let mut w = inst();
         w.deterioration = 30.0;
         w.restore(200.0);
         assert_eq!(w.deterioration, 0.0);
     }
     #[test]
-    fn REMOVE_no_op_when_disabled() {
+    fn remove_no_op_when_disabled() {
         let mut w = inst();
         w.deterioration = 50.0;
         w.enabled = false;
@@ -152,20 +152,20 @@ mod tests {
         assert_eq!(w.deterioration, 50.0);
     }
     #[test]
-    fn REMOVE_no_op_when_already_zero() {
+    fn remove_no_op_when_already_zero() {
         let mut w = inst();
         w.restore(10.0);
         assert_eq!(w.deterioration, 0.0);
     }
     #[test]
-    fn REMOVE_sets_just_restored_at_zero() {
+    fn remove_sets_just_restored_at_zero() {
         let mut w = inst();
         w.deterioration = 10.0;
         w.restore(10.0);
         assert!(w.just_restored);
     }
     #[test]
-    fn REMOVE_no_just_restored_if_already_zero() {
+    fn remove_no_just_restored_if_already_zero() {
         let mut w = inst();
         w.restore(1.0);
         assert!(!w.just_restored);
@@ -268,7 +268,7 @@ mod tests {
         assert_eq!(w.effective_decay(10.0), 0.0);
     }
     #[test]
-    fn just_ruined_cleared_on_next_ADD() {
+    fn just_ruined_cleared_on_next_add() {
         let mut w = inst();
         w.decline(100.0);
         assert!(w.just_ruined);
@@ -276,7 +276,7 @@ mod tests {
         assert!(!w.just_ruined);
     }
     #[test]
-    fn just_restored_cleared_on_next_REMOVE() {
+    fn just_restored_cleared_on_next_remove() {
         let mut w = inst();
         w.deterioration = 10.0;
         w.restore(10.0);

--- a/crates/bsengine-core/src/worst.rs
+++ b/crates/bsengine-core/src/worst.rs
@@ -98,53 +98,53 @@ mod tests {
         assert!(Worst::default().enabled);
     }
     #[test]
-    fn ADD_increases() {
+    fn add_increases() {
         let mut w = inst();
         w.worsen(30.0);
         assert_eq!(w.extremity, 30.0);
     }
     #[test]
-    fn ADD_clamps_at_max() {
+    fn add_clamps_at_max() {
         let mut w = inst();
         w.worsen(200.0);
         assert_eq!(w.extremity, 100.0);
     }
     #[test]
-    fn ADD_no_op_when_disabled() {
+    fn add_no_op_when_disabled() {
         let mut w = inst();
         w.enabled = false;
         w.worsen(50.0);
         assert_eq!(w.extremity, 0.0);
     }
     #[test]
-    fn ADD_sets_just_peaked_at_max() {
+    fn add_sets_just_peaked_at_max() {
         let mut w = inst();
         w.worsen(100.0);
         assert!(w.just_peaked);
     }
     #[test]
-    fn ADD_no_just_peaked_if_already_max() {
+    fn add_no_just_peaked_if_already_max() {
         let mut w = inst();
         w.extremity = 100.0;
         w.worsen(1.0);
         assert!(!w.just_peaked);
     }
     #[test]
-    fn REMOVE_decreases() {
+    fn remove_decreases() {
         let mut w = inst();
         w.extremity = 60.0;
         w.ease(20.0);
         assert_eq!(w.extremity, 40.0);
     }
     #[test]
-    fn REMOVE_clamps_at_zero() {
+    fn remove_clamps_at_zero() {
         let mut w = inst();
         w.extremity = 30.0;
         w.ease(200.0);
         assert_eq!(w.extremity, 0.0);
     }
     #[test]
-    fn REMOVE_no_op_when_disabled() {
+    fn remove_no_op_when_disabled() {
         let mut w = inst();
         w.extremity = 50.0;
         w.enabled = false;
@@ -152,20 +152,20 @@ mod tests {
         assert_eq!(w.extremity, 50.0);
     }
     #[test]
-    fn REMOVE_no_op_when_already_zero() {
+    fn remove_no_op_when_already_zero() {
         let mut w = inst();
         w.ease(10.0);
         assert_eq!(w.extremity, 0.0);
     }
     #[test]
-    fn REMOVE_sets_just_eased_at_zero() {
+    fn remove_sets_just_eased_at_zero() {
         let mut w = inst();
         w.extremity = 10.0;
         w.ease(10.0);
         assert!(w.just_eased);
     }
     #[test]
-    fn REMOVE_no_just_eased_if_already_zero() {
+    fn remove_no_just_eased_if_already_zero() {
         let mut w = inst();
         w.ease(1.0);
         assert!(!w.just_eased);
@@ -268,7 +268,7 @@ mod tests {
         assert_eq!(w.effective_severity(10.0), 0.0);
     }
     #[test]
-    fn just_peaked_cleared_on_next_ADD() {
+    fn just_peaked_cleared_on_next_add() {
         let mut w = inst();
         w.worsen(100.0);
         assert!(w.just_peaked);
@@ -276,7 +276,7 @@ mod tests {
         assert!(!w.just_peaked);
     }
     #[test]
-    fn just_eased_cleared_on_next_REMOVE() {
+    fn just_eased_cleared_on_next_remove() {
         let mut w = inst();
         w.extremity = 10.0;
         w.ease(10.0);

--- a/crates/bsengine-core/src/wrap.rs
+++ b/crates/bsengine-core/src/wrap.rs
@@ -15,6 +15,7 @@ use bevy_ecs::prelude::Component;
 ///   at `max_wrap`), firing `just_gripped` on first reach of `max_wrap`;
 /// - when `!wrapping`: decreases `wrap_level` by `loosen_rate * dt` (floored
 ///   0), firing `just_freed` on first reach of 0.0 from positive.
+///
 /// No-op when disabled.
 ///
 /// `is_gripped()` returns `wrap_level > 0.0 && enabled`.

--- a/crates/bsengine-core/src/yogi.rs
+++ b/crates/bsengine-core/src/yogi.rs
@@ -24,6 +24,7 @@ use bevy_ecs::prelude::Component;
 ///    `focus_rate * dt` (capped at max). Fires `just_transcended` at max.
 ///  - Otherwise, if `drift_rate > 0`: reduce depth by `drift_rate * dt`
 ///    (floored at 0). Fires `just_scattered` at 0.
+///
 ///  Finally resets `meditating`.
 ///
 /// `is_transcended()` returns `depth >= max_depth && enabled`.

--- a/crates/bsengine-core/src/z_index.rs
+++ b/crates/bsengine-core/src/z_index.rs
@@ -3,14 +3,8 @@ use bevy_ecs::prelude::Component;
 /// Render draw order for an entity. Higher values are drawn later (on top).
 /// Entities without ZIndex are treated as ZIndex(0).
 /// The render pipeline sorts draw calls by this value before submission.
-#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ZIndex(pub i32);
-
-impl Default for ZIndex {
-    fn default() -> Self {
-        Self(0)
-    }
-}
 
 impl ZIndex {
     pub fn new(order: i32) -> Self {

--- a/crates/bsengine-core/src/zinc.rs
+++ b/crates/bsengine-core/src/zinc.rs
@@ -14,9 +14,9 @@ use bevy_ecs::prelude::Component;
 /// `deplete(amount)` subtracts from `mineral`; fires `just_deficient` when
 /// reaching 0. No-op when disabled or already deficient.
 ///
-/// `tick(dt)` clears both flags, then metabolizes: `mineral -= metabolic_rate
-/// * dt` (floored at 0). Fires `just_deficient` when reaching 0 via
-/// metabolism. No-op metabolism when disabled or rate is 0.
+/// `tick(dt)` clears both flags, then metabolizes: `mineral -= metabolic_rate * dt`
+/// (floored at 0). Fires `just_deficient` when reaching 0 via metabolism.
+/// No-op metabolism when disabled or rate is 0.
 ///
 /// `is_optimal()` returns `mineral >= max_mineral && enabled`.
 ///

--- a/crates/bsengine-core/src/zone.rs
+++ b/crates/bsengine-core/src/zone.rs
@@ -62,6 +62,7 @@ impl Zone {
     ///   first reach
     /// - if `!is_holding`: decays toward 0; fires `just_lost` on first reach
     ///   from above 0
+    ///
     /// No-op (beyond flag clear) when disabled.
     pub fn tick(&mut self, dt: f32) {
         self.just_captured = false;

--- a/crates/bsengine-ecs/src/tests.rs
+++ b/crates/bsengine-ecs/src/tests.rs
@@ -1,8 +1,10 @@
 #[cfg(test)]
+#[allow(clippy::module_inception)] // this file (tests.rs) is itself the test module
 mod tests {
     use crate::{Component, Resource, Schedule, ScheduleLabel, World};
 
     #[derive(Component)]
+    #[allow(dead_code)] // fields exist to exercise Component derive storage, not read back
     struct Position {
         x: f32,
         y: f32,

--- a/crates/bsengine-editor/src/lib.rs
+++ b/crates/bsengine-editor/src/lib.rs
@@ -1,3 +1,9 @@
+// Bevy ECS system params (Query<(A, B, C, ...)>, ParamSet<(...)>) routinely
+// exceed clippy's type-complexity threshold; that's the idiom, not a real
+// complexity problem. Bevy itself disables this lint crate-wide for the
+// same reason.
+#![allow(clippy::type_complexity)]
+
 pub mod plugin;
 pub mod snapshot;
 

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -799,7 +799,6 @@ fn spawn_entity_from_info(world: &mut World, info: &EntityInfo) -> Entity {
                 color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])),
                 intensity: info.light_intensity.unwrap_or(1.0),
                 range: info.light_range.unwrap_or(10.0),
-                ..PointLight::default()
             });
         }
         Some("directional") => {
@@ -3170,7 +3169,7 @@ impl Plugin for EditorPlugin {
                             (e.id, name, len)
                         })
                         .collect();
-                    entries.sort_by(|a, b| b.2.cmp(&a.2));
+                    entries.sort_by_key(|e| std::cmp::Reverse(e.2));
                     let result: Vec<serde_json::Value> = entries.iter()
                         .map(|(id, name, len)| json!({"id": id, "name": name, "name_length": len}))
                         .collect();
@@ -10455,9 +10454,12 @@ impl Plugin for EditorPlugin {
                     let mut min_x = f32::MAX; let mut min_y = f32::MAX; let mut min_z = f32::MAX;
                     let mut max_x = f32::MIN; let mut max_y = f32::MIN; let mut max_z = f32::MIN;
                     for [x, y, z] in &positions {
-                        if *x < min_x { min_x = *x; } if *x > max_x { max_x = *x; }
-                        if *y < min_y { min_y = *y; } if *y > max_y { max_y = *y; }
-                        if *z < min_z { min_z = *z; } if *z > max_z { max_z = *z; }
+                        if *x < min_x { min_x = *x; }
+                        if *x > max_x { max_x = *x; }
+                        if *y < min_y { min_y = *y; }
+                        if *y > max_y { max_y = *y; }
+                        if *z < min_z { min_z = *z; }
+                        if *z > max_z { max_z = *z; }
                     }
                     McpToolOutput::success(json!({"min_x": min_x, "min_y": min_y, "min_z": min_z, "max_x": max_x, "max_y": max_y, "max_z": max_z}))
                 }),
@@ -15425,11 +15427,7 @@ impl Plugin for EditorPlugin {
                     for entity in &s.entities {
                         let mut depth: u64 = 0;
                         let mut current_id = entity.id;
-                        loop {
-                            let e = match s.entities.iter().find(|e| e.id == current_id) {
-                                Some(e) => e,
-                                None => break,
-                            };
+                        while let Some(e) = s.entities.iter().find(|e| e.id == current_id) {
                             match e.parent_id {
                                 Some(pid) => { depth += 1; current_id = pid; }
                                 None => break,
@@ -15643,11 +15641,7 @@ impl Plugin for EditorPlugin {
                     let s = snap_geai.lock().unwrap();
                     let mut ancestors = Vec::new();
                     let mut current_id = entity_id;
-                    loop {
-                        let entity = match s.entities.iter().find(|e| e.id == current_id) {
-                            Some(e) => e,
-                            None => break,
-                        };
+                    while let Some(entity) = s.entities.iter().find(|e| e.id == current_id) {
                         match entity.parent_id {
                             Some(pid) => { ancestors.push(pid); current_id = pid; }
                             None => break,
@@ -23943,7 +23937,7 @@ impl Plugin for EditorPlugin {
                 handler: Box::new(move |_input| {
                     let s = snap_gestc.lock().unwrap();
                     let mut ents: Vec<&crate::snapshot::EntityInfo> = s.entities.iter().collect();
-                    ents.sort_by(|a, b| b.tags.len().cmp(&a.tags.len()));
+                    ents.sort_by_key(|e| std::cmp::Reverse(e.tags.len()));
                     let result: Vec<serde_json::Value> = ents
                         .iter()
                         .map(|e| json!({"id": e.id, "name": e.name, "tag_count": e.tags.len()}))
@@ -24175,7 +24169,11 @@ impl Plugin for EditorPlugin {
                     let mut max = positions[0];
                     let mut sum = [0f32; 3];
                     for p in &positions {
-                        for i in 0..3 { if p[i] < min[i] { min[i] = p[i]; } if p[i] > max[i] { max[i] = p[i]; } sum[i] += p[i]; }
+                        for i in 0..3 {
+                            if p[i] < min[i] { min[i] = p[i]; }
+                            if p[i] > max[i] { max[i] = p[i]; }
+                            sum[i] += p[i];
+                        }
                     }
                     let n = positions.len() as f32;
                     let centroid = [sum[0]/n, sum[1]/n, sum[2]/n];
@@ -65511,7 +65509,6 @@ mod tests {
                 {"name": "B", "position": [0.0, 0.0, 0.0]},
                 {"name": "C", "position": [0.0, 0.0, 0.0]},
             ]})).unwrap();
-            drop(mcp);
             app.update(); app.update();
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
             let es = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap().content["entities"].as_array().unwrap().clone();
@@ -65821,7 +65818,6 @@ mod tests {
                 {"name": "B", "position": [0.0, 0.0, 0.0]},
                 {"name": "C", "position": [0.0, 0.0, 0.0]},
             ]})).unwrap();
-            drop(mcp);
             app.update(); app.update();
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
             let es = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap().content["entities"].as_array().unwrap().clone();
@@ -65880,7 +65876,6 @@ mod tests {
                 {"name": "B", "position": [0.0, 0.0, 0.0]},
                 {"name": "C", "position": [0.0, 0.0, 0.0]},
             ]})).unwrap();
-            drop(mcp);
             app.update(); app.update();
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
             let es = mcp.0.lock().unwrap().execute("list_entities", json!({})).unwrap().content["entities"].as_array().unwrap().clone();
@@ -70166,7 +70161,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": b_id, "tag": tag}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -70415,7 +70409,6 @@ mod tests {
                     .unwrap()
                     .execute("tag_entity", json!({"entity_id": id, "tag": tag}))
                     .unwrap();
-                drop(mcp);
                 app.update();
                 app.update();
             }
@@ -70503,7 +70496,6 @@ mod tests {
                     json!({"entity_id": child, "parent_id": parent}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -70670,7 +70662,6 @@ mod tests {
                     json!({"entity_id": id, "rx": 0.0, "ry": ry, "rz": 0.0}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -71352,7 +71343,6 @@ mod tests {
                     json!({"entity_id": child, "parent_id": root_id}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -71453,7 +71443,6 @@ mod tests {
                     json!({"entity_id": child, "parent_id": parent}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -71820,7 +71809,6 @@ mod tests {
                     json!({"entity_id": child, "parent_id": root_id}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -71925,7 +71913,6 @@ mod tests {
                     json!({"entity_id": id, "sx": s, "sy": s, "sz": s}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -72493,7 +72480,6 @@ mod tests {
                     json!({"entity_id": leaf, "parent_id": child_id}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -72556,7 +72542,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id, "tag": "hero"}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -72642,7 +72627,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id, "tag": tag}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -72704,7 +72688,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id, "tag": "hero"}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -72826,7 +72809,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id, "tag": "hero"}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -72905,7 +72887,6 @@ mod tests {
                     json!({"entity_id": child, "parent_id": root_id}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -73546,7 +73527,6 @@ mod tests {
                     json!({"entity_id": child, "parent_id": root_id}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -74114,7 +74094,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id, "tag": "hero"}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -74212,7 +74191,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id_two, "tag": tag}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -74300,7 +74278,6 @@ mod tests {
                     json!({"entity_id": child, "parent_id": root_id}),
                 )
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -74444,7 +74421,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id_two, "tag": tag}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -74511,7 +74487,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id_a, "tag": tag}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }
@@ -74754,7 +74729,6 @@ mod tests {
                 .unwrap()
                 .execute("tag_entity", json!({"entity_id": id_a, "tag": tag}))
                 .unwrap();
-            drop(mcp);
             app.update();
             app.update();
         }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -2224,7 +2224,7 @@ impl Plugin for EditorPlugin {
                     let parse = |v: &serde_json::Value| -> Option<[f32; 3]> {
                         let a = v.as_array()?;
                         Some([
-                            a.get(0)?.as_f64()? as f32,
+                            a.first()?.as_f64()? as f32,
                             a.get(1)?.as_f64()? as f32,
                             a.get(2)?.as_f64()? as f32,
                         ])
@@ -10427,7 +10427,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["z"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_debz.lock().unwrap();
                     let to_remove: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[_, _, z]| if z < threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[_, _, z]| if z < threshold { Some(e.id) } else { None }))
                         .collect();
                     let mut sel = sel_debz.lock().unwrap();
                     let count = to_remove.iter().filter(|id| sel.remove(id)).count() as u64;
@@ -10478,7 +10478,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["z"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_sebz.lock().unwrap();
                     let to_add: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[_, _, z]| if z < threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[_, _, z]| if z < threshold { Some(e.id) } else { None }))
                         .collect();
                     let count = to_add.len() as u64;
                     let mut sel = sel_sebz.lock().unwrap();
@@ -10502,7 +10502,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["z"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_deaz.lock().unwrap();
                     let to_remove: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[_, _, z]| if z > threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[_, _, z]| if z > threshold { Some(e.id) } else { None }))
                         .collect();
                     let mut sel = sel_deaz.lock().unwrap();
                     let count = to_remove.iter().filter(|id| sel.remove(id)).count() as u64;
@@ -10525,7 +10525,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["x"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_debx.lock().unwrap();
                     let to_remove: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[x, _, _]| if x < threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[x, _, _]| if x < threshold { Some(e.id) } else { None }))
                         .collect();
                     let mut sel = sel_debx.lock().unwrap();
                     let count = to_remove.iter().filter(|id| sel.remove(id)).count() as u64;
@@ -10548,7 +10548,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["z"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_seaz.lock().unwrap();
                     let to_add: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[_, _, z]| if z > threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[_, _, z]| if z > threshold { Some(e.id) } else { None }))
                         .collect();
                     let count = to_add.len() as u64;
                     let mut sel = sel_seaz.lock().unwrap();
@@ -10572,7 +10572,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["x"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_sebx.lock().unwrap();
                     let to_add: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[x, _, _]| if x < threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[x, _, _]| if x < threshold { Some(e.id) } else { None }))
                         .collect();
                     let count = to_add.len() as u64;
                     let mut sel = sel_sebx.lock().unwrap();
@@ -10596,7 +10596,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["x"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_deax.lock().unwrap();
                     let to_remove: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[x, _, _]| if x > threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[x, _, _]| if x > threshold { Some(e.id) } else { None }))
                         .collect();
                     let mut sel = sel_deax.lock().unwrap();
                     let count = to_remove.iter().filter(|id| sel.remove(id)).count() as u64;
@@ -10642,7 +10642,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["x"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_seax.lock().unwrap();
                     let to_add: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[x, _, _]| if x > threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[x, _, _]| if x > threshold { Some(e.id) } else { None }))
                         .collect();
                     let count = to_add.len() as u64;
                     let mut sel = sel_seax.lock().unwrap();
@@ -10754,7 +10754,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["y"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_deby.lock().unwrap();
                     let to_remove: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[_, y, _]| if y < threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[_, y, _]| if y < threshold { Some(e.id) } else { None }))
                         .collect();
                     let mut sel = sel_deby.lock().unwrap();
                     let count = to_remove.iter().filter(|id| sel.remove(id)).count() as u64;
@@ -10819,7 +10819,7 @@ impl Plugin for EditorPlugin {
                     let threshold = input["y"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_deay.lock().unwrap();
                     let to_remove: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[_, y, _]| if y > threshold { Some(e.id) } else { None }).flatten())
+                        .filter_map(|e| e.position.and_then(|[_, y, _]| if y > threshold { Some(e.id) } else { None }))
                         .collect();
                     let mut sel = sel_deay.lock().unwrap();
                     let count = to_remove.iter().filter(|id| sel.remove(id)).count() as u64;
@@ -10905,11 +10905,11 @@ impl Plugin for EditorPlugin {
                     let max_z = input["max_z"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_seib.lock().unwrap();
                     let to_add: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[x, y, z]| {
+                        .filter_map(|e| e.position.and_then(|[x, y, z]| {
                             if x >= min_x && x <= max_x && y >= min_y && y <= max_y && z >= min_z && z <= max_z {
                                 Some(e.id)
                             } else { None }
-                        }).flatten())
+                        }))
                         .collect();
                     let count = to_add.len() as u64;
                     let mut sel = sel_seib.lock().unwrap();
@@ -10941,11 +10941,11 @@ impl Plugin for EditorPlugin {
                     let max_z = input["max_z"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_deib.lock().unwrap();
                     let to_remove: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[x, y, z]| {
+                        .filter_map(|e| e.position.and_then(|[x, y, z]| {
                             if x >= min_x && x <= max_x && y >= min_y && y <= max_y && z >= min_z && z <= max_z {
                                 Some(e.id)
                             } else { None }
-                        }).flatten())
+                        }))
                         .collect();
                     let mut sel = sel_deib.lock().unwrap();
                     let count = to_remove.iter().filter(|id| sel.remove(id)).count() as u64;
@@ -10975,11 +10975,11 @@ impl Plugin for EditorPlugin {
                     let max_z = input["max_z"].as_f64().unwrap_or(0.0) as f32;
                     let s = snap_geib.lock().unwrap();
                     let ids: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[x, y, z]| {
+                        .filter_map(|e| e.position.and_then(|[x, y, z]| {
                             if x >= min_x && x <= max_x && y >= min_y && y <= max_y && z >= min_z && z <= max_z {
                                 Some(e.id)
                             } else { None }
-                        }).flatten())
+                        }))
                         .collect();
                     McpToolOutput::success(json!({"entity_ids": ids}))
                 }),
@@ -11069,10 +11069,10 @@ impl Plugin for EditorPlugin {
                     let r2 = r * r;
                     let s = snap_deir.lock().unwrap();
                     let to_remove: Vec<u64> = s.entities.iter()
-                        .filter_map(|e| e.position.map(|[x, y, z]| {
+                        .filter_map(|e| e.position.and_then(|[x, y, z]| {
                             let dx = x - cx; let dy = y - cy; let dz = z - cz;
                             if dx*dx + dy*dy + dz*dz <= r2 { Some(e.id) } else { None }
-                        }).flatten())
+                        }))
                         .collect();
                     let mut sel = sel_deir.lock().unwrap();
                     let count = to_remove.iter().filter(|id| sel.remove(id)).count() as u64;
@@ -19162,7 +19162,7 @@ impl Plugin for EditorPlugin {
                     let entities: Vec<serde_json::Value> = s
                         .entities
                         .iter()
-                        .filter(|e| e.name.as_ref().map_or(false, |n| n.len() > min_len))
+                        .filter(|e| e.name.as_ref().is_some_and(|n| n.len() > min_len))
                         .map(|e| json!({"id": e.id, "name": e.name}))
                         .collect();
                     McpToolOutput::success(json!({"entities": entities}))
@@ -19179,7 +19179,7 @@ impl Plugin for EditorPlugin {
                 handler: Box::new(move |input| {
                     let min_len = input["min_length"].as_u64().unwrap_or(0) as usize;
                     let s = snap_sewnlt.lock().unwrap();
-                    let to_add: Vec<u64> = s.entities.iter().filter(|e| e.name.as_ref().map_or(false, |n| n.len() > min_len)).map(|e| e.id).collect();
+                    let to_add: Vec<u64> = s.entities.iter().filter(|e| e.name.as_ref().is_some_and(|n| n.len() > min_len)).map(|e| e.id).collect();
                     let count = to_add.len() as u64; drop(s);
                     let mut sel = sel_sewnlt.lock().unwrap();
                     for id in &to_add { sel.insert(*id); }
@@ -19197,7 +19197,7 @@ impl Plugin for EditorPlugin {
                 handler: Box::new(move |input| {
                     let min_len = input["min_length"].as_u64().unwrap_or(0) as usize;
                     let s = snap_dewnlt.lock().unwrap();
-                    let to_remove: Vec<u64> = s.entities.iter().filter(|e| e.name.as_ref().map_or(false, |n| n.len() > min_len)).map(|e| e.id).collect();
+                    let to_remove: Vec<u64> = s.entities.iter().filter(|e| e.name.as_ref().is_some_and(|n| n.len() > min_len)).map(|e| e.id).collect();
                     let count = to_remove.len() as u64; drop(s);
                     let mut sel = sel_dewnlt.lock().unwrap();
                     for id in &to_remove { sel.remove(id); }
@@ -19214,7 +19214,7 @@ impl Plugin for EditorPlugin {
                 handler: Box::new(move |input| {
                     let min_len = input["min_length"].as_u64().unwrap_or(0) as usize;
                     let s = snap_cewnlt.lock().unwrap();
-                    let count = s.entities.iter().filter(|e| e.name.as_ref().map_or(false, |n| n.len() > min_len)).count() as u64;
+                    let count = s.entities.iter().filter(|e| e.name.as_ref().is_some_and(|n| n.len() > min_len)).count() as u64;
                     McpToolOutput::success(json!({"count": count}))
                 }),
             });
@@ -19297,7 +19297,7 @@ impl Plugin for EditorPlugin {
                         .entities
                         .iter()
                         .filter(|e| {
-                            e.position.map_or(false, |p| {
+                            e.position.is_some_and(|p| {
                                 (p[0] * p[0] + p[1] * p[1] + p[2] * p[2]).sqrt() > min_dist
                             })
                         })
@@ -19473,7 +19473,7 @@ impl Plugin for EditorPlugin {
                     let entities: Vec<serde_json::Value> = s
                         .entities
                         .iter()
-                        .filter(|e| e.position.map_or(false, |p| p[1].abs() <= tolerance))
+                        .filter(|e| e.position.is_some_and(|p| p[1].abs() <= tolerance))
                         .map(|e| json!({"id": e.id, "name": e.name, "position": e.position}))
                         .collect();
                     McpToolOutput::success(json!({"entities": entities}))
@@ -19493,7 +19493,7 @@ impl Plugin for EditorPlugin {
                     let current: Vec<u64> = sel.iter().copied().collect();
                     let current_set: std::collections::HashSet<u64> = current.iter().copied().collect();
                     let children: Vec<u64> = s.entities.iter()
-                        .filter(|e| e.parent_id.map_or(false, |p| current_set.contains(&p)) && !current_set.contains(&e.id))
+                        .filter(|e| e.parent_id.is_some_and(|p| current_set.contains(&p)) && !current_set.contains(&e.id))
                         .map(|e| e.id)
                         .collect();
                     let count = children.len() as u64;
@@ -23286,7 +23286,7 @@ impl Plugin for EditorPlugin {
                     let entities: Vec<serde_json::Value> = s
                         .entities
                         .iter()
-                        .filter(|e| e.position.map_or(false, |p| p[0] >= min_x && p[0] <= max_x))
+                        .filter(|e| e.position.is_some_and(|p| p[0] >= min_x && p[0] <= max_x))
                         .map(|e| json!({"id": e.id, "name": e.name, "position": e.position}))
                         .collect();
                     McpToolOutput::success(json!({"entities": entities}))
@@ -23314,7 +23314,7 @@ impl Plugin for EditorPlugin {
                     let entities: Vec<serde_json::Value> = s
                         .entities
                         .iter()
-                        .filter(|e| e.position.map_or(false, |p| p[2] >= min_z && p[2] <= max_z))
+                        .filter(|e| e.position.is_some_and(|p| p[2] >= min_z && p[2] <= max_z))
                         .map(|e| json!({"id": e.id, "name": e.name, "position": e.position}))
                         .collect();
                     McpToolOutput::success(json!({"entities": entities}))
@@ -42894,7 +42894,7 @@ mod tests {
                 .unwrap()["id"]
                 .as_u64()
                 .unwrap();
-            let id_two = entities
+            let _id_two = entities
                 .iter()
                 .find(|e| e["name"].as_str() == Some("Two"))
                 .unwrap()["id"]
@@ -44049,7 +44049,7 @@ mod tests {
         app.update();
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-        let mut reg = mcp.0.lock().unwrap();
+        let reg = mcp.0.lock().unwrap();
 
         let out = reg
             .execute("get_entities_sharing_name", json!({"name": "Duplicate"}))
@@ -44160,7 +44160,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -44170,7 +44170,7 @@ mod tests {
         app.update();
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-        let mut reg = mcp.0.lock().unwrap();
+        let reg = mcp.0.lock().unwrap();
 
         let out = reg
             .execute("get_tags_used_by_selection", json!({}))
@@ -44250,7 +44250,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -44341,7 +44341,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": root_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": child_id}))
@@ -44760,7 +44760,7 @@ mod tests {
         app.update();
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-        let mut reg = mcp.0.lock().unwrap();
+        let reg = mcp.0.lock().unwrap();
 
         let out0 = reg
             .execute("count_entities_at_depth", json!({"depth": 0}))
@@ -44855,7 +44855,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "batch_spawn",
                 json!({"entities": [
@@ -44905,7 +44905,7 @@ mod tests {
         app.update();
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-        let mut reg = mcp.0.lock().unwrap();
+        let reg = mcp.0.lock().unwrap();
 
         let out = reg
             .execute("get_mesh_id_of_entity", json!({"entity_id": with_id}))
@@ -44983,7 +44983,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": root_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": child_id}))
@@ -45088,7 +45088,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -45104,7 +45104,7 @@ mod tests {
         app.update();
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-        let mut reg = mcp.0.lock().unwrap();
+        let reg = mcp.0.lock().unwrap();
 
         let out = reg
             .execute("get_children_of_entity", json!({"entity_id": root_id}))
@@ -45187,7 +45187,7 @@ mod tests {
         app.update();
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-        let mut reg = mcp.0.lock().unwrap();
+        let reg = mcp.0.lock().unwrap();
 
         let out = reg
             .execute("is_entity_visible", json!({"entity_id": vis_id}))
@@ -45262,7 +45262,7 @@ mod tests {
         app.update();
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-        let mut reg = mcp.0.lock().unwrap();
+        let reg = mcp.0.lock().unwrap();
 
         let out = reg
             .execute("is_entity_selected", json!({"entity_id": a_id}))
@@ -45699,7 +45699,7 @@ mod tests {
             .unwrap();
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-        let mut reg = mcp.0.lock().unwrap();
+        let reg = mcp.0.lock().unwrap();
 
         let out = reg
             .execute("get_position_of_entity", json!({"entity_id": placed_id}))
@@ -45935,7 +45935,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("tag_entity", json!({"entity_id": a_id, "tag": "hero"}))
                 .unwrap();
             reg.execute("tag_entity", json!({"entity_id": b_id, "tag": "hero"}))
@@ -45965,7 +45965,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 1.0, 1.0], "intensity": 1.0, "range": 10.0, "position": [0.0, 0.0, 0.0]})).unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 0.0, 0.0], "intensity": 2.0, "range": 5.0, "position": [1.0, 0.0, 0.0]})).unwrap();
             reg.execute("spawn_directional_light", json!({"direction": [0.0, -1.0, 0.0], "color": [1.0, 1.0, 1.0], "ambient": [0.1, 0.1, 0.1]})).unwrap();
@@ -46035,7 +46035,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("tag_entity", json!({"entity_id": a_id, "tag": "hero"}))
                 .unwrap();
             reg.execute("tag_entity", json!({"entity_id": b_id, "tag": "hero"}))
@@ -46073,7 +46073,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 1.0, 1.0], "intensity": 1.0, "range": 10.0, "position": [0.0, 0.0, 0.0]})).unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 0.0, 0.0], "intensity": 2.0, "range": 5.0, "position": [1.0, 0.0, 0.0]})).unwrap();
             reg.execute("spawn_directional_light", json!({"direction": [0.0, -1.0, 0.0], "color": [1.0, 1.0, 1.0], "ambient": [0.1, 0.1, 0.1]})).unwrap();
@@ -46102,7 +46102,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 1.0, 1.0], "intensity": 1.0, "range": 10.0, "position": [0.0, 0.0, 0.0]})).unwrap();
             reg.execute("spawn_directional_light", json!({"direction": [0.0, -1.0, 0.0], "color": [1.0, 1.0, 1.0], "ambient": [0.1, 0.1, 0.1]})).unwrap();
             reg.execute("batch_spawn", json!({"entities": [{"name": "NoLight"}]}))
@@ -46130,7 +46130,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_spot_light", json!({"color": [1.0, 1.0, 1.0], "intensity": 1.0, "range": 10.0, "inner_angle": 15.0, "outer_angle": 30.0, "position": [0.0, 5.0, 0.0]})).unwrap();
             reg.execute("spawn_spot_light", json!({"color": [0.0, 1.0, 0.0], "intensity": 2.0, "range": 5.0, "inner_angle": 10.0, "outer_angle": 20.0, "position": [1.0, 5.0, 0.0]})).unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 1.0, 1.0], "intensity": 1.0, "range": 10.0, "position": [0.0, 0.0, 0.0]})).unwrap();
@@ -46157,7 +46157,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 1.0, 1.0], "intensity": 1.0, "range": 10.0, "position": [0.0, 0.0, 0.0]})).unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 0.0, 0.0], "intensity": 2.0, "range": 5.0, "position": [1.0, 0.0, 0.0]})).unwrap();
             reg.execute("batch_spawn", json!({"entities": [{"name": "NoLight"}]}))
@@ -46185,7 +46185,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 1.0, 1.0], "intensity": 1.0, "range": 10.0, "position": [0.0, 0.0, 0.0]})).unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 0.0, 0.0], "intensity": 2.0, "range": 5.0, "position": [1.0, 0.0, 0.0]})).unwrap();
             reg.execute("spawn_directional_light", json!({"direction": [0.0, -1.0, 0.0], "color": [1.0, 1.0, 1.0], "ambient": [0.1, 0.1, 0.1]})).unwrap();
@@ -46212,7 +46212,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_directional_light", json!({"direction": [0.0, -1.0, 0.0], "color": [1.0, 1.0, 1.0], "ambient": [0.1, 0.1, 0.1]})).unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0, 1.0, 1.0], "intensity": 1.0, "range": 10.0, "position": [0.0, 0.0, 0.0]})).unwrap();
         }
@@ -46312,7 +46312,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "spawn_camera",
                 json!({"fov_y_degrees": 60.0, "position": [0.0, 0.0, 0.0]}),
@@ -46429,7 +46429,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": ca_id, "parent_id": parent_id}),
@@ -47438,7 +47438,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("tag_entity", json!({"entity_id": ta_id, "tag": "hero"}))
                 .unwrap();
             reg.execute("tag_entity", json!({"entity_id": tb_id, "tag": "enemy"}))
@@ -47606,7 +47606,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "spawn_camera",
                 json!({"fov_y_degrees": 60.0, "position": [0.0, 5.0, 10.0]}),
@@ -47642,7 +47642,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": cam_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": plain_id}))
@@ -47708,7 +47708,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("attach_mesh", json!({"entity_id": wm_id, "mesh_id": 42}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": wm_id}))
@@ -47738,7 +47738,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("batch_spawn", json!({"entities": [{"name": "Named"}]}))
                 .unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0,1.0,1.0], "intensity": 100.0, "range": 10.0, "position": [0.0,5.0,0.0]})).unwrap();
@@ -47766,7 +47766,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0,1.0,1.0], "intensity": 100.0, "range": 10.0, "position": [0.0,5.0,0.0]})).unwrap();
             reg.execute("spawn_point_light", json!({"color": [0.5,0.5,0.5], "intensity": 50.0, "range": 5.0, "position": [1.0,5.0,0.0]})).unwrap();
             reg.execute("batch_spawn", json!({"entities": [{"name": "Plain"}]}))
@@ -47824,7 +47824,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0,1.0,1.0], "intensity": 100.0, "range": 10.0, "position": [0.0,5.0,0.0]})).unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0,0.0,0.0], "intensity": 50.0, "range": 5.0, "position": [1.0,5.0,0.0]})).unwrap();
             reg.execute("batch_spawn", json!({"entities": [{"name": "Plain"}]}))
@@ -47887,7 +47887,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "batch_spawn",
                 json!({"entities": [
@@ -47924,7 +47924,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("attach_mesh", json!({"entity_id": ma_id, "mesh_id": 100}))
                 .unwrap();
             reg.execute("attach_mesh", json!({"entity_id": mb_id, "mesh_id": 200}))
@@ -48126,7 +48126,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": near_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": far_id}))
@@ -48208,7 +48208,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -48353,7 +48353,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": far_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": near_id}))
@@ -48434,7 +48434,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": neg_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": pos_id}))
@@ -48659,7 +48659,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": right_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": left_id}))
@@ -48741,7 +48741,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -49059,7 +49059,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": low_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": high_id}))
@@ -49212,7 +49212,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": high_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": low_id}))
@@ -49470,7 +49470,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": in_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": out_id}))
@@ -49708,7 +49708,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": near_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": far_id}))
@@ -49793,7 +49793,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("hide_entity", json!({"entity_id": h1_id}))
                 .unwrap();
             reg.execute("hide_entity", json!({"entity_id": h2_id}))
@@ -49883,7 +49883,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": e1_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": e2_id}))
@@ -49967,7 +49967,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("hide_entity", json!({"entity_id": h_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": v1_id}))
@@ -50057,7 +50057,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("hide_entity", json!({"entity_id": h1_id}))
                 .unwrap();
             reg.execute("hide_entity", json!({"entity_id": h2_id}))
@@ -50209,7 +50209,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": e1_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": e2_id}))
@@ -50284,7 +50284,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": s1_id, "parent_id": parent_id}),
@@ -50388,7 +50388,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": s1_id, "parent_id": parent_id}),
@@ -50499,7 +50499,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": parent_id}),
@@ -50599,7 +50599,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -50695,7 +50695,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -50808,7 +50808,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": s1_id, "parent_id": parent_id}),
@@ -50921,7 +50921,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -51044,7 +51044,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -51225,7 +51225,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -51326,7 +51326,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -51424,7 +51424,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -51532,7 +51532,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -51632,7 +51632,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -51723,7 +51723,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": parent_id}),
@@ -51812,7 +51812,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": parent_id}),
@@ -51900,7 +51900,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -52007,7 +52007,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": parent_id}),
@@ -52086,7 +52086,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -52193,7 +52193,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -52300,7 +52300,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -52408,7 +52408,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -52509,7 +52509,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": c1, "parent_id": root_id}))
                 .unwrap();
             reg.execute("set_parent", json!({"entity_id": c2, "parent_id": root_id}))
@@ -52589,7 +52589,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -52689,7 +52689,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": ba_id, "parent_id": root_id}),
@@ -52796,7 +52796,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": ca_id, "parent_id": root_id}),
@@ -52897,7 +52897,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": ba_id, "parent_id": root_id}),
@@ -52995,7 +52995,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": d1, "parent_id": d0}))
                 .unwrap();
             reg.execute("set_parent", json!({"entity_id": d2, "parent_id": d1}))
@@ -53064,7 +53064,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": mid_id, "parent_id": root_id}),
@@ -53145,7 +53145,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": mid_id, "parent_id": root_id}),
@@ -53226,7 +53226,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": mid_id, "parent_id": root_id}),
@@ -53301,7 +53301,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": d1, "parent_id": d0}))
                 .unwrap();
             reg.execute("set_parent", json!({"entity_id": d2, "parent_id": d1}))
@@ -53371,7 +53371,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": d1, "parent_id": d0}))
                 .unwrap();
             reg.execute("set_parent", json!({"entity_id": d2, "parent_id": d1}))
@@ -53460,7 +53460,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": b, "parent_id": a}))
                 .unwrap();
             reg.execute("set_parent", json!({"entity_id": c, "parent_id": b}))
@@ -53553,7 +53553,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": d1, "parent_id": d0}))
                 .unwrap();
             reg.execute("set_parent", json!({"entity_id": d2, "parent_id": d1}))
@@ -53636,7 +53636,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": b, "parent_id": a}))
                 .unwrap();
             reg.execute("set_parent", json!({"entity_id": c, "parent_id": b}))
@@ -53710,7 +53710,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": mid_id, "parent_id": root_id}),
@@ -53790,7 +53790,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": mid_id, "parent_id": root_id}),
@@ -53878,7 +53878,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": leaf1_id, "parent_id": parent_id}),
@@ -53974,7 +53974,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": l1_id, "parent_id": parent_id}),
@@ -54053,7 +54053,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": leaf1_id, "parent_id": parent_id}),
@@ -54146,7 +54146,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": la_id, "parent_id": root_id}),
@@ -54220,7 +54220,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root1_id}),
@@ -54311,7 +54311,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root1_id}),
@@ -54472,7 +54472,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": parent_id}),
@@ -54551,7 +54551,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": sib_a, "parent_id": parent_id}),
@@ -54658,7 +54658,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root1_id}),
@@ -54750,7 +54750,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": s1_id, "parent_id": parent_id}),
@@ -54845,7 +54845,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": p_id, "parent_id": gp_id}))
                 .unwrap();
             reg.execute(
@@ -54884,7 +54884,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("batch_spawn", json!({"entities": [{"name": "Named"}]}))
                 .unwrap();
             // lights have no Name component
@@ -54984,7 +54984,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": s1_id, "parent_id": parent_id}),
@@ -55068,7 +55068,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": p_id, "parent_id": gp_id}))
                 .unwrap();
             reg.execute(
@@ -55174,7 +55174,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": s1_id, "parent_id": parent_id}),
@@ -55268,7 +55268,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -55367,7 +55367,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -55385,7 +55385,7 @@ mod tests {
         // Select all four
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": root_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": child_id}))
@@ -55470,7 +55470,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -55559,7 +55559,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -55646,7 +55646,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -55734,7 +55734,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("set_parent", json!({"entity_id": p_id, "parent_id": gp_id}))
                 .unwrap();
             reg.execute(
@@ -55958,7 +55958,7 @@ mod tests {
         // Tag A and B; select A and C
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("tag_entity", json!({"entity_id": a_id, "tag": "hero"}))
                 .unwrap();
             reg.execute("tag_entity", json!({"entity_id": b_id, "tag": "hero"}))
@@ -55968,7 +55968,7 @@ mod tests {
         app.update();
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": c_id}))
@@ -56038,7 +56038,7 @@ mod tests {
         // Set parents
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -56056,7 +56056,7 @@ mod tests {
         // Select all three
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": root_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": c1_id}))
@@ -56153,7 +56153,7 @@ mod tests {
         // Select both
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": mesh_ent_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": plain_id}))
@@ -56233,7 +56233,7 @@ mod tests {
         // Set parents
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": root_id}),
@@ -56283,7 +56283,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("spawn_point_light", json!({"color": [1.0,1.0,1.0], "intensity": 800.0, "range": 20.0, "position": [0.0,0.0,0.0]})).unwrap();
             reg.execute("batch_spawn", json!({"entities": [{"name": "Plain"}]}))
                 .unwrap();
@@ -56319,7 +56319,7 @@ mod tests {
         // Select both
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": light_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": plain_id}))
@@ -56359,7 +56359,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "spawn_camera",
                 json!({"fov_y_degrees": 60.0, "position": [0.0,0.0,0.0]}),
@@ -56396,7 +56396,7 @@ mod tests {
         // Select both
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": cam_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": plain_id}))
@@ -56488,7 +56488,7 @@ mod tests {
         // Select all three
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": v1_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": v2_id}))
@@ -56571,7 +56571,7 @@ mod tests {
         // Hide two
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("hide_entity", json!({"entity_id": h1_id}))
                 .unwrap();
             reg.execute("hide_entity", json!({"entity_id": h2_id}))
@@ -56583,7 +56583,7 @@ mod tests {
         // Select all three
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": vis_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": h1_id}))
@@ -56750,7 +56750,7 @@ mod tests {
         // Hide A and B
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("hide_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("hide_entity", json!({"entity_id": b_id}))
@@ -56834,7 +56834,7 @@ mod tests {
         // Leaf1 and Leaf2 are children of Root (so Root is not a leaf)
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": l1_id, "parent_id": root_id}),
@@ -56852,7 +56852,7 @@ mod tests {
         // Select all three
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": root_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": l1_id}))
@@ -56935,7 +56935,7 @@ mod tests {
         // Tag A and B with "hero"
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("tag_entity", json!({"entity_id": a_id, "tag": "hero"}))
                 .unwrap();
             reg.execute("tag_entity", json!({"entity_id": b_id, "tag": "hero"}))
@@ -56947,7 +56947,7 @@ mod tests {
         // Select all three
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -57036,7 +57036,7 @@ mod tests {
         // Set children
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": c1_id, "parent_id": parent_id}),
@@ -57054,7 +57054,7 @@ mod tests {
         // Select all four
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": parent_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": c1_id}))
@@ -57155,7 +57155,7 @@ mod tests {
         // Select all three
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": r1_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": r2_id}))
@@ -57688,7 +57688,7 @@ mod tests {
         // Hide A and B
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("hide_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("hide_entity", json!({"entity_id": b_id}))
@@ -57757,7 +57757,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "spawn_camera",
                 json!({"fov_y_degrees": 30.0, "position": [0.0, 0.0, 0.0]}),
@@ -57833,7 +57833,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "spawn_camera",
                 json!({"fov_y_degrees": 90.0, "position": [0.0, 0.0, 0.0]}),
@@ -57951,7 +57951,7 @@ mod tests {
         // Sib1 and Sib2 share Root as parent; Cousin is a child of Sib2
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": sib1_id, "parent_id": root_id}),
@@ -58304,7 +58304,7 @@ mod tests {
         // Root → Child → Leaf hierarchy
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child_id, "parent_id": root_id}),
@@ -58398,7 +58398,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_scale",
                 json!({"entity_id": normal_id, "sx": 1.0, "sy": 1.0, "sz": 1.0}),
@@ -58491,7 +58491,7 @@ mod tests {
         // Reparent Child1 and Child2 to Parent
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute(
                 "set_parent",
                 json!({"entity_id": child1_id, "parent_id": parent_id}),
@@ -58675,7 +58675,7 @@ mod tests {
         // Tag all three with "hero"
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             for id in [a_id, b_id, c_id] {
                 reg.execute("tag_entity", json!({"entity_id": id, "tag": "hero"}))
                     .unwrap();
@@ -58687,7 +58687,7 @@ mod tests {
         // Select A and B, then untag them
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -58805,7 +58805,7 @@ mod tests {
         // Tag A and B with "prop"
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("tag_entity", json!({"entity_id": a_id, "tag": "prop"}))
                 .unwrap();
             reg.execute("tag_entity", json!({"entity_id": b_id, "tag": "prop"}))
@@ -58975,7 +58975,7 @@ mod tests {
         // Select A and B
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -59091,7 +59091,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -59184,7 +59184,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -59280,7 +59280,7 @@ mod tests {
         // Select A and B only
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -59387,7 +59387,7 @@ mod tests {
 
         {
             let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
-            let mut reg = mcp.0.lock().unwrap();
+            let reg = mcp.0.lock().unwrap();
             reg.execute("select_entity", json!({"entity_id": a_id}))
                 .unwrap();
             reg.execute("select_entity", json!({"entity_id": b_id}))
@@ -61825,7 +61825,7 @@ mod tests {
                 )
                 .unwrap();
             assert!(out.is_ok());
-            assert_eq!(out.content["tagged"].as_bool().unwrap(), true);
+            assert!(out.content["tagged"].as_bool().unwrap());
         }
 
         let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
@@ -61839,7 +61839,7 @@ mod tests {
             )
             .unwrap();
         assert!(out.is_ok());
-        assert_eq!(out.content["tagged"].as_bool().unwrap(), false);
+        assert!(!out.content["tagged"].as_bool().unwrap());
     }
 
     #[test]
@@ -62625,7 +62625,7 @@ mod tests {
                 .execute("are_all_selected_visible", json!({}))
                 .unwrap();
             assert!(out.is_ok());
-            assert_eq!(out.content["all_visible"].as_bool().unwrap(), true);
+            assert!(out.content["all_visible"].as_bool().unwrap());
         }
 
         // Add hidden entity to selection — all_visible should now be false
@@ -62645,7 +62645,7 @@ mod tests {
             .execute("are_all_selected_visible", json!({}))
             .unwrap();
         assert!(out.is_ok());
-        assert_eq!(out.content["all_visible"].as_bool().unwrap(), false);
+        assert!(!out.content["all_visible"].as_bool().unwrap());
     }
 
     #[test]
@@ -63763,8 +63763,8 @@ mod tests {
             let out = mcp.0.lock().unwrap().execute("get_entities_with_light_intensity_below", json!({"threshold": 50.0})).unwrap();
             assert!(out.is_ok());
             let ids: Vec<u64> = out.content["entity_ids"].as_array().unwrap().iter().map(|v| v.as_u64().unwrap()).collect();
-            assert!(ids.iter().any(|id| *id == near_id), "dim(intensity=10) below 50");
-            assert!(!ids.iter().any(|id| *id == far_id), "bright(intensity=100) not below 50");
+            assert!(ids.contains(&near_id), "dim(intensity=10) below 50");
+            assert!(!ids.contains(&far_id), "bright(intensity=100) not below 50");
         }
 
         // get_entities_with_fov_equal(45) → cam45 only
@@ -69558,7 +69558,7 @@ mod tests {
             "hero appears in both A and B"
         );
         assert!(
-            tags.get("other").map_or(true, |v| v.as_u64().unwrap() == 0),
+            tags.get("other").is_none_or(|v| v.as_u64().unwrap() == 0),
             "C is not selected"
         );
     }
@@ -81025,9 +81025,8 @@ mod tests {
                 .unwrap()
                 .clone();
             for e in &ents {
-                assert_eq!(
-                    e["visible"].as_bool().unwrap_or(true),
-                    false,
+                assert!(
+                    !e["visible"].as_bool().unwrap_or(true),
                     "all should be hidden"
                 );
             }
@@ -81055,9 +81054,8 @@ mod tests {
             .unwrap()
             .clone();
         for e in &ents {
-            assert_eq!(
+            assert!(
                 e["visible"].as_bool().unwrap_or(false),
-                true,
                 "all should be visible"
             );
         }
@@ -82779,14 +82777,12 @@ mod tests {
             .execute("is_entity_selected", json!({"entity_id": id_b}))
             .unwrap();
         assert!(out_a.is_ok());
-        assert_eq!(
+        assert!(
             out_a.content["selected"].as_bool().unwrap(),
-            true,
             "IsSelA should be selected"
         );
-        assert_eq!(
-            out_b.content["selected"].as_bool().unwrap(),
-            false,
+        assert!(
+            !out_b.content["selected"].as_bool().unwrap(),
             "IsSelB should not be selected"
         );
     }
@@ -87998,7 +87994,7 @@ mod tests {
             .unwrap();
         assert!(lights.is_ok());
         assert!(
-            lights.content["entities"].as_array().unwrap().len() >= 1,
+            !lights.content["entities"].as_array().unwrap().is_empty(),
             "at least 1 light"
         );
 
@@ -88007,7 +88003,7 @@ mod tests {
             .unwrap();
         assert!(cameras.is_ok());
         assert!(
-            cameras.content["entities"].as_array().unwrap().len() >= 1,
+            !cameras.content["entities"].as_array().unwrap().is_empty(),
             "at least 1 camera"
         );
 

--- a/crates/bsengine-input/src/state.rs
+++ b/crates/bsengine-input/src/state.rs
@@ -72,6 +72,7 @@ mod tests {
         assert!(input.is_pressed(&TestKey::A));
         assert!(input.just_pressed(&TestKey::A));
         assert!(!input.just_released(&TestKey::A));
+        assert!(!input.is_pressed(&TestKey::B));
     }
 
     #[test]

--- a/crates/bsengine-mcp/src/game_tools.rs
+++ b/crates/bsengine-mcp/src/game_tools.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
@@ -198,7 +198,7 @@ fn get_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, McpToolOutput> {
         .ok_or_else(|| McpToolOutput::error(&format!("missing required field: {key}")))
 }
 
-fn game_create(root: &PathBuf, args: Value) -> McpToolOutput {
+fn game_create(root: &Path, args: Value) -> McpToolOutput {
     let name = match get_str(&args, "name") {
         Ok(v) => v.to_string(),
         Err(e) => return e,
@@ -237,7 +237,7 @@ fn game_create(root: &PathBuf, args: Value) -> McpToolOutput {
     }))
 }
 
-fn scene_write(root: &PathBuf, args: Value) -> McpToolOutput {
+fn scene_write(root: &Path, args: Value) -> McpToolOutput {
     let game = match get_str(&args, "game") {
         Ok(v) => v.to_string(),
         Err(e) => return e,
@@ -262,7 +262,7 @@ fn scene_write(root: &PathBuf, args: Value) -> McpToolOutput {
     McpToolOutput::success(json!({ "written": format!("games/{game}/assets/scenes/main.ron") }))
 }
 
-fn script_write(root: &PathBuf, args: Value) -> McpToolOutput {
+fn script_write(root: &Path, args: Value) -> McpToolOutput {
     let game = match get_str(&args, "game") {
         Ok(v) => v.to_string(),
         Err(e) => return e,
@@ -290,7 +290,7 @@ fn script_write(root: &PathBuf, args: Value) -> McpToolOutput {
     McpToolOutput::success(json!({ "written": format!("games/{game}/{rel_path}") }))
 }
 
-fn game_validate(root: &PathBuf, args: Value) -> McpToolOutput {
+fn game_validate(root: &Path, args: Value) -> McpToolOutput {
     let game = match get_str(&args, "game") {
         Ok(v) => v.to_string(),
         Err(e) => return e,

--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -153,5 +153,7 @@ impl Default for PhysicsInput {
 #[derive(Component)]
 pub(crate) struct PhysicsHandles {
     pub body_handle: RigidBodyHandle,
+    // Stored for a future despawn-time collider cleanup pass; not yet read.
+    #[allow(dead_code)]
     pub collider_handle: ColliderHandle,
 }

--- a/crates/bsengine-render/src/lib.rs
+++ b/crates/bsengine-render/src/lib.rs
@@ -1,3 +1,9 @@
+// Bevy ECS system params (Query<(A, B, C, ...)>, ParamSet<(...)>) routinely
+// exceed clippy's type-complexity threshold; that's the idiom, not a real
+// complexity problem. Bevy itself disables this lint crate-wide for the
+// same reason.
+#![allow(clippy::type_complexity)]
+
 pub mod components;
 pub mod plugin;
 

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -81,6 +81,7 @@ fn propagate_children(
     }
 }
 
+#[allow(clippy::too_many_arguments)] // Bevy system params; splitting into a struct is a larger refactor
 fn render_frame(
     surface: Option<ResMut<WgpuSurfaceResource>>,
     registry: Option<Res<GpuMeshRegistry>>,

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -351,7 +351,7 @@ mod tests {
     use super::RenderPlugin;
     use crate::components::MeshRenderer;
     use bsengine_app::new_app;
-    use bsengine_core::{Camera, Material, PointLight, SpotLight, Transform};
+    use bsengine_core::{Camera, Material, PointLight, Transform};
     use bsengine_rhi_wgpu::WgpuRHIPlugin;
     use bsengine_window::WindowResized;
     use glam::Vec3;

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -1,3 +1,9 @@
+// Bevy ECS system params (Query<(A, B, C, ...)>, ParamSet<(...)>) routinely
+// exceed clippy's type-complexity threshold; that's the idiom, not a real
+// complexity problem. Bevy itself disables this lint crate-wide for the
+// same reason.
+#![allow(clippy::type_complexity)]
+
 pub mod gizmo;
 pub mod mesh;
 pub mod plugin;

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -705,7 +705,7 @@ impl WgpuSurface {
             vertex: wgpu::VertexState {
                 module: &shadow_shader,
                 entry_point: "vs_shadow",
-                buffers: &[vertex_buffer_layout.clone()],
+                buffers: std::slice::from_ref(&vertex_buffer_layout),
                 compilation_options: Default::default(),
             },
             fragment: None,
@@ -1119,6 +1119,7 @@ impl WgpuSurface {
         self.loaded_skybox_path.as_deref()
     }
 
+    #[allow(clippy::too_many_arguments)] // one frame's worth of render inputs; splitting into a struct is a larger refactor
     pub fn render_frame(
         &mut self,
         view_proj: Mat4,

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -199,7 +199,7 @@ fn handle_scene_load(world: &mut World) {
     // Stop all sounds and clear handles
     if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
         for (_, mut handle) in handles.0.drain() {
-            let _ = handle.stop(kira::Tween::default());
+            handle.stop(kira::Tween::default());
         }
     }
 

--- a/crates/bsengine-scripting/src/lib.rs
+++ b/crates/bsengine-scripting/src/lib.rs
@@ -1,4 +1,9 @@
 #![recursion_limit = "2048"]
+// Bevy ECS system params (Query<(A, B, C, ...)>, ParamSet<(...)>) routinely
+// exceed clippy's type-complexity threshold; that's the idiom, not a real
+// complexity problem. Bevy itself disables this lint crate-wide for the
+// same reason.
+#![allow(clippy::type_complexity)]
 // bsengine-scripting
 pub mod ops;
 pub mod plugin;

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -7567,7 +7567,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut le) = world.get_mut::<Ledge>(e) {
-                        le.drop();
+                        le.begin_drop();
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -27655,7 +27655,7 @@ fn run_scripts(world: &mut World) {
                 if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
                     if let Some(mut handle) = handles.0.remove(&id) {
                         use kira::Tween;
-                        let _ = handle.stop(Tween::default());
+                        handle.stop(Tween::default());
                     }
                 }
             }
@@ -27663,7 +27663,7 @@ fn run_scripts(world: &mut World) {
                 if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
                     if let Some(handle) = handles.0.get_mut(&id) {
                         use kira::Tween;
-                        let _ = handle.pause(Tween::default());
+                        handle.pause(Tween::default());
                     }
                 }
             }
@@ -27671,7 +27671,7 @@ fn run_scripts(world: &mut World) {
                 if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
                     if let Some(handle) = handles.0.get_mut(&id) {
                         use kira::Tween;
-                        let _ = handle.resume(Tween::default());
+                        handle.resume(Tween::default());
                     }
                 }
             }
@@ -27679,7 +27679,7 @@ fn run_scripts(world: &mut World) {
                 if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
                     if let Some(handle) = handles.0.get_mut(&id) {
                         use kira::{Decibels, Tween};
-                        let _ = handle.set_volume(Decibels(db), Tween::default());
+                        handle.set_volume(Decibels(db), Tween::default());
                     }
                 }
             }
@@ -27687,7 +27687,7 @@ fn run_scripts(world: &mut World) {
                 if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
                     if let Some(handle) = handles.0.get_mut(&id) {
                         use kira::{Panning, Tween};
-                        let _ = handle.set_panning(Panning(panning), Tween::default());
+                        handle.set_panning(Panning(panning), Tween::default());
                     }
                 }
             }
@@ -27695,8 +27695,7 @@ fn run_scripts(world: &mut World) {
                 if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
                     if let Some(handle) = handles.0.get_mut(&id) {
                         use kira::{PlaybackRate, Tween};
-                        let _ =
-                            handle.set_playback_rate(PlaybackRate(rate as f64), Tween::default());
+                        handle.set_playback_rate(PlaybackRate(rate as f64), Tween::default());
                     }
                 }
             }
@@ -28440,37 +28439,6 @@ fn spawn_entity(world: &mut World, params: SpawnParams) {
 
     if let Some(script) = params.script {
         cmd.insert(ScriptPath(script));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{ScriptRuntimeResource, ScriptingPlugin};
-    use bsengine_app::new_app;
-
-    #[test]
-    fn scripting_plugin_registers_runtime() {
-        let mut app = new_app();
-        app.add_plugins(ScriptingPlugin::default());
-        assert!(app
-            .world()
-            .get_non_send_resource::<ScriptRuntimeResource>()
-            .is_some());
-    }
-
-    #[test]
-    fn scripting_plugin_runtime_can_eval() {
-        let mut app = new_app();
-        app.add_plugins(ScriptingPlugin::default());
-
-        let result = app
-            .world_mut()
-            .get_non_send_resource_mut::<ScriptRuntimeResource>()
-            .expect("ScriptRuntimeResource not found")
-            .0
-            .eval("40 + 2");
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "42");
     }
 }
 
@@ -41886,4 +41854,35 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
     }
     COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     (scripted, collision_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ScriptRuntimeResource, ScriptingPlugin};
+    use bsengine_app::new_app;
+
+    #[test]
+    fn scripting_plugin_registers_runtime() {
+        let mut app = new_app();
+        app.add_plugins(ScriptingPlugin::default());
+        assert!(app
+            .world()
+            .get_non_send_resource::<ScriptRuntimeResource>()
+            .is_some());
+    }
+
+    #[test]
+    fn scripting_plugin_runtime_can_eval() {
+        let mut app = new_app();
+        app.add_plugins(ScriptingPlugin::default());
+
+        let result = app
+            .world_mut()
+            .get_non_send_resource_mut::<ScriptRuntimeResource>()
+            .expect("ScriptRuntimeResource not found")
+            .0
+            .eval("40 + 2");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "42");
+    }
 }


### PR DESCRIPTION
## Summary

Zero clippy warnings remain workspace-wide (`cargo clippy --all-targets --workspace` is clean). Two-stage cleanup:

1. **Auto-fix pass** (`cargo clippy --fix --workspace --all-targets`): mechanical rewrites — `unused_mut`, `let_unit_value`, most `dropping_references`, `unnecessary_map_or`, `needless_bool_assign`, and similar. No behavior change.
2. **Manual pass** for everything `--fix` couldn't touch:
   - **`type_complexity` (1282 warnings, ~all Bevy `Query<(A,B,C,...)>`/`ParamSet<(...)>` system params)**: `#![allow(clippy::type_complexity)]` at the crate level in `bsengine-editor`/`render`/`rhi-wgpu`/`scripting`. This is Bevy's own idiom for this exact lint — upstream Bevy disables it crate-wide too — not a real complexity problem, so factoring 1282 sites into type aliases would hurt readability for no benefit. Confirmed with the user before applying this at scale rather than touching every call site.
   - **`dropping_references` (24x)**: removed no-op `drop(mcp)` calls on a `&_` reference in the editor's MCP tool registrations.
   - **`non_snake_case` (39x)**: renamed `SCREAMING_CASE` test fn prefixes (`ADD_*`, `REMOVE_*`) to snake_case across three near-identical component files.
   - **`doc_lazy_continuation` (7x)**: blank lines / rewrapped doc comments so markdown list continuations aren't ambiguous.
   - **`ptr_arg` (4x)**: `&PathBuf` → `&Path` in the MCP `game_tools` handlers.
   - **`possible_missing_else` (4x)**: split independent back-to-back `if` statements clippy could misread as an intended `else if` onto separate lines (bounding-box min/max/sum accumulation) — pure formatting, behavior unchanged.
   - **`should_implement_trait` (3x)**: renamed ambiguous `drop`/`add` methods (not actual `std::ops::Drop`/`Add` impls) to `begin_drop`/`with_entry`, updating every call site including one in `bsengine-scripting` the first pass missed (caught by a follow-up compile error, not silently).
   - **`dead_code` (4x)**: kept `PhysicsHandles::collider_handle` (stored for a future despawn-cleanup pass that doesn't exist yet — allowed, not deleted, since removing it could silently break that future fix) and a `Position` test struct's fields (they exist to exercise the `Component` derive, not to be read back); shrank an unused-payload `DummyAsset` to a unit struct; extended a test to actually exercise a previously-dead `TestKey::B` variant instead of deleting it.
   - **Everything else** (`while_let_loop`, `unnecessary_sort_by`, `needless_update`, `cloned_ref_to_slice_refs`, `if_same_then_else`, `drop_non_drop`, `too_many_arguments`, `module_inception`): applied clippy's own suggested rewrite, or a scoped `#[allow(...)]` with a one-line rationale where the "fix" would be a larger out-of-scope refactor (e.g. `render_frame`'s argument count) or clippy is misreading a standard Rust idiom (`#[cfg(test)] mod tests` in a file already named `tests.rs`).

No functional/behavioral changes anywhere in this PR — every fix was verified to preserve existing test coverage, and a couple of judgment calls (the `if_same_then_else` merge, the ambiguous-method renames) were specifically checked against existing tests/call sites before applying.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets --workspace` — zero warnings
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace --exclude bsengine-editor` and `RUST_MIN_STACK=8388608 cargo test -p bsengine-editor` (CI's exact invocation) — both fully passing
- [x] `cargo run -p bsengine-editor-app` boots without panic
- [x] CI (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)