### PR TITLE
docs: add crate-level rustdoc for all 18 workspace crates

### DIFF
--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -1,3 +1,12 @@
+//! Gameplay-systems layer for BSEngine, built on `bevy_app`.
+//!
+//! Each module is a small, independent `Plugin` (e.g. `VelocityPlugin`,
+//! `GravityPlugin`, `TweenPlugin`) that a game wires up via
+//! `App::add_plugins`. Also re-exports the app-level schedule labels
+//! (`Startup`, `PreUpdate`, `Update`, `PostUpdate`, `Last`) and the
+//! `new_app()`/`BsPlugin` entry points.
+#![warn(missing_docs)]
+
 pub mod angular_velocity;
 pub mod animation_player;
 pub mod animation_state_machine;

--- a/crates/bsengine-asset/src/lib.rs
+++ b/crates/bsengine-asset/src/lib.rs
@@ -1,3 +1,10 @@
+//! Asset loading for BSEngine — textures and meshes.
+//!
+//! `AssetServer` loads and caches assets behind a `Handle<T>`, backed by
+//! `MeshAsset`/`TextureAsset`. `AssetPlugin` wires the server into the app
+//! as the `AssetServerResource`.
+#![warn(missing_docs)]
+
 pub mod handle;
 pub mod plugin;
 pub mod server;

--- a/crates/bsengine-audio/src/lib.rs
+++ b/crates/bsengine-audio/src/lib.rs
@@ -1,3 +1,10 @@
+//! Audio playback for BSEngine, built on the `kira` audio engine.
+//!
+//! `AudioPlugin` adds an `AudioWorld` resource that manages playback.
+//! `AudioSource`/`AudioPlayer` are the ECS-facing components, with
+//! `PlaybackState` tracking whether a sound is playing, paused, or stopped.
+#![warn(missing_docs)]
+
 pub mod components;
 pub mod plugin;
 pub mod world;

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -1,3 +1,13 @@
+//! Core ECS components and resources shared across BSEngine.
+//!
+//! Defines the real, actively-used component types (`Transform`, `Camera`,
+//! light variants, `Material`, physics-adjacent components like
+//! `Velocity`/`Damping`/`Shield`, ...) plus their `bevy_reflect`
+//! registrations backing the editor's generic Inspector UI, the
+//! `ReflectVec3`/`ReflectColor`/... opaque wrapper types reflection needs,
+//! and editor-facing infrastructure (`InspectorState`, `EditorPanelRegistry`).
+#![warn(missing_docs)]
+
 pub mod ambient_occlusion;
 pub mod angular_velocity;
 pub mod animation_player;

--- a/crates/bsengine-ecs/src/lib.rs
+++ b/crates/bsengine-ecs/src/lib.rs
@@ -1,3 +1,11 @@
+//! Thin re-export of the `bevy_ecs` prelude used across BSEngine.
+//!
+//! No logic of its own — exists so the rest of the workspace depends on
+//! one internal crate (`bsengine_ecs::{Query, Commands, Component, ...}`)
+//! instead of `bevy_ecs` directly, keeping the ECS dependency version
+//! centralized.
+#![warn(missing_docs)]
+
 pub use bevy_ecs::prelude::{
     Added, Bundle, Commands, Component, Entity, Event, EventReader, EventWriter, Query, Res,
     ResMut, Resource, With, Without, World,

--- a/crates/bsengine-editor/src/lib.rs
+++ b/crates/bsengine-editor/src/lib.rs
@@ -1,8 +1,16 @@
+//! Editor backend for BSEngine, exposed via MCP (Model Context Protocol).
+//!
+//! `EditorPlugin` wires up the editor's ECS systems; `EditorCommand` is the
+//! command layer an AI agent or UI drives the editor through (spawn,
+//! transform, hierarchy, tags, selection, ...), snapshotted each frame via
+//! `EditorSnapshot`/`EntityInfo` for the ~700 MCP tools described in the
+//! project README.
 // Bevy ECS system params (Query<(A, B, C, ...)>, ParamSet<(...)>) routinely
 // exceed clippy's type-complexity threshold; that's the idiom, not a real
 // complexity problem. Bevy itself disables this lint crate-wide for the
 // same reason.
 #![allow(clippy::type_complexity)]
+#![warn(missing_docs)]
 
 pub mod plugin;
 pub mod snapshot;

--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -1,3 +1,11 @@
+//! GLTF/GLB asset import for BSEngine.
+//!
+//! `GltfLoader` parses a glTF file into `LoadedGltf` (mesh + `MeshData`),
+//! with `AnimationClip`/`AnimationChannel`/`Interpolation` covering
+//! skeletal animation data. `GltfPlugin` wires loading into the app;
+//! `GltfAsset` is the resulting ECS-facing handle.
+#![warn(missing_docs)]
+
 pub mod animation;
 pub mod loader;
 pub mod plugin;

--- a/crates/bsengine-input/src/lib.rs
+++ b/crates/bsengine-input/src/lib.rs
@@ -1,3 +1,11 @@
+//! Keyboard, mouse, and gamepad input abstraction for BSEngine.
+//!
+//! `InputPlugin` polls the platform window layer and exposes `Input<T>`
+//! (for `KeyCode`/`MouseButton`/`GamepadButton`) plus cursor/wheel events
+//! (`CursorMoved`, `MouseMotion`, `MouseWheel`) and `MouseState` as
+//! ECS resources.
+#![warn(missing_docs)]
+
 pub mod convert;
 pub mod plugin;
 pub mod state;

--- a/crates/bsengine-mcp/src/lib.rs
+++ b/crates/bsengine-mcp/src/lib.rs
@@ -1,3 +1,12 @@
+//! Generic Model Context Protocol (MCP) server runtime for BSEngine.
+//!
+//! `McpServer` exposes `McpTool`s (registered via `McpToolRegistry`) over
+//! MCP so an external client — typically an AI agent — can invoke them.
+//! `McpPlugin`/`McpRegistryResource` wire the registry into the app;
+//! `bsengine-editor` is the primary consumer, registering its ~700 tools
+//! here rather than reimplementing a protocol server itself.
+#![warn(missing_docs)]
+
 pub mod game_tools;
 pub mod plugin;
 pub mod registry;

--- a/crates/bsengine-network/src/lib.rs
+++ b/crates/bsengine-network/src/lib.rs
@@ -1,3 +1,11 @@
+//! Network session and wire-protocol layer for BSEngine.
+//!
+//! `NetworkPlugin` manages a `NetworkSession` with a `NetworkRole`
+//! (host/client), and the (private) `packet` module defines the
+//! `TransformData` wire format used to replicate entity transforms across
+//! the network.
+#![warn(missing_docs)]
+
 mod packet;
 mod plugin;
 mod session;

--- a/crates/bsengine-physics/src/lib.rs
+++ b/crates/bsengine-physics/src/lib.rs
@@ -1,3 +1,12 @@
+//! Rigid-body physics for BSEngine.
+//!
+//! `PhysicsPlugin` steps a `PhysicsWorld` each frame. `RigidBody`/
+//! `RigidBodyType` and `Collider`/`ColliderShape` are the ECS-facing
+//! components; `CollisionEvent` reports contacts, and `PhysicsInput`/
+//! `PhysicsTransform` are the sync points with the engine's own
+//! `Transform` component.
+#![warn(missing_docs)]
+
 pub mod components;
 pub mod plugin;
 pub mod world;

--- a/crates/bsengine-plugin/src/lib.rs
+++ b/crates/bsengine-plugin/src/lib.rs
@@ -1,3 +1,11 @@
+//! Runtime plugin loader for BSEngine.
+//!
+//! `PluginLoader` reads a `PluginDescriptor` and loads the described
+//! plugin at runtime; `PluginRegistry`/`PluginRegistryResource` track
+//! what's currently loaded. `PluginSystemPlugin` wires the loader into
+//! the app.
+#![warn(missing_docs)]
+
 pub mod descriptor;
 pub mod loader;
 pub mod plugin;

--- a/crates/bsengine-render/src/lib.rs
+++ b/crates/bsengine-render/src/lib.rs
@@ -1,8 +1,15 @@
+//! Scene rendering pipeline for BSEngine, built on `bsengine-rhi`.
+//!
+//! `RenderPlugin` drives the per-frame render systems (transform
+//! propagation, draw-call collection, lighting) against the abstract GPU
+//! interface; `MeshRenderer` is the ECS-facing component marking an
+//! entity as drawable.
 // Bevy ECS system params (Query<(A, B, C, ...)>, ParamSet<(...)>) routinely
 // exceed clippy's type-complexity threshold; that's the idiom, not a real
 // complexity problem. Bevy itself disables this lint crate-wide for the
 // same reason.
 #![allow(clippy::type_complexity)]
+#![warn(missing_docs)]
 
 pub mod components;
 pub mod plugin;

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -1,8 +1,17 @@
+//! `wgpu`-based implementation of the `bsengine-rhi` abstract GPU
+//! interface.
+//!
+//! `WgpuRHIPlugin`/`WgpuRHI` implement the RHI traits; `GpuMeshRegistry`/
+//! `GpuTextureRegistry` and `WgpuSurfaceResource` manage GPU-side mesh,
+//! texture, and swapchain state. Also hosts the editor's viewport gizmo
+//! and Inspector panel rendering (`gizmo`, `panels` modules), since both
+//! need direct GPU surface access.
 // Bevy ECS system params (Query<(A, B, C, ...)>, ParamSet<(...)>) routinely
 // exceed clippy's type-complexity threshold; that's the idiom, not a real
 // complexity problem. Bevy itself disables this lint crate-wide for the
 // same reason.
 #![allow(clippy::type_complexity)]
+#![warn(missing_docs)]
 
 pub mod gizmo;
 pub mod mesh;

--- a/crates/bsengine-rhi/src/lib.rs
+++ b/crates/bsengine-rhi/src/lib.rs
@@ -1,2 +1,9 @@
+//! Abstract render hardware interface (RHI) for BSEngine.
+//!
+//! Defines the `RHI`/`RHIMesh`/`RHIShader`/`RHITexture` traits that a
+//! concrete GPU backend implements — see `bsengine-rhi-wgpu` for the only
+//! current implementation, built on `wgpu`.
+#![warn(missing_docs)]
+
 pub mod traits;
 pub use traits::{RHIMesh, RHIShader, RHITexture, RHI};

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -1,3 +1,11 @@
+//! Scene graph, entity transforms, and scene file I/O for BSEngine.
+//!
+//! `ScenePlugin`/`spawn_scene_entities` load a `SceneDescriptor` (RON
+//! format) into the ECS world, deserializing `EntityDescriptor` and its
+//! nested light/physics/collider/transform descriptor types
+//! (`PointLightDescriptor`, `RigidBodyDesc`, `TransformDescriptor`, ...).
+#![warn(missing_docs)]
+
 pub mod plugin;
 pub mod types;
 

--- a/crates/bsengine-scripting/src/lib.rs
+++ b/crates/bsengine-scripting/src/lib.rs
@@ -1,9 +1,16 @@
+//! JavaScript scripting runtime for BSEngine, via Deno Core (V8).
+//!
+//! `ScriptingPlugin` loads `.js` files (`Script`) and exposes ECS
+//! operations to scripts as async Deno ops (`ops` module);
+//! `ScriptRuntime` wraps the underlying V8 isolate, and `save` handles
+//! script-driven save-game serialization.
 #![recursion_limit = "2048"]
 // Bevy ECS system params (Query<(A, B, C, ...)>, ParamSet<(...)>) routinely
 // exceed clippy's type-complexity threshold; that's the idiom, not a real
 // complexity problem. Bevy itself disables this lint crate-wide for the
 // same reason.
 #![allow(clippy::type_complexity)]
+#![warn(missing_docs)]
 // bsengine-scripting
 pub mod ops;
 pub mod plugin;

--- a/crates/bsengine-window/src/lib.rs
+++ b/crates/bsengine-window/src/lib.rs
@@ -1,3 +1,10 @@
+//! Platform window management for BSEngine, via `winit`.
+//!
+//! `WindowPlugin` creates and owns the OS window, exposing `WindowHandle`
+//! and firing `WindowCreated`/`WindowResized`/`WindowClosed` events;
+//! `WindowDescriptor` configures initial size/title.
+#![warn(missing_docs)]
+
 pub mod plugin;
 pub mod runner;
 pub mod types;


### PR DESCRIPTION
## Summary
- Closes #103. Adds a module-level `//!` doc comment plus `#![warn(missing_docs)]` to all 18 `crates/*/src/lib.rs` files in the workspace.
- Content is crate-specific (not boilerplate): 15 crates expand on their existing README one-liner, the 3 crates absent from README (`bsengine-audio`, `bsengine-physics`, `bsengine-network`) get a description written directly from their code.
- Pure doc-comment addition — no logic changed, no public-item (`///`) docs added in this pass (deliberately out of scope; `missing_docs` will surface those as warnings for future incremental cleanup, not blocking since this repo's CI doesn't use `-D warnings`).
- For the 4 crates with a pre-existing crate-level attribute (`bsengine-editor`, `bsengine-render`, `bsengine-rhi-wgpu`, `bsengine-scripting`), the new `//!` block is inserted above the existing `#![allow(...)]`/`#![recursion_limit]` attributes per Rust's doc-comment-ordering rule, with those attributes left byte-for-byte unchanged.

## Test plan
- [x] `cargo build -p <each of the 18 crates>` — clean after each of the 3 task commits
- [x] `cargo doc --workspace --no-deps` — succeeds (missing-docs warnings on individual public items expected, not blocking)
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --exclude bsengine-editor --exclude bsengine-editor-app` — 0 failed
- [x] `cargo test -p bsengine-editor --lib` — 802/802 passed (isolated per this repo's V8/VA conflict)
- [x] `rustfmt --check --edition 2021` on each touched file individually — no diff (note: `bsengine-editor/src/lib.rs` itself couldn't be locally format-checked — the whole `bsengine-editor` crate crashes standalone `rustfmt` due to `.rustfmt.toml`'s `plugin.rs` ignore-list entry, not just `plugin.rs` directly; relying on CI's format check for that one file)
- [x] `git diff master --shortstat` — 18 files changed, 144 insertions(+), 0 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)