### PR TITLE
feat(editor): migrate Camera.fov_y_radians to ReflectDegrees (PR C-2, Camera-only)

### DIFF
--- a/crates/bsengine-core/src/camera.rs
+++ b/crates/bsengine-core/src/camera.rs
@@ -1,3 +1,4 @@
+use crate::reflect_degrees::ReflectDegrees;
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
@@ -6,7 +7,7 @@ use glam::Mat4;
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct Camera {
-    pub fov_y_radians: f32,
+    pub fov_y_degrees: ReflectDegrees,
     pub aspect_ratio: f32,
     pub near: f32,
     pub far: f32,
@@ -15,7 +16,7 @@ pub struct Camera {
 impl Camera {
     pub fn perspective(fov_y_degrees: f32, aspect_ratio: f32) -> Self {
         Self {
-            fov_y_radians: fov_y_degrees.to_radians(),
+            fov_y_degrees: fov_y_degrees.into(),
             aspect_ratio,
             near: 0.1,
             far: 1000.0,
@@ -23,7 +24,12 @@ impl Camera {
     }
 
     pub fn projection_matrix(&self) -> Mat4 {
-        Mat4::perspective_rh(self.fov_y_radians, self.aspect_ratio, self.near, self.far)
+        Mat4::perspective_rh(
+            self.fov_y_degrees.to_radians(),
+            self.aspect_ratio,
+            self.near,
+            self.far,
+        )
     }
 
     pub fn update_aspect_ratio(&mut self, width: u32, height: u32) {
@@ -46,7 +52,7 @@ mod tests {
     #[test]
     fn default_camera_has_60_fov() {
         let cam = Camera::default();
-        assert!((cam.fov_y_radians - 60_f32.to_radians()).abs() < 1e-6);
+        assert!((cam.fov_y_degrees.0 - 60.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/bsengine-core/src/camera.rs
+++ b/crates/bsengine-core/src/camera.rs
@@ -63,6 +63,13 @@ mod tests {
     }
 
     #[test]
+    fn projection_matrix_converts_degrees_to_radians_at_point_of_use() {
+        let cam = Camera::perspective(90.0, 1.0);
+        let expected = Mat4::perspective_rh(90_f32.to_radians(), 1.0, 0.1, 1000.0);
+        assert!(cam.projection_matrix().abs_diff_eq(expected, 1e-6));
+    }
+
+    #[test]
     fn update_aspect_ratio_ignores_zero_height() {
         let mut cam = Camera::default();
         let original = cam.aspect_ratio;

--- a/crates/bsengine-core/src/reflect_degrees.rs
+++ b/crates/bsengine-core/src/reflect_degrees.rs
@@ -14,10 +14,11 @@
 //! This type exists purely as a *display* signal for the generic reflected-
 //! field editor: a struct field's *type* (not its name, not a comment)
 //! declares "this number means degrees", so `draw_reflect_ui` can render it
-//! without per-field naming conventions or hints. As of this writing, no
-//! real component field uses this type yet — `Camera.fov_y_radians` and
-//! `SpotLight.inner_angle`/`outer_angle` remain in radians until "PR C-2"
-//! migrates them (a wider call-site change, deferred — see the design doc).
+//! without per-field naming conventions or hints. `Camera.fov_y_degrees`
+//! ("PR C-2") is the first real field wired to this type.
+//! `SpotLight.inner_angle`/`outer_angle` remain in radians for now — a wider,
+//! more scattered call-site migration, deferred to a separate follow-up PR
+//! (see the design docs for both PRs).
 use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -82,7 +82,7 @@ fn update_editor_snapshot(
                     light_ambient: dir.map(|l| l.ambient.to_array()),
                     spot_inner_angle: spot.map(|l| l.inner_angle.to_degrees()),
                     spot_outer_angle: spot.map(|l| l.outer_angle.to_degrees()),
-                    camera_fov: cam.map(|c| c.fov_y_radians.to_degrees()),
+                    camera_fov: cam.map(|c| c.fov_y_degrees.0),
                     material_base_color: mat.map(|m| m.base_color.to_array()),
                     material_metallic: mat.map(|m| m.metallic),
                     material_roughness: mat.map(|m| m.roughness),
@@ -287,7 +287,7 @@ fn process_editor_commands(
                 for (e, mut cam) in params.p5().iter_mut() {
                     if e.index() as u64 == entity_id {
                         if let Some(fov) = fov_y_degrees {
-                            cam.fov_y_radians = fov.to_radians();
+                            cam.fov_y_degrees = fov.into();
                         }
                         break;
                     }
@@ -858,7 +858,7 @@ fn sync_entity_to_info(world: &mut World, entity: Entity, info: &EntityInfo) {
     match info.camera_fov {
         Some(fov_deg) => {
             if let Some(mut cam) = e.get_mut::<Camera>() {
-                cam.fov_y_radians = fov_deg.to_radians();
+                cam.fov_y_degrees = fov_deg.into();
             }
         }
         None => {
@@ -29145,7 +29145,7 @@ mod tests {
         app.update();
 
         let edited = bsengine_core::Camera {
-            fov_y_radians: 1.2345,
+            fov_y_degrees: 1.2345.into(),
             ..Default::default()
         };
         {
@@ -29163,8 +29163,8 @@ mod tests {
             .get::<bsengine_core::Camera>(eid)
             .expect("Camera should still be attached");
         assert!(
-            (cam.fov_y_radians - 1.2345).abs() < f32::EPSILON,
-            "Camera.fov_y_radians should have been updated to the applied value"
+            (cam.fov_y_degrees.0 - 1.2345).abs() < f32::EPSILON,
+            "Camera.fov_y_degrees should have been updated to the applied value"
         );
     }
 
@@ -29180,7 +29180,7 @@ mod tests {
         app.update();
 
         let edited = bsengine_core::Camera {
-            fov_y_radians: 0.5,
+            fov_y_degrees: 0.5.into(),
             ..Default::default()
         };
         {
@@ -29195,7 +29195,7 @@ mod tests {
 
         let cam = app.world().get::<bsengine_core::Camera>(eid).expect("Camera should exist");
         assert!(
-            (cam.fov_y_radians - 0.5).abs() < f32::EPSILON,
+            (cam.fov_y_degrees.0 - 0.5).abs() < f32::EPSILON,
             "Camera should have been updated end-to-end via InspectorCmd"
         );
     }
@@ -29268,9 +29268,10 @@ mod tests {
             .downcast_ref::<bsengine_core::Camera>()
             .expect("cloned value should downcast back to Camera");
         assert!(
-            (cloned_camera.fov_y_radians - bsengine_core::Camera::default().fov_y_radians).abs()
-                < f32::EPSILON,
-            "cloned Camera's fov_y_radians should match the real component's default value"
+            (cloned_camera.fov_y_degrees.0 - 60.0).abs() < f32::EPSILON,
+            "cloned Camera's fov_y_degrees should be 60.0 (degrees) — proves the field is wired \
+             through the real reflection pipeline with the correct unit, not just internally \
+             self-consistent"
         );
     }
 
@@ -90488,9 +90489,9 @@ mod tests {
                 .find(|(n, _)| n.0 == "MainCam")
                 .expect("MainCam not found after load");
             assert!(
-                (cam.fov_y_radians.to_degrees() - 75.0).abs() < 1e-3,
+                (cam.fov_y_degrees.0 - 75.0).abs() < 1e-3,
                 "wrong fov: {}",
-                cam.fov_y_radians.to_degrees()
+                cam.fov_y_degrees.0
             );
 
             let mut prim_q = app.world_mut().query::<(

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -677,7 +677,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut cam) = world.get_mut::<Camera>(e) {
-                        cam.fov_y_radians = deg.to_radians();
+                        cam.fov_y_degrees = deg.into();
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- `Camera.fov_y_radians: f32` → `Camera.fov_y_degrees: ReflectDegrees` — the first real component field wired to PR C-1's `ReflectDegrees` wrapper type (built in #1699 but left unwired to any field).
- `Camera::perspective(fov_y_degrees: f32, ...)` (the single production constructor every call site already uses) now stores the degrees value directly instead of converting to radians at construction; `projection_matrix()` converts to radians at the point of use instead.
- Three real call sites updated, all using the same `.into()` write idiom: `UpdateCamera` command handler, `sync_entity_to_info` (Undo/Redo snapshot reconciliation — found during plan-writing, not in the original design survey), and the script API's `SetCameraFov` handler.
- The Inspector's generic "Reflected Fields → bsengine_core::camera::Camera" section (added in #1699, alongside the hand-built "Camera" section) now renders FOV correctly in degrees with a "°" suffix, instead of a confusing raw-radians value — this closes the specific gap #1699's own code review flagged as an "Important" (non-blocking) finding.
- Also included: a stale doc comment in `reflect_degrees.rs` (left over from #1699, claiming no real field used `ReflectDegrees` yet) was corrected to reflect the current state — this was a coordinator-added fixup, not part of the original task list, flagged here for transparency.

Design doc: `docs/superpowers/specs/2026-07-15-editor-camera-fov-reflect-degrees-pr-c2-design.md`
Plan: `docs/superpowers/plans/2026-07-15-editor-camera-fov-reflect-degrees-pr-c2.md`

This is "PR C-2" (Camera-only) of the phase-2 editor UI overhaul, following #1699 ("PR C-1" — the generic reflected-field editing pipeline). Independent of that work otherwise.

## Explicit scope exclusions (disclosed, not silently dropped)
- **`SpotLight.inner_angle`/`outer_angle`'s equivalent migration** — separate, not-yet-designed follow-up PR. Unlike `Camera`, `SpotLight` has no single constructor centralizing degrees→radians conversion — the equivalent migration touches more, more scattered call sites and was deliberately split off after investigation during this PR's own brainstorming found it architecturally messier.
- **Pre-existing unit inconsistencies found during investigation** (`InspectorCmd::UpdateLight.inner_angle`/`outer_angle` undocumented-radians vs. `UpdateCamera.fov_y_degrees` documented-degrees; MCP tools `spawn_spot_light`/`update_spot_light` accepting raw radians while the Inspector UI/script API use degrees) are entirely on the `SpotLight` side — verified `Camera`'s own `InspectorCmd`/MCP surfaces are already fully degrees-consistent, so there's nothing to fix here; these will be addressed naturally in the deferred `SpotLight` PR.
- **Removing the hand-built Inspector "Camera" section** in favor of the generic "Reflected Fields" section alone — deferred until both `Camera` and `SpotLight` migrations are complete. Both UI surfaces remain active in this PR, same deliberate interim state #1699 established.
- No field-level range/validation constraints added to the generic reflection pipeline (the hand-built section's `10.0..=170.0` FOV clamp remains hand-built-section-only, unchanged).

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --all-targets --workspace` (0 warnings)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace --exclude bsengine-editor`
- [x] `RUST_MIN_STACK=8388608 cargo test -p bsengine-editor` (803 passed, unchanged count — existing tests updated for the field rename)
- [x] New test: `projection_matrix_converts_degrees_to_radians_at_point_of_use` — a value-level regression test added after code review flagged that no existing test actually exercised the degrees→radians conversion arithmetic (the prior `projection_matrix_is_non_identity` test would pass even if the conversion were silently skipped)
- [x] One existing test strengthened (`populate_reflected_component_snapshot_clones_attached_camera`): now asserts against a literal `60.0` instead of a self-referential comparison against `Camera::default()`, proving the field genuinely carries degrees through the real reflection pipeline
- [x] Manual smoke test: `cargo run -p bsengine-editor-app` launches and runs without panic. Additionally confirmed the existing PR C-1 headless render test (`reflected_fields_section_renders_without_panicking_for_a_real_camera_clone`) now genuinely exercises `ReflectDegrees`'s leaf-rendering branch for the first time (it constructs a real `Camera::default()`, which now has the migrated field shape) — still passes.
- [ ] **Needs a human**: full interactive verification — attach a Camera to an entity, drag the FOV value in the new generic "Reflected Fields" section, confirm it visibly reads/writes in degrees and matches the hand-built section's value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)