### PR TITLE
feat(core): migrate SpotLight.inner_angle/outer_angle to ReflectDegrees (PR C-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
 
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y mesa-vulkan-drivers libasound2-dev libudev-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers libasound2-dev libudev-dev
 
       - name: Format check
         run: cargo +nightly fmt --all -- --check

--- a/crates/bsengine-core/src/light.rs
+++ b/crates/bsengine-core/src/light.rs
@@ -1,3 +1,4 @@
+use crate::reflect_degrees::ReflectDegrees;
 use crate::reflect_glam::ReflectVec3;
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::prelude::ReflectDefault;
@@ -50,10 +51,10 @@ pub struct SpotLight {
     pub color: ReflectVec3,
     pub intensity: f32,
     pub range: f32,
-    /// Inner cone half-angle (radians) — full brightness inside.
-    pub inner_angle: f32,
-    /// Outer cone half-angle (radians) — zero brightness outside.
-    pub outer_angle: f32,
+    /// Inner cone half-angle (degrees) — full brightness inside.
+    pub inner_angle_degrees: ReflectDegrees,
+    /// Outer cone half-angle (degrees) — zero brightness outside.
+    pub outer_angle_degrees: ReflectDegrees,
 }
 
 impl Default for SpotLight {
@@ -62,8 +63,8 @@ impl Default for SpotLight {
             color: Vec3::ONE.into(),
             intensity: 1.0,
             range: 10.0,
-            inner_angle: std::f32::consts::PI / 8.0, // 22.5°
-            outer_angle: std::f32::consts::PI / 6.0, // 30°
+            inner_angle_degrees: 22.5.into(),
+            outer_angle_degrees: 30.0.into(),
         }
     }
 }
@@ -119,7 +120,7 @@ mod tests {
     fn spot_light_inner_angle_less_than_outer() {
         let sl = SpotLight::default();
         assert!(
-            sl.inner_angle < sl.outer_angle,
+            sl.inner_angle_degrees.0 < sl.outer_angle_degrees.0,
             "inner must be narrower than outer"
         );
     }
@@ -128,7 +129,7 @@ mod tests {
     fn spot_light_inner_cos_greater_than_outer_cos() {
         let sl = SpotLight::default();
         assert!(
-            sl.inner_angle.cos() > sl.outer_angle.cos(),
+            sl.inner_angle_degrees.to_radians().cos() > sl.outer_angle_degrees.to_radians().cos(),
             "cos(inner) > cos(outer) because inner < outer"
         );
     }

--- a/crates/bsengine-core/src/reflect_degrees.rs
+++ b/crates/bsengine-core/src/reflect_degrees.rs
@@ -15,10 +15,10 @@
 //! field editor: a struct field's *type* (not its name, not a comment)
 //! declares "this number means degrees", so `draw_reflect_ui` can render it
 //! without per-field naming conventions or hints. `Camera.fov_y_degrees`
-//! ("PR C-2") is the first real field wired to this type.
-//! `SpotLight.inner_angle`/`outer_angle` remain in radians for now — a wider,
-//! more scattered call-site migration, deferred to a separate follow-up PR
-//! (see the design docs for both PRs).
+//! ("PR C-2") was the first real field wired to this type;
+//! `SpotLight.inner_angle_degrees`/`outer_angle_degrees` ("PR C-3") is the
+//! second. Both Camera and SpotLight now store their angle fields in
+//! degrees internally.
 use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -80,8 +80,8 @@ fn update_editor_snapshot(
                     light_intensity,
                     light_range,
                     light_ambient: dir.map(|l| l.ambient.to_array()),
-                    spot_inner_angle: spot.map(|l| l.inner_angle.to_degrees()),
-                    spot_outer_angle: spot.map(|l| l.outer_angle.to_degrees()),
+                    spot_inner_angle: spot.map(|l| l.inner_angle_degrees.0),
+                    spot_outer_angle: spot.map(|l| l.outer_angle_degrees.0),
                     camera_fov: cam.map(|c| c.fov_y_degrees.0),
                     material_base_color: mat.map(|m| m.base_color.to_array()),
                     material_metallic: mat.map(|m| m.metallic),
@@ -464,8 +464,8 @@ fn process_editor_commands(
                         color: glam::Vec3::from(color).into(),
                         intensity,
                         range,
-                        inner_angle,
-                        outer_angle,
+                        inner_angle_degrees: inner_angle.to_degrees().into(),
+                        outer_angle_degrees: outer_angle.to_degrees().into(),
                     },
                     Transform::from_translation(glam::Vec3::from(position)),
                     GlobalTransform::default(),
@@ -491,10 +491,10 @@ fn process_editor_commands(
                             light.range = r;
                         }
                         if let Some(a) = inner_angle {
-                            light.inner_angle = a;
+                            light.inner_angle_degrees = a.to_degrees().into();
                         }
                         if let Some(o) = outer_angle {
-                            light.outer_angle = o;
+                            light.outer_angle_degrees = o.to_degrees().into();
                         }
                         break;
                     }
@@ -663,8 +663,8 @@ fn process_editor_commands(
                             color: glam::Vec3::from(sl.color).into(),
                             intensity: sl.intensity,
                             range: sl.range,
-                            inner_angle: sl.inner_angle_degrees.to_radians(),
-                            outer_angle: sl.outer_angle_degrees.to_radians(),
+                            inner_angle_degrees: sl.inner_angle_degrees.into(),
+                            outer_angle_degrees: sl.outer_angle_degrees.into(),
                         });
                     }
                     if let Some(script) = &entity.script {
@@ -29087,11 +29087,11 @@ mod tests {
             .get::<bsengine_core::SpotLight>(eid)
             .expect("SpotLight should still be attached");
         assert!(
-            (light.inner_angle - 0.1).abs() < 1e-6,
+            (light.inner_angle_degrees.0 - 0.1_f32.to_degrees()).abs() < 1e-4,
             "inner_angle was not updated — dispatch bug not fixed"
         );
         assert!(
-            (light.outer_angle - 0.2).abs() < 1e-6,
+            (light.outer_angle_degrees.0 - 0.2_f32.to_degrees()).abs() < 1e-4,
             "outer_angle was not updated — dispatch bug not fixed"
         );
     }
@@ -89916,7 +89916,7 @@ mod tests {
         let lights: Vec<_> = q.iter(app.world()).collect();
         assert_eq!(lights.len(), 1);
         assert!((lights[0].intensity - 3.0).abs() < 1e-4);
-        assert!((lights[0].inner_angle - 0.3).abs() < 1e-4);
+        assert!((lights[0].inner_angle_degrees.0 - 0.3_f32.to_degrees()).abs() < 1e-3);
     }
 
     #[test]
@@ -90447,8 +90447,8 @@ mod tests {
                     color: Vec3::new(0.2, 0.8, 1.0).into(),
                     intensity: 3.0,
                     range: 20.0,
-                    inner_angle: 15_f32.to_radians(),
-                    outer_angle: 25_f32.to_radians(),
+                    inner_angle_degrees: 15.0.into(),
+                    outer_angle_degrees: 25.0.into(),
                 },
                 Transform::from_translation(Vec3::new(2.0, 4.0, 0.0)),
                 bsengine_core::GlobalTransform::default(),
@@ -90527,8 +90527,8 @@ mod tests {
                 .expect("Spot not found after load");
             assert!((sl.intensity - 3.0).abs() < 1e-4);
             assert!((sl.range - 20.0).abs() < 1e-4);
-            assert!((sl.inner_angle.to_degrees() - 15.0).abs() < 1e-2);
-            assert!((sl.outer_angle.to_degrees() - 25.0).abs() < 1e-2);
+            assert!((sl.inner_angle_degrees.0 - 15.0).abs() < 1e-2);
+            assert!((sl.outer_angle_degrees.0 - 25.0).abs() < 1e-2);
         }
     }
 

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -57,6 +57,24 @@ fn compute_light_view_proj(light_dir: Vec3) -> Mat4 {
     proj * view
 }
 
+fn spot_light_entry(sl: &SpotLight, gt: Option<&GlobalTransform>, t: &Transform) -> SpotLightEntry {
+    let pos = gt
+        .map(|g| g.to_matrix().w_axis.truncate())
+        .unwrap_or(t.translation);
+    let dir = gt
+        .map(|g| -glam::Mat3::from_mat4(g.to_matrix()).z_axis)
+        .unwrap_or_else(|| t.rotation * Vec3::NEG_Z);
+    SpotLightEntry {
+        position: pos,
+        direction: dir,
+        color: *sl.color,
+        intensity: sl.intensity,
+        range: sl.range,
+        inner_angle: sl.inner_angle_degrees.to_radians(),
+        outer_angle: sl.outer_angle_degrees.to_radians(),
+    }
+}
+
 /// Pass 1: root entities (no Parent) get GlobalTransform = local Transform.
 fn propagate_roots(mut query: Query<(&Transform, &mut GlobalTransform), Without<Parent>>) {
     for (t, mut gt) in query.iter_mut() {
@@ -285,23 +303,7 @@ fn render_frame(
     let collected_spot_lights: Vec<SpotLightEntry> = render_queries
         .p4()
         .iter()
-        .map(|(sl, gt, t)| {
-            let pos = gt
-                .map(|g| g.to_matrix().w_axis.truncate())
-                .unwrap_or(t.translation);
-            let dir = gt
-                .map(|g| -glam::Mat3::from_mat4(g.to_matrix()).z_axis)
-                .unwrap_or_else(|| t.rotation * Vec3::NEG_Z);
-            SpotLightEntry {
-                position: pos,
-                direction: dir,
-                color: *sl.color,
-                intensity: sl.intensity,
-                range: sl.range,
-                inner_angle: sl.inner_angle,
-                outer_angle: sl.outer_angle,
-            }
-        })
+        .map(|(sl, gt, t)| spot_light_entry(sl, gt, t))
         .collect();
 
     let light = if let Some((l, gt, t)) = render_queries.p2().iter().next() {
@@ -480,6 +482,23 @@ mod tests {
             Transform::from_translation(Vec3::new(0.0, 5.0, 0.0)),
         ));
         app.update();
+    }
+
+    #[test]
+    fn spot_light_entry_converts_degrees_to_radians() {
+        use bsengine_core::SpotLight;
+
+        let sl = SpotLight {
+            inner_angle_degrees: 45.0.into(),
+            outer_angle_degrees: 60.0.into(),
+            ..SpotLight::default()
+        };
+        let t = Transform::from_translation(Vec3::new(0.0, 5.0, 0.0));
+
+        let entry = super::spot_light_entry(&sl, None, &t);
+
+        assert!((entry.inner_angle - 45_f32.to_radians()).abs() < 1e-6);
+        assert!((entry.outer_angle - 60_f32.to_radians()).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -122,8 +122,8 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
                 color: Vec3::from(sl.color).into(),
                 intensity: sl.intensity,
                 range: sl.range,
-                inner_angle: sl.inner_angle_degrees.to_radians(),
-                outer_angle: sl.outer_angle_degrees.to_radians(),
+                inner_angle_degrees: sl.inner_angle_degrees.into(),
+                outer_angle_degrees: sl.outer_angle_degrees.into(),
             });
         }
 

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -615,7 +615,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut light) = world.get_mut::<SpotLight>(e) {
-                        light.inner_angle = deg.to_radians();
+                        light.inner_angle_degrees = deg.into();
                     }
                 }
             }
@@ -627,7 +627,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut light) = world.get_mut::<SpotLight>(e) {
-                        light.outer_angle = deg.to_radians();
+                        light.outer_angle_degrees = deg.into();
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Migrates `SpotLight.inner_angle`/`outer_angle` (raw `f32` radians) to `inner_angle_degrees`/`outer_angle_degrees: ReflectDegrees`, mirroring #1700's identical `Camera.fov_y_degrees` migration — the deferred "SpotLight" half of that PR's scope split.
- Unlike Camera, SpotLight's external command/MCP layer (`EditorCommand::SpawnSpotLight`/`UpdateSpotLight`, `InspectorCmd::UpdateLight`, both MCP tool schemas) is and stays radians by explicit scope decision, so this migration is boundary-inverted: some call sites gain a `.to_degrees()` conversion (external radians → internal degrees), others lose a `.to_radians()` conversion (source was already degrees — the scene-file DTO, the script API). All ~9 real call sites were independently re-derived and verified for correct conversion direction.
- Adds a new value-level regression test (`spot_light_entry_converts_degrees_to_radians`) at the render/GPU boundary, closing a gap #1700's own retrospective flagged for its Camera equivalent — no prior test exercised the degrees→radians conversion at a *value* level there.

## Explicitly out of scope (disclosed, pre-existing, not introduced by this PR)

- `EditorCommand::SpawnSpotLight`/`UpdateSpotLight` and the MCP `spawn_spot_light`/`update_spot_light` tool schemas stay undocumented-but-radians — not renamed/redocumented this PR.
- No new `SpotLight::new(...)` constructor.
- `bsengine-scene`'s `spawn_scene_entities` has no direct value-level test for its spot-light angle conversion (the analogous editor-side `LoadScene` path does, via a save/load round-trip test) — a pre-existing coverage gap, not introduced here.
- Removing the 5 hand-built Inspector sections in favor of the generic reflected-field path — deferred until both Camera and SpotLight migrations are done (this PR completes that precondition).

## Test plan

- [x] `cargo build --workspace --all-targets` — clean, 0 errors
- [x] `cargo clippy --all-targets --workspace` — clean, 0 warnings
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace --exclude bsengine-editor` — all 46 test-result lines report 0 failed
- [x] `RUST_MIN_STACK=8388608 cargo test -p bsengine-editor` (isolated per the documented V8/RHI conflict) — 803 passed, 0 failed, unchanged from the pre-migration baseline
- [x] `cargo test -p bsengine-render spot_light` — 2 passed (including the new regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)