### PR TITLE
feat(editor): Hierarchy tree, drag-and-drop reparenting, rename, context menu, Tag/Script/Mesh editing

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -21,6 +21,16 @@ pub struct InspectorEntityInfo {
     pub material_metallic: Option<f32>,
     pub material_roughness: Option<f32>,
     pub material_emissive: Option<[f32; 3]>,
+    // hierarchy / tags / script / mesh
+    pub parent_id: Option<u64>,
+    pub tags: Vec<String>,
+    pub script_path: Option<String>,
+    /// One of `"cube"`/`"sphere"`/`"plane"`/`"capsule"` (lowercase), or `None`
+    /// if no `PrimitiveMesh` is attached. A plain `String`, not
+    /// `bsengine_scene::Primitive`, because `bsengine-core` cannot depend on
+    /// `bsengine-scene` (that crate already depends on `bsengine-core`).
+    /// Mirrors this same struct's `light_type: Option<String>` convention.
+    pub primitive: Option<String>,
     pub visible: bool,
     pub selected: bool,
 }
@@ -129,6 +139,8 @@ pub struct InspectorState {
     pub edit_mat_metallic: f32,
     pub edit_mat_roughness: f32,
     pub edit_mat_emissive: [f32; 3],
+    pub edit_new_tag: String,
+    pub edit_script_path: String,
     pub edit_visible: bool,
     prev_selected_id: Option<u64>,
 
@@ -196,6 +208,8 @@ impl Default for InspectorState {
             edit_mat_metallic: 0.0,
             edit_mat_roughness: 0.5,
             edit_mat_emissive: [0.0, 0.0, 0.0],
+            edit_new_tag: String::new(),
+            edit_script_path: String::new(),
             edit_visible: true,
             prev_selected_id: None,
             editor_mode: false,
@@ -249,6 +263,8 @@ impl InspectorState {
                     self.edit_mat_metallic = info.material_metallic.unwrap_or(0.0);
                     self.edit_mat_roughness = info.material_roughness.unwrap_or(0.5);
                     self.edit_mat_emissive = info.material_emissive.unwrap_or([0.0, 0.0, 0.0]);
+                    self.edit_new_tag.clear();
+                    self.edit_script_path = info.script_path.clone().unwrap_or_default();
                     self.edit_visible = info.visible;
                 }
             }

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -124,6 +124,26 @@ pub enum InspectorCmd {
         id: u64,
         tag: String,
     },
+    AttachScript {
+        id: u64,
+        path: String,
+    },
+    DetachScript {
+        id: u64,
+    },
+    AttachPrimitiveMesh {
+        id: u64,
+        /// `"cube"`/`"sphere"`/`"plane"`/`"capsule"` (lowercase) — a plain
+        /// `String`, not `bsengine_scene::Primitive`, for the same
+        /// circular-dependency reason as `InspectorEntityInfo.primitive`
+        /// (see this plan's header notes). Parsed back into the real enum
+        /// in `apply_inspector_cmds` below, where `bsengine_scene` is
+        /// already in scope.
+        primitive: String,
+    },
+    DetachPrimitiveMesh {
+        id: u64,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -105,6 +105,25 @@ pub enum InspectorCmd {
         id: u64,
         type_path: String,
     },
+    RenameEntity {
+        id: u64,
+        name: String,
+    },
+    SetParent {
+        id: u64,
+        parent_id: u64,
+    },
+    RemoveParent {
+        id: u64,
+    },
+    TagEntity {
+        id: u64,
+        tag: String,
+    },
+    UntagEntity {
+        id: u64,
+        tag: String,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1212,10 +1212,24 @@ fn populate_inspector(
             material_metallic: e.material_metallic,
             material_roughness: e.material_roughness,
             material_emissive: e.material_emissive,
+            parent_id: e.parent_id,
+            tags: e.tags.clone(),
+            script_path: e.script_path.clone(),
+            primitive: e.primitive.as_ref().map(primitive_to_str),
             visible: e.visible,
             selected: e.selected,
         })
         .collect();
+}
+
+fn primitive_to_str(p: &bsengine_scene::Primitive) -> String {
+    match p {
+        bsengine_scene::Primitive::Cube => "cube",
+        bsengine_scene::Primitive::Sphere => "sphere",
+        bsengine_scene::Primitive::Plane => "plane",
+        bsengine_scene::Primitive::Capsule => "capsule",
+    }
+    .to_string()
 }
 
 fn apply_inspector_cmds(
@@ -28789,6 +28803,42 @@ mod tests {
 
         let registry = app.world().resource::<bsengine_core::EditorPanelRegistry>();
         assert!(registry.0.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn populate_inspector_copies_parent_tags_script_primitive() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let parent = app.world_mut().spawn(Name("Parent".to_string())).id();
+        let child = app
+            .world_mut()
+            .spawn((
+                Name("Child".to_string()),
+                bsengine_core::Parent(parent),
+                crate::snapshot::Tags(vec!["enemy".to_string(), "boss".to_string()]),
+                bsengine_scene::ScriptPath("assets/scripts/child.js".to_string()),
+                bsengine_scene::PrimitiveMesh(bsengine_scene::Primitive::Sphere),
+            ))
+            .id();
+        app.update();
+
+        let insp = app.world().resource::<InspectorState>();
+        let child_info = insp
+            .entities
+            .iter()
+            .find(|e| e.id == child.index() as u64)
+            .expect("child entity should be in inspector snapshot");
+        assert_eq!(child_info.parent_id, Some(parent.index() as u64));
+        assert_eq!(
+            child_info.tags,
+            vec!["enemy".to_string(), "boss".to_string()]
+        );
+        assert_eq!(
+            child_info.script_path,
+            Some("assets/scripts/child.js".to_string())
+        );
+        assert_eq!(child_info.primitive, Some("sphere".to_string()));
     }
 
     #[test]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -525,6 +525,36 @@ fn process_editor_commands(
                     }
                 }
             }
+            EditorCommand::AttachScript { entity_id, path } => {
+                let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
+                if let Some(entity) = target {
+                    commands
+                        .entity(entity)
+                        .insert(bsengine_scene::ScriptPath(path));
+                }
+            }
+            EditorCommand::DetachScript { entity_id } => {
+                let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
+                if let Some(entity) = target {
+                    commands.entity(entity).remove::<bsengine_scene::ScriptPath>();
+                }
+            }
+            EditorCommand::AttachPrimitiveMesh { entity_id, primitive } => {
+                let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
+                if let Some(entity) = target {
+                    commands
+                        .entity(entity)
+                        .insert(bsengine_scene::PrimitiveMesh(primitive));
+                }
+            }
+            EditorCommand::DetachPrimitiveMesh { entity_id } => {
+                let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
+                if let Some(entity) = target {
+                    commands
+                        .entity(entity)
+                        .remove::<bsengine_scene::PrimitiveMesh>();
+                }
+            }
             EditorCommand::AttachPointLight {
                 entity_id,
                 color,
@@ -1232,6 +1262,16 @@ fn primitive_to_str(p: &bsengine_scene::Primitive) -> String {
     .to_string()
 }
 
+fn str_to_primitive(s: &str) -> Option<bsengine_scene::Primitive> {
+    match s {
+        "cube" => Some(bsengine_scene::Primitive::Cube),
+        "sphere" => Some(bsengine_scene::Primitive::Sphere),
+        "plane" => Some(bsengine_scene::Primitive::Plane),
+        "capsule" => Some(bsengine_scene::Primitive::Capsule),
+        _ => None,
+    }
+}
+
 fn apply_inspector_cmds(
     inspector: Option<ResMut<InspectorState>>,
     queue_res: Res<EditorCommandQueueResource>,
@@ -1373,6 +1413,25 @@ fn apply_inspector_cmds(
             }
             InspectorCmd::UntagEntity { id, tag } => {
                 queue.push(EditorCommand::UntagEntity { entity_id: id, tag });
+            }
+            InspectorCmd::AttachScript { id, path } => {
+                queue.push(EditorCommand::AttachScript { entity_id: id, path });
+            }
+            InspectorCmd::DetachScript { id } => {
+                queue.push(EditorCommand::DetachScript { entity_id: id });
+            }
+            InspectorCmd::AttachPrimitiveMesh { id, primitive } => {
+                if let Some(primitive) = str_to_primitive(&primitive) {
+                    queue.push(EditorCommand::AttachPrimitiveMesh {
+                        entity_id: id,
+                        primitive,
+                    });
+                } else {
+                    tracing::warn!("unknown primitive kind '{primitive}'");
+                }
+            }
+            InspectorCmd::DetachPrimitiveMesh { id } => {
+                queue.push(EditorCommand::DetachPrimitiveMesh { entity_id: id });
             }
         }
     }
@@ -90296,6 +90355,82 @@ mod tests {
         assert_eq!(
             app.world().get::<Tags>(eid).map(|t| t.0.clone()),
             Some(vec![]),
+        );
+    }
+
+    #[test]
+    fn editor_command_attach_and_detach_script() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app.world_mut().spawn(Name("Target".to_string())).id();
+        app.update();
+
+        {
+            let queue = app.world().resource::<EditorCommandQueueResource>();
+            queue.0.lock().unwrap().push(EditorCommand::AttachScript {
+                entity_id: eid.index() as u64,
+                path: "assets/scripts/foo.js".to_string(),
+            });
+        }
+        app.update();
+        assert_eq!(
+            app.world()
+                .get::<bsengine_scene::ScriptPath>(eid)
+                .map(|s| s.0.clone()),
+            Some("assets/scripts/foo.js".to_string())
+        );
+
+        {
+            let queue = app.world().resource::<EditorCommandQueueResource>();
+            queue
+                .0
+                .lock()
+                .unwrap()
+                .push(EditorCommand::DetachScript { entity_id: eid.index() as u64 });
+        }
+        app.update();
+        assert!(app.world().get::<bsengine_scene::ScriptPath>(eid).is_none());
+    }
+
+    #[test]
+    fn editor_command_attach_and_detach_primitive_mesh() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app.world_mut().spawn(Name("Target".to_string())).id();
+        app.update();
+
+        {
+            let queue = app.world().resource::<EditorCommandQueueResource>();
+            queue
+                .0
+                .lock()
+                .unwrap()
+                .push(EditorCommand::AttachPrimitiveMesh {
+                    entity_id: eid.index() as u64,
+                    primitive: bsengine_scene::Primitive::Capsule,
+                });
+        }
+        app.update();
+        assert_eq!(
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(eid)
+                .map(|p| p.0.clone()),
+            Some(bsengine_scene::Primitive::Capsule)
+        );
+
+        {
+            let queue = app.world().resource::<EditorCommandQueueResource>();
+            queue.0.lock().unwrap().push(EditorCommand::DetachPrimitiveMesh {
+                entity_id: eid.index() as u64,
+            });
+        }
+        app.update();
+        assert!(
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(eid)
+                .is_none()
         );
     }
 }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1356,6 +1356,24 @@ fn apply_inspector_cmds(
                     type_path,
                 });
             }
+            InspectorCmd::RenameEntity { id, name } => {
+                queue.push(EditorCommand::RenameEntity { entity_id: id, name });
+            }
+            InspectorCmd::SetParent { id, parent_id } => {
+                queue.push(EditorCommand::SetParent {
+                    entity_id: id,
+                    parent_id,
+                });
+            }
+            InspectorCmd::RemoveParent { id } => {
+                queue.push(EditorCommand::RemoveParent { entity_id: id });
+            }
+            InspectorCmd::TagEntity { id, tag } => {
+                queue.push(EditorCommand::TagEntity { entity_id: id, tag });
+            }
+            InspectorCmd::UntagEntity { id, tag } => {
+                queue.push(EditorCommand::UntagEntity { entity_id: id, tag });
+            }
         }
     }
 }
@@ -28776,7 +28794,7 @@ fn parse_vec3_input(v: &serde_json::Value) -> Option<[f32; 3]> {
 mod tests {
     use super::EditorPlugin;
     use bsengine_app::new_app;
-    use bsengine_core::{InspectorCmd, InspectorState, Transform};
+    use bsengine_core::{InspectorCmd, InspectorState, Parent, Transform};
     use bsengine_mcp::McpPlugin;
     use bsengine_scene::Name;
     use glam::Vec3;
@@ -28784,6 +28802,7 @@ mod tests {
 
     use crate::snapshot::{
         EditorCommand, EditorCommandQueueResource, EditorSelectionResource, EditorSnapshotResource,
+        Tags,
     };
 
     #[test]
@@ -90187,5 +90206,96 @@ mod tests {
             .expect("Crate not found");
         let pos = crate_entity.position.expect("no position");
         assert!((pos[0] - 10.0).abs() < 1e-4, "expected x=10 got {}", pos[0]);
+    }
+
+    #[test]
+    fn inspector_cmd_rename_entity_renames_via_existing_pipeline() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app.world_mut().spawn(Name("Old Name".to_string())).id();
+        app.update();
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.cmd_queue.push(InspectorCmd::RenameEntity {
+                id: eid.index() as u64,
+                name: "New Name".to_string(),
+            });
+        }
+        app.update();
+
+        let name = app.world().get::<Name>(eid).expect("Name should exist");
+        assert_eq!(name.0, "New Name");
+    }
+
+    #[test]
+    fn inspector_cmd_set_and_remove_parent_reparents_via_existing_pipeline() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let parent = app.world_mut().spawn(Name("Parent".to_string())).id();
+        let child = app.world_mut().spawn(Name("Child".to_string())).id();
+        app.update();
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.cmd_queue.push(InspectorCmd::SetParent {
+                id: child.index() as u64,
+                parent_id: parent.index() as u64,
+            });
+        }
+        app.update();
+        assert_eq!(
+            app.world().get::<Parent>(child).map(|p| p.0),
+            Some(parent),
+            "child should be parented after SetParent"
+        );
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.cmd_queue
+                .push(InspectorCmd::RemoveParent { id: child.index() as u64 });
+        }
+        app.update();
+        assert!(
+            app.world().get::<Parent>(child).is_none(),
+            "child should be unparented after RemoveParent"
+        );
+    }
+
+    #[test]
+    fn inspector_cmd_tag_and_untag_entity_via_existing_pipeline() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app.world_mut().spawn(Name("Target".to_string())).id();
+        app.update();
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.cmd_queue.push(InspectorCmd::TagEntity {
+                id: eid.index() as u64,
+                tag: "enemy".to_string(),
+            });
+        }
+        app.update();
+        assert_eq!(
+            app.world().get::<Tags>(eid).map(|t| t.0.clone()),
+            Some(vec!["enemy".to_string()]),
+        );
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.cmd_queue.push(InspectorCmd::UntagEntity {
+                id: eid.index() as u64,
+                tag: "enemy".to_string(),
+            });
+        }
+        app.update();
+        assert_eq!(
+            app.world().get::<Tags>(eid).map(|t| t.0.clone()),
+            Some(vec![]),
+        );
     }
 }

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -191,6 +191,20 @@ pub enum EditorCommand {
         roughness: Option<f32>,
         emissive: Option<[f32; 3]>,
     },
+    AttachScript {
+        entity_id: u64,
+        path: String,
+    },
+    DetachScript {
+        entity_id: u64,
+    },
+    AttachPrimitiveMesh {
+        entity_id: u64,
+        primitive: bsengine_scene::Primitive,
+    },
+    DetachPrimitiveMesh {
+        entity_id: u64,
+    },
 }
 
 /// Undo/redo checkpoint stacks. Each entry is a full `EditorSnapshot` taken

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -136,12 +136,32 @@ impl EditorPanel for HierarchyPanel {
             insp.cmd_queue.push(InspectorCmd::Duplicate { id });
         }
         if !despawn_ids.is_empty() {
-            for id in despawn_ids {
+            for &id in &despawn_ids {
                 insp.cmd_queue.push(InspectorCmd::Despawn { id });
             }
-            insp.selected_id = None;
-            insp.cmd_queue
-                .push(InspectorCmd::SetSelection { ids: vec![] });
+            // Only touch selection for ids that were actually deleted here —
+            // a context-menu Delete on an unselected row must not silently
+            // clear whatever else was selected (unlike the toolbar "－"
+            // button above, which always despawns exactly the selected set).
+            let selected_ids: Vec<u64> = entities_snapshot
+                .iter()
+                .filter(|e| e.selected)
+                .map(|e| e.id)
+                .collect();
+            let remaining_selected: Vec<u64> = selected_ids
+                .iter()
+                .copied()
+                .filter(|id| !despawn_ids.contains(id))
+                .collect();
+            if remaining_selected.len() != selected_ids.len() {
+                insp.cmd_queue.push(InspectorCmd::SetSelection {
+                    ids: remaining_selected.clone(),
+                });
+            }
+            if insp.selected_id.is_some_and(|id| despawn_ids.contains(&id)) {
+                insp.selected_id = remaining_selected.first().copied();
+                insp.sync_selection();
+            }
         }
         if let Some((id, name)) = rename_commit {
             if !name.is_empty() {
@@ -152,6 +172,35 @@ impl EditorPanel for HierarchyPanel {
 }
 
 impl HierarchyPanel {
+    /// Would setting `dropped_id`'s parent to `target_id` create a cycle in
+    /// the `parent_id` graph? True if `dropped_id` is `target_id` itself or
+    /// one of `target_id`'s existing ancestors (walking up via `parent_id`).
+    /// Bounded by `all_entities.len()` steps so a pre-existing cycle in the
+    /// snapshot (which should never happen, but this is UI code reacting to
+    /// a live snapshot, not the source of truth) can't spin forever.
+    fn would_create_cycle(
+        all_entities: &[InspectorEntityInfo],
+        dropped_id: u64,
+        target_id: u64,
+    ) -> bool {
+        let mut current = Some(target_id);
+        let mut steps = 0;
+        while let Some(id) = current {
+            if id == dropped_id {
+                return true;
+            }
+            steps += 1;
+            if steps > all_entities.len() {
+                return true;
+            }
+            current = all_entities
+                .iter()
+                .find(|e| e.id == id)
+                .and_then(|e| e.parent_id);
+        }
+        false
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn draw_row(
         ui: &mut egui::Ui,
@@ -272,7 +321,17 @@ impl HierarchyPanel {
 
             row_response.dnd_set_drag_payload(info.id);
             if let Some(dropped_id) = row_response.dnd_release_payload::<u64>() {
-                *set_parent = Some((*dropped_id, info.id));
+                let dropped_id = *dropped_id;
+                // Refuse reparents that would create a cycle (e.g. dragging a
+                // parent row onto one of its own descendants, which renders
+                // right below it and is an easy accidental drop target). A
+                // cycle would make `draw_row`'s root filter
+                // (`parent_id.is_none()`) unable to ever reach that subtree
+                // again — the entity and everything under it would silently
+                // vanish from the panel with no error.
+                if !Self::would_create_cycle(all_entities, dropped_id, info.id) {
+                    *set_parent = Some((dropped_id, info.id));
+                }
             }
 
             row_response.context_menu(|ui| {

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -76,10 +76,8 @@ impl EditorPanel for HierarchyPanel {
 
             // Root drop zone: drag a row here to unparent it. Occupies the
             // remaining empty space below the tree.
-            let (_, root_drop_response) = ui.allocate_exact_size(
-                egui::vec2(ui.available_width(), 40.0),
-                egui::Sense::hover(),
-            );
+            let (_, root_drop_response) = ui
+                .allocate_exact_size(egui::vec2(ui.available_width(), 40.0), egui::Sense::hover());
             if let Some(dropped_id) = root_drop_response.dnd_release_payload::<u64>() {
                 remove_parent = Some(*dropped_id);
             }
@@ -125,8 +123,10 @@ impl EditorPanel for HierarchyPanel {
         }
         if let Some((child_id, parent_id)) = set_parent {
             if child_id != parent_id {
-                insp.cmd_queue
-                    .push(InspectorCmd::SetParent { id: child_id, parent_id });
+                insp.cmd_queue.push(InspectorCmd::SetParent {
+                    id: child_id,
+                    parent_id,
+                });
             }
         }
         if let Some(id) = remove_parent {
@@ -223,7 +223,9 @@ impl HierarchyPanel {
             .collect();
         let label = info.name.as_deref().unwrap_or("(unnamed)");
         let text = format!("[{}] {}", info.id, label);
-        let is_renaming = rename_state.as_ref().is_some_and(|r| r.entity_id == info.id);
+        let is_renaming = rename_state
+            .as_ref()
+            .is_some_and(|r| r.entity_id == info.id);
 
         ui.horizontal(|ui| {
             ui.add_space(depth as f32 * 16.0);
@@ -232,8 +234,7 @@ impl HierarchyPanel {
                 let state = rename_state.as_mut().expect("checked by is_renaming");
                 let edit_response =
                     ui.add(egui::TextEdit::singleline(&mut state.buffer).id_salt(info.id));
-                if edit_response.lost_focus()
-                    && ui.ctx().input(|i| i.key_pressed(egui::Key::Enter))
+                if edit_response.lost_focus() && ui.ctx().input(|i| i.key_pressed(egui::Key::Enter))
                 {
                     *rename_commit = Some((info.id, state.buffer.clone()));
                     *rename_state = None;
@@ -288,7 +289,10 @@ impl HierarchyPanel {
             if row_response.clicked() {
                 let mods = ui.ctx().input(|i| i.modifiers);
                 if mods.shift {
-                    let idx = all_entities.iter().position(|e| e.id == info.id).unwrap_or(0);
+                    let idx = all_entities
+                        .iter()
+                        .position(|e| e.id == info.id)
+                        .unwrap_or(0);
                     let anchor_idx = current_sel
                         .and_then(|id| all_entities.iter().position(|e| e.id == id))
                         .unwrap_or(idx);

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -224,6 +224,18 @@ impl HierarchyPanel {
                 return;
             }
 
+            // `selectable_label`/`CollapsingHeader` only allocate with
+            // `Sense::click()`, so `row_response.drag_started()` (which
+            // `dnd_set_drag_payload` gates on) would never fire on its own.
+            // Mirror `Ui::dnd_drag_source`'s own internals: union in a
+            // second same-rect interact that senses drags, so the row
+            // becomes an actual DnD source without disturbing its existing
+            // click/double-click behavior (`Response::union` ORs
+            // `clicked`/`double_clicked`/`drag_started`/`dragged`).
+            let drag_id = ui.id().with(("hierarchy_row_drag", info.id));
+            let drag_response = ui.interact(row_response.rect, drag_id, egui::Sense::drag());
+            let row_response = drag_response | row_response;
+
             if row_response.clicked() {
                 let mods = ui.ctx().input(|i| i.modifiers);
                 if mods.shift {

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -1,6 +1,14 @@
-use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd};
+use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd, InspectorEntityInfo};
 
 pub struct HierarchyPanel;
+
+/// Which row is currently being renamed inline (double-click target), and
+/// the in-progress edit buffer. `None` when no row is being renamed.
+#[derive(Clone, Default)]
+struct RenameState {
+    entity_id: u64,
+    buffer: String,
+}
 
 impl EditorPanel for HierarchyPanel {
     fn id(&self) -> &str {
@@ -20,6 +28,11 @@ impl EditorPanel for HierarchyPanel {
         let mut despawn_entity = false;
         let mut new_selection: Option<Vec<u64>> = None;
         let mut new_sel = insp.selected_id;
+        let mut set_parent: Option<(u64, u64)> = None;
+        let mut remove_parent: Option<u64> = None;
+        let mut duplicate: Option<u64> = None;
+        let mut rename_commit: Option<(u64, String)> = None;
+        let mut despawn_ids: Vec<u64> = Vec::new();
 
         ui.horizontal(|ui| {
             if ui.button("＋").clicked() {
@@ -32,39 +45,51 @@ impl EditorPanel for HierarchyPanel {
                 despawn_entity = true;
             }
         });
-        ui.label("Ctrl+click: toggle · Shift+click: range");
+        ui.label("Ctrl+click: toggle · Shift+click: range · double-click: rename · right-click: menu · drag onto a row to reparent");
         ui.separator();
+
+        // Egui's own per-widget memory persists the rename-edit buffer across
+        // frames using a fixed Id — we don't need our own InspectorState field
+        // for this, matching how CollapsingHeader persists its own open/closed
+        // state without any app-level bookkeeping.
+        let rename_id = egui::Id::new("hierarchy_rename_state");
+        let mut rename_state: Option<RenameState> = ui.data(|d| d.get_temp(rename_id));
+
         egui::ScrollArea::vertical().show(ui, |ui| {
-            for (idx, info) in entities_snapshot.iter().enumerate() {
-                let label = info.name.as_deref().unwrap_or("(unnamed)");
-                let text = format!("[{}] {}", info.id, label);
-                let resp = ui.selectable_label(info.selected, text);
-                if resp.clicked() {
-                    let mods = ui.ctx().input(|i| i.modifiers);
-                    if mods.shift {
-                        let anchor_idx = current_sel
-                            .and_then(|id| entities_snapshot.iter().position(|e| e.id == id))
-                            .unwrap_or(idx);
-                        let (lo, hi) = (anchor_idx.min(idx), anchor_idx.max(idx));
-                        new_selection =
-                            Some(entities_snapshot[lo..=hi].iter().map(|e| e.id).collect());
-                    } else if mods.ctrl {
-                        let mut ids: Vec<u64> = entities_snapshot
-                            .iter()
-                            .filter(|e| e.selected)
-                            .map(|e| e.id)
-                            .collect();
-                        if let Some(pos) = ids.iter().position(|&id| id == info.id) {
-                            ids.remove(pos);
-                        } else {
-                            ids.push(info.id);
-                        }
-                        new_selection = Some(ids);
-                    } else {
-                        new_selection = Some(vec![info.id]);
-                    }
-                    new_sel = Some(info.id);
-                }
+            for root in entities_snapshot.iter().filter(|e| e.parent_id.is_none()) {
+                Self::draw_row(
+                    ui,
+                    root,
+                    entities_snapshot,
+                    current_sel,
+                    &mut new_selection,
+                    &mut new_sel,
+                    &mut set_parent,
+                    &mut remove_parent,
+                    &mut duplicate,
+                    &mut despawn_ids,
+                    &mut rename_state,
+                    &mut rename_commit,
+                    0,
+                );
+            }
+
+            // Root drop zone: drag a row here to unparent it. Occupies the
+            // remaining empty space below the tree.
+            let (_, root_drop_response) = ui.allocate_exact_size(
+                egui::vec2(ui.available_width(), 40.0),
+                egui::Sense::hover(),
+            );
+            if let Some(dropped_id) = root_drop_response.dnd_release_payload::<u64>() {
+                remove_parent = Some(*dropped_id);
+            }
+        });
+
+        ui.data_mut(|d| {
+            if let Some(state) = rename_state {
+                d.insert_temp(rename_id, state);
+            } else {
+                d.remove_temp::<RenameState>(rename_id);
             }
         });
 
@@ -98,5 +123,167 @@ impl EditorPanel for HierarchyPanel {
             insp.selected_id = new_sel;
             insp.sync_selection();
         }
+        if let Some((child_id, parent_id)) = set_parent {
+            if child_id != parent_id {
+                insp.cmd_queue
+                    .push(InspectorCmd::SetParent { id: child_id, parent_id });
+            }
+        }
+        if let Some(id) = remove_parent {
+            insp.cmd_queue.push(InspectorCmd::RemoveParent { id });
+        }
+        if let Some(id) = duplicate {
+            insp.cmd_queue.push(InspectorCmd::Duplicate { id });
+        }
+        if !despawn_ids.is_empty() {
+            for id in despawn_ids {
+                insp.cmd_queue.push(InspectorCmd::Despawn { id });
+            }
+            insp.selected_id = None;
+            insp.cmd_queue
+                .push(InspectorCmd::SetSelection { ids: vec![] });
+        }
+        if let Some((id, name)) = rename_commit {
+            if !name.is_empty() {
+                insp.cmd_queue.push(InspectorCmd::RenameEntity { id, name });
+            }
+        }
+    }
+}
+
+impl HierarchyPanel {
+    #[allow(clippy::too_many_arguments)]
+    fn draw_row(
+        ui: &mut egui::Ui,
+        info: &InspectorEntityInfo,
+        all_entities: &[InspectorEntityInfo],
+        current_sel: Option<u64>,
+        new_selection: &mut Option<Vec<u64>>,
+        new_sel: &mut Option<u64>,
+        set_parent: &mut Option<(u64, u64)>,
+        remove_parent: &mut Option<u64>,
+        duplicate: &mut Option<u64>,
+        despawn_ids: &mut Vec<u64>,
+        rename_state: &mut Option<RenameState>,
+        rename_commit: &mut Option<(u64, String)>,
+        depth: usize,
+    ) {
+        let children: Vec<&InspectorEntityInfo> = all_entities
+            .iter()
+            .filter(|e| e.parent_id == Some(info.id))
+            .collect();
+        let label = info.name.as_deref().unwrap_or("(unnamed)");
+        let text = format!("[{}] {}", info.id, label);
+        let is_renaming = rename_state.as_ref().is_some_and(|r| r.entity_id == info.id);
+
+        ui.horizontal(|ui| {
+            ui.add_space(depth as f32 * 16.0);
+
+            let row_response = if is_renaming {
+                let state = rename_state.as_mut().expect("checked by is_renaming");
+                let edit_response =
+                    ui.add(egui::TextEdit::singleline(&mut state.buffer).id_salt(info.id));
+                if edit_response.lost_focus()
+                    && ui.ctx().input(|i| i.key_pressed(egui::Key::Enter))
+                {
+                    *rename_commit = Some((info.id, state.buffer.clone()));
+                    *rename_state = None;
+                } else if ui.ctx().input(|i| i.key_pressed(egui::Key::Escape)) {
+                    *rename_state = None;
+                }
+                edit_response
+            } else if children.is_empty() {
+                ui.selectable_label(info.selected, text)
+            } else {
+                egui::CollapsingHeader::new(text)
+                    .id_salt(info.id)
+                    .default_open(true)
+                    .show(ui, |ui| {
+                        for child in &children {
+                            Self::draw_row(
+                                ui,
+                                child,
+                                all_entities,
+                                current_sel,
+                                new_selection,
+                                new_sel,
+                                set_parent,
+                                remove_parent,
+                                duplicate,
+                                despawn_ids,
+                                rename_state,
+                                rename_commit,
+                                depth + 1,
+                            );
+                        }
+                    })
+                    .header_response
+            };
+
+            if is_renaming {
+                return;
+            }
+
+            if row_response.clicked() {
+                let mods = ui.ctx().input(|i| i.modifiers);
+                if mods.shift {
+                    let idx = all_entities.iter().position(|e| e.id == info.id).unwrap_or(0);
+                    let anchor_idx = current_sel
+                        .and_then(|id| all_entities.iter().position(|e| e.id == id))
+                        .unwrap_or(idx);
+                    let (lo, hi) = (anchor_idx.min(idx), anchor_idx.max(idx));
+                    *new_selection = Some(all_entities[lo..=hi].iter().map(|e| e.id).collect());
+                } else if mods.ctrl {
+                    let mut ids: Vec<u64> = all_entities
+                        .iter()
+                        .filter(|e| e.selected)
+                        .map(|e| e.id)
+                        .collect();
+                    if let Some(pos) = ids.iter().position(|&id| id == info.id) {
+                        ids.remove(pos);
+                    } else {
+                        ids.push(info.id);
+                    }
+                    *new_selection = Some(ids);
+                } else {
+                    *new_selection = Some(vec![info.id]);
+                }
+                *new_sel = Some(info.id);
+            }
+
+            if row_response.double_clicked() {
+                *rename_state = Some(RenameState {
+                    entity_id: info.id,
+                    buffer: info.name.clone().unwrap_or_default(),
+                });
+            }
+
+            row_response.dnd_set_drag_payload(info.id);
+            if let Some(dropped_id) = row_response.dnd_release_payload::<u64>() {
+                *set_parent = Some((*dropped_id, info.id));
+            }
+
+            row_response.context_menu(|ui| {
+                if ui.button("Rename").clicked() {
+                    *rename_state = Some(RenameState {
+                        entity_id: info.id,
+                        buffer: info.name.clone().unwrap_or_default(),
+                    });
+                    ui.close_menu();
+                }
+                if ui.button("Duplicate").clicked() {
+                    *duplicate = Some(info.id);
+                    ui.close_menu();
+                }
+                if ui.button("Delete").clicked() {
+                    despawn_ids.push(info.id);
+                    ui.close_menu();
+                }
+                if info.parent_id.is_some() && ui.button("Unparent").clicked() {
+                    *remove_parent = Some(info.id);
+                    ui.close_menu();
+                }
+            });
+        });
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -279,6 +279,78 @@ impl EditorPanel for InspectorPanel {
             ui.separator();
         }
 
+        // Tags
+        ui.strong("Tags");
+        ui.horizontal_wrapped(|ui| {
+            for tag in &sel_info.tags {
+                ui.horizontal(|ui| {
+                    ui.label(tag);
+                    if ui.small_button("×").clicked() {
+                        insp.cmd_queue.push(InspectorCmd::UntagEntity {
+                            id: sel_id,
+                            tag: tag.clone(),
+                        });
+                    }
+                });
+            }
+        });
+        ui.horizontal(|ui| {
+            ui.text_edit_singleline(&mut insp.edit_new_tag);
+            if ui.button("Add").clicked() && !insp.edit_new_tag.is_empty() {
+                insp.cmd_queue.push(InspectorCmd::TagEntity {
+                    id: sel_id,
+                    tag: insp.edit_new_tag.clone(),
+                });
+                insp.edit_new_tag.clear();
+            }
+        });
+        ui.separator();
+
+        // Script
+        ui.strong("Script");
+        ui.horizontal(|ui| {
+            ui.text_edit_singleline(&mut insp.edit_script_path);
+            if ui.button("Attach").clicked() && !insp.edit_script_path.is_empty() {
+                insp.cmd_queue.push(InspectorCmd::AttachScript {
+                    id: sel_id,
+                    path: insp.edit_script_path.clone(),
+                });
+            }
+            if sel_info.script_path.is_some() && ui.button("Clear").clicked() {
+                insp.cmd_queue
+                    .push(InspectorCmd::DetachScript { id: sel_id });
+                insp.edit_script_path.clear();
+            }
+        });
+        ui.separator();
+
+        // Mesh
+        ui.strong("Mesh");
+        ui.horizontal(|ui| {
+            let current_label = sel_info.primitive.as_deref().unwrap_or("None");
+            let mut chosen: Option<&str> = None;
+            egui::ComboBox::from_id_salt("mesh_primitive_combo")
+                .selected_text(current_label)
+                .show_ui(ui, |ui| {
+                    for p in ["cube", "sphere", "plane", "capsule"] {
+                        if ui.selectable_label(false, p).clicked() {
+                            chosen = Some(p);
+                        }
+                    }
+                });
+            if let Some(primitive) = chosen {
+                insp.cmd_queue.push(InspectorCmd::AttachPrimitiveMesh {
+                    id: sel_id,
+                    primitive: primitive.to_string(),
+                });
+            }
+            if sel_info.primitive.is_some() && ui.button("Remove").clicked() {
+                insp.cmd_queue
+                    .push(InspectorCmd::DetachPrimitiveMesh { id: sel_id });
+            }
+        });
+        ui.separator();
+
         // Add Component
         ui.strong("Add Component");
         ui.horizontal(|ui| {


### PR DESCRIPTION
## Summary
- Hierarchy panel becomes a real parent/child tree (from the existing `Parent` component / `parent_id`, already tracked in the snapshot but never rendered as a tree).
- Drag-and-drop reparenting: drag a row onto another row to reparent, drag onto empty space to unparent (egui 0.29's `Response`-level `dnd_set_drag_payload`/`dnd_release_payload` API, `u64` entity-id payload). Includes a cycle guard to prevent reparenting an entity under its own descendant.
- Double-click a row to rename inline; right-click for a context menu (Rename / Duplicate / Delete / Unparent).
- Inspector gains three new sections: Tags (removable chips + add), Script path assignment (plain text field, no file picker — no Project/Assets browser yet), Primitive mesh assignment (dropdown + attach/remove).
- The backend for rename/reparent/tag already existed (used by MCP tools today) — this PR only adds the missing `InspectorCmd` UI-side wiring for those five. Script/Mesh attach-detach needed four new backend commands, added with minimal handlers reusing the existing `resolve_primitives` system for mesh resolution.

Design doc: `docs/superpowers/specs/2026-07-14-editor-hierarchy-tag-script-mesh-design.md`
Plan: `docs/superpowers/plans/2026-07-14-editor-hierarchy-tag-script-mesh.md`

This is "PR B" of the phase-2 editor UI overhaul, following #1695/#1696 (reflection-based Add/Remove Component). Independent of that work.

## Explicit scope exclusions (disclosed, not silently dropped)
- No OS-native file picker for script assignment (plain text field only — no Project/Assets browser yet; phase 4).
- No visual restyling (component cards, tree icons — phase 3).
- No multi-entity batch editing in Inspector.
- Generic per-field reflected component editing (`draw_reflect_ui` wiring) — separate effort ("PR C"), not started.

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --all-targets --workspace` (0 warnings)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace --exclude bsengine-editor`
- [x] `RUST_MIN_STACK=8388608 cargo test -p bsengine-editor` (isolated, matches CI)
- [x] New tests: `InspectorEntityInfo` field-copy, Rename/SetParent/RemoveParent/Tag/Untag end-to-end via `InspectorCmd`, Script/PrimitiveMesh attach-detach end-to-end via `EditorCommand`
- [x] Manual smoke test: `cargo run -p bsengine-editor-app` launches and runs without panic
- [ ] **Needs a human**: interactive verification of drag-to-reparent, double-click rename, context menu, tag chips, script/mesh assignment in the running editor — this PR's UI code (the Hierarchy tree rewrite especially) has the least automated coverage of any PR in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)