### PR TITLE
feat(editor): reflect DirectionalLight/SpotLight/Material, Remove buttons, spot cone angles

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -12,6 +12,8 @@ pub struct InspectorEntityInfo {
     pub light_color: Option<[f32; 3]>,
     pub light_intensity: Option<f32>,
     pub light_range: Option<f32>,
+    pub spot_inner_angle: Option<f32>,
+    pub spot_outer_angle: Option<f32>,
     // camera
     pub camera_fov: Option<f32>,
     // material
@@ -50,9 +52,12 @@ pub enum InspectorCmd {
     },
     UpdateLight {
         id: u64,
+        light_type: String,
         color: Option<[f32; 3]>,
         intensity: Option<f32>,
         range: Option<f32>,
+        inner_angle: Option<f32>,
+        outer_angle: Option<f32>,
     },
     UpdateCamera {
         id: u64,
@@ -117,6 +122,8 @@ pub struct InspectorState {
     pub edit_light_color: [f32; 3],
     pub edit_light_intensity: f32,
     pub edit_light_range: f32,
+    pub edit_spot_inner_angle: f32,
+    pub edit_spot_outer_angle: f32,
     pub edit_camera_fov: f32,
     pub edit_mat_base_color: [f32; 3],
     pub edit_mat_metallic: f32,
@@ -182,6 +189,8 @@ impl Default for InspectorState {
             edit_light_color: [1.0, 1.0, 1.0],
             edit_light_intensity: 1.0,
             edit_light_range: 10.0,
+            edit_spot_inner_angle: 22.5,
+            edit_spot_outer_angle: 30.0,
             edit_camera_fov: 60.0,
             edit_mat_base_color: [1.0, 1.0, 1.0],
             edit_mat_metallic: 0.0,
@@ -233,6 +242,8 @@ impl InspectorState {
                     self.edit_light_color = info.light_color.unwrap_or([1.0, 1.0, 1.0]);
                     self.edit_light_intensity = info.light_intensity.unwrap_or(1.0);
                     self.edit_light_range = info.light_range.unwrap_or(10.0);
+                    self.edit_spot_inner_angle = info.spot_inner_angle.unwrap_or(22.5);
+                    self.edit_spot_outer_angle = info.spot_outer_angle.unwrap_or(30.0);
                     self.edit_camera_fov = info.camera_fov.unwrap_or(60.0);
                     self.edit_mat_base_color = info.material_base_color.unwrap_or([1.0, 1.0, 1.0]);
                     self.edit_mat_metallic = info.material_metallic.unwrap_or(0.0);

--- a/crates/bsengine-core/src/light.rs
+++ b/crates/bsengine-core/src/light.rs
@@ -10,17 +10,18 @@ use glam::Vec3;
 // for "which way is this thing facing" across all light/entity types, so
 // the existing move/rotate gizmos, Inspector Rot fields, and undo/redo all
 // work on directional lights for free.
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component, Default)]
 pub struct DirectionalLight {
-    pub color: Vec3,
-    pub ambient: Vec3,
+    pub color: ReflectVec3,
+    pub ambient: ReflectVec3,
 }
 
 impl Default for DirectionalLight {
     fn default() -> Self {
         Self {
-            color: Vec3::ONE,
-            ambient: Vec3::splat(0.15),
+            color: Vec3::ONE.into(),
+            ambient: Vec3::splat(0.15).into(),
         }
     }
 }
@@ -73,8 +74,22 @@ mod tests {
     #[test]
     fn default_light_has_white_color_and_dim_ambient() {
         let light = DirectionalLight::default();
-        assert_eq!(light.color, Vec3::ONE);
+        assert_eq!(light.color, Vec3::ONE.into());
         assert!(light.ambient.x > 0.0 && light.ambient.x < 1.0);
+    }
+
+    #[test]
+    fn directional_light_is_registered_reflectable() {
+        use bevy_reflect::TypeRegistry;
+        let mut registry = TypeRegistry::default();
+        registry.register::<DirectionalLight>();
+        let registration = registry
+            .get(std::any::TypeId::of::<DirectionalLight>())
+            .expect("DirectionalLight not registered");
+        assert_eq!(
+            registration.type_info().type_path(),
+            "bsengine_core::light::DirectionalLight"
+        );
     }
 
     #[test]

--- a/crates/bsengine-core/src/light.rs
+++ b/crates/bsengine-core/src/light.rs
@@ -44,9 +44,10 @@ impl Default for PointLight {
     }
 }
 
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component, Default)]
 pub struct SpotLight {
-    pub color: Vec3,
+    pub color: ReflectVec3,
     pub intensity: f32,
     pub range: f32,
     /// Inner cone half-angle (radians) — full brightness inside.
@@ -58,7 +59,7 @@ pub struct SpotLight {
 impl Default for SpotLight {
     fn default() -> Self {
         Self {
-            color: Vec3::ONE,
+            color: Vec3::ONE.into(),
             intensity: 1.0,
             range: 10.0,
             inner_angle: std::f32::consts::PI / 8.0, // 22.5°
@@ -129,6 +130,20 @@ mod tests {
         assert!(
             sl.inner_angle.cos() > sl.outer_angle.cos(),
             "cos(inner) > cos(outer) because inner < outer"
+        );
+    }
+
+    #[test]
+    fn spot_light_is_registered_reflectable() {
+        use bevy_reflect::TypeRegistry;
+        let mut registry = TypeRegistry::default();
+        registry.register::<SpotLight>();
+        let registration = registry
+            .get(std::any::TypeId::of::<SpotLight>())
+            .expect("SpotLight not registered");
+        assert_eq!(
+            registration.type_info().type_path(),
+            "bsengine_core::light::SpotLight"
         );
     }
 }

--- a/crates/bsengine-core/src/material.rs
+++ b/crates/bsengine-core/src/material.rs
@@ -1,13 +1,17 @@
-use bevy_ecs::prelude::Component;
+use crate::reflect_glam::ReflectVec3;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
 use glam::Vec3;
 
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component, Default)]
 pub struct Material {
     pub texture_id: Option<u64>,
     pub metallic: f32,
     pub roughness: f32,
-    pub emissive: Vec3,
-    pub base_color: Vec3,
+    pub emissive: ReflectVec3,
+    pub base_color: ReflectVec3,
 }
 
 impl Default for Material {
@@ -16,8 +20,8 @@ impl Default for Material {
             texture_id: None,
             metallic: 0.0,
             roughness: 0.5,
-            emissive: Vec3::ZERO,
-            base_color: Vec3::ONE,
+            emissive: Vec3::ZERO.into(),
+            base_color: Vec3::ONE.into(),
         }
     }
 }
@@ -37,6 +41,20 @@ mod tests {
         let m = Material::default();
         assert_eq!(m.metallic, 0.0);
         assert!((m.roughness - 0.5).abs() < 1e-6);
-        assert_eq!(m.emissive, Vec3::ZERO);
+        assert_eq!(m.emissive, Vec3::ZERO.into());
+    }
+
+    #[test]
+    fn material_is_registered_reflectable() {
+        use bevy_reflect::TypeRegistry;
+        let mut registry = TypeRegistry::default();
+        registry.register::<Material>();
+        let registration = registry
+            .get(std::any::TypeId::of::<Material>())
+            .expect("Material not registered");
+        assert_eq!(
+            registration.type_info().type_path(),
+            "bsengine_core::material::Material"
+        );
     }
 }

--- a/crates/bsengine-demo/src/main.rs
+++ b/crates/bsengine-demo/src/main.rs
@@ -37,8 +37,8 @@ fn setup(mut commands: Commands, registry: Option<ResMut<GpuMeshRegistry>>, mut 
     let dir = Vec3::new(-0.5, -1.0, -0.5).normalize();
     commands.spawn((
         DirectionalLight {
-            color: Vec3::ONE,
-            ambient: Vec3::splat(0.15),
+            color: Vec3::ONE.into(),
+            ambient: Vec3::splat(0.15).into(),
         },
         Transform {
             rotation: Quat::from_rotation_arc(Vec3::NEG_Z, dir),

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1365,6 +1365,9 @@ impl Plugin for EditorPlugin {
         app.insert_resource(EditorPanelRegistry::default());
         app.register_type::<bsengine_core::Camera>();
         app.register_type::<bsengine_core::PointLight>();
+        app.register_type::<bsengine_core::DirectionalLight>();
+        app.register_type::<bsengine_core::SpotLight>();
+        app.register_type::<bsengine_core::Material>();
         app.add_systems(Update, update_editor_snapshot);
         app.add_systems(Update, update_editor_camera);
         app.add_systems(Update, populate_inspector.after(update_editor_snapshot));
@@ -28903,6 +28906,35 @@ mod tests {
         assert!(
             registry.get(std::any::TypeId::of::<bsengine_core::PointLight>()).is_some(),
             "PointLight not registered in AppTypeRegistry"
+        );
+    }
+
+    #[test]
+    fn editor_plugin_registers_lights_and_material_reflected_types() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        let registry = app.world().resource::<bevy_ecs::reflect::AppTypeRegistry>();
+        let registry = registry.read();
+        assert!(
+            registry
+                .get(std::any::TypeId::of::<bsengine_core::DirectionalLight>())
+                .is_some(),
+            "DirectionalLight not registered in AppTypeRegistry"
+        );
+        assert!(
+            registry
+                .get(std::any::TypeId::of::<bsengine_core::SpotLight>())
+                .is_some(),
+            "SpotLight not registered in AppTypeRegistry"
+        );
+        assert!(
+            registry
+                .get(std::any::TypeId::of::<bsengine_core::Material>())
+                .is_some(),
+            "Material not registered in AppTypeRegistry"
         );
     }
 

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -461,7 +461,7 @@ fn process_editor_commands(
             } => {
                 commands.spawn((
                     SpotLight {
-                        color: glam::Vec3::from(color),
+                        color: glam::Vec3::from(color).into(),
                         intensity,
                         range,
                         inner_angle,
@@ -482,7 +482,7 @@ fn process_editor_commands(
                 for (e, mut light) in params.p4().iter_mut() {
                     if e.index() as u64 == entity_id {
                         if let Some(c) = color {
-                            light.color = glam::Vec3::from(c);
+                            light.color = glam::Vec3::from(c).into();
                         }
                         if let Some(i) = intensity {
                             light.intensity = i;
@@ -630,7 +630,7 @@ fn process_editor_commands(
                     }
                     if let Some(sl) = &entity.spot_light {
                         eb.insert(SpotLight {
-                            color: glam::Vec3::from(sl.color),
+                            color: glam::Vec3::from(sl.color).into(),
                             intensity: sl.intensity,
                             range: sl.range,
                             inner_angle: sl.inner_angle_degrees.to_radians(),
@@ -806,7 +806,7 @@ fn sync_entity_to_info(world: &mut World, entity: Entity, info: &EntityInfo) {
             e.remove::<DirectionalLight>();
             if let Some(mut sl) = e.get_mut::<SpotLight>() {
                 if let Some(c) = info.light_color {
-                    sl.color = glam::Vec3::from(c);
+                    sl.color = glam::Vec3::from(c).into();
                 }
                 if let Some(i) = info.light_intensity {
                     sl.intensity = i;
@@ -900,7 +900,7 @@ fn spawn_entity_from_info(world: &mut World, info: &EntityInfo) -> Entity {
         }
         Some("spot") => {
             e.insert(SpotLight {
-                color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])),
+                color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])).into(),
                 intensity: info.light_intensity.unwrap_or(1.0),
                 range: info.light_range.unwrap_or(10.0),
                 ..SpotLight::default()
@@ -1199,6 +1199,8 @@ fn populate_inspector(
             light_color: e.light_color,
             light_intensity: e.light_intensity,
             light_range: e.light_range,
+            spot_inner_angle: e.spot_inner_angle,
+            spot_outer_angle: e.spot_outer_angle,
             camera_fov: e.camera_fov,
             material_base_color: e.material_base_color,
             material_metallic: e.material_metallic,
@@ -1250,14 +1252,42 @@ fn apply_inspector_cmds(
             InspectorCmd::Despawn { id } => {
                 queue.push(EditorCommand::Despawn { entity_id: id });
             }
-            InspectorCmd::UpdateLight { id, color, intensity, range } => {
-                queue.push(EditorCommand::UpdatePointLight {
-                    entity_id: id,
-                    color,
-                    intensity,
-                    range,
-                });
-            }
+            InspectorCmd::UpdateLight {
+                id,
+                light_type,
+                color,
+                intensity,
+                range,
+                inner_angle,
+                outer_angle,
+            } => match light_type.as_str() {
+                "directional" => {
+                    queue.push(EditorCommand::UpdateDirectionalLight {
+                        entity_id: id,
+                        direction: None,
+                        color,
+                        ambient: None,
+                    });
+                }
+                "spot" => {
+                    queue.push(EditorCommand::UpdateSpotLight {
+                        entity_id: id,
+                        color,
+                        intensity,
+                        range,
+                        inner_angle,
+                        outer_angle,
+                    });
+                }
+                _ => {
+                    queue.push(EditorCommand::UpdatePointLight {
+                        entity_id: id,
+                        color,
+                        intensity,
+                        range,
+                    });
+                }
+            },
             InspectorCmd::UpdateCamera { id, fov_y_degrees } => {
                 queue.push(EditorCommand::UpdateCamera { entity_id: id, fov_y_degrees });
             }
@@ -28750,6 +28780,45 @@ mod tests {
 
         let registry = app.world().resource::<bsengine_core::EditorPanelRegistry>();
         assert!(registry.0.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn inspector_cmd_update_light_dispatches_to_correct_light_type() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app
+            .world_mut()
+            .spawn(bsengine_core::SpotLight::default())
+            .id();
+        app.update();
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.cmd_queue.push(InspectorCmd::UpdateLight {
+                id: eid.index() as u64,
+                light_type: "spot".to_string(),
+                color: None,
+                intensity: None,
+                range: None,
+                inner_angle: Some(0.1),
+                outer_angle: Some(0.2),
+            });
+        }
+        app.update();
+
+        let light = app
+            .world()
+            .get::<bsengine_core::SpotLight>(eid)
+            .expect("SpotLight should still be attached");
+        assert!(
+            (light.inner_angle - 0.1).abs() < 1e-6,
+            "inner_angle was not updated — dispatch bug not fixed"
+        );
+        assert!(
+            (light.outer_angle - 0.2).abs() < 1e-6,
+            "outer_angle was not updated — dispatch bug not fixed"
+        );
     }
 
     #[test]
@@ -89902,7 +89971,7 @@ mod tests {
             app.world_mut().spawn((
                 Name("Spot".to_string()),
                 bsengine_core::SpotLight {
-                    color: Vec3::new(0.2, 0.8, 1.0),
+                    color: Vec3::new(0.2, 0.8, 1.0).into(),
                     intensity: 3.0,
                     range: 20.0,
                     inner_angle: 15_f32.to_radians(),

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -189,8 +189,8 @@ fn process_editor_commands(
                 let rotation = glam::Quat::from_rotation_arc(glam::Vec3::NEG_Z, dir);
                 commands.spawn((
                     DirectionalLight {
-                        color: glam::Vec3::from(color),
-                        ambient: glam::Vec3::from(ambient),
+                        color: glam::Vec3::from(color).into(),
+                        ambient: glam::Vec3::from(ambient).into(),
                     },
                     Transform {
                         rotation,
@@ -239,10 +239,10 @@ fn process_editor_commands(
                 for (e, mut light) in params.p3().iter_mut() {
                     if e.index() as u64 == entity_id {
                         if let Some(c) = color {
-                            light.color = glam::Vec3::from(c);
+                            light.color = glam::Vec3::from(c).into();
                         }
                         if let Some(a) = ambient {
-                            light.ambient = glam::Vec3::from(a);
+                            light.ambient = glam::Vec3::from(a).into();
                         }
                         break;
                     }
@@ -599,8 +599,8 @@ fn process_editor_commands(
                     }
                     if let Some(dl) = &entity.directional_light {
                         eb.insert(DirectionalLight {
-                            color: glam::Vec3::from(dl.color),
-                            ambient: glam::Vec3::from(dl.ambient),
+                            color: glam::Vec3::from(dl.color).into(),
+                            ambient: glam::Vec3::from(dl.ambient).into(),
                         });
                         // Direction lives on Transform.rotation (rotation * -Z), same
                         // as SpotLight; reuse translation/scale from the scene file's
@@ -797,7 +797,7 @@ fn sync_entity_to_info(world: &mut World, entity: Entity, info: &EntityInfo) {
             e.remove::<SpotLight>();
             if let Some(mut dl) = e.get_mut::<DirectionalLight>() {
                 if let Some(c) = info.light_color {
-                    dl.color = glam::Vec3::from(c);
+                    dl.color = glam::Vec3::from(c).into();
                 }
             }
         }
@@ -894,7 +894,7 @@ fn spawn_entity_from_info(world: &mut World, info: &EntityInfo) -> Entity {
         }
         Some("directional") => {
             e.insert(DirectionalLight {
-                color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])),
+                color: glam::Vec3::from(info.light_color.unwrap_or([1.0; 3])).into(),
                 ..DirectionalLight::default()
             });
         }
@@ -89317,7 +89317,7 @@ mod tests {
         let eid = app
             .world_mut()
             .spawn(bsengine_core::DirectionalLight {
-                color: glam::Vec3::new(0.8, 0.8, 0.8),
+                color: glam::Vec3::new(0.8, 0.8, 0.8).into(),
                 ..Default::default()
             })
             .id();

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -510,7 +510,7 @@ fn process_editor_commands(
                 for (e, mut mat) in params.p7().iter_mut() {
                     if e.index() as u64 == entity_id {
                         if let Some(c) = base_color {
-                            mat.base_color = glam::Vec3::from(c);
+                            mat.base_color = glam::Vec3::from(c).into();
                         }
                         if let Some(m) = metallic {
                             mat.metallic = m;
@@ -519,7 +519,7 @@ fn process_editor_commands(
                             mat.roughness = r;
                         }
                         if let Some(em) = emissive {
-                            mat.emissive = glam::Vec3::from(em);
+                            mat.emissive = glam::Vec3::from(em).into();
                         }
                         break;
                     }
@@ -645,11 +645,13 @@ fn process_editor_commands(
                             emissive: entity
                                 .emissive
                                 .map(glam::Vec3::from)
-                                .unwrap_or(glam::Vec3::ZERO),
+                                .unwrap_or(glam::Vec3::ZERO)
+                                .into(),
                             base_color: entity
                                 .color
                                 .map(glam::Vec3::from)
-                                .unwrap_or(glam::Vec3::ONE),
+                                .unwrap_or(glam::Vec3::ONE)
+                                .into(),
                             ..Default::default()
                         });
                     }
@@ -837,7 +839,7 @@ fn sync_entity_to_info(world: &mut World, entity: Entity, info: &EntityInfo) {
     match info.material_base_color {
         Some(base_color) => {
             if let Some(mut mat) = e.get_mut::<Material>() {
-                mat.base_color = glam::Vec3::from(base_color);
+                mat.base_color = glam::Vec3::from(base_color).into();
                 if let Some(m) = info.material_metallic {
                     mat.metallic = m;
                 }
@@ -845,7 +847,7 @@ fn sync_entity_to_info(world: &mut World, entity: Entity, info: &EntityInfo) {
                     mat.roughness = r;
                 }
                 if let Some(em) = info.material_emissive {
-                    mat.emissive = glam::Vec3::from(em);
+                    mat.emissive = glam::Vec3::from(em).into();
                 }
             }
         }
@@ -913,10 +915,14 @@ fn spawn_entity_from_info(world: &mut World, info: &EntityInfo) -> Entity {
     }
     if let Some(base_color) = info.material_base_color {
         e.insert(Material {
-            base_color: glam::Vec3::from(base_color),
+            base_color: glam::Vec3::from(base_color).into(),
             metallic: info.material_metallic.unwrap_or(0.0),
             roughness: info.material_roughness.unwrap_or(0.5),
-            emissive: info.material_emissive.map(glam::Vec3::from).unwrap_or(glam::Vec3::ZERO),
+            emissive: info
+                .material_emissive
+                .map(glam::Vec3::from)
+                .unwrap_or(glam::Vec3::ZERO)
+                .into(),
             ..Material::default()
         });
     }

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -252,8 +252,8 @@ fn render_frame(
                 .map(|m| MaterialParams {
                     metallic: m.metallic,
                     roughness: m.roughness,
-                    emissive: m.emissive,
-                    base_color: m.base_color,
+                    emissive: *m.emissive,
+                    base_color: *m.base_color,
                 })
                 .unwrap_or_default();
             Some((
@@ -457,7 +457,7 @@ mod tests {
             Material {
                 metallic: 0.8,
                 roughness: 0.2,
-                emissive: Vec3::new(0.1, 0.0, 0.0),
+                emissive: Vec3::new(0.1, 0.0, 0.0).into(),
                 ..Default::default()
             },
         ));

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -310,8 +310,8 @@ fn render_frame(
             .unwrap_or_else(|| t.rotation * Vec3::NEG_Z);
         LightData {
             direction,
-            color: l.color,
-            ambient: l.ambient,
+            color: *l.color,
+            ambient: *l.ambient,
             point_lights: collected_point_lights,
             spot_lights: collected_spot_lights,
         }

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -295,7 +295,7 @@ fn render_frame(
             SpotLightEntry {
                 position: pos,
                 direction: dir,
-                color: sl.color,
+                color: *sl.color,
                 intensity: sl.intensity,
                 range: sl.range,
                 inner_angle: sl.inner_angle,
@@ -472,7 +472,7 @@ mod tests {
         app.add_plugins(RenderPlugin);
         app.world_mut().spawn((
             SpotLight {
-                color: Vec3::new(0.9, 0.9, 1.0),
+                color: Vec3::new(0.9, 0.9, 1.0).into(),
                 intensity: 3.0,
                 range: 12.0,
                 ..Default::default()

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -148,12 +148,45 @@ impl EditorPanel for InspectorPanel {
                         .changed();
                 });
             }
+            if lt == "spot" {
+                ui.horizontal(|ui| {
+                    ui.label("Inner Angle°");
+                    light_changed |= ui
+                        .add(
+                            egui::DragValue::new(&mut insp.edit_spot_inner_angle)
+                                .speed(0.5)
+                                .range(0.0..=insp.edit_spot_outer_angle),
+                        )
+                        .changed();
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Outer Angle°");
+                    light_changed |= ui
+                        .add(
+                            egui::DragValue::new(&mut insp.edit_spot_outer_angle)
+                                .speed(0.5)
+                                .range(insp.edit_spot_inner_angle..=89.0),
+                        )
+                        .changed();
+                });
+            }
             if light_changed {
                 insp.cmd_queue.push(InspectorCmd::UpdateLight {
                     id: sel_id,
+                    light_type: lt.clone(),
                     color: Some(insp.edit_light_color),
                     intensity: Some(insp.edit_light_intensity),
                     range: Some(insp.edit_light_range),
+                    inner_angle: if lt == "spot" {
+                        Some(insp.edit_spot_inner_angle.to_radians())
+                    } else {
+                        None
+                    },
+                    outer_angle: if lt == "spot" {
+                        Some(insp.edit_spot_outer_angle.to_radians())
+                    } else {
+                        None
+                    },
                 });
             }
             ui.separator();

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -194,7 +194,15 @@ impl EditorPanel for InspectorPanel {
 
         // Camera
         if has_camera {
-            ui.strong("Camera");
+            ui.horizontal(|ui| {
+                ui.strong("Camera");
+                if ui.small_button("✕").clicked() {
+                    insp.cmd_queue.push(InspectorCmd::RemoveComponentByType {
+                        id: sel_id,
+                        type_path: "bsengine_core::camera::Camera".to_string(),
+                    });
+                }
+            });
             let mut cam_fov_changed = false;
             ui.horizontal(|ui| {
                 ui.label("FOV°");
@@ -217,7 +225,15 @@ impl EditorPanel for InspectorPanel {
 
         // Material
         if has_material {
-            ui.strong("Material");
+            ui.horizontal(|ui| {
+                ui.strong("Material");
+                if ui.small_button("✕").clicked() {
+                    insp.cmd_queue.push(InspectorCmd::RemoveComponentByType {
+                        id: sel_id,
+                        type_path: "bsengine_core::material::Material".to_string(),
+                    });
+                }
+            });
             let mut mat_changed = false;
             ui.horizontal(|ui| {
                 ui.label("Base Color");

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -86,8 +86,8 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
 
         if let Some(dl) = &entity.directional_light {
             builder.insert(DirectionalLight {
-                color: Vec3::from(dl.color),
-                ambient: Vec3::from(dl.ambient),
+                color: Vec3::from(dl.color).into(),
+                ambient: Vec3::from(dl.ambient).into(),
             });
             // Direction lives on Transform.rotation (rotation * -Z), same as
             // SpotLight; reuse any explicit translation/scale from the scene

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -137,8 +137,8 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
 
         if entity.emissive.is_some() || entity.color.is_some() {
             builder.insert(Material {
-                emissive: entity.emissive.map(Vec3::from).unwrap_or(Vec3::ZERO),
-                base_color: entity.color.map(Vec3::from).unwrap_or(Vec3::ONE),
+                emissive: entity.emissive.map(Vec3::from).unwrap_or(Vec3::ZERO).into(),
+                base_color: entity.color.map(Vec3::from).unwrap_or(Vec3::ONE).into(),
                 ..Default::default()
             });
         }

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -119,7 +119,7 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
 
         if let Some(sl) = &entity.spot_light {
             builder.insert(SpotLight {
-                color: Vec3::from(sl.color),
+                color: Vec3::from(sl.color).into(),
                 intensity: sl.intensity,
                 range: sl.range,
                 inner_angle: sl.inner_angle_degrees.to_radians(),

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -639,7 +639,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut light) = world.get_mut::<DirectionalLight>(e) {
-                        light.color = glam::Vec3::new(r, g, b);
+                        light.color = glam::Vec3::new(r, g, b).into();
                     }
                 }
             }
@@ -651,7 +651,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut light) = world.get_mut::<DirectionalLight>(e) {
-                        light.ambient = glam::Vec3::new(r, g, b);
+                        light.ambient = glam::Vec3::new(r, g, b).into();
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -579,7 +579,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut light) = world.get_mut::<SpotLight>(e) {
-                        light.color = glam::Vec3::new(r, g, b);
+                        light.color = glam::Vec3::new(r, g, b).into();
                     }
                 }
             }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -478,10 +478,10 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut mat) = world.get_mut::<Material>(e) {
-                        mat.emissive = Vec3::new(r, g, b);
+                        mat.emissive = Vec3::new(r, g, b).into();
                     } else {
                         world.entity_mut(e).insert(Material {
-                            emissive: Vec3::new(r, g, b),
+                            emissive: Vec3::new(r, g, b).into(),
                             ..Default::default()
                         });
                     }
@@ -494,10 +494,10 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut mat) = world.get_mut::<Material>(e) {
-                        mat.base_color = Vec3::new(r, g, b);
+                        mat.base_color = Vec3::new(r, g, b).into();
                     } else {
                         world.entity_mut(e).insert(Material {
-                            base_color: Vec3::new(r, g, b),
+                            base_color: Vec3::new(r, g, b).into(),
                             ..Default::default()
                         });
                     }
@@ -28433,8 +28433,8 @@ fn spawn_entity(world: &mut World, params: SpawnParams) {
     let has_color = params.color.is_some() || params.emissive.is_some();
     if has_color {
         cmd.insert(Material {
-            base_color: params.color.map(Vec3::from).unwrap_or(Vec3::ONE),
-            emissive: params.emissive.map(Vec3::from).unwrap_or(Vec3::ZERO),
+            base_color: params.color.map(Vec3::from).unwrap_or(Vec3::ONE).into(),
+            emissive: params.emissive.map(Vec3::from).unwrap_or(Vec3::ZERO).into(),
             ..Default::default()
         });
     }


### PR DESCRIPTION
## Summary
- Extends PR #1695's reflection-based Add/Remove Component system to `DirectionalLight`, `SpotLight`, and `Material` — same proven pattern as `Camera`/`PointLight` (derive `Reflect`, migrate `glam::Vec3` fields to the `ReflectVec3` wrapper type, register via `app.register_type::<T>()`).
- All three now attach through the existing generic "Add Component (reflected)" dropdown automatically — no new UI code needed for Add.
- Adds Remove (✕) buttons to the Inspector's Camera and Material section headers, reusing the existing generic `RemoveComponentByType` pipeline with a literal, section-known type path. Light is untouched — it already has a working remove path via `RemoveLight`.
- Wires Spot Light cone-angle (inner/outer) editing into the Inspector, using data that already flowed to the backend (`EditorCommand::UpdateSpotLight` already had `inner_angle`/`outer_angle` fields) but never reached the UI.
- **Found and fixed a pre-existing bug**: `InspectorCmd::UpdateLight` unconditionally dispatched to `EditorCommand::UpdatePointLight` regardless of the selected entity's actual light type, meaning editing color/intensity/range on a `DirectionalLight`/`SpotLight` entity via the Inspector silently did nothing. Fixed as part of wiring spot cone-angle editing (which required correct light-type dispatch to work at all), covered by a new regression test.

Design doc: `docs/superpowers/specs/2026-07-14-editor-reflect-lights-material-design.md`
Plan: `docs/superpowers/plans/2026-07-14-editor-reflect-lights-material.md`

## Explicit scope exclusions (disclosed, not silently dropped)
- Generic per-field editing via `draw_reflect_ui` for these newly-reflected components is deferred to a future PR (needs a new snapshot-clone + apply-back architecture — the Inspector is snapshot-driven, has no `&mut World` access).
- Hierarchy tree, drag-and-drop reparenting, rename, context menu, Tag/Script/Mesh editing — deferred to a separate PR (the rest of the original phase 2 design).
- "Add Component (reflected)" dropdown still doesn't filter out components the entity already has (pre-existing accepted rough edge from PR #1695).

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --all-targets --workspace` (0 warnings)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace --exclude bsengine-editor`
- [x] `RUST_MIN_STACK=8388608 cargo test -p bsengine-editor` (isolated, matches CI) — 791 passed, 0 failed
- [x] New tests: DirectionalLight/SpotLight/Material Reflect registration, `AppTypeRegistry` registration, `InspectorCmd::UpdateLight` dispatch-bug regression test
- [x] Manual smoke test: `cargo run -p bsengine-editor-app` launches and runs without panic
- [ ] **Needs a human**: interactive verification of the new dropdown entries, Remove buttons, and spot cone-angle fields in the running editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)