### PR TITLE
feat(mcp,runtime): record + AI-free replay of test sessions (3/3)

### DIFF
--- a/crates/bsengine-mcp/src/session.rs
+++ b/crates/bsengine-mcp/src/session.rs
@@ -13,6 +13,14 @@ use serde_json::Value;
 
 static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Result of running a saved recording via `bsengine-runtime --test --replay`.
+pub struct ReplayResult {
+    /// Whether the replayed run's assertions all passed (child exit success).
+    pub passed: bool,
+    /// The child process's captured stderr output.
+    pub stderr: String,
+}
+
 struct Session {
     game: String,
     child: Child,
@@ -103,6 +111,34 @@ impl SessionRegistry {
             .map_err(|e| format!("failed to encode recording: {e}"))?;
         std::fs::write(&path, content).map_err(|e| format!("failed to write recording: {e}"))?;
         Ok(path)
+    }
+
+    /// Spawns `bsengine-runtime --test <game> --replay <name>.testlog.json`,
+    /// waits for it to finish, and reports pass/fail. Independent of any
+    /// live interactive session.
+    pub fn run_replay(&self, game: &str, name: &str) -> Result<ReplayResult, String> {
+        let game_dir = self.games_root.join(game);
+        let log_path = self
+            .games_root
+            .join(game)
+            .join("tests")
+            .join(format!("{name}.testlog.json"));
+        if !log_path.exists() {
+            return Err(format!("no recorded log at {}", log_path.display()));
+        }
+
+        let output = Command::new(&self.runtime_bin)
+            .arg("--test")
+            .arg(&game_dir)
+            .arg("--replay")
+            .arg(&log_path)
+            .output()
+            .map_err(|e| format!("failed to run replay: {e}"))?;
+
+        Ok(ReplayResult {
+            passed: output.status.success(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
     }
 
     /// Sends `shutdown` to the session's child (best-effort), waits for it

--- a/crates/bsengine-mcp/src/session.rs
+++ b/crates/bsengine-mcp/src/session.rs
@@ -14,9 +14,11 @@ use serde_json::Value;
 static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
 
 struct Session {
+    game: String,
     child: Child,
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
+    actions: Vec<Value>,
 }
 
 /// Manages live `bsengine-runtime --test` child processes keyed by session id.
@@ -58,9 +60,11 @@ impl SessionRegistry {
 
         let session_id = format!("session-{}", NEXT_SESSION_ID.fetch_add(1, Ordering::SeqCst));
         let session = Session {
+            game: game.to_string(),
             child,
             stdin,
             stdout: BufReader::new(stdout),
+            actions: Vec::new(),
         };
         self.sessions
             .lock()
@@ -76,7 +80,29 @@ impl SessionRegistry {
         let session = sessions
             .get_mut(session_id)
             .ok_or_else(|| format!("no such session: {session_id}"))?;
-        write_and_read(session, &command)
+        let response = write_and_read(session, &command)?;
+        if command.get("cmd").and_then(|v| v.as_str()) != Some("query") {
+            session.actions.push(command);
+        }
+        Ok(response)
+    }
+
+    /// Serializes the session's accumulated action log to
+    /// `<games_root>/<game>/tests/<name>.testlog.json` and returns that path.
+    pub fn save_recording(&self, session_id: &str, name: &str) -> Result<PathBuf, String> {
+        let sessions = self.sessions.lock().unwrap();
+        let session = sessions
+            .get(session_id)
+            .ok_or_else(|| format!("no such session: {session_id}"))?;
+
+        let log = serde_json::json!({ "game": session.game, "actions": session.actions });
+        let dir = self.games_root.join(&session.game).join("tests");
+        std::fs::create_dir_all(&dir).map_err(|e| format!("failed to create tests dir: {e}"))?;
+        let path = dir.join(format!("{name}.testlog.json"));
+        let content = serde_json::to_string_pretty(&log)
+            .map_err(|e| format!("failed to encode recording: {e}"))?;
+        std::fs::write(&path, content).map_err(|e| format!("failed to write recording: {e}"))?;
+        Ok(path)
     }
 
     /// Sends `shutdown` to the session's child (best-effort), waits for it

--- a/crates/bsengine-mcp/src/test_tools.rs
+++ b/crates/bsengine-mcp/src/test_tools.rs
@@ -11,7 +11,12 @@ use crate::tool::{McpTool, McpToolOutput};
 
 /// Builds the full set of `test_*` tools bound to a shared `SessionRegistry`.
 pub fn test_tools(registry: Arc<SessionRegistry>) -> Vec<McpTool> {
-    let mut tools = vec![start_tool(registry.clone()), stop_tool(registry.clone())];
+    let mut tools = vec![
+        start_tool(registry.clone()),
+        stop_tool(registry.clone()),
+        save_recording_tool(registry.clone()),
+        run_replay_tool(registry.clone()),
+    ];
     tools.extend(passthrough_tools(registry));
     tools
 }
@@ -61,6 +66,72 @@ fn stop_tool(registry: Arc<SessionRegistry>) -> McpTool {
             };
             match registry.stop_session(session_id) {
                 Ok(()) => McpToolOutput::success(json!({ "stopped": session_id })),
+                Err(e) => McpToolOutput::error(&e),
+            }
+        }),
+    }
+}
+
+fn save_recording_tool(registry: Arc<SessionRegistry>) -> McpTool {
+    McpTool {
+        name: "test_save_recording".to_string(),
+        description: "Saves the session's accumulated commands (step/press/release/assert, in \
+            order) as games/<game>/tests/<name>.testlog.json — replayable with test_run_replay \
+            or `bsengine-runtime --test <game> --replay <file>` with no AI involved."
+            .to_string(),
+        input_schema: Some(json!({
+            "type": "object",
+            "properties": {
+                "session_id": { "type": "string" },
+                "name": { "type": "string", "description": "Recording name, no extension" },
+            },
+            "required": ["session_id", "name"],
+        })),
+        handler: Box::new(move |args| {
+            let session_id = match args.get("session_id").and_then(|v| v.as_str()) {
+                Some(s) => s,
+                None => return McpToolOutput::error("missing required field: session_id"),
+            };
+            let name = match args.get("name").and_then(|v| v.as_str()) {
+                Some(n) => n,
+                None => return McpToolOutput::error("missing required field: name"),
+            };
+            match registry.save_recording(session_id, name) {
+                Ok(path) => McpToolOutput::success(json!({ "saved": path.display().to_string() })),
+                Err(e) => McpToolOutput::error(&e),
+            }
+        }),
+    }
+}
+
+fn run_replay_tool(registry: Arc<SessionRegistry>) -> McpTool {
+    McpTool {
+        name: "test_run_replay".to_string(),
+        description: "Runs a saved recording (games/<game>/tests/<name>.testlog.json) through \
+            bsengine-runtime --test --replay with no AI involved — the same check CI runs. \
+            Lets Claude verify a recording still passes without needing a CI run."
+            .to_string(),
+        input_schema: Some(json!({
+            "type": "object",
+            "properties": {
+                "game": { "type": "string" },
+                "name": { "type": "string" },
+            },
+            "required": ["game", "name"],
+        })),
+        handler: Box::new(move |args| {
+            let game = match args.get("game").and_then(|v| v.as_str()) {
+                Some(g) => g,
+                None => return McpToolOutput::error("missing required field: game"),
+            };
+            let name = match args.get("name").and_then(|v| v.as_str()) {
+                Some(n) => n,
+                None => return McpToolOutput::error("missing required field: name"),
+            };
+            match registry.run_replay(game, name) {
+                Ok(result) => McpToolOutput::success(
+                    json!({ "passed": result.passed, "stderr": result.stderr }),
+                ),
                 Err(e) => McpToolOutput::error(&e),
             }
         }),

--- a/crates/bsengine-mcp/tests/session.rs
+++ b/crates/bsengine-mcp/tests/session.rs
@@ -112,7 +112,11 @@ fn save_recording_records_non_query_commands_only() {
     let log: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert_eq!(log["game"], "cube-evader");
     let actions = log["actions"].as_array().unwrap();
-    assert_eq!(actions.len(), 2, "query should not be recorded: {actions:?}");
+    assert_eq!(
+        actions.len(),
+        2,
+        "query should not be recorded: {actions:?}"
+    );
     assert_eq!(actions[0]["cmd"], "press_key");
     assert_eq!(actions[1]["cmd"], "step");
 

--- a/crates/bsengine-mcp/tests/session.rs
+++ b/crates/bsengine-mcp/tests/session.rs
@@ -85,3 +85,34 @@ fn stop_unknown_session_errors() {
     let registry = test_registry();
     assert!(registry.stop_session("no-such-session").is_err());
 }
+
+#[test]
+fn save_recording_records_non_query_commands_only() {
+    let registry = test_registry();
+    let id = registry.start_session("cube-evader").unwrap();
+
+    registry
+        .send(&id, serde_json::json!({"cmd": "press_key", "key": "W"}))
+        .unwrap();
+    registry
+        .send(&id, serde_json::json!({"cmd": "step", "frames": 5}))
+        .unwrap();
+    registry
+        .send(
+            &id,
+            serde_json::json!({"cmd": "query", "tool": "get_entity_names", "args": {}}),
+        )
+        .unwrap();
+
+    let path = registry.save_recording(&id, "example").unwrap();
+    let content = std::fs::read_to_string(&path).unwrap();
+    let log: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(log["game"], "cube-evader");
+    let actions = log["actions"].as_array().unwrap();
+    assert_eq!(actions.len(), 2, "query should not be recorded: {actions:?}");
+    assert_eq!(actions[0]["cmd"], "press_key");
+    assert_eq!(actions[1]["cmd"], "step");
+
+    registry.stop_session(&id).unwrap();
+    std::fs::remove_file(&path).ok();
+}

--- a/crates/bsengine-mcp/tests/test_tools.rs
+++ b/crates/bsengine-mcp/tests/test_tools.rs
@@ -130,7 +130,11 @@ fn record_save_and_replay_round_trip() {
     let replay = find(&tools, "test_run_replay");
     let out = (replay.handler)(json!({"game": "cube-evader", "name": "round-trip-test"}));
     assert!(out.is_ok(), "{:?}", out.error);
-    assert_eq!(out.content["passed"], true, "replay stderr: {}", out.content["stderr"]);
+    assert_eq!(
+        out.content["passed"], true,
+        "replay stderr: {}",
+        out.content["stderr"]
+    );
 
     let saved_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../games/cube-evader/tests/round-trip-test.testlog.json");

--- a/crates/bsengine-mcp/tests/test_tools.rs
+++ b/crates/bsengine-mcp/tests/test_tools.rs
@@ -57,9 +57,9 @@ fn find<'a>(tools: &'a [McpTool], name: &str) -> &'a McpTool {
 }
 
 #[test]
-fn builds_nine_tools() {
+fn builds_eleven_tools() {
     let tools = test_tools(test_registry());
-    assert_eq!(tools.len(), 9);
+    assert_eq!(tools.len(), 11);
 }
 
 #[test]
@@ -95,6 +95,40 @@ fn full_session_round_trip() {
     let stop = find(&tools, "test_session_stop");
     let out = (stop.handler)(json!({"session_id": session_id}));
     assert!(out.is_ok(), "{:?}", out.error);
+}
+
+#[test]
+fn record_save_and_replay_round_trip() {
+    let tools = test_tools(test_registry());
+
+    let start = find(&tools, "test_session_start");
+    let out = (start.handler)(json!({"game": "cube-evader"}));
+    assert!(out.is_ok(), "{:?}", out.error);
+    let session_id = out.content["session_id"].as_str().unwrap().to_string();
+
+    (find(&tools, "test_press_key").handler)(json!({"session_id": session_id, "key": "W"}));
+    (find(&tools, "test_step").handler)(json!({"session_id": session_id, "frames": 20}));
+    (find(&tools, "test_assert").handler)(json!({
+        "session_id": session_id,
+        "query": {"tool": "get_transform", "args": {"name": "Player"}},
+        "path": "z", "op": "<", "value": -1.5,
+        "label": "player moved forward",
+    }));
+
+    let save = find(&tools, "test_save_recording");
+    let out = (save.handler)(json!({"session_id": session_id, "name": "round-trip-test"}));
+    assert!(out.is_ok(), "{:?}", out.error);
+
+    (find(&tools, "test_session_stop").handler)(json!({"session_id": session_id}));
+
+    let replay = find(&tools, "test_run_replay");
+    let out = (replay.handler)(json!({"game": "cube-evader", "name": "round-trip-test"}));
+    assert!(out.is_ok(), "{:?}", out.error);
+    assert_eq!(out.content["passed"], true, "replay stderr: {}", out.content["stderr"]);
+
+    let saved_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../games/cube-evader/tests/round-trip-test.testlog.json");
+    std::fs::remove_file(saved_path).ok();
 }
 
 #[test]

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -25,7 +25,17 @@ fn main() {
 
     if first_arg == "--test" {
         let project_dir = args.next().unwrap_or_else(|| ".".to_string());
-        test_mode::run_test_mode(&project_dir);
+        match args.next().as_deref() {
+            Some("--replay") => {
+                let log_path = args
+                    .next()
+                    .unwrap_or_else(|| panic!("--replay requires a log file path"));
+                let passed = test_mode::run_replay_mode(&project_dir, &log_path);
+                std::process::exit(if passed { 0 } else { 1 });
+            }
+            Some(other) => panic!("unknown argument after project dir: {other}"),
+            None => test_mode::run_test_mode(&project_dir),
+        }
         return;
     }
 

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -77,90 +77,93 @@ pub fn run_test_mode(project_dir: &str) {
             }
         };
 
-        match command {
-            Command::Step { frames } => {
-                for _ in 0..frames {
-                    app.update();
-                    frame += 1;
-                }
-                write_response(&mut stdout, &CommandResponse::ok(json!({"frame": frame})));
-            }
-            Command::PressKey { key } => match key_from_str(&key) {
-                Some(code) => {
-                    app.world_mut().resource_mut::<Input<KeyCode>>().press(code);
-                    write_response(&mut stdout, &CommandResponse::ok(json!({})));
-                }
-                None => write_response(
-                    &mut stdout,
-                    &CommandResponse::err(format!("unknown key: {key}")),
-                ),
-            },
-            Command::ReleaseKey { key } => match key_from_str(&key) {
-                Some(code) => {
-                    app.world_mut()
-                        .resource_mut::<Input<KeyCode>>()
-                        .release(code);
-                    write_response(&mut stdout, &CommandResponse::ok(json!({})));
-                }
-                None => write_response(
-                    &mut stdout,
-                    &CommandResponse::err(format!("unknown key: {key}")),
-                ),
-            },
-            Command::PressMouse { button } => match mouse_button_from_u8(button) {
-                Some(b) => {
-                    app.world_mut()
-                        .resource_mut::<Input<MouseButton>>()
-                        .press(b);
-                    write_response(&mut stdout, &CommandResponse::ok(json!({})));
-                }
-                None => write_response(
-                    &mut stdout,
-                    &CommandResponse::err(format!("unknown mouse button: {button}")),
-                ),
-            },
-            Command::ReleaseMouse { button } => match mouse_button_from_u8(button) {
-                Some(b) => {
-                    app.world_mut()
-                        .resource_mut::<Input<MouseButton>>()
-                        .release(b);
-                    write_response(&mut stdout, &CommandResponse::ok(json!({})));
-                }
-                None => write_response(
-                    &mut stdout,
-                    &CommandResponse::err(format!("unknown mouse button: {button}")),
-                ),
-            },
-            Command::Query { tool, args } => match run_query(app.world_mut(), &tool, &args) {
-                Ok(result) => write_response(&mut stdout, &CommandResponse::ok(result)),
-                Err(e) => write_response(&mut stdout, &CommandResponse::err(e)),
-            },
-            Command::Assert {
-                query,
-                path,
-                op,
-                value,
-                label,
-            } => match run_query(app.world_mut(), &query.tool, &query.args) {
-                Ok(result) => {
-                    let actual = eval_path(&result, &path).cloned().unwrap_or(Value::Null);
-                    match eval_op(&actual, &op, &value) {
-                        Ok(passed) => write_response(
-                            &mut stdout,
-                            &CommandResponse::ok(
-                                json!({"passed": passed, "actual": actual, "label": label}),
-                            ),
-                        ),
-                        Err(e) => write_response(&mut stdout, &CommandResponse::err(e)),
-                    }
-                }
-                Err(e) => write_response(&mut stdout, &CommandResponse::err(e)),
-            },
-            Command::Shutdown => {
-                write_response(&mut stdout, &CommandResponse::ok(json!({})));
-                break;
-            }
+        let (response, should_stop) = execute_command(&mut app, &mut frame, command);
+        write_response(&mut stdout, &response);
+        if should_stop {
+            break;
         }
+    }
+}
+
+/// Runs one protocol command against `app`, returning its response and
+/// whether the caller should stop the loop (true only for `Shutdown`).
+/// Shared by the interactive stdin loop above and a replay loop added in a
+/// later task — both must execute commands identically for replay fidelity.
+pub fn execute_command(app: &mut App, frame: &mut u64, command: Command) -> (CommandResponse, bool) {
+    match command {
+        Command::Step { frames } => {
+            for _ in 0..frames {
+                app.update();
+                *frame += 1;
+            }
+            (CommandResponse::ok(json!({"frame": *frame})), false)
+        }
+        Command::PressKey { key } => match key_from_str(&key) {
+            Some(code) => {
+                app.world_mut().resource_mut::<Input<KeyCode>>().press(code);
+                (CommandResponse::ok(json!({})), false)
+            }
+            None => (CommandResponse::err(format!("unknown key: {key}")), false),
+        },
+        Command::ReleaseKey { key } => match key_from_str(&key) {
+            Some(code) => {
+                app.world_mut()
+                    .resource_mut::<Input<KeyCode>>()
+                    .release(code);
+                (CommandResponse::ok(json!({})), false)
+            }
+            None => (CommandResponse::err(format!("unknown key: {key}")), false),
+        },
+        Command::PressMouse { button } => match mouse_button_from_u8(button) {
+            Some(b) => {
+                app.world_mut()
+                    .resource_mut::<Input<MouseButton>>()
+                    .press(b);
+                (CommandResponse::ok(json!({})), false)
+            }
+            None => (
+                CommandResponse::err(format!("unknown mouse button: {button}")),
+                false,
+            ),
+        },
+        Command::ReleaseMouse { button } => match mouse_button_from_u8(button) {
+            Some(b) => {
+                app.world_mut()
+                    .resource_mut::<Input<MouseButton>>()
+                    .release(b);
+                (CommandResponse::ok(json!({})), false)
+            }
+            None => (
+                CommandResponse::err(format!("unknown mouse button: {button}")),
+                false,
+            ),
+        },
+        Command::Query { tool, args } => match run_query(app.world_mut(), &tool, &args) {
+            Ok(result) => (CommandResponse::ok(result), false),
+            Err(e) => (CommandResponse::err(e), false),
+        },
+        Command::Assert {
+            query,
+            path,
+            op,
+            value,
+            label,
+        } => match run_query(app.world_mut(), &query.tool, &query.args) {
+            Ok(result) => {
+                let actual = eval_path(&result, &path).cloned().unwrap_or(Value::Null);
+                match eval_op(&actual, &op, &value) {
+                    Ok(passed) => (
+                        CommandResponse::ok(
+                            json!({"passed": passed, "actual": actual, "label": label}),
+                        ),
+                        false,
+                    ),
+                    Err(e) => (CommandResponse::err(e), false),
+                }
+            }
+            Err(e) => (CommandResponse::err(e), false),
+        },
+        Command::Shutdown => (CommandResponse::ok(json!({})), true),
     }
 }
 

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -173,3 +173,60 @@ fn write_response(stdout: &mut io::Stdout, response: &CommandResponse) {
         let _ = stdout.flush();
     }
 }
+
+#[derive(serde::Deserialize)]
+struct RecordedLog {
+    actions: Vec<Command>,
+}
+
+/// Runs a saved action log to completion with no stdin/AI involvement.
+/// Returns `true` if every command succeeded and every `Assert` passed;
+/// on the first failure, prints details to stderr and returns `false`.
+pub fn run_replay_mode(project_dir: &str, log_path: &str) -> bool {
+    let log_str = std::fs::read_to_string(log_path)
+        .unwrap_or_else(|e| panic!("cannot read replay log {log_path}: {e}"));
+    let log: RecordedLog = serde_json::from_str(&log_str)
+        .unwrap_or_else(|e| panic!("cannot parse replay log {log_path}: {e}"));
+
+    let mut app = build_test_app(project_dir);
+    let mut frame: u64 = 0;
+
+    for command in log.actions {
+        let is_assert = matches!(command, Command::Assert { .. });
+        let (response, _) = execute_command(&mut app, &mut frame, command);
+
+        if !response.ok {
+            eprintln!(
+                "REPLAY FAILED: {}",
+                response.error.unwrap_or_else(|| "unknown error".to_string())
+            );
+            return false;
+        }
+
+        if is_assert {
+            let passed = response
+                .data
+                .as_ref()
+                .and_then(|d| d.get("passed"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !passed {
+                let label = response
+                    .data
+                    .as_ref()
+                    .and_then(|d| d.get("label"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("(unlabeled assertion)");
+                let actual = response
+                    .data
+                    .as_ref()
+                    .and_then(|d| d.get("actual"))
+                    .cloned()
+                    .unwrap_or(Value::Null);
+                eprintln!("REPLAY FAILED: {label} — actual: {actual}");
+                return false;
+            }
+        }
+    }
+    true
+}

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -92,7 +92,11 @@ pub fn run_test_mode(project_dir: &str) {
 /// whether the caller should stop the loop (true only for `Shutdown`).
 /// Shared by the interactive stdin loop above and a replay loop added in a
 /// later task — both must execute commands identically for replay fidelity.
-pub fn execute_command(app: &mut App, frame: &mut u64, command: Command) -> (CommandResponse, bool) {
+pub fn execute_command(
+    app: &mut App,
+    frame: &mut u64,
+    command: Command,
+) -> (CommandResponse, bool) {
     match command {
         Command::Step { frames } => {
             for _ in 0..frames {
@@ -201,7 +205,9 @@ pub fn run_replay_mode(project_dir: &str, log_path: &str) -> bool {
         if !response.ok {
             eprintln!(
                 "REPLAY FAILED: {}",
-                response.error.unwrap_or_else(|| "unknown error".to_string())
+                response
+                    .error
+                    .unwrap_or_else(|| "unknown error".to_string())
             );
             return false;
         }

--- a/crates/bsengine-runtime/tests/replay.rs
+++ b/crates/bsengine-runtime/tests/replay.rs
@@ -1,0 +1,70 @@
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn game_fixture_path() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{manifest_dir}/../../games/cube-evader")
+}
+
+// Tests in this file run as threads within the same test-binary process, so
+// `std::process::id()` alone is identical across them; add a per-call
+// counter to keep temp log paths from colliding under parallel test runs.
+static LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn write_log(actions_json: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir();
+    let unique = LOG_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = dir.join(format!(
+        "bsengine-replay-test-{}-{unique}.json",
+        std::process::id()
+    ));
+    std::fs::write(
+        &path,
+        format!(r#"{{"game":"cube-evader","actions":{actions_json}}}"#),
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn replay_passes_when_all_assertions_hold() {
+    let log_path = write_log(
+        r#"[
+            {"cmd":"press_key","key":"W"},
+            {"cmd":"step","frames":20},
+            {"cmd":"assert","query":{"tool":"get_transform","args":{"name":"Player"}},"path":"z","op":"<","value":-1.5,"label":"player moved forward"}
+        ]"#,
+    );
+
+    let status = Command::new(env!("CARGO_BIN_EXE_bsengine-runtime"))
+        .arg("--test")
+        .arg(game_fixture_path())
+        .arg("--replay")
+        .arg(&log_path)
+        .status()
+        .expect("failed to run replay");
+
+    std::fs::remove_file(&log_path).ok();
+    assert!(status.success(), "expected replay to pass: {status:?}");
+}
+
+#[test]
+fn replay_fails_when_assertion_does_not_hold() {
+    let log_path = write_log(
+        r#"[
+            {"cmd":"step","frames":5},
+            {"cmd":"assert","query":{"tool":"get_transform","args":{"name":"Player"}},"path":"z","op":"<","value":-100,"label":"impossible without holding W"}
+        ]"#,
+    );
+
+    let status = Command::new(env!("CARGO_BIN_EXE_bsengine-runtime"))
+        .arg("--test")
+        .arg(game_fixture_path())
+        .arg("--replay")
+        .arg(&log_path)
+        .status()
+        .expect("failed to run replay");
+
+    std::fs::remove_file(&log_path).ok();
+    assert!(!status.success(), "expected replay to fail: {status:?}");
+}


### PR DESCRIPTION
## Summary
- `bsengine-runtime --test <game> --replay <log>`: runs a saved action log to completion with no stdin/AI involved, exits 0 if every command succeeds and every `assert` passes, non-zero (with the failing label/actual/expected on stderr) otherwise — a standard CI pass/fail signal. Shares its command execution (`execute_command`) with the interactive stdin loop from PR 1 for identical behavior.
- `SessionRegistry` now records every non-`query` command a session receives (in order) and can serialize it to `games/<game>/tests/<name>.testlog.json` via `test_save_recording`.
- `test_run_replay(game, name)` MCP tool spawns `bsengine-runtime --test --replay` against a saved recording and reports pass/fail — lets Claude verify a recording still passes without a CI run.
- `bsengine-mcp-server` now exposes 11 `test_*` tools total: interactive session control (from PR 2) plus this PR's record/save/replay loop.

This completes the "record an interactive AI session once, replay it deterministically forever after with no AI in the loop" design decided during brainstorming (`docs/superpowers/specs/2026-07-22-ai-gameplay-e2e-testing-design.md`). Third of 3 PRs — stacked on #1714 (PR 2/3), which is stacked on #1713 (PR 1/3). Plan: `docs/superpowers/plans/2026-07-22-test-recording-replay.md`.

**Note on the plan's original test design (same lesson as PR 2):** tests needing to spawn the `bsengine-runtime` binary from `bsengine-mcp`'s test suite can't use `CARGO_BIN_EXE_bsengine-runtime` — that only works for a package's own binaries. `crates/bsengine-mcp/tests/session.rs` and `tests/test_tools.rs` (from PR 2) already solved this by shelling out to `cargo build --message-format=json`; this PR's new tests reuse that same helper. `crates/bsengine-runtime/tests/replay.rs`'s tests reference `bsengine-runtime`'s own binary from its own `tests/`, so `CARGO_BIN_EXE_bsengine-runtime` works fine there.

## Test plan
- [x] `cargo test -p bsengine-runtime` (incl. new `tests/replay.rs`, both pass/fail paths) — all pass
- [x] `cargo test -p bsengine-mcp --lib` / `--test session` (incl. new recording test) / `--test test_tools` (incl. full record→save→replay round trip) — all pass
- [x] `cargo test --workspace --exclude bsengine-editor --exclude bsengine-editor-app` — 0 failures
- [x] `cargo test -p bsengine-editor --lib` — 0 failures
- [x] Confirmed no leftover `.testlog.json` artifacts after test runs