### PR TITLE
feat(core): reflect 6 Vec3/Entity components (bevy_reflect PR 2/3)

### DIFF
--- a/crates/bsengine-app/src/damping.rs
+++ b/crates/bsengine-app/src/damping.rs
@@ -14,7 +14,7 @@ fn apply_damping(mut query: Query<(&Damping, &mut Velocity)>, time: Res<Time>) {
     let dt = time.delta_seconds;
     for (damping, mut vel) in query.iter_mut() {
         let factor = (1.0 - damping.linear * dt).max(0.0);
-        vel.linear *= factor;
+        vel.linear.0 *= factor;
     }
 }
 
@@ -81,7 +81,7 @@ mod tests {
 
         let vel = app.world().get::<Velocity>(entity).unwrap();
         // factor = (1.0 - 1.0 * 1.0).max(0.0) = 0.0
-        assert_eq!(vel.linear, Vec3::ZERO);
+        assert_eq!(vel.linear, Vec3::ZERO.into());
     }
 
     #[test]
@@ -96,7 +96,7 @@ mod tests {
 
         let vel = app.world().get::<Velocity>(entity).unwrap();
         // factor = (1.0 - 2.0 * 1.0).max(0.0) = 0.0 — no sign reversal
-        assert_eq!(vel.linear, Vec3::ZERO);
+        assert_eq!(vel.linear, Vec3::ZERO.into());
     }
 
     #[test]

--- a/crates/bsengine-app/src/external_impulse.rs
+++ b/crates/bsengine-app/src/external_impulse.rs
@@ -25,10 +25,10 @@ fn apply_external_impulses(
 
         let inv_mass = mass.map(|m| m.inverse()).unwrap_or(1.0);
 
-        velocity.linear += impulse.linear * inv_mass;
+        velocity.linear.0 += impulse.linear.0 * inv_mass;
 
         if let Some(mut av) = angular_velocity {
-            av.angular += impulse.angular * inv_mass;
+            av.angular.0 += impulse.angular.0 * inv_mass;
         }
 
         impulse.clear();

--- a/crates/bsengine-app/src/follow.rs
+++ b/crates/bsengine-app/src/follow.rs
@@ -21,7 +21,7 @@ fn apply_follow(
         let Ok(target_gt) = targets.get(follow.target) else {
             continue;
         };
-        let desired = target_gt.0.w_axis.truncate() + follow.offset;
+        let desired = target_gt.0.w_axis.truncate() + follow.offset.0;
         let diff = desired - transform.translation;
         let dist = diff.length();
         if dist < 1e-5 {
@@ -45,7 +45,7 @@ fn apply_look_at(mut lookers: Query<(&LookAt, &mut Transform)>, targets: Query<&
             continue;
         }
         let fwd = direction.normalize();
-        let up = look_at.up;
+        let up = look_at.up.0;
 
         // Guard against degenerate up == fwd
         let up = if fwd.abs_diff_eq(up, 0.01) || fwd.abs_diff_eq(-up, 0.01) {

--- a/crates/bsengine-app/src/gravity.rs
+++ b/crates/bsengine-app/src/gravity.rs
@@ -19,7 +19,7 @@ fn apply_gravity(
     let dt = time.delta_seconds;
     for (mut vel, scale) in query.iter_mut() {
         let s = scale.map(|gs| gs.value()).unwrap_or(1.0);
-        vel.linear += gravity.acceleration * s * dt;
+        vel.linear.0 += gravity.acceleration * s * dt;
     }
 }
 
@@ -93,7 +93,7 @@ mod tests {
         app.update();
 
         let vel = app.world().get::<Velocity>(entity).unwrap();
-        assert_eq!(vel.linear, Vec3::ZERO);
+        assert_eq!(vel.linear, Vec3::ZERO.into());
     }
 
     #[test]

--- a/crates/bsengine-app/src/nav_mesh.rs
+++ b/crates/bsengine-app/src/nav_mesh.rs
@@ -46,6 +46,7 @@ fn navigate_agents(
             cache.0.remove(&entity);
             continue;
         };
+        let dest = dest.0;
 
         // Check arrival before computing paths.
         let flat_pos = Vec3::new(transform.translation.x, 0.0, transform.translation.z);
@@ -293,7 +294,7 @@ mod tests {
 
         // Change destination.
         let mut agent = app.world_mut().get_mut::<NavMeshAgent>(entity).unwrap();
-        agent.destination = Some(Vec3::new(-3.0, 0.0, 0.0));
+        agent.destination = Some(Vec3::new(-3.0, 0.0, 0.0).into());
         app.update();
 
         let state = app

--- a/crates/bsengine-app/src/velocity.rs
+++ b/crates/bsengine-app/src/velocity.rs
@@ -12,7 +12,7 @@ impl Plugin for VelocityPlugin {
 
 fn apply_velocity(mut query: Query<(&Velocity, &mut Transform)>, time: Res<Time>) {
     for (vel, mut transform) in query.iter_mut() {
-        transform.translation += vel.linear * time.delta_seconds;
+        transform.translation += vel.linear.0 * time.delta_seconds;
     }
 }
 

--- a/crates/bsengine-core/src/angular_velocity.rs
+++ b/crates/bsengine-core/src/angular_velocity.rs
@@ -1,18 +1,22 @@
-use bevy_ecs::prelude::Component;
+use crate::ReflectVec3;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
 use glam::Vec3;
 
 /// Angular velocity in radians per second (Euler rates: x=pitch, y=yaw, z=roll).
 /// `AngularVelocityPlugin` integrates this into `Transform.rotation` each frame.
 /// For physics-driven rotation use `bsengine-physics` instead.
-#[derive(Component, Debug, Clone, PartialEq)]
+#[derive(Component, Debug, Clone, PartialEq, Reflect)]
+#[reflect(Component, Default)]
 pub struct AngularVelocity {
-    pub angular: Vec3,
+    pub angular: ReflectVec3,
 }
 
 impl Default for AngularVelocity {
     fn default() -> Self {
         Self {
-            angular: Vec3::ZERO,
+            angular: Vec3::ZERO.into(),
         }
     }
 }
@@ -20,12 +24,14 @@ impl Default for AngularVelocity {
 impl AngularVelocity {
     pub fn new(pitch: f32, yaw: f32, roll: f32) -> Self {
         Self {
-            angular: Vec3::new(pitch, yaw, roll),
+            angular: Vec3::new(pitch, yaw, roll).into(),
         }
     }
 
     pub fn from_vec3(angular: Vec3) -> Self {
-        Self { angular }
+        Self {
+            angular: angular.into(),
+        }
     }
 }
 
@@ -35,19 +41,19 @@ mod tests {
 
     #[test]
     fn default_is_zero() {
-        assert_eq!(AngularVelocity::default().angular, Vec3::ZERO);
+        assert_eq!(AngularVelocity::default().angular, Vec3::ZERO.into());
     }
 
     #[test]
     fn new_sets_components() {
         let av = AngularVelocity::new(1.0, 2.0, 3.0);
-        assert_eq!(av.angular, Vec3::new(1.0, 2.0, 3.0));
+        assert_eq!(av.angular, Vec3::new(1.0, 2.0, 3.0).into());
     }
 
     #[test]
     fn from_vec3_stores_value() {
         let av = AngularVelocity::from_vec3(Vec3::Y * std::f32::consts::PI);
-        assert_eq!(av.angular, Vec3::Y * std::f32::consts::PI);
+        assert_eq!(av.angular, (Vec3::Y * std::f32::consts::PI).into());
     }
 
     #[test]

--- a/crates/bsengine-core/src/external_impulse.rs
+++ b/crates/bsengine-core/src/external_impulse.rs
@@ -1,4 +1,7 @@
-use bevy_ecs::prelude::Component;
+use crate::ReflectVec3;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
 use glam::Vec3;
 
 /// Accumulated impulses (kg·m/s) to apply to this entity during the physics step.
@@ -7,42 +10,43 @@ use glam::Vec3;
 ///
 /// Add individual impulses by calling `.add_linear()` / `.add_angular()` rather than
 /// assigning directly, so multiple systems can contribute without clobbering each other.
-#[derive(Component, Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Component, Debug, Clone, Copy, PartialEq, Default, Reflect)]
+#[reflect(Component, Default)]
 pub struct ExternalImpulse {
-    pub linear: Vec3,
-    pub angular: Vec3,
+    pub linear: ReflectVec3,
+    pub angular: ReflectVec3,
 }
 
 impl ExternalImpulse {
     pub fn linear(linear: Vec3) -> Self {
         Self {
-            linear,
-            angular: Vec3::ZERO,
+            linear: linear.into(),
+            angular: Vec3::ZERO.into(),
         }
     }
 
     pub fn angular(angular: Vec3) -> Self {
         Self {
-            linear: Vec3::ZERO,
-            angular,
+            linear: Vec3::ZERO.into(),
+            angular: angular.into(),
         }
     }
 
     pub fn add_linear(&mut self, impulse: Vec3) {
-        self.linear += impulse;
+        self.linear.0 += impulse;
     }
 
     pub fn add_angular(&mut self, impulse: Vec3) {
-        self.angular += impulse;
+        self.angular.0 += impulse;
     }
 
     pub fn clear(&mut self) {
-        self.linear = Vec3::ZERO;
-        self.angular = Vec3::ZERO;
+        self.linear = Vec3::ZERO.into();
+        self.angular = Vec3::ZERO.into();
     }
 
     pub fn is_zero(&self) -> bool {
-        self.linear == Vec3::ZERO && self.angular == Vec3::ZERO
+        self.linear.0 == Vec3::ZERO && self.angular.0 == Vec3::ZERO
     }
 }
 
@@ -61,7 +65,7 @@ mod tests {
         let mut i = ExternalImpulse::default();
         i.add_linear(Vec3::X);
         i.add_linear(Vec3::X);
-        assert_eq!(i.linear, Vec3::new(2.0, 0.0, 0.0));
+        assert_eq!(i.linear, Vec3::new(2.0, 0.0, 0.0).into());
     }
 
     #[test]
@@ -69,7 +73,7 @@ mod tests {
         let mut i = ExternalImpulse::default();
         i.add_angular(Vec3::Y);
         i.add_angular(Vec3::Y);
-        assert_eq!(i.angular, Vec3::new(0.0, 2.0, 0.0));
+        assert_eq!(i.angular, Vec3::new(0.0, 2.0, 0.0).into());
     }
 
     #[test]
@@ -82,14 +86,14 @@ mod tests {
     #[test]
     fn linear_ctor_sets_only_linear() {
         let i = ExternalImpulse::linear(Vec3::Z);
-        assert_eq!(i.linear, Vec3::Z);
-        assert_eq!(i.angular, Vec3::ZERO);
+        assert_eq!(i.linear, Vec3::Z.into());
+        assert_eq!(i.angular, Vec3::ZERO.into());
     }
 
     #[test]
     fn angular_ctor_sets_only_angular() {
         let i = ExternalImpulse::angular(Vec3::Y);
-        assert_eq!(i.linear, Vec3::ZERO);
-        assert_eq!(i.angular, Vec3::Y);
+        assert_eq!(i.linear, Vec3::ZERO.into());
+        assert_eq!(i.angular, Vec3::Y.into());
     }
 }

--- a/crates/bsengine-core/src/follow.rs
+++ b/crates/bsengine-core/src/follow.rs
@@ -1,14 +1,17 @@
-use bevy_ecs::prelude::{Component, Entity};
+use crate::ReflectVec3;
+use bevy_ecs::prelude::{Component, Entity, ReflectComponent};
+use bevy_reflect::Reflect;
 use glam::Vec3;
 
 /// Causes this entity's `Transform` to move toward another entity's position
 /// at the given `speed` (units/second), with a local `offset` applied to the
 /// target position. The `FollowPlugin` reads this and updates `Transform`.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(Component)]
 pub struct Follow {
     pub target: Entity,
     /// World-space offset added to the target's position before interpolation.
-    pub offset: Vec3,
+    pub offset: ReflectVec3,
     /// Maximum move speed (units/second). Use `f32::INFINITY` for instant snap.
     pub speed: f32,
 }
@@ -17,13 +20,13 @@ impl Follow {
     pub fn new(target: Entity) -> Self {
         Self {
             target,
-            offset: Vec3::ZERO,
+            offset: Vec3::ZERO.into(),
             speed: f32::INFINITY,
         }
     }
 
     pub fn with_offset(mut self, offset: Vec3) -> Self {
-        self.offset = offset;
+        self.offset = offset.into();
         self
     }
 
@@ -35,23 +38,24 @@ impl Follow {
 
 /// Causes this entity's `Transform` rotation to orient toward another entity's
 /// position each frame. The `LookAtPlugin` reads this and updates `Transform`.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(Component)]
 pub struct LookAt {
     pub target: Entity,
     /// World-space up vector used to compute the orientation.
-    pub up: Vec3,
+    pub up: ReflectVec3,
 }
 
 impl LookAt {
     pub fn new(target: Entity) -> Self {
         Self {
             target,
-            up: Vec3::Y,
+            up: Vec3::Y.into(),
         }
     }
 
     pub fn with_up(mut self, up: Vec3) -> Self {
-        self.up = up.normalize();
+        self.up = up.normalize().into();
         self
     }
 }
@@ -71,7 +75,7 @@ mod tests {
         let e = dummy_entity();
         let f = Follow::new(e);
         assert!(f.speed.is_infinite());
-        assert_eq!(f.offset, Vec3::ZERO);
+        assert_eq!(f.offset, Vec3::ZERO.into());
     }
 
     #[test]
@@ -79,14 +83,14 @@ mod tests {
         let e = dummy_entity();
         let f = Follow::new(e).with_speed(5.0).with_offset(Vec3::Y * 2.0);
         assert_eq!(f.speed, 5.0);
-        assert_eq!(f.offset, Vec3::new(0.0, 2.0, 0.0));
+        assert_eq!(f.offset, Vec3::new(0.0, 2.0, 0.0).into());
     }
 
     #[test]
     fn look_at_defaults_y_up() {
         let e = dummy_entity();
         let l = LookAt::new(e);
-        assert_eq!(l.up, Vec3::Y);
+        assert_eq!(l.up, Vec3::Y.into());
     }
 
     #[test]

--- a/crates/bsengine-core/src/nav_mesh_agent.rs
+++ b/crates/bsengine-core/src/nav_mesh_agent.rs
@@ -1,8 +1,11 @@
-use bevy_ecs::prelude::Component;
+use crate::ReflectVec3;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
 use glam::Vec3;
 
 /// State of the navigation agent's movement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Reflect)]
 pub enum NavAgentState {
     /// No destination set. Agent is idle.
     #[default]
@@ -17,10 +20,16 @@ pub enum NavAgentState {
 
 /// Pathfinding agent that steers an entity along a navigation mesh.
 /// The navigation system reads `destination`, computes a path, and moves the entity each frame.
-#[derive(Component, Debug, Clone, PartialEq)]
+#[derive(Component, Debug, Clone, PartialEq, Reflect)]
+#[reflect(Component, Default)]
 pub struct NavMeshAgent {
-    /// Desired world-space destination. Set to `None` to stop pathfinding.
-    pub destination: Option<Vec3>,
+    /// Reflected as `Option<ReflectVec3>` -- `bevy_reflect` represents
+    /// `Option` via its `Enum` trait, and the generic Inspector field editor
+    /// (`draw_reflect_ui`) has no `Enum`-editing branch yet (same disclosed,
+    /// pre-existing gap as `Material.texture_id: Option<u64>` from #1702),
+    /// so this field is reflected but not editable through the generic UI
+    /// for now.
+    pub destination: Option<ReflectVec3>,
     /// Maximum movement speed in world units per second.
     pub speed: f32,
     /// Maximum rotation speed in radians per second.
@@ -69,7 +78,7 @@ impl NavMeshAgent {
     }
 
     pub fn with_destination(mut self, destination: Vec3) -> Self {
-        self.destination = Some(destination);
+        self.destination = Some(destination.into());
         self
     }
 
@@ -84,6 +93,16 @@ impl NavMeshAgent {
 
     pub fn has_arrived(&self) -> bool {
         self.state == NavAgentState::Arrived
+    }
+}
+
+impl Default for NavMeshAgent {
+    // speed=0.0, not the constructor's usual positive default -- an agent
+    // added via the Inspector's "Add Component" dropdown with no configured
+    // speed shouldn't start silently trying to move once a destination is
+    // set some other way; Idle/stationary is the safer neutral default.
+    fn default() -> Self {
+        Self::new(0.0)
     }
 }
 
@@ -110,13 +129,13 @@ mod tests {
     fn with_destination() {
         let agent = NavMeshAgent::new(5.0).with_destination(Vec3::new(10.0, 0.0, 5.0));
         assert!(agent.destination.is_some());
-        assert_eq!(agent.destination.unwrap(), Vec3::new(10.0, 0.0, 5.0));
+        assert_eq!(agent.destination.unwrap(), Vec3::new(10.0, 0.0, 5.0).into());
     }
 
     #[test]
     fn clear_destination_resets_state() {
         let mut agent = NavMeshAgent::new(5.0);
-        agent.destination = Some(Vec3::ZERO);
+        agent.destination = Some(Vec3::ZERO.into());
         agent.state = NavAgentState::Moving;
         agent.clear_destination();
         assert!(agent.destination.is_none());

--- a/crates/bsengine-core/src/velocity.rs
+++ b/crates/bsengine-core/src/velocity.rs
@@ -1,29 +1,37 @@
-use bevy_ecs::prelude::Component;
+use crate::ReflectVec3;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
 use glam::Vec3;
 
 /// Kinematic linear velocity in world units per second.
 /// `VelocityPlugin` integrates this into `Transform.translation` each frame.
 /// For physics-driven motion use `bsengine-physics` instead.
-#[derive(Component, Debug, Clone, PartialEq)]
+#[derive(Component, Debug, Clone, PartialEq, Reflect)]
+#[reflect(Component, Default)]
 pub struct Velocity {
-    pub linear: Vec3,
+    pub linear: ReflectVec3,
 }
 
 impl Default for Velocity {
     fn default() -> Self {
-        Self { linear: Vec3::ZERO }
+        Self {
+            linear: Vec3::ZERO.into(),
+        }
     }
 }
 
 impl Velocity {
     pub fn new(x: f32, y: f32, z: f32) -> Self {
         Self {
-            linear: Vec3::new(x, y, z),
+            linear: Vec3::new(x, y, z).into(),
         }
     }
 
     pub fn from_vec3(linear: Vec3) -> Self {
-        Self { linear }
+        Self {
+            linear: linear.into(),
+        }
     }
 }
 
@@ -33,19 +41,19 @@ mod tests {
 
     #[test]
     fn default_is_zero() {
-        assert_eq!(Velocity::default().linear, Vec3::ZERO);
+        assert_eq!(Velocity::default().linear, Vec3::ZERO.into());
     }
 
     #[test]
     fn new_sets_components() {
         let v = Velocity::new(1.0, 2.0, 3.0);
-        assert_eq!(v.linear, Vec3::new(1.0, 2.0, 3.0));
+        assert_eq!(v.linear, Vec3::new(1.0, 2.0, 3.0).into());
     }
 
     #[test]
     fn from_vec3_stores_value() {
         let v = Velocity::from_vec3(Vec3::X * 5.0);
-        assert_eq!(v.linear, Vec3::X * 5.0);
+        assert_eq!(v.linear, (Vec3::X * 5.0).into());
     }
 
     #[test]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1514,6 +1514,12 @@ impl Plugin for EditorPlugin {
         app.register_type::<bsengine_core::Timer>();
         app.register_type::<bsengine_core::ToneMap>();
         app.register_type::<bsengine_core::Visible>();
+        app.register_type::<bsengine_core::AngularVelocity>();
+        app.register_type::<bsengine_core::ExternalImpulse>();
+        app.register_type::<bsengine_core::Follow>();
+        app.register_type::<bsengine_core::LookAt>();
+        app.register_type::<bsengine_core::NavMeshAgent>();
+        app.register_type::<bsengine_core::Velocity>();
         app.add_systems(Update, update_editor_snapshot);
         app.add_systems(Update, update_editor_camera);
         app.add_systems(Update, populate_inspector.after(update_editor_snapshot));

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -450,6 +450,65 @@ mod tests {
     }
 
     #[test]
+    fn reflected_fields_section_renders_without_panicking_for_the_pr2_batch() {
+        // Same rationale as the PR1 batch test. Follow/LookAt are included
+        // here even though they have no ReflectDefault (so they'd never
+        // appear via the Inspector's own Add Component flow) -- this test
+        // exercises the read/render path directly with a hand-constructed
+        // instance instead, to prove the generic field renderer handles an
+        // Entity field (via new(Entity::PLACEHOLDER)) without panicking.
+        let mut insp = InspectorState::default();
+        insp.selected_id = Some(1);
+        insp.reflected_components = vec![
+            (
+                "bsengine_core::angular_velocity::AngularVelocity".to_string(),
+                Box::new(bsengine_core::AngularVelocity::default())
+                    as Box<dyn bevy_reflect::Reflect>,
+            ),
+            (
+                "bsengine_core::external_impulse::ExternalImpulse".to_string(),
+                Box::new(bsengine_core::ExternalImpulse::default())
+                    as Box<dyn bevy_reflect::Reflect>,
+            ),
+            (
+                "bsengine_core::follow::Follow".to_string(),
+                Box::new(bsengine_core::Follow::new(
+                    bevy_ecs::prelude::Entity::PLACEHOLDER,
+                )) as Box<dyn bevy_reflect::Reflect>,
+            ),
+            (
+                "bsengine_core::follow::LookAt".to_string(),
+                Box::new(bsengine_core::LookAt::new(
+                    bevy_ecs::prelude::Entity::PLACEHOLDER,
+                )) as Box<dyn bevy_reflect::Reflect>,
+            ),
+            (
+                "bsengine_core::nav_mesh_agent::NavMeshAgent".to_string(),
+                Box::new(bsengine_core::NavMeshAgent::default()) as Box<dyn bevy_reflect::Reflect>,
+            ),
+            (
+                "bsengine_core::velocity::Velocity".to_string(),
+                Box::new(bsengine_core::Velocity::default()) as Box<dyn bevy_reflect::Reflect>,
+            ),
+        ];
+
+        let entities_snapshot: Vec<InspectorEntityInfo> = Vec::new();
+        let mut panel = InspectorPanel;
+
+        with_test_ui(|ui| {
+            let mut ctx = EditorPanelContext {
+                insp: &mut insp,
+                entities_snapshot: &entities_snapshot,
+                cursor_pos: (0.0, 0.0),
+                type_registry: None,
+            };
+            panel.ui(ui, &mut ctx);
+        });
+
+        assert!(insp.cmd_queue.is_empty());
+    }
+
+    #[test]
     fn validate_after_edit_clamps_an_out_of_range_spot_light() {
         let mut registry = bevy_reflect::TypeRegistry::default();
         registry.register::<bsengine_core::SpotLight>();

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -767,7 +767,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut a) = world.get_mut::<NavMeshAgent>(e) {
-                        a.destination = Some(glam::Vec3::new(x, y, z));
+                        a.destination = Some(glam::Vec3::new(x, y, z).into());
                     }
                 }
             }
@@ -1147,7 +1147,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut f) = world.get_mut::<Follow>(e) {
-                        f.offset = Vec3::new(x, y, z);
+                        f.offset = Vec3::new(x, y, z).into();
                     }
                 }
             }
@@ -1189,7 +1189,7 @@ fn run_scripts(world: &mut World) {
                 };
                 if let Some(e) = entity {
                     if let Some(mut la) = world.get_mut::<LookAt>(e) {
-                        la.up = Vec3::new(x, y, z);
+                        la.up = Vec3::new(x, y, z).into();
                     }
                 }
             }

--- a/games/cube-roller/src/main.rs
+++ b/games/cube-roller/src/main.rs
@@ -145,7 +145,7 @@ fn player_control(
     vel.linear.z *= DAMPING;
     vel.linear.y -= GRAVITY * dt;
 
-    transform.translation += vel.linear * dt;
+    transform.translation += vel.linear.0 * dt;
 
     if transform.translation.y < FLOOR_Y {
         transform.translation.y = FLOOR_Y;
@@ -180,7 +180,7 @@ fn respawn(mut query: Query<(&mut Transform, &mut Velocity), With<Player>>) {
     };
     if t.translation.y < RESPAWN_Y {
         t.translation = Vec3::new(0.0, FLOOR_Y, 0.0);
-        vel.linear = Vec3::ZERO;
+        vel.linear = Vec3::ZERO.into();
         println!("Respawned!");
     }
 }


### PR DESCRIPTION
## Summary
- PR 2 of 3 continuing the bevy_reflect adoption plan (PR 1 / #1708 already merged: 14 components with no glam fields). This PR reflects the 6 remaining real components that have `glam::Vec3` fields, reusing the existing `ReflectVec3` wrapper (`PointLight.color` etc. already use it).
- Components: `AngularVelocity`, `ExternalImpulse`, `Follow`, `LookAt`, `NavMeshAgent`, `Velocity`.
- **Confirmed empirically that `bevy_ecs::Entity` already implements `Reflect`** (no wrapper type needed) -- `bevy_ecs`'s `bevy_reflect` cargo feature is already enabled workspace-wide.
- `Follow`/`LookAt` deliberately get `#[reflect(Component)]` **without** `Default` -- both require a valid `target: Entity` with no sensible default, so they won't appear in the Inspector's "Add Component" dropdown, but their fields ARE viewable/editable through the generic "Reflected Fields" section once already attached (e.g. via script or scene load).
- `NavMeshAgent.destination: Option<Vec3>` becomes `Option<ReflectVec3>` -- reflected but not editable in the generic UI yet (same disclosed gap as `Material.texture_id: Option<u64>` from #1702; `bevy_reflect` represents `Option` via its `Enum` trait, which the generic field renderer doesn't handle yet).

## A real gap found and fixed mid-implementation
The original plan only surveyed `bsengine-core`'s own files for each component's `Vec3` field usage. `cargo build -p bsengine-core` passed clean after every core-editing task, but a subsequent full `cargo build --workspace` failed with a dozen+ errors: `bsengine-app`'s actual gameplay systems (`VelocityPlugin`, `AngularVelocityPlugin`, `ExternalImpulsePlugin`, `FollowPlugin`/look-at, `DampingPlugin`, `GravityPlugin`, `NavMeshPlugin`) do real per-frame arithmetic (`+=`, `*=`, `Mul<f32>`) on these fields, which `ReflectVec3` deliberately doesn't implement (same "opaque wrapper" design as `ReflectColor`/`ReflectDegrees`). `bsengine-scripting`'s JS setters and even `games/cube-roller`'s own gameplay code needed fixes too. Fixed by reading through `.0` (or `.into()`) at each arithmetic/assignment site -- individual field reads like `vel.linear.x` needed no change, since `Deref`/`DerefMut` handle those transparently; only whole-value arithmetic is the gap. See the `fix(app,scripting)` commit for the full list of touched files.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace` clean (2 pre-existing warnings from #1708, unrelated to this PR, not touched)
- [x] `cargo test --workspace --exclude bsengine-editor --exclude bsengine-editor-app` all green
- [x] `cargo test -p bsengine-editor --lib` in isolation: 802/802 (pre-existing `STATUS_STACK_OVERFLOW` workaround, unrelated to this change)
- [x] New combined render-path smoke test covering all 6 components in one frame, following PR 1's pattern (`Follow`/`LookAt` use a hand-constructed instance via `Entity::PLACEHOLDER` since they have no `ReflectDefault`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)