### PR TITLE
feat(runtime): let a recorded testlog pin its own starting scene

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
+ "tempfile",
  "toml",
  "tracing",
 ]

--- a/crates/bsengine-runtime/Cargo.toml
+++ b/crates/bsengine-runtime/Cargo.toml
@@ -34,3 +34,4 @@ tracing         = { workspace = true }
 
 [dev-dependencies]
 glam            = { workspace = true }
+tempfile        = "3"

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -17,13 +17,20 @@ use crate::scene_systems::{register_scene_systems, ProjectManifest};
 use crate::test_protocol::{Command, CommandResponse};
 use crate::test_query::{eval_op, eval_path, run_query};
 
-pub fn build_test_app(project_dir: &str) -> App {
+/// Builds the headless app rooted at `project_dir`. Loads `scene_override`
+/// (a path relative to `project_dir`, e.g. `"assets/scenes/level3.ron"`) if
+/// given, otherwise falls back to `project.toml`'s `entry_scene` — lets a
+/// replay log pin its own starting scene instead of always depending on
+/// whatever the project's entry scene currently is (which changes as a
+/// multi-level game's "real" entry point evolves during development).
+pub fn build_test_app(project_dir: &str, scene_override: Option<&str>) -> App {
     let manifest_path = format!("{project_dir}/project.toml");
     let manifest_str = std::fs::read_to_string(&manifest_path)
         .unwrap_or_else(|e| panic!("Cannot read {manifest_path}: {e}"));
     let manifest: ProjectManifest = toml::from_str(&manifest_str)
         .unwrap_or_else(|e| panic!("Cannot parse {manifest_path}: {e}"));
-    let scene_path = format!("{project_dir}/{}", manifest.project.entry_scene);
+    let relative_scene = scene_override.unwrap_or(&manifest.project.entry_scene);
+    let scene_path = format!("{project_dir}/{relative_scene}");
 
     let mut app = bsengine_app::new_app();
     app.add_plugins(InputPlugin)
@@ -54,7 +61,7 @@ fn mouse_button_from_u8(button: u8) -> Option<MouseButton> {
 }
 
 pub fn run_test_mode(project_dir: &str) {
-    let mut app = build_test_app(project_dir);
+    let mut app = build_test_app(project_dir, None);
     let mut frame: u64 = 0;
 
     let stdin = io::stdin();
@@ -183,6 +190,15 @@ fn write_response(stdout: &mut io::Stdout, response: &CommandResponse) {
 
 #[derive(serde::Deserialize)]
 struct RecordedLog {
+    /// Path (relative to `project_dir`) of the scene this log was recorded
+    /// against, e.g. `"assets/scenes/level3.ron"`. When present, replay
+    /// loads this scene directly instead of the project's current
+    /// `entry_scene` — needed once a game has more than one independently
+    /// replayable level, since only one `entry_scene` can be active at a
+    /// time. Absent for older logs recorded before this field existed,
+    /// which fall back to `entry_scene` as before.
+    #[serde(default)]
+    scene: Option<String>,
     actions: Vec<Command>,
 }
 
@@ -195,7 +211,7 @@ pub fn run_replay_mode(project_dir: &str, log_path: &str) -> bool {
     let log: RecordedLog = serde_json::from_str(&log_str)
         .unwrap_or_else(|e| panic!("cannot parse replay log {log_path}: {e}"));
 
-    let mut app = build_test_app(project_dir);
+    let mut app = build_test_app(project_dir, log.scene.as_deref());
     let mut frame: u64 = 0;
 
     for command in log.actions {
@@ -238,4 +254,55 @@ pub fn run_replay_mode(project_dir: &str, log_path: &str) -> bool {
         }
     }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_two_scene_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("assets/scenes")).unwrap();
+        std::fs::write(
+            root.join("project.toml"),
+            "[project]\nname = \"Test\"\nentry_scene = \"assets/scenes/a.ron\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("assets/scenes/a.ron"),
+            "SceneDescriptor(entities: [EntityDescriptor(name: \"SceneA\")])",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("assets/scenes/b.ron"),
+            "SceneDescriptor(entities: [EntityDescriptor(name: \"SceneB\")])",
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn build_test_app_with_no_override_loads_entry_scene() {
+        let dir = write_two_scene_project();
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None);
+        app.update();
+
+        let names = crate::test_query::get_entity_names(app.world_mut());
+        let names: Vec<String> = serde_json::from_value(names).unwrap();
+        assert!(names.contains(&"SceneA".to_string()), "names: {names:?}");
+        assert!(!names.contains(&"SceneB".to_string()), "names: {names:?}");
+    }
+
+    #[test]
+    fn build_test_app_with_override_loads_that_scene_instead() {
+        let dir = write_two_scene_project();
+        let mut app = build_test_app(dir.path().to_str().unwrap(), Some("assets/scenes/b.ron"));
+        app.update();
+
+        let names = crate::test_query::get_entity_names(app.world_mut());
+        let names: Vec<String> = serde_json::from_value(names).unwrap();
+        assert!(names.contains(&"SceneB".to_string()), "names: {names:?}");
+        assert!(!names.contains(&"SceneA".to_string()), "names: {names:?}");
+    }
 }


### PR DESCRIPTION
## Summary
- `RecordedLog` gains an optional `"scene"` field (a path relative to the project dir). When present, `bsengine-runtime --test <game> --replay <log>` loads that scene directly instead of `project.toml`'s `entry_scene`.
- `build_test_app` takes a new `scene_override: Option<&str>` parameter.
- Backward compatible: logs without `"scene"` (all existing recordings) fall back to `entry_scene` exactly as before.

## Why
Each level of a multi-level game needs its own independently-replayable regression log, but only one `entry_scene` can be active in `project.toml` at a time. As soon as a game has more than one level, only whichever level `entry_scene` currently points at replays correctly — every other level's saved log silently loads the wrong scene and fails for reasons that have nothing to do with the game logic it's meant to test. Discovered while building a 5-level game (`games/tilt-run`, in progress on a separate branch) where levels 1-4 each have their own recorded log.

## Test plan
- [x] New tests `build_test_app_with_no_override_loads_entry_scene` / `build_test_app_with_override_loads_that_scene_instead` (temp project with two distinct scenes, confirms the override actually changes which one loads) — written first to prove the gap, pass with the fix
- [x] `cargo test -p bsengine-runtime --bin bsengine-runtime` — 20 passed, 0 failed
- [x] `cargo test --workspace --exclude bsengine-editor --exclude bsengine-editor-app` — 0 failures
- [x] `cargo test -p bsengine-editor --lib` — 0 failures