### PR TITLE
fix(editor): Mesh dropdown drift protection + Hierarchy range-select tree order

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -1,5 +1,13 @@
 use bevy_ecs::prelude::Resource;
 
+/// Canonical set of recognized primitive-mesh kind strings, lowercase,
+/// shared between the Inspector's Mesh dropdown (`bsengine-rhi-wgpu`) and
+/// `InspectorEntityInfo.primitive`/`InspectorCmd::AttachPrimitiveMesh.primitive`
+/// below. `bsengine-editor`'s `primitive_to_str`/`str_to_primitive` (the only
+/// place these strings convert to/from the real `bsengine_scene::Primitive`
+/// enum) must stay in sync with this list — see the doc comments there.
+pub const PRIMITIVE_KINDS: [&str; 4] = ["cube", "sphere", "plane", "capsule"];
+
 #[derive(Clone, Default)]
 pub struct InspectorEntityInfo {
     pub id: u64,
@@ -25,11 +33,11 @@ pub struct InspectorEntityInfo {
     pub parent_id: Option<u64>,
     pub tags: Vec<String>,
     pub script_path: Option<String>,
-    /// One of `"cube"`/`"sphere"`/`"plane"`/`"capsule"` (lowercase), or `None`
-    /// if no `PrimitiveMesh` is attached. A plain `String`, not
-    /// `bsengine_scene::Primitive`, because `bsengine-core` cannot depend on
-    /// `bsengine-scene` (that crate already depends on `bsengine-core`).
-    /// Mirrors this same struct's `light_type: Option<String>` convention.
+    /// One of [`PRIMITIVE_KINDS`], or `None` if no `PrimitiveMesh` is
+    /// attached. A plain `String`, not `bsengine_scene::Primitive`, because
+    /// `bsengine-core` cannot depend on `bsengine-scene` (that crate already
+    /// depends on `bsengine-core`). Mirrors this same struct's
+    /// `light_type: Option<String>` convention.
     pub primitive: Option<String>,
     pub visible: bool,
     pub selected: bool,
@@ -133,12 +141,11 @@ pub enum InspectorCmd {
     },
     AttachPrimitiveMesh {
         id: u64,
-        /// `"cube"`/`"sphere"`/`"plane"`/`"capsule"` (lowercase) — a plain
-        /// `String`, not `bsengine_scene::Primitive`, for the same
-        /// circular-dependency reason as `InspectorEntityInfo.primitive`
-        /// (see this plan's header notes). Parsed back into the real enum
-        /// in `apply_inspector_cmds` below, where `bsengine_scene` is
-        /// already in scope.
+        /// One of [`PRIMITIVE_KINDS`] — a plain `String`, not
+        /// `bsengine_scene::Primitive`, for the same circular-dependency
+        /// reason as `InspectorEntityInfo.primitive`. Parsed back into the
+        /// real enum in `apply_inspector_cmds` (`bsengine-editor`), where
+        /// `bsengine_scene` is already in scope.
         primitive: String,
     },
     DetachPrimitiveMesh {

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1112,7 +1112,7 @@ pub use immune::Immune;
 pub use impact::Impact;
 pub use input_map::{Binding, InputCode, InputMap};
 pub use inspector::{
-    EditorPlayState, GizmoMode, InspectorCmd, InspectorEntityInfo, InspectorState,
+    EditorPlayState, GizmoMode, InspectorCmd, InspectorEntityInfo, InspectorState, PRIMITIVE_KINDS,
 };
 pub use interactable::{InteractTrigger, Interactable};
 pub use intercept::Intercept;

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1252,6 +1252,11 @@ fn populate_inspector(
         .collect();
 }
 
+/// Exhaustive match with no wildcard arm — adding a `Primitive` variant
+/// forces a compile error here. If you land here from that error, also
+/// update `bsengine_core::PRIMITIVE_KINDS` and `str_to_primitive` below to
+/// keep the DTO-boundary string set in sync (see the "primitive kinds test"
+/// in this file's test module, which round-trip-checks that sync).
 fn primitive_to_str(p: &bsengine_scene::Primitive) -> String {
     match p {
         bsengine_scene::Primitive::Cube => "cube",
@@ -1262,6 +1267,8 @@ fn primitive_to_str(p: &bsengine_scene::Primitive) -> String {
     .to_string()
 }
 
+/// Inverse of [`primitive_to_str`] — see its doc comment for the
+/// keep-in-sync note with `bsengine_core::PRIMITIVE_KINDS`.
 fn str_to_primitive(s: &str) -> Option<bsengine_scene::Primitive> {
     match s {
         "cube" => Some(bsengine_scene::Primitive::Cube),
@@ -28917,6 +28924,29 @@ mod tests {
             Some("assets/scripts/child.js".to_string())
         );
         assert_eq!(child_info.primitive, Some("sphere".to_string()));
+    }
+
+    #[test]
+    fn primitive_kinds_const_round_trips_through_str_conversions() {
+        // Every string in the canonical `PRIMITIVE_KINDS` list (used by the
+        // Inspector's Mesh dropdown in bsengine-rhi-wgpu) must parse via
+        // `str_to_primitive` and the parsed value must map back to the same
+        // string via `primitive_to_str`. This doesn't catch a *new*
+        // `Primitive` variant going unlisted (that gap is inherent to the
+        // circular-dependency string-boundary design — see
+        // `primitive_to_str`'s doc comment for the compile-time nudge that
+        // partially mitigates it), but it does catch drift/typos between
+        // `PRIMITIVE_KINDS` and the two conversion functions.
+        assert_eq!(bsengine_core::PRIMITIVE_KINDS.len(), 4);
+        for &kind in &bsengine_core::PRIMITIVE_KINDS {
+            let parsed = super::str_to_primitive(kind)
+                .unwrap_or_else(|| panic!("PRIMITIVE_KINDS entry {kind:?} did not parse"));
+            assert_eq!(
+                super::primitive_to_str(&parsed),
+                kind,
+                "str_to_primitive/primitive_to_str do not round-trip for {kind:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -10,6 +10,23 @@ struct RenameState {
     buffer: String,
 }
 
+/// Read-only, whole-tree context threaded through the `draw_row` recursion
+/// unchanged at every depth — bundled into one struct rather than three
+/// separate positional parameters to keep `draw_row`'s already-long
+/// argument list from growing further.
+struct TreeCtx<'a> {
+    all_entities: &'a [InspectorEntityInfo],
+    current_sel: Option<u64>,
+    /// Entity ids in depth-first rendered order (same traversal `draw_row`
+    /// itself performs: roots in snapshot order, each subtree's children
+    /// immediately after their parent). Shift-click range-select uses this
+    /// instead of `all_entities`' raw snapshot-array order, so the
+    /// highlighted range actually matches what's visually between the two
+    /// clicked rows in the tree — snapshot order and render order are not
+    /// the same thing once entities have parents.
+    order: &'a [u64],
+}
+
 impl EditorPanel for HierarchyPanel {
     fn id(&self) -> &str {
         "hierarchy"
@@ -55,13 +72,19 @@ impl EditorPanel for HierarchyPanel {
         let rename_id = egui::Id::new("hierarchy_rename_state");
         let mut rename_state: Option<RenameState> = ui.data(|d| d.get_temp(rename_id));
 
+        let order = Self::dfs_order(entities_snapshot);
+        let tree = TreeCtx {
+            all_entities: entities_snapshot,
+            current_sel,
+            order: &order,
+        };
+
         egui::ScrollArea::vertical().show(ui, |ui| {
             for root in entities_snapshot.iter().filter(|e| e.parent_id.is_none()) {
                 Self::draw_row(
                     ui,
                     root,
-                    entities_snapshot,
-                    current_sel,
+                    &tree,
                     &mut new_selection,
                     &mut new_sel,
                     &mut set_parent,
@@ -201,12 +224,41 @@ impl HierarchyPanel {
         false
     }
 
+    /// Entity ids in depth-first rendered order — same traversal `draw_row`
+    /// performs (roots in snapshot order, then each subtree's children
+    /// immediately after their parent). A `visited` guard makes this safe
+    /// against a pre-existing cycle in the live snapshot (external data,
+    /// not something the UI's own drag-and-drop can create — see
+    /// `would_create_cycle`), unlike `draw_row`'s own unguarded recursion.
+    fn dfs_order(all_entities: &[InspectorEntityInfo]) -> Vec<u64> {
+        let mut order = Vec::with_capacity(all_entities.len());
+        let mut visited = std::collections::HashSet::with_capacity(all_entities.len());
+        for root in all_entities.iter().filter(|e| e.parent_id.is_none()) {
+            Self::push_dfs(root, all_entities, &mut order, &mut visited);
+        }
+        order
+    }
+
+    fn push_dfs(
+        info: &InspectorEntityInfo,
+        all_entities: &[InspectorEntityInfo],
+        order: &mut Vec<u64>,
+        visited: &mut std::collections::HashSet<u64>,
+    ) {
+        if !visited.insert(info.id) {
+            return;
+        }
+        order.push(info.id);
+        for child in all_entities.iter().filter(|e| e.parent_id == Some(info.id)) {
+            Self::push_dfs(child, all_entities, order, visited);
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn draw_row(
         ui: &mut egui::Ui,
         info: &InspectorEntityInfo,
-        all_entities: &[InspectorEntityInfo],
-        current_sel: Option<u64>,
+        tree: &TreeCtx,
         new_selection: &mut Option<Vec<u64>>,
         new_sel: &mut Option<u64>,
         set_parent: &mut Option<(u64, u64)>,
@@ -217,7 +269,8 @@ impl HierarchyPanel {
         rename_commit: &mut Option<(u64, String)>,
         depth: usize,
     ) {
-        let children: Vec<&InspectorEntityInfo> = all_entities
+        let children: Vec<&InspectorEntityInfo> = tree
+            .all_entities
             .iter()
             .filter(|e| e.parent_id == Some(info.id))
             .collect();
@@ -253,8 +306,7 @@ impl HierarchyPanel {
                             Self::draw_row(
                                 ui,
                                 child,
-                                all_entities,
-                                current_sel,
+                                tree,
                                 new_selection,
                                 new_sel,
                                 set_parent,
@@ -289,17 +341,21 @@ impl HierarchyPanel {
             if row_response.clicked() {
                 let mods = ui.ctx().input(|i| i.modifiers);
                 if mods.shift {
-                    let idx = all_entities
-                        .iter()
-                        .position(|e| e.id == info.id)
-                        .unwrap_or(0);
-                    let anchor_idx = current_sel
-                        .and_then(|id| all_entities.iter().position(|e| e.id == id))
+                    // Range-select by *rendered* (depth-first) order, not
+                    // raw snapshot-array order — the two diverge once
+                    // entities have parents, and using array order here
+                    // would select a range with no visual relationship to
+                    // what's actually between the two clicked rows.
+                    let idx = tree.order.iter().position(|&id| id == info.id).unwrap_or(0);
+                    let anchor_idx = tree
+                        .current_sel
+                        .and_then(|id| tree.order.iter().position(|&oid| oid == id))
                         .unwrap_or(idx);
                     let (lo, hi) = (anchor_idx.min(idx), anchor_idx.max(idx));
-                    *new_selection = Some(all_entities[lo..=hi].iter().map(|e| e.id).collect());
+                    *new_selection = Some(tree.order[lo..=hi].to_vec());
                 } else if mods.ctrl {
-                    let mut ids: Vec<u64> = all_entities
+                    let mut ids: Vec<u64> = tree
+                        .all_entities
                         .iter()
                         .filter(|e| e.selected)
                         .map(|e| e.id)
@@ -333,7 +389,7 @@ impl HierarchyPanel {
                 // (`parent_id.is_none()`) unable to ever reach that subtree
                 // again — the entity and everything under it would silently
                 // vanish from the panel with no error.
-                if !Self::would_create_cycle(all_entities, dropped_id, info.id) {
+                if !Self::would_create_cycle(tree.all_entities, dropped_id, info.id) {
                     *set_parent = Some((dropped_id, info.id));
                 }
             }

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -226,10 +226,13 @@ impl HierarchyPanel {
 
     /// Entity ids in depth-first rendered order — same traversal `draw_row`
     /// performs (roots in snapshot order, then each subtree's children
-    /// immediately after their parent). A `visited` guard makes this safe
-    /// against a pre-existing cycle in the live snapshot (external data,
-    /// not something the UI's own drag-and-drop can create — see
-    /// `would_create_cycle`), unlike `draw_row`'s own unguarded recursion.
+    /// immediately after their parent). The `visited` guard is defensive
+    /// rather than load-bearing: each entity has exactly one `parent_id`, so
+    /// any cycle in the graph is necessarily a component with no root-reachable
+    /// entity (same reasoning as `would_create_cycle`'s "vanishes from the
+    /// panel" doc comment, not a hang risk for `draw_row` either) — but the
+    /// guard costs nothing and keeps this function correct even if that
+    /// invariant is ever violated by future changes.
     fn dfs_order(all_entities: &[InspectorEntityInfo]) -> Vec<u64> {
         let mut order = Vec::with_capacity(all_entities.len());
         let mut visited = std::collections::HashSet::with_capacity(all_entities.len());
@@ -416,5 +419,63 @@ impl HierarchyPanel {
                 }
             });
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entity(id: u64, parent_id: Option<u64>) -> InspectorEntityInfo {
+        InspectorEntityInfo {
+            id,
+            parent_id,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn dfs_order_matches_draw_rows_traversal() {
+        // Two roots (1, 5); 1 has children 2 and 3 (in that array order); 2
+        // has a grandchild 4. Expected order mirrors exactly what draw_row
+        // would render: root 1, then its subtree depth-first (2, then 2's
+        // child 4, then 3), then root 5.
+        let entities = vec![
+            entity(1, None),
+            entity(2, Some(1)),
+            entity(3, Some(1)),
+            entity(4, Some(2)),
+            entity(5, None),
+        ];
+        assert_eq!(HierarchyPanel::dfs_order(&entities), vec![1, 2, 4, 3, 5]);
+    }
+
+    #[test]
+    fn dfs_order_ignores_entities_unreachable_from_any_root() {
+        // 10 and 11 form a 2-cycle (parent_id points at each other) with no
+        // path to a root — the `parent_id` relation is single-valued per
+        // entity, so a cycle member's parent_id can never simultaneously
+        // match a root-reachable id, meaning cycle members are simply never
+        // visited (consistent with `would_create_cycle`'s "vanishes from the
+        // panel" framing, not a hang risk). Only the genuine root (20)
+        // should appear in the output.
+        let entities = vec![entity(10, Some(11)), entity(11, Some(10)), entity(20, None)];
+        assert_eq!(HierarchyPanel::dfs_order(&entities), vec![20]);
+    }
+
+    #[test]
+    fn dfs_order_visited_guard_prevents_duplicate_output_on_malformed_duplicate_ids() {
+        // Defensive case: two array entries sharing the same id (should
+        // never happen from a real snapshot, but this is UI code reacting
+        // to external data, not the source of truth). Without the
+        // `visited` guard, the second occurrence would be walked again as
+        // its own root, producing a duplicate entry.
+        let entities = vec![entity(1, None), entity(1, None), entity(2, Some(1))];
+        let order = HierarchyPanel::dfs_order(&entities);
+        assert_eq!(
+            order,
+            vec![1, 2],
+            "duplicate id must not appear twice in the output"
+        );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -332,7 +332,7 @@ impl EditorPanel for InspectorPanel {
             egui::ComboBox::from_id_salt("mesh_primitive_combo")
                 .selected_text(current_label)
                 .show_ui(ui, |ui| {
-                    for p in ["cube", "sphere", "plane", "capsule"] {
+                    for p in bsengine_core::PRIMITIVE_KINDS {
                         if ui.selectable_label(false, p).clicked() {
                             chosen = Some(p);
                         }

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -1,4 +1,4 @@
-use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd};
+use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd, PRIMITIVE_KINDS};
 
 pub struct InspectorPanel;
 
@@ -332,7 +332,7 @@ impl EditorPanel for InspectorPanel {
             egui::ComboBox::from_id_salt("mesh_primitive_combo")
                 .selected_text(current_label)
                 .show_ui(ui, |ui| {
-                    for p in bsengine_core::PRIMITIVE_KINDS {
+                    for p in PRIMITIVE_KINDS {
                         if ui.selectable_label(false, p).clicked() {
                             chosen = Some(p);
                         }


### PR DESCRIPTION
## Summary

Two follow-up fixes for Important (non-blocking) findings from #1697's code review.

- **Primitive-list drift protection.** The Inspector's Mesh `ComboBox` had its own hardcoded `["cube","sphere","plane","capsule"]` literal, independent of `primitive_to_str`/`str_to_primitive`'s exhaustive matches over the real `bsengine_scene::Primitive` enum. A new `Primitive` variant would force those two functions to update (compile error) but the UI list would silently keep compiling with the old options. Introduces `bsengine_core::PRIMITIVE_KINDS` as a single canonical string list used by both the UI and cross-referenced from the conversion functions' doc comments, plus a round-trip regression test. This does not fully close the gap (a human still has to update `PRIMITIVE_KINDS` by hand when a variant is added) — documented as such, not oversold.
- **Hierarchy shift-click range-select now uses tree render order.** Since #1697 turned the Hierarchy panel into a real parent/child tree, shift-click range-select still indexed into the flat snapshot array — correct for the old flat list, wrong for a tree, since array order and depth-first render order diverge once entities have parents. Adds a `dfs_order()` helper mirroring `draw_row`'s own traversal, threaded through via a new `TreeCtx` struct (bundling the three previously-separate read-only parameters instead of growing `draw_row`'s already-13-parameter signature further, per #1697's own review recommendation).

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --all-targets --workspace` (0 warnings)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace --exclude bsengine-editor`
- [x] `RUST_MIN_STACK=8388608 cargo test -p bsengine-editor` (798 passed, up from 797)
- [x] New tests: `primitive_kinds_const_round_trips_through_str_conversions`, plus `dfs_order`/`push_dfs` unit tests (multi-level tree order, cycle-member exclusion, malformed-duplicate-id defense)
- [x] Manual smoke test: `cargo run -p bsengine-editor-app` launches and runs without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)