### PR TITLE
chore: gitignore superpowers scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -456,3 +456,6 @@ Document/
 
 # vcpkg
 Scripts/vcpkg
+
+# Brainstorming visual companion scratch files
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -459,3 +459,6 @@ Scripts/vcpkg
 
 # Brainstorming visual companion scratch files
 .superpowers/
+
+# Git worktrees for isolated subagent-driven development
+.worktrees/


### PR DESCRIPTION
## Summary
- Gitignores .superpowers/ (visual-companion brainstorming scratch files) and .worktrees/ (git worktree isolation dirs for subagent-driven development) — neither should be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)