### PR TITLE
feat(runtime): headless --test mode for gameplay E2E testing (1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,7 @@ dependencies = [
  "kira",
  "ron",
  "serde",
+ "serde_json",
  "toml",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "bsengine-scene",
  "bsengine-scripting",
  "bsengine-window",
+ "glam 0.29.3",
  "kira",
  "ron",
  "serde",

--- a/crates/bsengine-core/src/logging.rs
+++ b/crates/bsengine-core/src/logging.rs
@@ -10,6 +10,7 @@ pub fn init_logging() {
                 EnvFilter::try_from_default_env()
                     .unwrap_or_else(|_| EnvFilter::new("bsengine=debug,warn")),
             )
+            .with_writer(std::io::stderr)
             .init();
     });
 }

--- a/crates/bsengine-input/src/state.rs
+++ b/crates/bsengine-input/src/state.rs
@@ -37,14 +37,18 @@ impl<T: Eq + Hash + Clone> Input<T> {
         self.just_released.contains(key)
     }
 
-    pub(crate) fn press(&mut self, key: T) {
+    /// Marks `key` as pressed. Used by the real input pipeline and by the
+    /// headless test runtime's synthetic input injection — both go through
+    /// this same resource so scripts can't distinguish the two.
+    pub fn press(&mut self, key: T) {
         if !self.pressed.contains(&key) {
             self.just_pressed.insert(key.clone());
         }
         self.pressed.insert(key);
     }
 
-    pub(crate) fn release(&mut self, key: T) {
+    /// Marks `key` as released. See [`Input::press`].
+    pub fn release(&mut self, key: T) {
         self.pressed.remove(&key);
         self.just_released.insert(key);
     }

--- a/crates/bsengine-runtime/Cargo.toml
+++ b/crates/bsengine-runtime/Cargo.toml
@@ -31,3 +31,6 @@ serde           = { workspace = true }
 serde_json      = { workspace = true }
 toml            = { workspace = true }
 tracing         = { workspace = true }
+
+[dev-dependencies]
+glam            = { workspace = true }

--- a/crates/bsengine-runtime/Cargo.toml
+++ b/crates/bsengine-runtime/Cargo.toml
@@ -28,5 +28,6 @@ bevy_ecs        = { workspace = true }
 kira            = { workspace = true }
 ron             = { workspace = true }
 serde           = { workspace = true }
+serde_json      = { workspace = true }
 toml            = { workspace = true }
 tracing         = { workspace = true }

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -1,68 +1,39 @@
 use std::env;
 
-use bevy_app::{PostStartup, Update};
-use bevy_ecs::prelude::{IntoSystemConfigs, World};
 use bsengine_app::new_app;
 use bsengine_audio::AudioPlugin;
-use bsengine_core::{HudTexts, Transform};
-use bsengine_ecs::{Added, Commands, Entity, Query, ResMut};
 use bsengine_editor::EditorPlugin;
 use bsengine_input::InputPlugin;
 use bsengine_network::NetworkPlugin;
-use bsengine_physics::{Collider, PhysicsInput, PhysicsPlugin, RigidBody};
-use bsengine_render::{MeshRenderer, RenderPlugin};
-use bsengine_rhi_wgpu::{
-    capsule_vertices, cube_vertices, plane_vertices, sphere_vertices, GpuMeshRegistry,
-    WgpuRHIPlugin,
-};
-use bsengine_scene::{
-    spawn_scene_entities, ColliderShapeDesc, Name, PendingSceneLoad, PhysicsBodyDesc, Primitive,
-    PrimitiveMesh, RigidBodyDesc, SceneDescriptor, ScenePlugin,
-};
-use bsengine_scripting::{
-    load_scripts, ScriptRuntime, ScriptRuntimeResource, ScriptingPlugin, SoundHandles,
-};
+use bsengine_physics::PhysicsPlugin;
+use bsengine_render::RenderPlugin;
+use bsengine_rhi_wgpu::WgpuRHIPlugin;
+use bsengine_scene::ScenePlugin;
+use bsengine_scripting::ScriptingPlugin;
 use bsengine_window::{WindowDescriptor, WindowPlugin};
-use serde::Deserialize;
 
-#[derive(Deserialize)]
-struct ProjectManifest {
-    project: ProjectSection,
-    #[serde(default)]
-    window: WindowSection,
-}
+mod scene_systems;
+mod test_mode;
+mod test_protocol;
+mod test_query;
 
-#[derive(Deserialize)]
-struct ProjectSection {
-    name: String,
-    entry_scene: String,
-}
-
-#[derive(Deserialize, Default)]
-struct WindowSection {
-    #[serde(default)]
-    title: Option<String>,
-    #[serde(default = "default_width")]
-    width: u32,
-    #[serde(default = "default_height")]
-    height: u32,
-    #[serde(default = "default_true")]
-    resizable: bool,
-}
-
-fn default_width() -> u32 {
-    1280
-}
-fn default_height() -> u32 {
-    720
-}
-fn default_true() -> bool {
-    true
-}
+use scene_systems::{register_scene_systems, ProjectManifest};
 
 fn main() {
-    let project_dir = env::args().nth(1).unwrap_or_else(|| ".".to_string());
-    let manifest_path = format!("{}/project.toml", project_dir);
+    let mut args = env::args().skip(1);
+    let first_arg = args.next().unwrap_or_else(|| ".".to_string());
+
+    if first_arg == "--test" {
+        let project_dir = args.next().unwrap_or_else(|| ".".to_string());
+        test_mode::run_test_mode(&project_dir);
+        return;
+    }
+
+    run_windowed(&first_arg);
+}
+
+fn run_windowed(project_dir: &str) {
+    let manifest_path = format!("{project_dir}/project.toml");
 
     let manifest_str = std::fs::read_to_string(&manifest_path)
         .unwrap_or_else(|e| panic!("Cannot read {manifest_path}: {e}"));
@@ -73,10 +44,11 @@ fn main() {
     let title = manifest
         .window
         .title
+        .clone()
         .unwrap_or_else(|| manifest.project.name.clone());
 
-    new_app()
-        .add_plugins(WgpuRHIPlugin)
+    let mut app = new_app();
+    app.add_plugins(WgpuRHIPlugin)
         .add_plugins(WindowPlugin {
             descriptor: WindowDescriptor {
                 title,
@@ -93,170 +65,8 @@ fn main() {
         .add_plugins(RenderPlugin)
         .add_plugins(ScenePlugin::from_file(&scene_path))
         .add_plugins(ScriptingPlugin {
-            project_dir: project_dir.clone(),
-        })
-        // PostStartup: resolve primitive meshes, then physics bodies
-        .add_systems(
-            PostStartup,
-            (resolve_primitives, resolve_physics_bodies).chain(),
-        )
-        // Update: handle scene transitions first, then re-resolve newly spawned entities
-        .add_systems(Update, handle_scene_load)
-        .add_systems(Update, resolve_primitives.after(handle_scene_load))
-        .add_systems(Update, resolve_physics_bodies.after(resolve_primitives))
-        .run();
-}
-
-fn resolve_primitives(
-    query: Query<(Entity, &PrimitiveMesh), Added<PrimitiveMesh>>,
-    mut commands: Commands,
-    registry: Option<ResMut<GpuMeshRegistry>>,
-) {
-    let Some(mut registry) = registry else { return };
-
-    let mut cube_id: Option<u64> = None;
-    let mut sphere_id: Option<u64> = None;
-    let mut plane_id: Option<u64> = None;
-    let mut capsule_id: Option<u64> = None;
-
-    for (entity, prim) in query.iter() {
-        let mesh_id = match &prim.0 {
-            Primitive::Cube => *cube_id.get_or_insert_with(|| {
-                let (v, i) = cube_vertices();
-                registry.register(&v, &i)
-            }),
-            Primitive::Sphere => *sphere_id.get_or_insert_with(|| {
-                let (v, i) = sphere_vertices();
-                registry.register(&v, &i)
-            }),
-            Primitive::Plane => *plane_id.get_or_insert_with(|| {
-                let (v, i) = plane_vertices();
-                registry.register(&v, &i)
-            }),
-            Primitive::Capsule => *capsule_id.get_or_insert_with(|| {
-                let (v, i) = capsule_vertices();
-                registry.register(&v, &i)
-            }),
-        };
-        commands.entity(entity).insert(MeshRenderer { mesh_id });
-    }
-}
-
-fn resolve_physics_bodies(
-    query: Query<(Entity, &PhysicsBodyDesc), Added<PhysicsBodyDesc>>,
-    transforms: Query<&Transform>,
-    mut commands: Commands,
-) {
-    for (entity, desc) in query.iter() {
-        let rb = match desc.rigidbody {
-            RigidBodyDesc::Dynamic => RigidBody::dynamic(),
-            RigidBodyDesc::Static => RigidBody::fixed(),
-            RigidBodyDesc::Kinematic => RigidBody::kinematic(),
-        };
-        let col_base = match &desc.collider.shape {
-            ColliderShapeDesc::Box { hx, hy, hz } => Collider::cuboid(*hx, *hy, *hz),
-            ColliderShapeDesc::Sphere { radius } => Collider::ball(*radius),
-            ColliderShapeDesc::Capsule {
-                half_height,
-                radius,
-            } => Collider::capsule(*half_height, *radius),
-        };
-        let col = col_base
-            .with_restitution(desc.collider.restitution)
-            .with_friction(desc.collider.friction)
-            .with_sensor(desc.collider.sensor);
-        let t = transforms.get(entity).cloned().unwrap_or_default();
-        commands.entity(entity).insert((
-            rb,
-            col,
-            PhysicsInput {
-                translation: t.translation.0,
-                rotation: t.rotation.0,
-            },
-        ));
-    }
-}
-
-fn handle_scene_load(world: &mut World) {
-    let pending = world.remove_resource::<PendingSceneLoad>();
-    let Some(pending) = pending else { return };
-
-    let content = match std::fs::read_to_string(&pending.path) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!("[scene] failed to read {}: {e}", pending.path);
-            return;
-        }
-    };
-    let scene: SceneDescriptor = match ron::from_str(&content) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!("[scene] failed to parse {}: {e}", pending.path);
-            return;
-        }
-    };
-
-    // Stop all sounds and clear handles
-    if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
-        for (_, mut handle) in handles.0.drain() {
-            handle.stop(kira::Tween::default());
-        }
-    }
-
-    // Despawn all named entities
-    let named: Vec<Entity> = {
-        let mut q = world.query::<(Entity, &Name)>();
-        q.iter(world).map(|(e, _)| e).collect()
-    };
-    for e in named {
-        world.despawn(e);
-    }
-
-    // Clear HUD
-    if let Some(mut hud) = world.get_resource_mut::<HudTexts>() {
-        hud.0.clear();
-    }
-
-    // Reset script runtime
-    world.insert_non_send_resource(ScriptRuntimeResource(ScriptRuntime::new_with_ops()));
-
-    // Spawn scene and resolve physics inline (Added<> won't fire for same-frame spawns)
-    spawn_scene_entities(world, &scene.entities);
-    resolve_physics_bodies_world(world);
-    load_scripts(world);
-}
-
-fn resolve_physics_bodies_world(world: &mut World) {
-    let entities: Vec<(Entity, PhysicsBodyDesc)> = {
-        let mut q = world.query::<(Entity, &PhysicsBodyDesc)>();
-        q.iter(world).map(|(e, d)| (e, d.clone())).collect()
-    };
-    for (entity, desc) in entities {
-        let rb = match desc.rigidbody {
-            RigidBodyDesc::Dynamic => RigidBody::dynamic(),
-            RigidBodyDesc::Static => RigidBody::fixed(),
-            RigidBodyDesc::Kinematic => RigidBody::kinematic(),
-        };
-        let col_base = match desc.collider.shape {
-            ColliderShapeDesc::Box { hx, hy, hz } => Collider::cuboid(hx, hy, hz),
-            ColliderShapeDesc::Sphere { radius } => Collider::ball(radius),
-            ColliderShapeDesc::Capsule {
-                half_height,
-                radius,
-            } => Collider::capsule(half_height, radius),
-        };
-        let col = col_base
-            .with_restitution(desc.collider.restitution)
-            .with_friction(desc.collider.friction)
-            .with_sensor(desc.collider.sensor);
-        let t = world.get::<Transform>(entity).cloned().unwrap_or_default();
-        world.entity_mut(entity).insert((
-            rb,
-            col,
-            PhysicsInput {
-                translation: t.translation.0,
-                rotation: t.rotation.0,
-            },
-        ));
-    }
+            project_dir: project_dir.to_string(),
+        });
+    register_scene_systems(&mut app);
+    app.run();
 }

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -1,0 +1,221 @@
+//! Scene/project loading systems shared by the real-time runtime (`main.rs`)
+//! and the headless test runtime (`test_mode.rs`), so both run identical
+//! scene-load and physics-resolution behavior.
+
+use bevy_app::{App, PostStartup, Update};
+use bevy_ecs::prelude::{IntoSystemConfigs, World};
+use bsengine_core::{HudTexts, Transform};
+use bsengine_ecs::{Added, Commands, Entity, Query, ResMut};
+use bsengine_physics::{Collider, PhysicsInput, RigidBody};
+use bsengine_rhi_wgpu::{
+    capsule_vertices, cube_vertices, plane_vertices, sphere_vertices, GpuMeshRegistry,
+};
+use bsengine_scene::{
+    spawn_scene_entities, ColliderShapeDesc, Name, PendingSceneLoad, PhysicsBodyDesc, Primitive,
+    PrimitiveMesh, RigidBodyDesc, SceneDescriptor,
+};
+use bsengine_scripting::{load_scripts, ScriptRuntime, ScriptRuntimeResource, SoundHandles};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct ProjectManifest {
+    pub project: ProjectSection,
+    #[serde(default)]
+    pub window: WindowSection,
+}
+
+#[derive(Deserialize)]
+pub struct ProjectSection {
+    pub name: String,
+    pub entry_scene: String,
+}
+
+#[derive(Deserialize, Default)]
+pub struct WindowSection {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default = "default_width")]
+    pub width: u32,
+    #[serde(default = "default_height")]
+    pub height: u32,
+    #[serde(default = "default_true")]
+    pub resizable: bool,
+}
+
+fn default_width() -> u32 {
+    1280
+}
+fn default_height() -> u32 {
+    720
+}
+fn default_true() -> bool {
+    true
+}
+
+/// Registers the scene-load/physics-resolution systems shared by every
+/// runtime entry point (windowed and headless).
+pub fn register_scene_systems(app: &mut App) {
+    app.add_systems(
+        PostStartup,
+        (resolve_primitives, resolve_physics_bodies).chain(),
+    )
+    .add_systems(Update, handle_scene_load)
+    .add_systems(Update, resolve_primitives.after(handle_scene_load))
+    .add_systems(Update, resolve_physics_bodies.after(resolve_primitives));
+}
+
+pub fn resolve_primitives(
+    query: Query<(Entity, &PrimitiveMesh), Added<PrimitiveMesh>>,
+    mut commands: Commands,
+    registry: Option<ResMut<GpuMeshRegistry>>,
+) {
+    let Some(mut registry) = registry else { return };
+
+    let mut cube_id: Option<u64> = None;
+    let mut sphere_id: Option<u64> = None;
+    let mut plane_id: Option<u64> = None;
+    let mut capsule_id: Option<u64> = None;
+
+    for (entity, prim) in query.iter() {
+        let mesh_id = match &prim.0 {
+            Primitive::Cube => *cube_id.get_or_insert_with(|| {
+                let (v, i) = cube_vertices();
+                registry.register(&v, &i)
+            }),
+            Primitive::Sphere => *sphere_id.get_or_insert_with(|| {
+                let (v, i) = sphere_vertices();
+                registry.register(&v, &i)
+            }),
+            Primitive::Plane => *plane_id.get_or_insert_with(|| {
+                let (v, i) = plane_vertices();
+                registry.register(&v, &i)
+            }),
+            Primitive::Capsule => *capsule_id.get_or_insert_with(|| {
+                let (v, i) = capsule_vertices();
+                registry.register(&v, &i)
+            }),
+        };
+        commands
+            .entity(entity)
+            .insert(bsengine_render::MeshRenderer { mesh_id });
+    }
+}
+
+pub fn resolve_physics_bodies(
+    query: Query<(Entity, &PhysicsBodyDesc), Added<PhysicsBodyDesc>>,
+    transforms: Query<&Transform>,
+    mut commands: Commands,
+) {
+    for (entity, desc) in query.iter() {
+        let rb = match desc.rigidbody {
+            RigidBodyDesc::Dynamic => RigidBody::dynamic(),
+            RigidBodyDesc::Static => RigidBody::fixed(),
+            RigidBodyDesc::Kinematic => RigidBody::kinematic(),
+        };
+        let col_base = match &desc.collider.shape {
+            ColliderShapeDesc::Box { hx, hy, hz } => Collider::cuboid(*hx, *hy, *hz),
+            ColliderShapeDesc::Sphere { radius } => Collider::ball(*radius),
+            ColliderShapeDesc::Capsule {
+                half_height,
+                radius,
+            } => Collider::capsule(*half_height, *radius),
+        };
+        let col = col_base
+            .with_restitution(desc.collider.restitution)
+            .with_friction(desc.collider.friction)
+            .with_sensor(desc.collider.sensor);
+        let t = transforms.get(entity).cloned().unwrap_or_default();
+        commands.entity(entity).insert((
+            rb,
+            col,
+            PhysicsInput {
+                translation: t.translation.0,
+                rotation: t.rotation.0,
+            },
+        ));
+    }
+}
+
+pub fn handle_scene_load(world: &mut World) {
+    let pending = world.remove_resource::<PendingSceneLoad>();
+    let Some(pending) = pending else { return };
+
+    let content = match std::fs::read_to_string(&pending.path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("[scene] failed to read {}: {e}", pending.path);
+            return;
+        }
+    };
+    let scene: SceneDescriptor = match ron::from_str(&content) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("[scene] failed to parse {}: {e}", pending.path);
+            return;
+        }
+    };
+
+    // Stop all sounds and clear handles
+    if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
+        for (_, mut handle) in handles.0.drain() {
+            handle.stop(kira::Tween::default());
+        }
+    }
+
+    // Despawn all named entities
+    let named: Vec<Entity> = {
+        let mut q = world.query::<(Entity, &Name)>();
+        q.iter(world).map(|(e, _)| e).collect()
+    };
+    for e in named {
+        world.despawn(e);
+    }
+
+    // Clear HUD
+    if let Some(mut hud) = world.get_resource_mut::<HudTexts>() {
+        hud.0.clear();
+    }
+
+    // Reset script runtime
+    world.insert_non_send_resource(ScriptRuntimeResource(ScriptRuntime::new_with_ops()));
+
+    // Spawn scene and resolve physics inline (Added<> won't fire for same-frame spawns)
+    spawn_scene_entities(world, &scene.entities);
+    resolve_physics_bodies_world(world);
+    load_scripts(world);
+}
+
+pub fn resolve_physics_bodies_world(world: &mut World) {
+    let entities: Vec<(Entity, PhysicsBodyDesc)> = {
+        let mut q = world.query::<(Entity, &PhysicsBodyDesc)>();
+        q.iter(world).map(|(e, d)| (e, d.clone())).collect()
+    };
+    for (entity, desc) in entities {
+        let rb = match desc.rigidbody {
+            RigidBodyDesc::Dynamic => RigidBody::dynamic(),
+            RigidBodyDesc::Static => RigidBody::fixed(),
+            RigidBodyDesc::Kinematic => RigidBody::kinematic(),
+        };
+        let col_base = match desc.collider.shape {
+            ColliderShapeDesc::Box { hx, hy, hz } => Collider::cuboid(hx, hy, hz),
+            ColliderShapeDesc::Sphere { radius } => Collider::ball(radius),
+            ColliderShapeDesc::Capsule {
+                half_height,
+                radius,
+            } => Collider::capsule(half_height, radius),
+        };
+        let col = col_base
+            .with_restitution(desc.collider.restitution)
+            .with_friction(desc.collider.friction)
+            .with_sensor(desc.collider.sensor);
+        let t = world.get::<Transform>(entity).cloned().unwrap_or_default();
+        world.entity_mut(entity).insert((
+            rb,
+            col,
+            PhysicsInput {
+                translation: t.translation.0,
+                rotation: t.rotation.0,
+            },
+        ));
+    }
+}

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -72,7 +72,10 @@ pub fn run_test_mode(project_dir: &str) {
         let command: Command = match serde_json::from_str(&line) {
             Ok(c) => c,
             Err(e) => {
-                write_response(&mut stdout, &CommandResponse::err(format!("parse error: {e}")));
+                write_response(
+                    &mut stdout,
+                    &CommandResponse::err(format!("parse error: {e}")),
+                );
                 continue;
             }
         };

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -1,0 +1,3 @@
+pub fn run_test_mode(_project_dir: &str) {
+    todo!("implemented in a later task")
+}

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -1,3 +1,172 @@
-pub fn run_test_mode(_project_dir: &str) {
-    todo!("implemented in a later task")
+//! `bsengine-runtime --test <game>`: runs a game headless (no window, no
+//! renderer) and drives it via newline-delimited JSON commands on stdin,
+//! writing one JSON response per command to stdout. See
+//! `docs/superpowers/specs/2026-07-22-ai-gameplay-e2e-testing-design.md`.
+
+use std::io::{self, BufRead, Write};
+
+use bevy_app::App;
+use bsengine_audio::AudioPlugin;
+use bsengine_input::{Input, InputPlugin, KeyCode, MouseButton};
+use bsengine_physics::PhysicsPlugin;
+use bsengine_scene::ScenePlugin;
+use bsengine_scripting::{ScriptingPlugin, KEY_MAPPINGS};
+use serde_json::{json, Value};
+
+use crate::scene_systems::{register_scene_systems, ProjectManifest};
+use crate::test_protocol::{Command, CommandResponse};
+use crate::test_query::{eval_op, eval_path, run_query};
+
+pub fn build_test_app(project_dir: &str) -> App {
+    let manifest_path = format!("{project_dir}/project.toml");
+    let manifest_str = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|e| panic!("Cannot read {manifest_path}: {e}"));
+    let manifest: ProjectManifest = toml::from_str(&manifest_str)
+        .unwrap_or_else(|e| panic!("Cannot parse {manifest_path}: {e}"));
+    let scene_path = format!("{project_dir}/{}", manifest.project.entry_scene);
+
+    let mut app = bsengine_app::new_app();
+    app.add_plugins(InputPlugin)
+        .add_plugins(AudioPlugin)
+        .add_plugins(PhysicsPlugin)
+        .add_plugins(ScenePlugin::from_file(&scene_path))
+        .add_plugins(ScriptingPlugin {
+            project_dir: project_dir.to_string(),
+        });
+    register_scene_systems(&mut app);
+    app
+}
+
+fn key_from_str(key: &str) -> Option<KeyCode> {
+    KEY_MAPPINGS
+        .iter()
+        .find(|(_, name)| *name == key)
+        .map(|(code, _)| *code)
+}
+
+fn mouse_button_from_u8(button: u8) -> Option<MouseButton> {
+    match button {
+        0 => Some(MouseButton::Left),
+        1 => Some(MouseButton::Right),
+        2 => Some(MouseButton::Middle),
+        _ => None,
+    }
+}
+
+pub fn run_test_mode(project_dir: &str) {
+    let mut app = build_test_app(project_dir);
+    let mut frame: u64 = 0;
+
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let command: Command = match serde_json::from_str(&line) {
+            Ok(c) => c,
+            Err(e) => {
+                write_response(&mut stdout, &CommandResponse::err(format!("parse error: {e}")));
+                continue;
+            }
+        };
+
+        match command {
+            Command::Step { frames } => {
+                for _ in 0..frames {
+                    app.update();
+                    frame += 1;
+                }
+                write_response(&mut stdout, &CommandResponse::ok(json!({"frame": frame})));
+            }
+            Command::PressKey { key } => match key_from_str(&key) {
+                Some(code) => {
+                    app.world_mut().resource_mut::<Input<KeyCode>>().press(code);
+                    write_response(&mut stdout, &CommandResponse::ok(json!({})));
+                }
+                None => write_response(
+                    &mut stdout,
+                    &CommandResponse::err(format!("unknown key: {key}")),
+                ),
+            },
+            Command::ReleaseKey { key } => match key_from_str(&key) {
+                Some(code) => {
+                    app.world_mut()
+                        .resource_mut::<Input<KeyCode>>()
+                        .release(code);
+                    write_response(&mut stdout, &CommandResponse::ok(json!({})));
+                }
+                None => write_response(
+                    &mut stdout,
+                    &CommandResponse::err(format!("unknown key: {key}")),
+                ),
+            },
+            Command::PressMouse { button } => match mouse_button_from_u8(button) {
+                Some(b) => {
+                    app.world_mut()
+                        .resource_mut::<Input<MouseButton>>()
+                        .press(b);
+                    write_response(&mut stdout, &CommandResponse::ok(json!({})));
+                }
+                None => write_response(
+                    &mut stdout,
+                    &CommandResponse::err(format!("unknown mouse button: {button}")),
+                ),
+            },
+            Command::ReleaseMouse { button } => match mouse_button_from_u8(button) {
+                Some(b) => {
+                    app.world_mut()
+                        .resource_mut::<Input<MouseButton>>()
+                        .release(b);
+                    write_response(&mut stdout, &CommandResponse::ok(json!({})));
+                }
+                None => write_response(
+                    &mut stdout,
+                    &CommandResponse::err(format!("unknown mouse button: {button}")),
+                ),
+            },
+            Command::Query { tool, args } => match run_query(app.world_mut(), &tool, &args) {
+                Ok(result) => write_response(&mut stdout, &CommandResponse::ok(result)),
+                Err(e) => write_response(&mut stdout, &CommandResponse::err(e)),
+            },
+            Command::Assert {
+                query,
+                path,
+                op,
+                value,
+                label,
+            } => match run_query(app.world_mut(), &query.tool, &query.args) {
+                Ok(result) => {
+                    let actual = eval_path(&result, &path).cloned().unwrap_or(Value::Null);
+                    match eval_op(&actual, &op, &value) {
+                        Ok(passed) => write_response(
+                            &mut stdout,
+                            &CommandResponse::ok(
+                                json!({"passed": passed, "actual": actual, "label": label}),
+                            ),
+                        ),
+                        Err(e) => write_response(&mut stdout, &CommandResponse::err(e)),
+                    }
+                }
+                Err(e) => write_response(&mut stdout, &CommandResponse::err(e)),
+            },
+            Command::Shutdown => {
+                write_response(&mut stdout, &CommandResponse::ok(json!({})));
+                break;
+            }
+        }
+    }
+}
+
+fn write_response(stdout: &mut io::Stdout, response: &CommandResponse) {
+    if let Ok(s) = serde_json::to_string(response) {
+        let _ = writeln!(stdout, "{s}");
+        let _ = stdout.flush();
+    }
 }

--- a/crates/bsengine-runtime/src/test_protocol.rs
+++ b/crates/bsengine-runtime/src/test_protocol.rs
@@ -1,0 +1,129 @@
+//! JSON-line command/response protocol between `bsengine-mcp-server` and a
+//! `bsengine-runtime --test` child process. Private to the two processes —
+//! never exposed to MCP clients directly.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+pub enum Command {
+    Step { frames: u32 },
+    PressKey { key: String },
+    ReleaseKey { key: String },
+    PressMouse { button: u8 },
+    ReleaseMouse { button: u8 },
+    Query { tool: String, args: Value },
+    Assert {
+        query: QuerySpec,
+        path: String,
+        op: String,
+        value: Value,
+        label: String,
+    },
+    Shutdown,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct QuerySpec {
+    pub tool: String,
+    pub args: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl CommandResponse {
+    pub fn ok(data: Value) -> Self {
+        Self {
+            ok: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    pub fn err(message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            data: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_step_command() {
+        let cmd: Command = serde_json::from_str(r#"{"cmd":"step","frames":30}"#).unwrap();
+        match cmd {
+            Command::Step { frames } => assert_eq!(frames, 30),
+            other => panic!("expected Step, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_press_key_command() {
+        let cmd: Command = serde_json::from_str(r#"{"cmd":"press_key","key":"W"}"#).unwrap();
+        match cmd {
+            Command::PressKey { key } => assert_eq!(key, "W"),
+            other => panic!("expected PressKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_assert_command() {
+        let cmd: Command = serde_json::from_str(
+            r#"{"cmd":"assert","query":{"tool":"get_transform","args":{"name":"Player"}},"path":"z","op":">","value":3,"label":"moved"}"#,
+        )
+        .unwrap();
+        match cmd {
+            Command::Assert {
+                query,
+                path,
+                op,
+                value,
+                label,
+            } => {
+                assert_eq!(query.tool, "get_transform");
+                assert_eq!(path, "z");
+                assert_eq!(op, ">");
+                assert_eq!(value, json!(3));
+                assert_eq!(label, "moved");
+            }
+            other => panic!("expected Assert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_shutdown_command() {
+        let cmd: Command = serde_json::from_str(r#"{"cmd":"shutdown"}"#).unwrap();
+        assert!(matches!(cmd, Command::Shutdown));
+    }
+
+    #[test]
+    fn ok_response_serializes_without_error_field() {
+        let resp = CommandResponse::ok(json!({"frame": 30}));
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains("\"ok\":true"));
+        assert!(!s.contains("error"));
+    }
+
+    #[test]
+    fn err_response_serializes_without_data_field() {
+        let resp = CommandResponse::err("boom");
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains("\"ok\":false"));
+        assert!(s.contains("boom"));
+        assert!(!s.contains("\"data\""));
+    }
+}

--- a/crates/bsengine-runtime/src/test_protocol.rs
+++ b/crates/bsengine-runtime/src/test_protocol.rs
@@ -8,12 +8,25 @@ use serde_json::Value;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 pub enum Command {
-    Step { frames: u32 },
-    PressKey { key: String },
-    ReleaseKey { key: String },
-    PressMouse { button: u8 },
-    ReleaseMouse { button: u8 },
-    Query { tool: String, args: Value },
+    Step {
+        frames: u32,
+    },
+    PressKey {
+        key: String,
+    },
+    ReleaseKey {
+        key: String,
+    },
+    PressMouse {
+        button: u8,
+    },
+    ReleaseMouse {
+        button: u8,
+    },
+    Query {
+        tool: String,
+        args: Value,
+    },
     Assert {
         query: QuerySpec,
         path: String,

--- a/crates/bsengine-runtime/src/test_query.rs
+++ b/crates/bsengine-runtime/src/test_query.rs
@@ -1,0 +1,198 @@
+//! Read-only state queries and mechanical assertion evaluation for the
+//! headless test runtime. Queries are evaluated directly against the ECS
+//! `World` — no scripting/V8 involvement — using the same shapes as the
+//! `Bsengine.*` JS getters for consistency.
+
+use bevy_ecs::world::World;
+use bsengine_core::{Transform, Visible};
+use bsengine_scene::Name;
+use serde_json::{json, Value};
+
+pub fn get_transform(world: &mut World, name: &str) -> Value {
+    let mut q = world.query::<(&Name, &Transform)>();
+    for (n, t) in q.iter(world) {
+        if n.0 == name {
+            return json!({
+                "x": t.translation.0.x, "y": t.translation.0.y, "z": t.translation.0.z,
+                "rx": t.rotation.0.x, "ry": t.rotation.0.y, "rz": t.rotation.0.z, "rw": t.rotation.0.w,
+                "sx": t.scale.0.x, "sy": t.scale.0.y, "sz": t.scale.0.z,
+            });
+        }
+    }
+    Value::Null
+}
+
+pub fn get_visible(world: &mut World, name: &str) -> Value {
+    let mut q = world.query::<(&Name, Option<&Visible>)>();
+    for (n, v) in q.iter(world) {
+        if n.0 == name {
+            return json!(v.map(|v| v.is_visible).unwrap_or(true));
+        }
+    }
+    json!(true)
+}
+
+pub fn get_entity_names(world: &mut World) -> Value {
+    let mut q = world.query::<&Name>();
+    let names: Vec<String> = q.iter(world).map(|n| n.0.clone()).collect();
+    json!(names)
+}
+
+pub fn run_query(world: &mut World, tool: &str, args: &Value) -> Result<Value, String> {
+    match tool {
+        "get_transform" => {
+            let name = args
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "get_transform requires string 'name'".to_string())?;
+            Ok(get_transform(world, name))
+        }
+        "get_visible" => {
+            let name = args
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "get_visible requires string 'name'".to_string())?;
+            Ok(get_visible(world, name))
+        }
+        "get_entity_names" => Ok(get_entity_names(world)),
+        other => Err(format!("unknown query tool: {other}")),
+    }
+}
+
+pub fn eval_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    if path.is_empty() {
+        return Some(value);
+    }
+    let mut current = value;
+    for part in path.split('.') {
+        current = current.get(part)?;
+    }
+    Some(current)
+}
+
+pub fn eval_op(actual: &Value, op: &str, expected: &Value) -> Result<bool, String> {
+    match op {
+        "exists" => Ok(!actual.is_null()),
+        "==" => Ok(actual == expected),
+        "!=" => Ok(actual != expected),
+        ">" | ">=" | "<" | "<=" => {
+            let a = actual
+                .as_f64()
+                .ok_or_else(|| format!("actual value {actual} is not numeric"))?;
+            let e = expected
+                .as_f64()
+                .ok_or_else(|| format!("expected value {expected} is not numeric"))?;
+            Ok(match op {
+                ">" => a > e,
+                ">=" => a >= e,
+                "<" => a < e,
+                "<=" => a <= e,
+                _ => unreachable!(),
+            })
+        }
+        other => Err(format!("unknown operator: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    #[test]
+    fn get_transform_returns_null_when_entity_missing() {
+        let mut world = World::new();
+        assert_eq!(get_transform(&mut world, "Ghost"), Value::Null);
+    }
+
+    #[test]
+    fn get_transform_returns_position_for_named_entity() {
+        let mut world = World::new();
+        world.spawn((
+            Name("Player".to_string()),
+            Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
+        ));
+        let result = get_transform(&mut world, "Player");
+        assert_eq!(result["x"], json!(1.0));
+        assert_eq!(result["y"], json!(2.0));
+        assert_eq!(result["z"], json!(3.0));
+    }
+
+    #[test]
+    fn get_visible_defaults_true_when_no_visible_component() {
+        let mut world = World::new();
+        world.spawn((Name("Player".to_string()), Transform::default()));
+        assert_eq!(get_visible(&mut world, "Player"), json!(true));
+    }
+
+    #[test]
+    fn get_visible_reflects_visible_component() {
+        let mut world = World::new();
+        world.spawn((
+            Name("Player".to_string()),
+            Transform::default(),
+            Visible { is_visible: false },
+        ));
+        assert_eq!(get_visible(&mut world, "Player"), json!(false));
+    }
+
+    #[test]
+    fn get_entity_names_lists_all_named_entities() {
+        let mut world = World::new();
+        world.spawn((Name("A".to_string()), Transform::default()));
+        world.spawn((Name("B".to_string()), Transform::default()));
+        let result = get_entity_names(&mut world);
+        let names: Vec<String> =
+            serde_json::from_value(result).expect("should deserialize as Vec<String>");
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"A".to_string()));
+        assert!(names.contains(&"B".to_string()));
+    }
+
+    #[test]
+    fn run_query_dispatches_get_transform() {
+        let mut world = World::new();
+        world.spawn((
+            Name("Player".to_string()),
+            Transform::from_translation(Vec3::new(0.0, 0.0, 5.0)),
+        ));
+        let result = run_query(&mut world, "get_transform", &json!({"name": "Player"})).unwrap();
+        assert_eq!(result["z"], json!(5.0));
+    }
+
+    #[test]
+    fn run_query_unknown_tool_errors() {
+        let mut world = World::new();
+        assert!(run_query(&mut world, "nope", &json!({})).is_err());
+    }
+
+    #[test]
+    fn eval_path_extracts_nested_field() {
+        let v = json!({"x": 1, "nested": {"y": 2}});
+        assert_eq!(eval_path(&v, "x"), Some(&json!(1)));
+        assert_eq!(eval_path(&v, "nested.y"), Some(&json!(2)));
+    }
+
+    #[test]
+    fn eval_path_empty_returns_whole_value() {
+        let v = json!({"x": 1});
+        assert_eq!(eval_path(&v, ""), Some(&v));
+    }
+
+    #[test]
+    fn eval_op_greater_than_numeric() {
+        assert!(eval_op(&json!(5), ">", &json!(3)).unwrap());
+        assert!(!eval_op(&json!(2), ">", &json!(3)).unwrap());
+    }
+
+    #[test]
+    fn eval_op_exists_checks_non_null() {
+        assert!(!eval_op(&json!(null), "exists", &Value::Null).unwrap());
+        assert!(eval_op(&json!(1), "exists", &Value::Null).unwrap());
+    }
+
+    #[test]
+    fn eval_op_unknown_operator_errors() {
+        assert!(eval_op(&json!(1), "~=", &json!(1)).is_err());
+    }
+}

--- a/crates/bsengine-runtime/tests/test_mode.rs
+++ b/crates/bsengine-runtime/tests/test_mode.rs
@@ -13,7 +13,9 @@ fn send(stdin: &mut std::process::ChildStdin, json: &str) {
 
 fn read_response(reader: &mut impl BufRead) -> serde_json::Value {
     let mut line = String::new();
-    reader.read_line(&mut line).expect("failed to read response line");
+    reader
+        .read_line(&mut line)
+        .expect("failed to read response line");
     serde_json::from_str(&line).unwrap_or_else(|e| panic!("invalid JSON response {line:?}: {e}"))
 }
 
@@ -45,7 +47,10 @@ fn press_key_and_step_moves_player_forward() {
     );
     let resp = read_response(&mut reader);
     assert_eq!(resp["ok"], true, "assert command failed: {resp}");
-    assert_eq!(resp["data"]["passed"], true, "assertion did not pass: {resp}");
+    assert_eq!(
+        resp["data"]["passed"], true,
+        "assertion did not pass: {resp}"
+    );
 
     send(&mut stdin, r#"{"cmd":"shutdown"}"#);
     let resp = read_response(&mut reader);
@@ -72,7 +77,10 @@ fn get_entity_names_lists_scene_entities() {
     let resp = read_response(&mut reader);
     assert_eq!(resp["ok"], true, "initial step failed: {resp}");
 
-    send(&mut stdin, r#"{"cmd":"query","tool":"get_entity_names","args":{}}"#);
+    send(
+        &mut stdin,
+        r#"{"cmd":"query","tool":"get_entity_names","args":{}}"#,
+    );
     let resp = read_response(&mut reader);
     assert_eq!(resp["ok"], true, "query failed: {resp}");
     let names = resp["data"].as_array().expect("data should be an array");

--- a/crates/bsengine-runtime/tests/test_mode.rs
+++ b/crates/bsengine-runtime/tests/test_mode.rs
@@ -1,0 +1,86 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+fn game_fixture_path() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{manifest_dir}/../../games/cube-evader")
+}
+
+fn send(stdin: &mut std::process::ChildStdin, json: &str) {
+    writeln!(stdin, "{json}").unwrap();
+    stdin.flush().unwrap();
+}
+
+fn read_response(reader: &mut impl BufRead) -> serde_json::Value {
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("failed to read response line");
+    serde_json::from_str(&line).unwrap_or_else(|e| panic!("invalid JSON response {line:?}: {e}"))
+}
+
+#[test]
+fn press_key_and_step_moves_player_forward() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_bsengine-runtime"))
+        .arg("--test")
+        .arg(game_fixture_path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn bsengine-runtime --test");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, r#"{"cmd":"press_key","key":"W"}"#);
+    let resp = read_response(&mut reader);
+    assert_eq!(resp["ok"], true, "press_key failed: {resp}");
+
+    send(&mut stdin, r#"{"cmd":"step","frames":20}"#);
+    let resp = read_response(&mut reader);
+    assert_eq!(resp["ok"], true, "step failed: {resp}");
+    assert_eq!(resp["data"]["frame"], 20);
+
+    send(
+        &mut stdin,
+        r#"{"cmd":"assert","query":{"tool":"get_transform","args":{"name":"Player"}},"path":"z","op":"<","value":-1.5,"label":"player moved forward after holding W for 20 frames"}"#,
+    );
+    let resp = read_response(&mut reader);
+    assert_eq!(resp["ok"], true, "assert command failed: {resp}");
+    assert_eq!(resp["data"]["passed"], true, "assertion did not pass: {resp}");
+
+    send(&mut stdin, r#"{"cmd":"shutdown"}"#);
+    let resp = read_response(&mut reader);
+    assert_eq!(resp["ok"], true);
+
+    let status = child.wait().expect("failed to wait for child process");
+    assert!(status.success(), "process exited with {status:?}");
+}
+
+#[test]
+fn get_entity_names_lists_scene_entities() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_bsengine-runtime"))
+        .arg("--test")
+        .arg(game_fixture_path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn bsengine-runtime --test");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, r#"{"cmd":"step","frames":1}"#);
+    let resp = read_response(&mut reader);
+    assert_eq!(resp["ok"], true, "initial step failed: {resp}");
+
+    send(&mut stdin, r#"{"cmd":"query","tool":"get_entity_names","args":{}}"#);
+    let resp = read_response(&mut reader);
+    assert_eq!(resp["ok"], true, "query failed: {resp}");
+    let names = resp["data"].as_array().expect("data should be an array");
+    let names: Vec<&str> = names.iter().map(|v| v.as_str().unwrap()).collect();
+    assert!(names.contains(&"Player"), "names: {names:?}");
+    assert!(names.contains(&"Enemy1"), "names: {names:?}");
+
+    send(&mut stdin, r#"{"cmd":"shutdown"}"#);
+    read_response(&mut reader);
+    child.wait().unwrap();
+}

--- a/crates/bsengine-scripting/src/lib.rs
+++ b/crates/bsengine-scripting/src/lib.rs
@@ -18,5 +18,6 @@ pub mod runtime;
 pub mod save;
 pub use plugin::{
     load_scripts, ProjectDir, Script, ScriptRuntimeResource, ScriptingPlugin, SoundHandles,
+    KEY_MAPPINGS,
 };
 pub use runtime::ScriptRuntime;

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -164,7 +164,9 @@ pub fn load_scripts(world: &mut World) {
     }
 }
 
-const KEY_MAPPINGS: &[(KeyCode, &str)] = &[
+/// Canonical key-name table shared by the scripting snapshot (`Bsengine.isKeyPressed`)
+/// and the headless test runtime's `press_key`/`release_key` commands.
+pub const KEY_MAPPINGS: &[(KeyCode, &str)] = &[
     (KeyCode::W, "W"),
     (KeyCode::A, "A"),
     (KeyCode::S, "S"),


### PR DESCRIPTION
## Summary
- Adds `bsengine-runtime --test <game>` — runs a game with no window/renderer, driven by a newline-delimited JSON protocol on stdin/stdout (`step`, `press_key`/`release_key`, `press_mouse`/`release_mouse`, `query`, `assert`, `shutdown`).
- Synthetic input goes through the same `Input<KeyCode>`/`Input<MouseButton>` resources real OS input uses, so scripts can't tell the difference.
- `query`/`assert` read ECS `World` state directly (get_transform/get_visible/get_entity_names) for mechanical, replayable assertions.
- Extracted scene-loading/physics-resolution systems into `scene_systems.rs`, shared by both the windowed and headless entry points (behavior-preserving refactor).
- Bugfix found via the new end-to-end test: `bsengine_core::init_logging()` was writing tracing output to stdout, corrupting the new JSON protocol — routed logs to stderr instead.

First of 3 PRs building AI-driven gameplay E2E testing via MCP (design: `docs/superpowers/specs/2026-07-22-ai-gameplay-e2e-testing-design.md`; plan: `docs/superpowers/plans/2026-07-22-headless-test-runtime.md`). PR 2 adds MCP tools that spawn/control this binary; PR 3 adds action-log recording + AI-free replay for CI.

## Test plan
- [x] `cargo test -p bsengine-runtime` — new protocol/query/e2e tests pass
- [x] `cargo test -p bsengine-input -p bsengine-scripting -p bsengine-core` — unaffected, all pass
- [x] `cargo test --workspace --exclude bsengine-editor --exclude bsengine-editor-app` — 0 failures
- [x] `cargo test -p bsengine-editor --lib` — 802 passed, 0 failed