### PR TITLE
refactor(core): derive DirectionalLight direction from Transform, like SpotLight

### DIFF
--- a/apps/bsengine-editor-app/src/main.rs
+++ b/apps/bsengine-editor-app/src/main.rs
@@ -107,7 +107,14 @@ fn setup_empty_scene(mut commands: Commands, mut registry: Option<ResMut<GpuMesh
         Transform::from_translation(Vec3::new(0.0, 3.0, 10.0)),
     ));
 
-    commands.spawn(DirectionalLight::default());
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform {
+            rotation: Quat::from_rotation_arc(Vec3::NEG_Z, Vec3::new(-0.4, -0.8, -0.4).normalize()),
+            ..Default::default()
+        },
+        GlobalTransform::default(),
+    ));
 
     if let Some(ref mut reg) = registry {
         let (verts, indices) = cube_vertices();

--- a/crates/bsengine-app/src/main.rs
+++ b/crates/bsengine-app/src/main.rs
@@ -12,7 +12,7 @@ use bsengine_rhi_wgpu::{
 };
 use bsengine_scene::{Primitive, PrimitiveMesh};
 use bsengine_window::WindowPlugin;
-use glam::Vec3;
+use glam::{Quat, Vec3};
 
 fn main() {
     new_app()
@@ -93,7 +93,14 @@ fn setup(mut commands: Commands, registry: Option<ResMut<GpuMeshRegistry>>) {
         Parent(parent),
     ));
 
-    commands.spawn(DirectionalLight::default());
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform {
+            rotation: Quat::from_rotation_arc(Vec3::NEG_Z, Vec3::new(-0.4, -0.8, -0.4).normalize()),
+            ..Default::default()
+        },
+        GlobalTransform::default(),
+    ));
 
     // Orange point light above the scene
     commands.spawn((

--- a/crates/bsengine-core/src/light.rs
+++ b/crates/bsengine-core/src/light.rs
@@ -1,9 +1,14 @@
 use bevy_ecs::prelude::Component;
 use glam::Vec3;
 
+// Direction is intentionally not stored here: it's derived from the
+// entity's Transform.rotation (rotation * -Z), the same way SpotLight
+// already derives its cone direction. This keeps a single source of truth
+// for "which way is this thing facing" across all light/entity types, so
+// the existing move/rotate gizmos, Inspector Rot fields, and undo/redo all
+// work on directional lights for free.
 #[derive(Component, Debug, Clone)]
 pub struct DirectionalLight {
-    pub direction: Vec3,
     pub color: Vec3,
     pub ambient: Vec3,
 }
@@ -11,7 +16,6 @@ pub struct DirectionalLight {
 impl Default for DirectionalLight {
     fn default() -> Self {
         Self {
-            direction: Vec3::new(-0.4, -0.8, -0.4).normalize(),
             color: Vec3::ONE,
             ambient: Vec3::splat(0.15),
         }
@@ -63,9 +67,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_light_direction_is_unit() {
+    fn default_light_has_white_color_and_dim_ambient() {
         let light = DirectionalLight::default();
-        assert!((light.direction.length() - 1.0).abs() < 1e-5);
+        assert_eq!(light.color, Vec3::ONE);
+        assert!(light.ambient.x > 0.0 && light.ambient.x < 1.0);
     }
 
     #[test]

--- a/crates/bsengine-demo/src/main.rs
+++ b/crates/bsengine-demo/src/main.rs
@@ -34,11 +34,18 @@ fn setup(mut commands: Commands, registry: Option<ResMut<GpuMeshRegistry>>, mut 
         Transform::from_translation(Vec3::new(0.0, 1.5, 3.0)),
     ));
 
-    commands.spawn(DirectionalLight {
-        direction: Vec3::new(-0.5, -1.0, -0.5).normalize(),
-        color: Vec3::ONE,
-        ambient: Vec3::splat(0.15),
-    });
+    let dir = Vec3::new(-0.5, -1.0, -0.5).normalize();
+    commands.spawn((
+        DirectionalLight {
+            color: Vec3::ONE,
+            ambient: Vec3::splat(0.15),
+        },
+        Transform {
+            rotation: Quat::from_rotation_arc(Vec3::NEG_Z, dir),
+            ..Default::default()
+        },
+        GlobalTransform::default(),
+    ));
 
     tracing::info!("Demo scene ready — cube spawned");
     *done = true;

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -173,11 +173,19 @@ fn process_editor_commands(
                 color,
                 ambient,
             } => {
-                commands.spawn(DirectionalLight {
-                    direction: glam::Vec3::from(direction),
-                    color: glam::Vec3::from(color),
-                    ambient: glam::Vec3::from(ambient),
-                });
+                let dir = glam::Vec3::from(direction).normalize_or(glam::Vec3::NEG_Z);
+                let rotation = glam::Quat::from_rotation_arc(glam::Vec3::NEG_Z, dir);
+                commands.spawn((
+                    DirectionalLight {
+                        color: glam::Vec3::from(color),
+                        ambient: glam::Vec3::from(ambient),
+                    },
+                    Transform {
+                        rotation,
+                        ..Default::default()
+                    },
+                    GlobalTransform::default(),
+                ));
             }
             EditorCommand::RemoveLight { entity_id } => {
                 let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
@@ -218,9 +226,6 @@ fn process_editor_commands(
             } => {
                 for (e, mut light) in params.p3().iter_mut() {
                     if e.index() as u64 == entity_id {
-                        if let Some(d) = direction {
-                            light.direction = glam::Vec3::from(d);
-                        }
                         if let Some(c) = color {
                             light.color = glam::Vec3::from(c);
                         }
@@ -228,6 +233,16 @@ fn process_editor_commands(
                             light.ambient = glam::Vec3::from(a);
                         }
                         break;
+                    }
+                }
+                if let Some(d) = direction {
+                    let dir = glam::Vec3::from(d).normalize_or(glam::Vec3::NEG_Z);
+                    let rotation = glam::Quat::from_rotation_arc(glam::Vec3::NEG_Z, dir);
+                    for (e, mut t) in params.p1().iter_mut() {
+                        if e.index() as u64 == entity_id {
+                            t.rotation = rotation;
+                            break;
+                        }
                     }
                 }
             }
@@ -562,10 +577,27 @@ fn process_editor_commands(
                     }
                     if let Some(dl) = &entity.directional_light {
                         eb.insert(DirectionalLight {
-                            direction: glam::Vec3::from(dl.direction),
                             color: glam::Vec3::from(dl.color),
                             ambient: glam::Vec3::from(dl.ambient),
                         });
+                        // Direction lives on Transform.rotation (rotation * -Z), same
+                        // as SpotLight; reuse translation/scale from the scene file's
+                        // own `transform:` block if one was given.
+                        let dir = glam::Vec3::from(dl.direction).normalize_or(glam::Vec3::NEG_Z);
+                        let rotation = glam::Quat::from_rotation_arc(glam::Vec3::NEG_Z, dir);
+                        let (translation, scale) = entity
+                            .transform
+                            .as_ref()
+                            .map(|t| (glam::Vec3::from(t.translation), glam::Vec3::from(t.scale)))
+                            .unwrap_or((glam::Vec3::ZERO, glam::Vec3::ONE));
+                        eb.insert((
+                            Transform {
+                                translation,
+                                rotation,
+                                scale,
+                            },
+                            GlobalTransform::default(),
+                        ));
                     }
                     if entity.emissive.is_some() || entity.color.is_some() {
                         eb.insert(Material {
@@ -29127,10 +29159,70 @@ mod tests {
         }
         app.update();
 
-        let mut q = app.world_mut().query::<&bsengine_core::DirectionalLight>();
+        let mut q =
+            app.world_mut()
+                .query::<(&bsengine_core::DirectionalLight, &Transform)>();
+        let (_, transform) = q.iter(app.world()).next().expect("no DirectionalLight spawned");
+        // direction lives on Transform.rotation (rotation * -Z), same as SpotLight.
+        let derived_dir = transform.rotation * Vec3::NEG_Z;
         assert!(
-            q.iter(app.world()).next().is_some(),
-            "no DirectionalLight spawned"
+            (derived_dir - Vec3::new(0.0, -1.0, 0.0)).length() < 1e-4,
+            "expected direction (0,-1,0), derived {:?}",
+            derived_dir
+        );
+    }
+
+    #[test]
+    fn mcp_update_directional_light_direction_rotates_transform() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        let eid = {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let result = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "spawn_directional_light",
+                    json!({"direction":[0.0,-1.0,0.0],"color":[1.0,1.0,1.0],"ambient":[0.1,0.1,0.1]}),
+                )
+                .expect("spawn_directional_light not found");
+            assert!(result.is_ok(), "{:?}", result.error);
+            app.update();
+            let mut q = app
+                .world_mut()
+                .query::<(bevy_ecs::entity::Entity, &bsengine_core::DirectionalLight)>();
+            q.iter(app.world()).next().unwrap().0.index() as u64
+        };
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let result = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "update_directional_light",
+                    json!({"entity_id": eid, "direction": [1.0, 0.0, 0.0]}),
+                )
+                .expect("update_directional_light not found");
+            assert!(result.is_ok(), "{:?}", result.error);
+        }
+        app.update();
+        app.update();
+
+        let mut q = app.world_mut().query::<&Transform>();
+        let transform = q
+            .iter(app.world())
+            .next()
+            .expect("entity should still have a Transform");
+        let derived_dir = transform.rotation * Vec3::NEG_Z;
+        assert!(
+            (derived_dir - Vec3::new(1.0, 0.0, 0.0)).length() < 1e-4,
+            "expected direction (1,0,0) after update, derived {:?}",
+            derived_dir
         );
     }
 

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -109,7 +109,7 @@ fn render_frame(
         Option<&Visible>,
         Option<&CustomShader>,
     )>,
-    light_query: Query<&DirectionalLight>,
+    light_query: Query<(&DirectionalLight, Option<&GlobalTransform>, &Transform)>,
     point_light_query: Query<(&PointLight, Option<&GlobalTransform>, &Transform)>,
     spot_light_query: Query<(&SpotLight, Option<&GlobalTransform>, &Transform)>,
 ) {
@@ -291,9 +291,12 @@ fn render_frame(
         })
         .collect();
 
-    let light = if let Some(l) = light_query.iter().next() {
+    let light = if let Some((l, gt, t)) = light_query.iter().next() {
+        let direction = gt
+            .map(|g| -glam::Mat3::from_mat4(g.to_matrix()).z_axis)
+            .unwrap_or_else(|| t.rotation * Vec3::NEG_Z);
         LightData {
-            direction: l.direction,
+            direction,
             color: l.color,
             ambient: l.ambient,
             point_lights: collected_point_lights,

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -76,10 +76,27 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
 
         if let Some(dl) = &entity.directional_light {
             builder.insert(DirectionalLight {
-                direction: Vec3::from(dl.direction),
                 color: Vec3::from(dl.color),
                 ambient: Vec3::from(dl.ambient),
             });
+            // Direction lives on Transform.rotation (rotation * -Z), same as
+            // SpotLight; reuse any explicit translation/scale from the scene
+            // file's own `transform:` block if one was given.
+            let dir = Vec3::from(dl.direction).normalize_or(Vec3::NEG_Z);
+            let rotation = Quat::from_rotation_arc(Vec3::NEG_Z, dir);
+            let (translation, scale) = entity
+                .transform
+                .as_ref()
+                .map(|t| (Vec3::from(t.translation), Vec3::from(t.scale)))
+                .unwrap_or((Vec3::ZERO, Vec3::ONE));
+            builder.insert((
+                Transform {
+                    translation,
+                    rotation,
+                    scale,
+                },
+                GlobalTransform::default(),
+            ));
         }
 
         if let Some(prim) = &entity.primitive {
@@ -112,6 +129,7 @@ mod tests {
     use super::{Name, ScenePlugin};
     use bsengine_app::new_app;
     use bsengine_core::{Camera, DirectionalLight, GlobalTransform, Transform};
+    use glam::Vec3;
 
     fn write_temp_scene(filename: &str, content: &str) -> String {
         let path = std::env::temp_dir().join(filename);
@@ -212,12 +230,15 @@ mod tests {
         app.add_plugins(ScenePlugin::from_file(&path));
         app.update();
 
-        let mut q = app.world_mut().query::<(&Name, &DirectionalLight)>();
+        let mut q = app
+            .world_mut()
+            .query::<(&Name, &DirectionalLight, &Transform)>();
         let results: Vec<_> = q.iter(app.world()).collect();
         assert_eq!(results.len(), 1);
-        let (name, light) = &results[0];
+        let (name, _light, transform) = &results[0];
         assert_eq!(name.0, "Sun");
-        assert!((light.direction.y - (-1.0)).abs() < 1e-5);
+        let derived_dir = transform.rotation * Vec3::NEG_Z;
+        assert!((derived_dir.y - (-1.0)).abs() < 1e-5);
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -656,14 +656,16 @@ fn run_scripts(world: &mut World) {
                 }
             }
             ScriptCommand::SetDirectionalLightDirection { name, x, y, z } => {
-                use bsengine_core::DirectionalLight;
                 let entity = {
                     let mut q = world.query::<(Entity, &Name)>();
                     q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
                 };
                 if let Some(e) = entity {
-                    if let Some(mut light) = world.get_mut::<DirectionalLight>(e) {
-                        light.direction = glam::Vec3::new(x, y, z).normalize();
+                    // Direction lives on Transform.rotation (rotation * -Z), same as SpotLight.
+                    let dir = glam::Vec3::new(x, y, z).normalize_or(glam::Vec3::NEG_Z);
+                    let rotation = Quat::from_rotation_arc(glam::Vec3::NEG_Z, dir);
+                    if let Some(mut t) = world.get_mut::<Transform>(e) {
+                        t.rotation = rotation;
                     }
                 }
             }

--- a/games/cube-roller/src/main.rs
+++ b/games/cube-roller/src/main.rs
@@ -46,7 +46,14 @@ fn setup(mut commands: Commands, registry: Option<ResMut<GpuMeshRegistry>>) {
         Transform::from_translation(Vec3::new(0.0, 8.0, 12.0)),
     ));
 
-    commands.spawn(DirectionalLight::default());
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform {
+            rotation: Quat::from_rotation_arc(Vec3::NEG_Z, Vec3::new(-0.4, -0.8, -0.4).normalize()),
+            ..Default::default()
+        },
+        GlobalTransform::default(),
+    ));
 
     let Some(mut reg) = registry else { return };
     let (verts, indices) = cube_vertices();


### PR DESCRIPTION
## Summary

DirectionalLight was the odd one out among the three light types: `PointLight` derives position from `Transform`, `SpotLight` derives both position and cone direction from `Transform` (`t.rotation * Vec3::NEG_Z` — already an established convention), but `DirectionalLight` stored its own `direction: Vec3` field and never got a `Transform` at all when spawned. That meant it had no rotation to show in the Inspector, and the rotate gizmo (and undo/redo, which reconciles through Transform) silently couldn't touch it.

- `DirectionalLight` drops its `direction` field (keeps `color`/`ambient`).
- `bsengine-render`'s `light_query` gains `Transform`/`GlobalTransform` and derives direction the same way spot lights already do.
- Every spawn site (`bsengine-scene`'s scene loader, the editor's `LoadScene` command's duplicate of it, `EditorCommand::SpawnDirectionalLight`, and the plain `DirectionalLight::default()` spawns in `bsengine-app`/`demo`/`editor-app`/`cube-roller`) now also inserts a `Transform`, with rotation derived via `Quat::from_rotation_arc(Vec3::NEG_Z, direction)` — the exact inverse of how `SpotLight` reads direction back out.
- `EditorCommand::UpdateDirectionalLight` and the scripting op `SetDirectionalLightDirection` now write `Transform.rotation` instead of a light field.
- **Scene file format and MCP tool parameters are unchanged** — `direction: (x,y,z)` is still the input shape everywhere; it's just converted to a rotation at spawn/update time instead of being stored verbatim. No existing scene files need to change.

Net effect: the existing move/rotate gizmo, Inspector Rot fields, and undo/redo reconciliation all work on directional lights for free now, with no light-specific code added to any of them.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo clippy --all-targets --workspace` — zero warnings
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace --exclude bsengine-editor` and `RUST_MIN_STACK=8388608 cargo test -p bsengine-editor` (CI's exact invocation) — both fully passing, including 2 new/strengthened regression tests (`mcp_spawn_directional_light_creates_entity` now asserts the derived direction, `mcp_update_directional_light_direction_rotates_transform` is new) that verify the direction↔rotation round-trip matches SpotLight's convention
- [x] Manually forced-selected the default scene's DirectionalLight and drove 10 `SetRotation` commands through it — Inspector's `edit_rot` reflected the light's actual initial orientation (previously impossible, since it had no Transform at all) and each rotation applied exactly as sent
- [x] CI (ubuntu + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)