### PR TITLE
fix(rhi-wgpu): stop egui_dock from painting over the rendered viewport

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/panels/dock.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/dock.rs
@@ -108,6 +108,15 @@ impl egui_dock::TabViewer for BseTabViewer<'_> {
             }
         }
     }
+
+    // The viewport tab draws no content of its own — the 3D scene is
+    // rendered directly into the swapchain texture before egui runs, and
+    // ViewportPanel::ui only paints gizmo overlays on top of it. Without
+    // this override, egui_dock's default opaque tab-body fill paints over
+    // that already-rendered scene every frame, hiding it completely.
+    fn clear_background(&self, tab: &String) -> bool {
+        tab != "viewport"
+    }
 }
 
 /// Renders the toolbar's "Window ▾" menu: a checkbox per registered panel


### PR DESCRIPTION
## Summary
- The editor's Viewport tab showed a completely blank/dark viewport even though camera, mesh, and lighting data were all computing correctly.
- Root cause: `egui_dock::TabViewer::clear_background()` defaults to `true`, so `DockArea` paints an opaque `tab_body.bg_fill` rect over every tab body right before calling `TabViewer::ui()`. BSEngine renders the 3D scene directly into the swapchain texture *before* egui runs, and `ViewportPanel::ui` only draws gizmo overlays on top of it — so that default opaque fill was silently erasing the already-rendered scene every frame.
- Fix: `BseTabViewer` now overrides `clear_background()` to return `false` only for the `"viewport"` tab, letting the pre-rendered scene show through while other panels (Hierarchy, Inspector) keep their normal background.

## Test plan
- [x] Reproduced the blank viewport locally with `cargo run -p bsengine-editor-app -- games/cube-roller/assets/scenes/main.ron`
- [x] Ruled out SSAO, shadow mapping, and lighting math via targeted debug builds (zero visual change confirmed the paint-over was happening after the render pass)
- [x] Verified the fix: Floor/Player/Item cubes and shadows now render correctly in the Viewport tab
- [x] `cargo build -p bsengine-editor-app` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)