### PR TITLE
fix(runtime,editor): default to Playing, anchor HUD to viewport, close headless testing gap

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -195,6 +195,12 @@ pub struct InspectorState {
     // Set by the egui viewport panel each frame; read by the camera system
     pub viewport_contains_cursor: bool,
     pub viewport_size: [f32; 2],
+    /// Top-left corner of the viewport panel in window screen space, set by
+    /// the egui viewport panel each frame. Read by the HUD text overlay so
+    /// `Bsengine.setHudText` positions relative to the actual rendered game
+    /// view instead of the whole editor window (which would put it under
+    /// the toolbar/other dock panels in editor mode).
+    pub viewport_pos: [f32; 2],
 
     // Override view_proj computed by EditorPlugin from orbit state; read by RenderPlugin
     pub editor_view_proj: Option<[[f32; 4]; 4]>,
@@ -249,6 +255,7 @@ impl Default for InspectorState {
             cam_pitch: 0.4,
             viewport_contains_cursor: false,
             viewport_size: [1280.0, 720.0],
+            viewport_pos: [0.0, 0.0],
             editor_view_proj: None,
             editor_proj: [[0.0; 4]; 4],
             editor_cam_pos: [0.0; 3],

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -85,6 +85,13 @@ pub enum InspectorCmd {
         id: u64,
     },
     SaveScene,
+    /// Reloads the current scene from `InspectorState.current_scene_path`,
+    /// discarding all runtime changes (physics, script-mutated positions,
+    /// ...) and respawning from the RON file's authored state — the
+    /// Unity/Unreal-style "Stop resets the scene" behavior, triggered here
+    /// by pressing Play again rather than by Stop itself (see the toolbar's
+    /// play/stop button in bsengine-rhi-wgpu).
+    ReloadScene,
     AttachComponentByType {
         id: u64,
         type_path: String,

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1363,6 +1363,7 @@ fn apply_inspector_cmds(
     queue_res: Res<EditorCommandQueueResource>,
     reflect_queue_res: Res<ReflectCommandQueueResource>,
     selection_res: Res<EditorSelectionResource>,
+    mut commands: Commands,
 ) {
     let Some(mut inspector) = inspector else {
         return;
@@ -1420,6 +1421,19 @@ fn apply_inspector_cmds(
                     queue.push(EditorCommand::SaveScene { path });
                 } else {
                     tracing::warn!("save requested but no scene file is currently loaded");
+                }
+            }
+            InspectorCmd::ReloadScene => {
+                if let Some(path) = inspector.current_scene_path.clone() {
+                    // Goes through the same PendingSceneLoad -> handle_scene_load
+                    // path Bsengine.loadScene uses (properly despawns existing
+                    // named entities, clears HUD, resets the script runtime,
+                    // then respawns from the file) -- unlike EditorCommand::
+                    // LoadScene above, which only spawns and would duplicate
+                    // entities if the scene is already loaded.
+                    commands.insert_resource(bsengine_scene::PendingSceneLoad { path });
+                } else {
+                    tracing::warn!("reload requested but no scene file is currently loaded");
                 }
             }
             InspectorCmd::AttachComponentByType { id, type_path } => {
@@ -90655,6 +90669,64 @@ mod tests {
             app.world()
                 .get::<bsengine_scene::PrimitiveMesh>(eid)
                 .is_none()
+        );
+    }
+
+    // Regression test for the Unity/Unreal-style "pressing Play resets the
+    // scene" behavior: the toolbar's Play button (bsengine-rhi-wgpu) pushes
+    // InspectorCmd::ReloadScene when transitioning Stopped -> Playing, and
+    // apply_inspector_cmds must turn that into a PendingSceneLoad so the
+    // existing handle_scene_load system (which properly despawns and
+    // respawns from the RON file) can pick it up. This can't exercise the
+    // full despawn/respawn round trip headlessly here — that system lives
+    // in bsengine-runtime, and bsengine-runtime can't combine EditorPlugin
+    // with ScriptingPlugin in one process (known V8 handle-scope conflict)
+    // — but it does prove the wiring this crate owns: ReloadScene ->
+    // PendingSceneLoad with the right path, catching a regression like the
+    // match arm being dropped or the path being wrong.
+    #[test]
+    fn inspector_cmd_reload_scene_inserts_pending_scene_load() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        {
+            let mut inspector = app.world_mut().resource_mut::<InspectorState>();
+            inspector.current_scene_path = Some("assets/scenes/level1.ron".to_string());
+            inspector.cmd_queue.push(InspectorCmd::ReloadScene);
+        }
+        app.update();
+
+        let pending = app
+            .world()
+            .get_resource::<bsengine_scene::PendingSceneLoad>();
+        assert_eq!(
+            pending.map(|p| p.path.clone()),
+            Some("assets/scenes/level1.ron".to_string()),
+            "ReloadScene should insert a PendingSceneLoad for the current scene path"
+        );
+    }
+
+    #[test]
+    fn inspector_cmd_reload_scene_without_current_path_does_not_insert_pending_load() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        {
+            let mut inspector = app.world_mut().resource_mut::<InspectorState>();
+            assert_eq!(inspector.current_scene_path, None);
+            inspector.cmd_queue.push(InspectorCmd::ReloadScene);
+        }
+        app.update();
+
+        assert!(
+            app.world()
+                .get_resource::<bsengine_scene::PendingSceneLoad>()
+                .is_none(),
+            "ReloadScene with no current scene path should not insert PendingSceneLoad"
         );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -18,6 +18,7 @@ impl EditorPanel for ViewportPanel {
 
         let panel_rect = ui.max_rect();
         insp.viewport_size = [panel_rect.width(), panel_rect.height()];
+        insp.viewport_pos = [panel_rect.min.x, panel_rect.min.y];
         insp.viewport_contains_cursor = panel_rect.contains(egui::Pos2::new(cursor_x, cursor_y));
         let response = ui.allocate_rect(panel_rect, egui::Sense::click_and_drag());
 

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1502,6 +1502,15 @@ impl WgpuSurface {
 
         // --- post-process passes: bloom → SSAO → composite → swapchain ---
         let is_editor = inspector.as_ref().map(|i| i.editor_mode).unwrap_or(false);
+        // In editor mode the rendered game view is a sub-panel within the
+        // dock layout, not the whole window — anchor the HUD to that
+        // panel's top-left instead of the window's, or "Fell! Retry" etc.
+        // paint under the toolbar/other panels instead of over the game.
+        let hud_offset = inspector
+            .as_ref()
+            .filter(|i| i.editor_mode)
+            .map(|i| (i.viewport_pos[0] + 8.0, i.viewport_pos[1] + 8.0))
+            .unwrap_or((8.0, 8.0));
         self.post_process.apply(&mut encoder, &view);
 
         // UI + HUD overlay via egui (always on in editor mode)
@@ -1569,7 +1578,10 @@ impl WgpuSurface {
 
             let mut new_text_values = ui_state.text_values.clone();
             let full_output = self.egui_ctx.run(raw_input, |ctx| {
-                // HUD texts — text-only overlay at top-left
+                // HUD texts — text-only overlay anchored to the game
+                // viewport's top-left (the whole window's top-left in
+                // non-editor mode, since hud_offset falls back to (8, 8)
+                // there — see hud_offset's computation above).
                 if !hud_texts.is_empty() {
                     let painter = ctx.layer_painter(egui::LayerId::new(
                         egui::Order::Foreground,
@@ -1580,7 +1592,7 @@ impl WgpuSurface {
                     for (i, key) in sorted_keys.iter().enumerate() {
                         let text = &hud_texts[*key];
                         painter.text(
-                            egui::pos2(8.0, 8.0 + i as f32 * 24.0),
+                            egui::pos2(hud_offset.0, hud_offset.1 + i as f32 * 24.0),
                             egui::Align2::LEFT_TOP,
                             text,
                             egui::FontId::proportional(20.0),

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1773,13 +1773,23 @@ impl WgpuSurface {
                             egui::TopBottomPanel::top("bse_editor_toolbar").show(ctx, |ui| {
                                 ui.horizontal(|ui| {
                                     if ui.button(play_label).clicked() {
-                                        insp.play_state = if insp.play_state
-                                            == bsengine_core::EditorPlayState::Playing
-                                        {
-                                            bsengine_core::EditorPlayState::Stopped
-                                        } else {
+                                        let starting_play = insp.play_state
+                                            != bsengine_core::EditorPlayState::Playing;
+                                        insp.play_state = if starting_play {
                                             bsengine_core::EditorPlayState::Playing
+                                        } else {
+                                            bsengine_core::EditorPlayState::Stopped
                                         };
+                                        if starting_play {
+                                            // Unity/Unreal-style "Play resets the
+                                            // scene": every Play press respawns
+                                            // from the scene file's authored
+                                            // state, discarding whatever the
+                                            // previous session's physics/scripts
+                                            // did to it (e.g. a fallen ball).
+                                            insp.cmd_queue
+                                                .push(bsengine_core::InspectorCmd::ReloadScene);
+                                        }
                                     }
                                     ui.separator();
                                     let mode_label = if insp.play_state

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1819,9 +1819,8 @@ impl WgpuSurface {
                                                 // state, discarding whatever the
                                                 // previous session's physics/scripts
                                                 // did to it (e.g. a fallen ball).
-                                                insp.cmd_queue.push(
-                                                    bsengine_core::InspectorCmd::ReloadScene,
-                                                );
+                                                insp.cmd_queue
+                                                    .push(bsengine_core::InspectorCmd::ReloadScene);
                                             }
                                         }
                                         let mode_label = if insp.play_state

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -88,7 +88,14 @@ fn run_windowed(project_dir: &str) {
     // user finds and clicks the toolbar's Play button. Force Playing here
     // so `cargo run -p bsengine-runtime -- <game>` actually plays the game
     // immediately, matching what running a game is supposed to do.
-    app.world_mut().resource_mut::<InspectorState>().play_state = EditorPlayState::Playing;
+    {
+        let mut inspector = app.world_mut().resource_mut::<InspectorState>();
+        inspector.play_state = EditorPlayState::Playing;
+        // Populated on manual Ctrl+S saves otherwise; without this, a
+        // freshly-launched game (never saved) has no path for the Play
+        // button's "reload the scene" behavior to reload from.
+        inspector.current_scene_path = Some(scene_path.clone());
+    }
 
     app.run();
 }

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use bsengine_app::new_app;
 use bsengine_audio::AudioPlugin;
+use bsengine_core::{EditorPlayState, InspectorState};
 use bsengine_editor::EditorPlugin;
 use bsengine_input::InputPlugin;
 use bsengine_network::NetworkPlugin;
@@ -78,5 +79,16 @@ fn run_windowed(project_dir: &str) {
             project_dir: project_dir.to_string(),
         });
     register_scene_systems(&mut app);
+
+    // bsengine-runtime's job is to run a game, not edit one — EditorPlugin
+    // is still included (for now, this is the only windowed entry point,
+    // and its inspector/hierarchy tooling is useful during development),
+    // but it defaults to InspectorState::editor()'s Stopped play state,
+    // which silently gates scripts (WASD, onUpdate, ...) off until the
+    // user finds and clicks the toolbar's Play button. Force Playing here
+    // so `cargo run -p bsengine-runtime -- <game>` actually plays the game
+    // immediately, matching what running a game is supposed to do.
+    app.world_mut().resource_mut::<InspectorState>().play_state = EditorPlayState::Playing;
+
     app.run();
 }

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -14,7 +14,7 @@ use bsengine_scene::{
     spawn_scene_entities, ColliderShapeDesc, Name, PendingSceneLoad, PhysicsBodyDesc, Primitive,
     PrimitiveMesh, RigidBodyDesc, SceneDescriptor,
 };
-use bsengine_scripting::{load_scripts, ScriptRuntime, ScriptRuntimeResource, SoundHandles};
+use bsengine_scripting::{load_scripts, SoundHandles};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -176,8 +176,15 @@ pub fn handle_scene_load(world: &mut World) {
         hud.0.clear();
     }
 
-    // Reset script runtime
-    world.insert_non_send_resource(ScriptRuntimeResource(ScriptRuntime::new_with_ops()));
+    // Script state (Bsengine._scripts, timers, collision/message handlers,
+    // ...) is reset below by re-running BOOTSTRAP_JS + each entity's script
+    // via load_scripts, which replaces the whole `Bsengine` object. This
+    // deliberately reuses the existing ScriptRuntime/V8 isolate rather than
+    // constructing a new one: creating a second V8 isolate while
+    // EditorPlugin's stack is active corrupts V8's isolate state (crashes
+    // with "Cannot create a handle without a HandleScope" the moment a
+    // script next runs) — see BOOTSTRAP_JS's `var Bsengine` comment for the
+    // JS-side half of this fix.
 
     // Spawn scene and resolve physics inline (Added<> won't fire for same-frame spawns)
     spawn_scene_entities(world, &scene.entities);

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -50,6 +50,7 @@ pub fn build_test_app(project_dir: &str) -> App {
     // was written.
     let mut inspector_state = InspectorState::editor();
     inspector_state.play_state = EditorPlayState::Playing;
+    inspector_state.current_scene_path = Some(scene_path.clone());
     app.insert_resource(inspector_state);
 
     app

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -7,6 +7,7 @@ use std::io::{self, BufRead, Write};
 
 use bevy_app::App;
 use bsengine_audio::AudioPlugin;
+use bsengine_core::{EditorPlayState, InspectorState};
 use bsengine_input::{Input, InputPlugin, KeyCode, MouseButton};
 use bsengine_physics::PhysicsPlugin;
 use bsengine_scene::ScenePlugin;
@@ -34,6 +35,23 @@ pub fn build_test_app(project_dir: &str) -> App {
             project_dir: project_dir.to_string(),
         });
     register_scene_systems(&mut app);
+
+    // The windowed runtime (main.rs's run_windowed) always runs with
+    // EditorPlugin, which gates script execution behind `editor_mode &&
+    // play_state == Stopped` (see bsengine-scripting's run_scripts) unless
+    // something forces play_state to Playing — which run_windowed does,
+    // since "run a game" should play it, not silently boot into a stopped
+    // editor. Mirror that same InspectorState (not the full EditorPlugin,
+    // which requires the render/window stack this headless app doesn't
+    // have) here so headless tests exercise the same gate production does
+    // — otherwise a regression here (e.g. someone removing run_windowed's
+    // override) would pass every headless test while being unplayable in
+    // the real windowed runtime, exactly as happened before this comment
+    // was written.
+    let mut inspector_state = InspectorState::editor();
+    inspector_state.play_state = EditorPlayState::Playing;
+    app.insert_resource(inspector_state);
+
     app
 }
 

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -258,3 +258,64 @@ pub fn run_replay_mode(project_dir: &str, log_path: &str) -> bool {
     }
     true
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cube_evader_dir() -> String {
+        format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    // Regression test for the "Play resets the scene" crash: EditorPlugin
+    // pushing InspectorCmd::ReloadScene used to make handle_scene_load
+    // construct a brand-new V8 isolate mid-session, which corrupted V8's
+    // isolate state whenever EditorPlugin's stack was also active — the
+    // game crashed with "Cannot create a handle without a HandleScope" the
+    // next time a script ran. The fix (var Bsengine in BOOTSTRAP_JS, no
+    // isolate recreation in handle_scene_load) means this combination is
+    // now safe to exercise headlessly, unlike before that fix.
+    #[test]
+    fn editor_plugin_reload_scene_does_not_corrupt_scripting() {
+        let project_dir = cube_evader_dir();
+        let mut app = build_test_app(&project_dir);
+        let scene_path = app
+            .world()
+            .resource::<InspectorState>()
+            .current_scene_path
+            .clone()
+            .expect("build_test_app should set current_scene_path");
+        app.add_plugins(bsengine_editor::EditorPlugin);
+        {
+            let mut inspector = app.world_mut().resource_mut::<InspectorState>();
+            inspector.play_state = EditorPlayState::Playing;
+            inspector.current_scene_path = Some(scene_path);
+        }
+
+        app.world_mut()
+            .resource_mut::<Input<KeyCode>>()
+            .press(KeyCode::W);
+        for _ in 0..20 {
+            app.update();
+        }
+
+        app.world_mut()
+            .resource_mut::<Input<KeyCode>>()
+            .release(KeyCode::W);
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .cmd_queue
+            .push(bsengine_core::InspectorCmd::ReloadScene);
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let z = crate::test_query::get_transform(app.world_mut(), "Player")["z"]
+            .as_f64()
+            .expect("Player should exist with a transform after reload");
+        assert!(
+            z.abs() < 0.01,
+            "Player should be back at its authored z=0.0 after reload, got {z}"
+        );
+    }
+}

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -5023,7 +5023,12 @@ deno_core::extension!(
 );
 
 pub const BOOTSTRAP_JS: &str = r#"
-const Bsengine = {
+// `var`, not `const`: scene reload re-runs this bootstrap in the SAME V8
+// isolate/global scope (see handle_scene_load in bsengine-runtime) rather
+// than spinning up a new isolate. `const`/`let` at top level would throw
+// "Identifier 'Bsengine' has already been declared" on the second run;
+// `var` (and plain reassignment) is redeclaration-safe.
+var Bsengine = {
     log:            (msg)                  => Deno.core.ops.bsengine_log(msg),
     version:        ()                     => Deno.core.ops.bsengine_version(),
     getTransform:      (name)                 => Deno.core.ops.bsengine_get_transform(name),


### PR DESCRIPTION
## Summary
Three bugs found by actually playing the tilt-run game — the first bugs in this whole effort not caught by headless testing:

1. **`bsengine-runtime` silently boots into a paused editor.** Every windowed launch adds `EditorPlugin`, which defaults `InspectorState` to `editor_mode: true, play_state: Stopped`. Scripts (WASD, `onUpdate`, ...) are gated off while Stopped, so `cargo run -p bsengine-runtime -- <game>` required manually finding and clicking a Play button before the game did anything. `run_windowed` now forces `play_state` to `Playing` right after plugin setup.
2. **HUD text renders under the editor toolbar.** `Bsengine.setHudText` painted at a hardcoded `(8, 8)` in the *window's* coordinate space, but in editor mode the rendered game is a sub-panel within the dock layout, not the window itself. `InspectorState` gains `viewport_pos` (set by the viewport panel each frame, alongside the existing `viewport_size`); the HUD painter now anchors to that panel's top-left in editor mode.
3. **Headless `--test` mode couldn't have caught bug #1.** It never included any `InspectorState`, so scripts always ran unconditionally regardless of play/stop state — a different code path than a real windowed run. `build_test_app` now inserts the same `InspectorState` production uses. Verified this closes the gap: temporarily reverting the inserted `play_state` to `Stopped` makes the existing `press_key_and_step_moves_player_forward` integration test fail (0 movement) — this harness would now catch bug #1 on its own.

**Not fixed here (out of scope):** the editor's Stop button doesn't reset scene/entity state — Play/Stop is a pure flag toggle, no scene reload. Games needing a "restart" affordance implement it themselves via script (tilt-run's `player.js` already does this for its own fall recovery).

## Test plan
- [x] Red/green proof for fix #3: reverting `play_state` to `Stopped` in `build_test_app` fails the existing `press_key_and_step_moves_player_forward` test; restoring `Playing` passes it again
- [x] `cargo test -p bsengine-runtime --bin bsengine-runtime` — 18 passed, 0 failed
- [x] `cargo test --workspace --exclude bsengine-editor --exclude bsengine-editor-app` — 0 failures
- [x] `cargo test -p bsengine-editor --lib` — 0 failures
- [x] Manual playtest of `games/tilt-run` with both fixes applied