### PR TITLE
Editor UI redesign: hybrid dark theme + Asset Browser panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,7 @@ dependencies = [
  "bsengine-app",
  "bsengine-core",
  "bsengine-ecs",
+ "bsengine-gltf",
  "bsengine-input",
  "bsengine-mcp",
  "bsengine-render",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "bsengine-window",
  "bytemuck",
  "egui",
+ "egui-phosphor",
  "egui-wgpu",
  "egui_dock",
  "glam 0.29.3",
@@ -1476,6 +1477,15 @@ dependencies = [
  "epaint",
  "nohash-hasher",
  "serde",
+]
+
+[[package]]
+name = "egui-phosphor"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74744068685d20e004d1a4326c48403b6759e325c7fce8c5eeeab93f0a9f67ca"
+dependencies = [
+ "egui",
 ]
 
 [[package]]
@@ -4327,7 +4337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,5 @@ kira              = { version = "0.12", default-features = false, features = ["c
 egui              = "0.29"
 egui-wgpu         = "0.29"
 egui_dock         = { version = "0.14", features = ["serde"] }
+egui-phosphor     = { version = "0.7.3", default-features = false, features = ["regular"] }
 gilrs             = "0.11"

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -179,6 +179,10 @@ pub struct InspectorState {
     pub edit_scale: [f32; 3],
     pub edit_new_tag: String,
     pub edit_script_path: String,
+    /// Live text in the Hierarchy panel's search box. Empty means "show the
+    /// full tree"; non-empty switches Hierarchy to a flat, name-filtered
+    /// list (see `HierarchyPanel::matches_search`).
+    pub hierarchy_search: String,
     pub edit_visible: bool,
     prev_selected_id: Option<u64>,
 
@@ -239,6 +243,7 @@ impl Default for InspectorState {
             edit_scale: [1.0, 1.0, 1.0],
             edit_new_tag: String::new(),
             edit_script_path: String::new(),
+            hierarchy_search: String::new(),
             edit_visible: true,
             prev_selected_id: None,
             editor_mode: false,

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -183,6 +183,9 @@ pub struct InspectorState {
     /// full tree"; non-empty switches Hierarchy to a flat, name-filtered
     /// list (see `HierarchyPanel::matches_search`).
     pub hierarchy_search: String,
+    /// Whether the viewport draws the ground-plane reference grid. Toggled
+    /// by the viewport overlay's grid button.
+    pub show_grid: bool,
     pub edit_visible: bool,
     prev_selected_id: Option<u64>,
 
@@ -244,6 +247,7 @@ impl Default for InspectorState {
             edit_new_tag: String::new(),
             edit_script_path: String::new(),
             hierarchy_search: String::new(),
+            show_grid: true,
             edit_visible: true,
             prev_selected_id: None,
             editor_mode: false,

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -85,6 +85,23 @@ pub enum InspectorCmd {
         id: u64,
     },
     SaveScene,
+    /// Replace the current scene by loading and parsing a `.ron` file at
+    /// `path`. Mirrors `EditorCommand::LoadScene`, which already does the
+    /// actual file read/parse/spawn — this variant only exists so UI code
+    /// (the Asset Browser) can request it through the same `InspectorCmd`
+    /// pipeline every other UI-driven command goes through.
+    LoadScene {
+        path: String,
+    },
+    /// Spawn a new named entity with a `GltfAsset { path }` component
+    /// attached, so `bsengine-gltf`'s existing `load_gltf_assets` system
+    /// (already registered in the editor app, already tested) picks it up
+    /// and asynchronously replaces it with the loaded mesh's
+    /// `MeshRenderer`/`Material`. Always spawns as a root entity.
+    SpawnMeshAsset {
+        name: String,
+        path: String,
+    },
     AttachComponentByType {
         id: u64,
         type_path: String,

--- a/crates/bsengine-editor/Cargo.toml
+++ b/crates/bsengine-editor/Cargo.toml
@@ -13,6 +13,7 @@ bsengine-mcp    = { workspace = true }
 bsengine-scene  = { workspace = true }
 bsengine-core   = { workspace = true }
 bsengine-render = { workspace = true }
+bsengine-gltf   = { workspace = true }
 bevy_app        = { workspace = true }
 bevy_ecs        = { workspace = true }
 bevy_reflect    = { workspace = true }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -136,6 +136,9 @@ fn process_editor_commands(
             EditorCommand::SpawnNamed(name) => {
                 commands.spawn(Name(name));
             }
+            EditorCommand::SpawnMeshAsset { name, path } => {
+                commands.spawn((Name(name), bsengine_gltf::GltfAsset::new(path)));
+            }
             EditorCommand::Despawn { entity_id } => {
                 let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
                 if let Some(entity) = target {
@@ -1421,6 +1424,12 @@ fn apply_inspector_cmds(
                 } else {
                     tracing::warn!("save requested but no scene file is currently loaded");
                 }
+            }
+            InspectorCmd::LoadScene { path } => {
+                queue.push(EditorCommand::LoadScene(path));
+            }
+            InspectorCmd::SpawnMeshAsset { name, path } => {
+                queue.push(EditorCommand::SpawnMeshAsset { name, path });
             }
             InspectorCmd::AttachComponentByType { id, type_path } => {
                 reflect_queue_res.0.lock().unwrap().push(ReflectCommand::AttachComponentByType {
@@ -90656,5 +90665,30 @@ mod tests {
                 .get::<bsengine_scene::PrimitiveMesh>(eid)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn spawn_mesh_asset_command_spawns_entity_with_name_and_gltf_asset() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        {
+            let queue = app.world().resource::<EditorCommandQueueResource>();
+            queue.0.lock().unwrap().push(EditorCommand::SpawnMeshAsset {
+                name: "Rock".to_string(),
+                path: "assets/models/rock.glb".to_string(),
+            });
+        }
+        app.update();
+
+        let mut query = app.world_mut().query::<(&Name, &bsengine_gltf::GltfAsset)>();
+        let (name, gltf_asset) = query
+            .iter(app.world())
+            .next()
+            .expect("expected one entity with Name + GltfAsset");
+        assert_eq!(name.0, "Rock");
+        assert_eq!(gltf_asset.path, "assets/models/rock.glb");
     }
 }

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -60,6 +60,13 @@ pub enum EditorCommand {
         entity_id: u64,
     },
     LoadScene(String),
+    /// Spawn a named entity with a `GltfAsset` component so the existing
+    /// `bsengine-gltf` async loader picks it up. See
+    /// `InspectorCmd::SpawnMeshAsset`'s doc comment for the full rationale.
+    SpawnMeshAsset {
+        name: String,
+        path: String,
+    },
     SaveScene {
         path: String,
     },

--- a/crates/bsengine-rhi-wgpu/Cargo.toml
+++ b/crates/bsengine-rhi-wgpu/Cargo.toml
@@ -17,6 +17,7 @@ winit.workspace = true
 egui.workspace = true
 egui-wgpu.workspace = true
 egui_dock.workspace = true
+egui-phosphor.workspace = true
 serde_json.workspace = true
 bevy_reflect.workspace = true
 bytemuck.workspace = true

--- a/crates/bsengine-rhi-wgpu/src/gizmo.rs
+++ b/crates/bsengine-rhi-wgpu/src/gizmo.rs
@@ -280,6 +280,51 @@ pub fn draw_rotate_gizmo(
     }
 }
 
+/// World-space ground-plane (Y=0) grid line endpoints, `spacing` world units
+/// apart, out to `half_extent` lines on each side of the origin, projected
+/// to screen space. A line is omitted if either endpoint is behind the
+/// camera (see `world_to_screen`).
+pub fn ground_grid_lines(
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+    spacing: f32,
+    half_extent: i32,
+) -> Vec<[Pos2; 2]> {
+    let extent = half_extent as f32 * spacing;
+    let mut lines = Vec::new();
+    for i in -half_extent..=half_extent {
+        let offset = i as f32 * spacing;
+        if let (Some(a), Some(b)) = (
+            world_to_screen(Vec3::new(-extent, 0.0, offset), view_proj, rect),
+            world_to_screen(Vec3::new(extent, 0.0, offset), view_proj, rect),
+        ) {
+            lines.push([a, b]);
+        }
+        if let (Some(a), Some(b)) = (
+            world_to_screen(Vec3::new(offset, 0.0, -extent), view_proj, rect),
+            world_to_screen(Vec3::new(offset, 0.0, extent), view_proj, rect),
+        ) {
+            lines.push([a, b]);
+        }
+    }
+    lines
+}
+
+/// Paints pre-projected ground-grid lines with a faint, constant stroke.
+///
+/// Uses `from_rgba_premultiplied` with all four channels equal (30, 30, 30,
+/// 30) rather than a naive (255, 255, 255, 30): egui's premultiplied-alpha
+/// convention requires `r, g, b <= a` (the stored channels are already
+/// alpha-scaled), so a "white at 30/255 opacity" value must be pre-scaled to
+/// r=g=b=a=30, not left at full 255 with alpha tacked on — the latter is
+/// what caused the `theme.rs` `ACCENT_WASH` bug earlier in this plan.
+pub fn draw_ground_grid(painter: &Painter, lines: &[[Pos2; 2]]) {
+    let stroke = Stroke::new(1.0, Color32::from_rgba_premultiplied(30, 30, 30, 30));
+    for [a, b] in lines {
+        painter.line_segment([*a, *b], stroke);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -480,5 +525,21 @@ mod tests {
             hit_test_rotate(Vec3::ZERO, 1.0, &vp, rect, Pos2::new(-500.0, -500.0)),
             None
         );
+    }
+
+    #[test]
+    fn ground_grid_lines_returns_one_line_pair_per_row_and_column() {
+        let eye = Vec3::new(0.0, 10.0, 20.0);
+        let view = Mat4::look_at_rh(eye, Vec3::ZERO, Vec3::Y);
+        let proj = Mat4::perspective_rh(60f32.to_radians(), 1.0, 0.1, 1000.0);
+        let view_proj = (proj * view).to_cols_array_2d();
+        let rect = Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0));
+
+        let lines = ground_grid_lines(&view_proj, rect, 1.0, 1);
+
+        // half_extent=1 means i in [-1, 0, 1]: 3 rows + 3 columns = 6 lines,
+        // all well within view of a camera at (0, 10, 20) looking at the
+        // origin, so none should be culled for being behind the camera.
+        assert_eq!(lines.len(), 6);
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -21,6 +21,7 @@ pub mod post_process;
 pub mod rhi;
 pub mod surface;
 pub mod texture;
+pub mod theme;
 pub use mesh::{
     capsule_vertices, cube_vertices, plane_vertices, sphere_vertices, triangle_vertices,
     GpuMeshRegistry, Vertex,

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -115,6 +115,10 @@ pub struct AssetBrowserPanel {
     /// `InspectorCmd::LoadScene` in a later task (Task 7 of this plan) —
     /// for now it's just stored, not yet consumed.
     pending_load_scene: Option<String>,
+    /// In-memory cache of decoded+downsampled Texture-tile thumbnails,
+    /// keyed by asset path. Cleared implicitly whenever this panel is
+    /// dropped — there is no disk cache in this task.
+    thumbnail_cache: std::collections::HashMap<PathBuf, egui::TextureHandle>,
 }
 
 impl Default for AssetBrowserPanel {
@@ -126,6 +130,7 @@ impl Default for AssetBrowserPanel {
             entries: Vec::new(),
             scanned: false,
             pending_load_scene: None,
+            thumbnail_cache: std::collections::HashMap::new(),
         }
     }
 }
@@ -242,9 +247,33 @@ impl AssetBrowserPanel {
             });
     }
 
+    /// Loads and downsamples `path` to a 64×64 `egui::TextureHandle`,
+    /// caching the result in-memory for the lifetime of this panel (cleared
+    /// implicitly whenever the whole `AssetBrowserPanel` is dropped — there
+    /// is no disk cache in this task). Returns `None` if the file can't be
+    /// decoded (corrupt/unsupported image); the tile falls back to the
+    /// fixed Texture icon in that case.
+    fn thumbnail_for(&mut self, ctx: &egui::Context, path: &Path) -> Option<egui::TextureHandle> {
+        if let Some(handle) = self.thumbnail_cache.get(path) {
+            return Some(handle.clone());
+        }
+        let img = image::open(path).ok()?;
+        let thumb = img.thumbnail(64, 64).to_rgba8();
+        let size = [thumb.width() as usize, thumb.height() as usize];
+        let color_image = egui::ColorImage::from_rgba_unmultiplied(size, thumb.as_raw());
+        let handle = ctx.load_texture(
+            path.to_string_lossy().to_string(),
+            color_image,
+            egui::TextureOptions::default(),
+        );
+        self.thumbnail_cache
+            .insert(path.to_path_buf(), handle.clone());
+        Some(handle)
+    }
+
     /// Fixed per-kind icon shown on a tile. Texture tiles get a real
-    /// decoded-image thumbnail in a later task; until then every kind
-    /// (including Texture) shows this fixed icon.
+    /// decoded-image thumbnail via `thumbnail_for`; other kinds always show
+    /// this fixed icon, and Texture falls back to it when decoding fails.
     fn icon_for_kind(kind: AssetKind) -> &'static str {
         match kind {
             AssetKind::Directory => egui_phosphor::regular::FOLDER,
@@ -265,7 +294,16 @@ impl AssetBrowserPanel {
     ) {
         ui.vertical(|ui| {
             ui.set_width(64.0);
-            let response = ui.button(Self::icon_for_kind(entry.kind));
+            let response = if entry.kind == AssetKind::Texture {
+                match self.thumbnail_for(ui.ctx(), &entry.path) {
+                    Some(handle) => ui.add(egui::ImageButton::new(
+                        egui::Image::new(&handle).fit_to_exact_size(egui::vec2(48.0, 48.0)),
+                    )),
+                    None => ui.button(Self::icon_for_kind(entry.kind)),
+                }
+            } else {
+                ui.button(Self::icon_for_kind(entry.kind))
+            };
             ui.label(&entry.name);
 
             if entry.is_dir {

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -40,6 +40,16 @@ fn categorize_by_extension(path: &Path) -> AssetKind {
     }
 }
 
+/// Drag payload for Mesh/Script tiles dragged out of the Asset Browser onto
+/// the Hierarchy or Viewport. Distinct from the `u64` entity-id payload
+/// Hierarchy rows already use for reparenting — egui's drag-and-drop keys
+/// drop targets by payload type, so both can coexist on the same rows.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssetDragPayload {
+    pub path: PathBuf,
+    pub kind: AssetKind,
+}
+
 /// One row in the Asset Browser's tile grid or folder tree.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssetEntry {
@@ -101,6 +111,10 @@ pub struct AssetBrowserPanel {
     current_dir: PathBuf,
     entries: Vec<AssetEntry>,
     scanned: bool,
+    /// Set by a double-clicked Scene tile; drained into
+    /// `InspectorCmd::LoadScene` in a later task (Task 7 of this plan) —
+    /// for now it's just stored, not yet consumed.
+    pending_load_scene: Option<String>,
 }
 
 impl Default for AssetBrowserPanel {
@@ -111,6 +125,7 @@ impl Default for AssetBrowserPanel {
             root,
             entries: Vec::new(),
             scanned: false,
+            pending_load_scene: None,
         }
     }
 }
@@ -124,16 +139,160 @@ impl EditorPanel for AssetBrowserPanel {
         "Assets".to_string()
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &mut EditorPanelContext) {
+    fn ui(&mut self, ui: &mut egui::Ui, ctx: &mut EditorPanelContext) {
         if !self.scanned {
             self.entries = scan_dir(&self.current_dir);
             self.scanned = true;
         }
-        ui.label(format!(
-            "{} entries in {:?}",
-            self.entries.len(),
-            self.current_dir
-        ));
+
+        ui.horizontal(|ui| {
+            if ui.button("Refresh").clicked() {
+                self.entries = scan_dir(&self.current_dir);
+            }
+            ui.separator();
+            self.draw_breadcrumb(ui);
+        });
+        ui.separator();
+
+        let mut navigate_to: Option<PathBuf> = None;
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                ui.set_width(160.0);
+                self.draw_folder_tree(ui, self.root.clone(), &mut navigate_to);
+            });
+            ui.separator();
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                ui.horizontal_wrapped(|ui| {
+                    for entry in self.entries.clone() {
+                        self.draw_tile(ui, &entry, &mut navigate_to, ctx);
+                    }
+                });
+            });
+        });
+
+        if let Some(dir) = navigate_to {
+            self.current_dir = dir;
+            self.entries = scan_dir(&self.current_dir);
+        }
+    }
+}
+
+impl AssetBrowserPanel {
+    /// Renders `Assets / Sub / Folder` as clickable segments; clicking a
+    /// segment sets `current_dir` to that ancestor and rescans.
+    fn draw_breadcrumb(&mut self, ui: &mut egui::Ui) {
+        let Ok(relative) = self.current_dir.strip_prefix(&self.root) else {
+            ui.label(self.current_dir.to_string_lossy());
+            return;
+        };
+        let mut path_so_far = self.root.clone();
+        let mut clicked_dir: Option<PathBuf> = None;
+        ui.horizontal(|ui| {
+            if ui.link("Assets").clicked() {
+                clicked_dir = Some(self.root.clone());
+            }
+            for component in relative.components() {
+                path_so_far.push(component);
+                ui.label("/");
+                if ui
+                    .link(component.as_os_str().to_string_lossy().to_string())
+                    .clicked()
+                {
+                    clicked_dir = Some(path_so_far.clone());
+                }
+            }
+        });
+        if let Some(dir) = clicked_dir {
+            self.current_dir = dir;
+            self.entries = scan_dir(&self.current_dir);
+        }
+    }
+
+    /// Recursively renders `dir`'s subdirectories as a `CollapsingHeader`
+    /// tree, mirroring `HierarchyPanel::draw_row`'s recursion shape.
+    /// Clicking a folder's label sets `*navigate_to`.
+    fn draw_folder_tree(&self, ui: &mut egui::Ui, dir: PathBuf, navigate_to: &mut Option<PathBuf>) {
+        let subdirs: Vec<PathBuf> = scan_dir(&dir)
+            .into_iter()
+            .filter(|e| e.is_dir)
+            .map(|e| e.path)
+            .collect();
+        let label = dir
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "Assets".to_string());
+
+        if subdirs.is_empty() {
+            if ui
+                .selectable_label(dir == self.current_dir, label)
+                .clicked()
+            {
+                *navigate_to = Some(dir);
+            }
+            return;
+        }
+
+        egui::CollapsingHeader::new(label)
+            .id_salt(dir.to_string_lossy().to_string())
+            .default_open(true)
+            .show(ui, |ui| {
+                for sub in subdirs {
+                    self.draw_folder_tree(ui, sub, navigate_to);
+                }
+            });
+    }
+
+    /// Fixed per-kind icon shown on a tile. Texture tiles get a real
+    /// decoded-image thumbnail in a later task; until then every kind
+    /// (including Texture) shows this fixed icon.
+    fn icon_for_kind(kind: AssetKind) -> &'static str {
+        match kind {
+            AssetKind::Directory => egui_phosphor::regular::FOLDER,
+            AssetKind::Scene => egui_phosphor::regular::FILM_STRIP,
+            AssetKind::Script => egui_phosphor::regular::FILE_JS,
+            AssetKind::Mesh => egui_phosphor::regular::CUBE,
+            AssetKind::Texture => egui_phosphor::regular::FILE_IMAGE,
+            AssetKind::Other => egui_phosphor::regular::FILE,
+        }
+    }
+
+    fn draw_tile(
+        &mut self,
+        ui: &mut egui::Ui,
+        entry: &AssetEntry,
+        navigate_to: &mut Option<PathBuf>,
+        _ctx: &mut EditorPanelContext,
+    ) {
+        ui.vertical(|ui| {
+            ui.set_width(64.0);
+            let response = ui.button(Self::icon_for_kind(entry.kind));
+            ui.label(&entry.name);
+
+            if entry.is_dir {
+                if response.clicked() {
+                    *navigate_to = Some(entry.path.clone());
+                }
+                return;
+            }
+
+            match entry.kind {
+                AssetKind::Scene => {
+                    if response.double_clicked() {
+                        self.pending_load_scene = Some(entry.path.to_string_lossy().to_string());
+                    }
+                }
+                AssetKind::Mesh | AssetKind::Script => {
+                    let drag_id = ui.id().with(("asset_tile_drag", &entry.path));
+                    let drag_response = ui.interact(response.rect, drag_id, egui::Sense::drag());
+                    let combined = drag_response | response;
+                    combined.dnd_set_drag_payload(AssetDragPayload {
+                        path: entry.path.clone(),
+                        kind: entry.kind,
+                    });
+                }
+                _ => {}
+            }
+        });
     }
 }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -118,6 +118,10 @@ pub struct AssetBrowserPanel {
     /// keyed by asset path. Cleared implicitly whenever this panel is
     /// dropped — there is no disk cache in this task.
     thumbnail_cache: std::collections::HashMap<PathBuf, egui::TextureHandle>,
+    /// Cached subdirectory paths under `root`, keyed by parent directory.
+    /// Rebuilt on Refresh and on navigation — NOT rescanned every frame,
+    /// unlike a naive implementation of `draw_folder_tree` would do.
+    tree_cache: std::collections::HashMap<PathBuf, Vec<PathBuf>>,
 }
 
 impl Default for AssetBrowserPanel {
@@ -130,6 +134,7 @@ impl Default for AssetBrowserPanel {
             scanned: false,
             pending_load_scene: None,
             thumbnail_cache: std::collections::HashMap::new(),
+            tree_cache: std::collections::HashMap::new(),
         }
     }
 }
@@ -152,6 +157,7 @@ impl EditorPanel for AssetBrowserPanel {
         ui.horizontal(|ui| {
             if ui.button("Refresh").clicked() {
                 self.entries = scan_dir(&self.current_dir);
+                self.tree_cache.clear();
             }
             ui.separator();
             self.draw_breadcrumb(ui);
@@ -177,6 +183,7 @@ impl EditorPanel for AssetBrowserPanel {
         if let Some(dir) = navigate_to {
             self.current_dir = dir;
             self.entries = scan_dir(&self.current_dir);
+            self.tree_cache.clear();
         }
 
         if let Some(path) = self.pending_load_scene.take() {
@@ -221,12 +228,29 @@ impl AssetBrowserPanel {
     /// Recursively renders `dir`'s subdirectories as a `CollapsingHeader`
     /// tree, mirroring `HierarchyPanel::draw_row`'s recursion shape.
     /// Clicking a folder's label sets `*navigate_to`.
-    fn draw_folder_tree(&self, ui: &mut egui::Ui, dir: PathBuf, navigate_to: &mut Option<PathBuf>) {
-        let subdirs: Vec<PathBuf> = scan_dir(&dir)
-            .into_iter()
-            .filter(|e| e.is_dir)
-            .map(|e| e.path)
-            .collect();
+    ///
+    /// Subdirectory lists are cached in `self.tree_cache` keyed by `dir`
+    /// rather than rescanned every frame — the cache is only populated here
+    /// (lazily, on first visit to a given `dir`) and is invalidated wholesale
+    /// by `ui()` on Refresh and on navigation, matching this panel's
+    /// existing "manual refresh only" design for `self.entries`.
+    fn draw_folder_tree(
+        &mut self,
+        ui: &mut egui::Ui,
+        dir: PathBuf,
+        navigate_to: &mut Option<PathBuf>,
+    ) {
+        let subdirs: Vec<PathBuf> = if let Some(cached) = self.tree_cache.get(&dir) {
+            cached.clone()
+        } else {
+            let subdirs: Vec<PathBuf> = scan_dir(&dir)
+                .into_iter()
+                .filter(|e| e.is_dir)
+                .map(|e| e.path)
+                .collect();
+            self.tree_cache.insert(dir.clone(), subdirs.clone());
+            subdirs
+        };
         let label = dir
             .file_name()
             .map(|n| n.to_string_lossy().to_string())

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -111,9 +111,8 @@ pub struct AssetBrowserPanel {
     current_dir: PathBuf,
     entries: Vec<AssetEntry>,
     scanned: bool,
-    /// Set by a double-clicked Scene tile; drained into
-    /// `InspectorCmd::LoadScene` in a later task (Task 7 of this plan) —
-    /// for now it's just stored, not yet consumed.
+    /// Set by a double-clicked Scene tile; drained at the end of `ui` into
+    /// `InspectorCmd::LoadScene` via `ctx.insp.cmd_queue`.
     pending_load_scene: Option<String>,
     /// In-memory cache of decoded+downsampled Texture-tile thumbnails,
     /// keyed by asset path. Cleared implicitly whenever this panel is
@@ -178,6 +177,12 @@ impl EditorPanel for AssetBrowserPanel {
         if let Some(dir) = navigate_to {
             self.current_dir = dir;
             self.entries = scan_dir(&self.current_dir);
+        }
+
+        if let Some(path) = self.pending_load_scene.take() {
+            ctx.insp
+                .cmd_queue
+                .push(bsengine_core::InspectorCmd::LoadScene { path });
         }
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -4,6 +4,7 @@
 //! `docs/superpowers/specs/2026-07-23-editor-ui-redesign-design.md` section
 //! B/C for the approved design.
 
+use bsengine_core::{EditorPanel, EditorPanelContext};
 use std::path::{Path, PathBuf};
 
 /// Coarse category used for the tile icon and drag/drop behavior. No
@@ -83,6 +84,57 @@ pub fn scan_dir(dir: &Path) -> Vec<AssetEntry> {
         _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
     });
     entries
+}
+
+/// Root directory the panel scans, relative to the editor process's cwd —
+/// same convention `dock.rs::layout_path()` uses for `editor_layout.json`.
+fn assets_root() -> PathBuf {
+    PathBuf::from("assets")
+}
+
+/// Unity Project panel / Unreal Content Browser equivalent: scans
+/// `assets_root()`, shows a folder tree + tile grid of the current
+/// directory, and lets the user spawn meshes / attach scripts / load
+/// scenes via drag-and-drop or double-click.
+pub struct AssetBrowserPanel {
+    root: PathBuf,
+    current_dir: PathBuf,
+    entries: Vec<AssetEntry>,
+    scanned: bool,
+}
+
+impl Default for AssetBrowserPanel {
+    fn default() -> Self {
+        let root = assets_root();
+        Self {
+            current_dir: root.clone(),
+            root,
+            entries: Vec::new(),
+            scanned: false,
+        }
+    }
+}
+
+impl EditorPanel for AssetBrowserPanel {
+    fn id(&self) -> &str {
+        "assets"
+    }
+
+    fn title(&self) -> String {
+        "Assets".to_string()
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &mut EditorPanelContext) {
+        if !self.scanned {
+            self.entries = scan_dir(&self.current_dir);
+            self.scanned = true;
+        }
+        ui.label(format!(
+            "{} entries in {:?}",
+            self.entries.len(),
+            self.current_dir
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -1,0 +1,81 @@
+//! Asset Browser panel: scans `./assets/`, categorizes files, and lets the
+//! user spawn meshes / attach scripts / load scenes by dragging or
+//! double-clicking tiles. See
+//! `docs/superpowers/specs/2026-07-23-editor-ui-redesign-design.md` section
+//! B/C for the approved design.
+
+use std::path::{Path, PathBuf};
+
+/// Coarse category used for the tile icon and drag/drop behavior. No
+/// `Material` variant — `bsengine-asset` has no material-asset type yet
+/// (confirmed during design), so texture files are their own terminal
+/// category with no attach target in this plan.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AssetKind {
+    Directory,
+    Scene,
+    Script,
+    Mesh,
+    Texture,
+    Other,
+}
+
+/// Categorizes a single path by extension. Directories are identified by
+/// the caller (via `Path::is_dir` at scan time, see `scan_dir`) rather than
+/// here, since a bare path string can't be checked against the filesystem
+/// in a pure function — this function only looks at the extension string.
+fn categorize_by_extension(path: &Path) -> AssetKind {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .as_deref()
+    {
+        Some("ron") => AssetKind::Scene,
+        Some("js") => AssetKind::Script,
+        Some("glb") | Some("gltf") => AssetKind::Mesh,
+        Some("png") | Some("jpg") | Some("jpeg") => AssetKind::Texture,
+        _ => AssetKind::Other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn categorize_by_extension_maps_known_extensions() {
+        assert_eq!(
+            categorize_by_extension(Path::new("scenes/main.ron")),
+            AssetKind::Scene
+        );
+        assert_eq!(
+            categorize_by_extension(Path::new("scripts/ball.js")),
+            AssetKind::Script
+        );
+        assert_eq!(
+            categorize_by_extension(Path::new("models/rig.glb")),
+            AssetKind::Mesh
+        );
+        assert_eq!(
+            categorize_by_extension(Path::new("models/rig.gltf")),
+            AssetKind::Mesh
+        );
+        assert_eq!(
+            categorize_by_extension(Path::new("tex/grass.png")),
+            AssetKind::Texture
+        );
+        assert_eq!(
+            categorize_by_extension(Path::new("tex/grass.JPG")),
+            AssetKind::Texture
+        );
+        assert_eq!(
+            categorize_by_extension(Path::new("readme.txt")),
+            AssetKind::Other
+        );
+        assert_eq!(
+            categorize_by_extension(Path::new("no_extension")),
+            AssetKind::Other
+        );
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -39,6 +39,52 @@ fn categorize_by_extension(path: &Path) -> AssetKind {
     }
 }
 
+/// One row in the Asset Browser's tile grid or folder tree.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssetEntry {
+    pub name: String,
+    pub path: PathBuf,
+    pub kind: AssetKind,
+    pub is_dir: bool,
+}
+
+/// Scans one directory (non-recursive — the panel navigates into
+/// subdirectories rather than showing the whole tree flattened) and returns
+/// its immediate children, directories first, then alphabetically within
+/// each group. Unreadable entries (permission errors, races with concurrent
+/// deletes) are silently skipped rather than failing the whole scan — this
+/// is a best-effort UI listing, not a source of truth.
+pub fn scan_dir(dir: &Path) -> Vec<AssetEntry> {
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut entries: Vec<AssetEntry> = read_dir
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let path = e.path();
+            let is_dir = e.file_type().ok()?.is_dir();
+            let name = e.file_name().to_string_lossy().to_string();
+            let kind = if is_dir {
+                AssetKind::Directory
+            } else {
+                categorize_by_extension(&path)
+            };
+            Some(AssetEntry {
+                name,
+                path,
+                kind,
+                is_dir,
+            })
+        })
+        .collect();
+    entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
+    entries
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,5 +123,34 @@ mod tests {
             categorize_by_extension(Path::new("no_extension")),
             AssetKind::Other
         );
+    }
+
+    #[test]
+    fn scan_dir_lists_files_and_dirs_sorted_dirs_first() {
+        let tmp = std::env::temp_dir().join("bse_asset_browser_scan_test");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("Models")).unwrap();
+        std::fs::write(tmp.join("main.ron"), "").unwrap();
+        std::fs::write(tmp.join("ball.js"), "").unwrap();
+
+        let entries = scan_dir(&tmp);
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].name, "Models");
+        assert!(entries[0].is_dir);
+        assert_eq!(entries[0].kind, AssetKind::Directory);
+        assert_eq!(entries[1].name, "ball.js");
+        assert_eq!(entries[1].kind, AssetKind::Script);
+        assert_eq!(entries[2].name, "main.ron");
+        assert_eq!(entries[2].kind, AssetKind::Scene);
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn scan_dir_on_missing_directory_returns_empty() {
+        let tmp = std::env::temp_dir().join("bse_asset_browser_scan_test_missing");
+        std::fs::remove_dir_all(&tmp).ok();
+        assert!(scan_dir(&tmp).is_empty());
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/dock.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/dock.rs
@@ -127,33 +127,37 @@ pub fn window_menu_ui(
     dock_state: &mut DockState<String>,
     registry: &EditorPanelRegistry,
 ) {
-    ui.menu_button("Window ▾", |ui| {
-        let panels: MutexGuard<HashMap<String, Box<dyn EditorPanel>>> = registry.0.lock().unwrap();
-        let mut ids: Vec<&String> = panels.keys().collect();
-        ids.sort();
-        for id in ids {
-            let title = panels
-                .get(id)
-                .map(|p| p.title())
-                .unwrap_or_else(|| id.clone());
-            let is_open = dock_state.iter_all_tabs().any(|(_, tab)| tab == id);
-            let mut checked = is_open;
-            if ui.checkbox(&mut checked, &title).changed() {
-                if checked && !is_open {
-                    dock_state.push_to_first_leaf(id.clone());
-                } else if !checked && is_open {
-                    if let Some(loc) = dock_state.find_tab(id) {
-                        dock_state.remove_tab(loc);
+    ui.menu_button(
+        format!("{} Window", egui_phosphor::regular::APP_WINDOW),
+        |ui| {
+            let panels: MutexGuard<HashMap<String, Box<dyn EditorPanel>>> =
+                registry.0.lock().unwrap();
+            let mut ids: Vec<&String> = panels.keys().collect();
+            ids.sort();
+            for id in ids {
+                let title = panels
+                    .get(id)
+                    .map(|p| p.title())
+                    .unwrap_or_else(|| id.clone());
+                let is_open = dock_state.iter_all_tabs().any(|(_, tab)| tab == id);
+                let mut checked = is_open;
+                if ui.checkbox(&mut checked, &title).changed() {
+                    if checked && !is_open {
+                        dock_state.push_to_first_leaf(id.clone());
+                    } else if !checked && is_open {
+                        if let Some(loc) = dock_state.find_tab(id) {
+                            dock_state.remove_tab(loc);
+                        }
                     }
                 }
             }
-        }
-        drop(panels);
-        ui.separator();
-        if ui.button("Reset Layout").clicked() {
-            *dock_state = default_dock_state();
-        }
-    });
+            drop(panels);
+            ui.separator();
+            if ui.button("Reset Layout").clicked() {
+                *dock_state = default_dock_state();
+            }
+        },
+    );
 }
 
 #[cfg(test)]

--- a/crates/bsengine-rhi-wgpu/src/panels/dock.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/dock.rs
@@ -50,7 +50,7 @@ pub fn ensure_builtin_panels(registry: &EditorPanelRegistry) {
     map.entry("viewport".to_string())
         .or_insert_with(|| Box::new(crate::panels::ViewportPanel) as Box<dyn EditorPanel>);
     map.entry("assets".to_string()).or_insert_with(|| {
-        Box::new(crate::panels::asset_browser::AssetBrowserPanel::default()) as Box<dyn EditorPanel>
+        Box::new(crate::panels::AssetBrowserPanel::default()) as Box<dyn EditorPanel>
     });
 }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/dock.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/dock.rs
@@ -12,8 +12,9 @@ pub fn layout_path() -> PathBuf {
     PathBuf::from("editor_layout.json")
 }
 
-/// Hierarchy (20%) | Viewport (~60%) | Inspector (~20%) — the same visual
-/// arrangement the fixed-panel layout used, just now rearrangeable.
+/// Hierarchy (20%) | Viewport (~60%) | Inspector (~20%) on top (70% of the
+/// window height), full-width Assets browser below (30%) — Unity Project
+/// panel / Unreal Content Browser convention.
 pub fn default_dock_state() -> DockState<String> {
     let mut state = DockState::new(vec!["hierarchy".to_string()]);
     let surface = SurfaceIndex::main();
@@ -29,10 +30,16 @@ pub fn default_dock_state() -> DockState<String> {
         0.75,
         Node::leaf("inspector".to_string()),
     );
+    let [_top, _assets] = state.split(
+        (surface, NodeIndex::root()),
+        Split::Below,
+        0.7,
+        Node::leaf("assets".to_string()),
+    );
     state
 }
 
-/// Idempotently registers the three built-in panels if they aren't already
+/// Idempotently registers the four built-in panels if they aren't already
 /// present (e.g. from a previous frame, or pre-registered by app code).
 pub fn ensure_builtin_panels(registry: &EditorPanelRegistry) {
     let mut map = registry.0.lock().unwrap();
@@ -42,6 +49,9 @@ pub fn ensure_builtin_panels(registry: &EditorPanelRegistry) {
         .or_insert_with(|| Box::new(crate::panels::InspectorPanel) as Box<dyn EditorPanel>);
     map.entry("viewport".to_string())
         .or_insert_with(|| Box::new(crate::panels::ViewportPanel) as Box<dyn EditorPanel>);
+    map.entry("assets".to_string()).or_insert_with(|| {
+        Box::new(crate::panels::asset_browser::AssetBrowserPanel::default()) as Box<dyn EditorPanel>
+    });
 }
 
 /// Loads a previously saved layout. Returns `None` if the file doesn't
@@ -165,13 +175,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_dock_state_has_three_builtin_tabs() {
+    fn default_dock_state_has_four_builtin_tabs_including_assets() {
         let state = default_dock_state();
         let mut ids: Vec<&String> = state.iter_all_tabs().map(|(_, tab)| tab).collect();
         ids.sort();
         assert_eq!(
             ids,
             vec![
+                &"assets".to_string(),
                 &"hierarchy".to_string(),
                 &"inspector".to_string(),
                 &"viewport".to_string()
@@ -225,10 +236,10 @@ mod tests {
     }
 
     #[test]
-    fn ensure_builtin_panels_is_idempotent() {
+    fn ensure_builtin_panels_registers_four_panels() {
         let registry = EditorPanelRegistry::default();
         ensure_builtin_panels(&registry);
         ensure_builtin_panels(&registry);
-        assert_eq!(registry.0.lock().unwrap().len(), 3);
+        assert_eq!(registry.0.lock().unwrap().len(), 4);
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -52,15 +52,27 @@ impl EditorPanel for HierarchyPanel {
         let mut despawn_ids: Vec<u64> = Vec::new();
 
         ui.horizontal(|ui| {
-            if ui.button("＋").clicked() {
+            if ui
+                .button(egui_phosphor::regular::PLUS)
+                .on_hover_text("Spawn Entity")
+                .clicked()
+            {
                 spawn_entity = true;
             }
             if ui
-                .add_enabled(current_sel.is_some(), egui::Button::new("－"))
+                .add_enabled(
+                    current_sel.is_some(),
+                    egui::Button::new(egui_phosphor::regular::MINUS),
+                )
+                .on_hover_text("Despawn Selected")
                 .clicked()
             {
                 despawn_entity = true;
             }
+        });
+        ui.horizontal(|ui| {
+            ui.label(egui_phosphor::regular::MAGNIFYING_GLASS);
+            ui.text_edit_singleline(&mut insp.hierarchy_search);
         });
         ui.label("Ctrl+click: toggle · Shift+click: range · double-click: rename · right-click: menu · drag onto a row to reparent");
         ui.separator();
@@ -80,29 +92,47 @@ impl EditorPanel for HierarchyPanel {
         };
 
         egui::ScrollArea::vertical().show(ui, |ui| {
-            for root in entities_snapshot.iter().filter(|e| e.parent_id.is_none()) {
-                Self::draw_row(
-                    ui,
-                    root,
-                    &tree,
-                    &mut new_selection,
-                    &mut new_sel,
-                    &mut set_parent,
-                    &mut remove_parent,
-                    &mut duplicate,
-                    &mut despawn_ids,
-                    &mut rename_state,
-                    &mut rename_commit,
-                    0,
-                );
-            }
+            if insp.hierarchy_search.is_empty() {
+                for root in entities_snapshot.iter().filter(|e| e.parent_id.is_none()) {
+                    Self::draw_row(
+                        ui,
+                        root,
+                        &tree,
+                        &mut new_selection,
+                        &mut new_sel,
+                        &mut set_parent,
+                        &mut remove_parent,
+                        &mut duplicate,
+                        &mut despawn_ids,
+                        &mut rename_state,
+                        &mut rename_commit,
+                        0,
+                    );
+                }
 
-            // Root drop zone: drag a row here to unparent it. Occupies the
-            // remaining empty space below the tree.
-            let (_, root_drop_response) = ui
-                .allocate_exact_size(egui::vec2(ui.available_width(), 40.0), egui::Sense::hover());
-            if let Some(dropped_id) = root_drop_response.dnd_release_payload::<u64>() {
-                remove_parent = Some(*dropped_id);
+                // Root drop zone: drag a row here to unparent it. Occupies
+                // the remaining empty space below the tree.
+                let (_, root_drop_response) = ui.allocate_exact_size(
+                    egui::vec2(ui.available_width(), 40.0),
+                    egui::Sense::hover(),
+                );
+                if let Some(dropped_id) = root_drop_response.dnd_release_payload::<u64>() {
+                    remove_parent = Some(*dropped_id);
+                }
+            } else {
+                // Filtered mode: a flat list of matches, no tree/DnD/rename —
+                // clear the search box to return to the full tree.
+                for info in entities_snapshot
+                    .iter()
+                    .filter(|e| Self::matches_search(e.name.as_deref(), &insp.hierarchy_search))
+                {
+                    let label = info.name.as_deref().unwrap_or("(unnamed)");
+                    let text = format!("{} [{}] {}", Self::icon_for(info), info.id, label);
+                    if ui.selectable_label(info.selected, text).clicked() {
+                        new_selection = Some(vec![info.id]);
+                        new_sel = Some(info.id);
+                    }
+                }
             }
         });
 
@@ -254,6 +284,21 @@ impl HierarchyPanel {
             .contains(&query.to_lowercase())
     }
 
+    /// Icon shown next to each Hierarchy row, chosen by the first matching
+    /// component on the entity: camera, light, primitive mesh, else a
+    /// generic node icon (used for group/empty entities like "Environment").
+    fn icon_for(info: &InspectorEntityInfo) -> &'static str {
+        if info.camera_fov.is_some() {
+            egui_phosphor::regular::CAMERA
+        } else if info.light_type.is_some() {
+            egui_phosphor::regular::LIGHTBULB
+        } else if info.primitive.is_some() {
+            egui_phosphor::regular::CUBE
+        } else {
+            egui_phosphor::regular::TREE_STRUCTURE
+        }
+    }
+
     fn push_dfs(
         info: &InspectorEntityInfo,
         all_entities: &[InspectorEntityInfo],
@@ -290,7 +335,7 @@ impl HierarchyPanel {
             .filter(|e| e.parent_id == Some(info.id))
             .collect();
         let label = info.name.as_deref().unwrap_or("(unnamed)");
-        let text = format!("[{}] {}", info.id, label);
+        let text = format!("{} [{}] {}", Self::icon_for(info), info.id, label);
         let is_renaming = rename_state
             .as_ref()
             .is_some_and(|r| r.entity_id == info.id);
@@ -516,5 +561,26 @@ mod tests {
     #[test]
     fn matches_search_unnamed_entity_only_matches_empty_query() {
         assert!(!HierarchyPanel::matches_search(None, "x"));
+    }
+
+    #[test]
+    fn icon_for_prefers_camera_over_light_and_mesh() {
+        let mut info = entity(1, None);
+        info.camera_fov = Some(60.0);
+        info.light_type = Some("point".to_string());
+        info.primitive = Some("cube".to_string());
+        assert_eq!(
+            HierarchyPanel::icon_for(&info),
+            egui_phosphor::regular::CAMERA
+        );
+    }
+
+    #[test]
+    fn icon_for_falls_back_to_generic_node_icon() {
+        let info = entity(1, None);
+        assert_eq!(
+            HierarchyPanel::icon_for(&info),
+            egui_phosphor::regular::TREE_STRUCTURE
+        );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -462,9 +462,9 @@ impl HierarchyPanel {
             }
 
             if let Some(payload) =
-                row_response.dnd_release_payload::<crate::panels::asset_browser::AssetDragPayload>()
+                row_response.dnd_release_payload::<crate::panels::AssetDragPayload>()
             {
-                if payload.kind == crate::panels::asset_browser::AssetKind::Script {
+                if payload.kind == crate::panels::AssetKind::Script {
                     *attach_script = Some((info.id, payload.path.to_string_lossy().to_string()));
                 }
             }

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -50,6 +50,7 @@ impl EditorPanel for HierarchyPanel {
         let mut duplicate: Option<u64> = None;
         let mut rename_commit: Option<(u64, String)> = None;
         let mut despawn_ids: Vec<u64> = Vec::new();
+        let mut attach_script: Option<(u64, String)> = None;
 
         ui.horizontal(|ui| {
             if ui
@@ -106,6 +107,7 @@ impl EditorPanel for HierarchyPanel {
                         &mut despawn_ids,
                         &mut rename_state,
                         &mut rename_commit,
+                        &mut attach_script,
                         0,
                     );
                 }
@@ -221,6 +223,9 @@ impl EditorPanel for HierarchyPanel {
                 insp.cmd_queue.push(InspectorCmd::RenameEntity { id, name });
             }
         }
+        if let Some((id, path)) = attach_script {
+            insp.cmd_queue.push(InspectorCmd::AttachScript { id, path });
+        }
     }
 }
 
@@ -327,6 +332,7 @@ impl HierarchyPanel {
         despawn_ids: &mut Vec<u64>,
         rename_state: &mut Option<RenameState>,
         rename_commit: &mut Option<(u64, String)>,
+        attach_script: &mut Option<(u64, String)>,
         depth: usize,
     ) {
         let children: Vec<&InspectorEntityInfo> = tree
@@ -375,6 +381,7 @@ impl HierarchyPanel {
                                 despawn_ids,
                                 rename_state,
                                 rename_commit,
+                                attach_script,
                                 depth + 1,
                             );
                         }
@@ -451,6 +458,14 @@ impl HierarchyPanel {
                 // vanish from the panel with no error.
                 if !Self::would_create_cycle(tree.all_entities, dropped_id, info.id) {
                     *set_parent = Some((dropped_id, info.id));
+                }
+            }
+
+            if let Some(payload) =
+                row_response.dnd_release_payload::<crate::panels::asset_browser::AssetDragPayload>()
+            {
+                if payload.kind == crate::panels::asset_browser::AssetKind::Script {
+                    *attach_script = Some((info.id, payload.path.to_string_lossy().to_string()));
                 }
             }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -242,6 +242,18 @@ impl HierarchyPanel {
         order
     }
 
+    /// Case-insensitive substring match used by the Hierarchy search box. An
+    /// empty `query` matches every entity (including unnamed ones), so the
+    /// panel shows the full tree when the search box is empty.
+    fn matches_search(name: Option<&str>, query: &str) -> bool {
+        if query.is_empty() {
+            return true;
+        }
+        name.unwrap_or("")
+            .to_lowercase()
+            .contains(&query.to_lowercase())
+    }
+
     fn push_dfs(
         info: &InspectorEntityInfo,
         all_entities: &[InspectorEntityInfo],
@@ -477,5 +489,32 @@ mod tests {
             vec![1, 2],
             "duplicate id must not appear twice in the output"
         );
+    }
+
+    #[test]
+    fn matches_search_is_case_insensitive_substring() {
+        assert!(HierarchyPanel::matches_search(
+            Some("PlayerCharacter"),
+            "player"
+        ));
+        assert!(HierarchyPanel::matches_search(
+            Some("PlayerCharacter"),
+            "CHAR"
+        ));
+        assert!(!HierarchyPanel::matches_search(
+            Some("PlayerCharacter"),
+            "zzz"
+        ));
+    }
+
+    #[test]
+    fn matches_search_empty_query_matches_everything() {
+        assert!(HierarchyPanel::matches_search(Some("Anything"), ""));
+        assert!(HierarchyPanel::matches_search(None, ""));
+    }
+
+    #[test]
+    fn matches_search_unnamed_entity_only_matches_empty_query() {
+        assert!(!HierarchyPanel::matches_search(None, "x"));
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -72,7 +72,13 @@ impl EditorPanel for InspectorPanel {
 
         // Transform
         if has_transform {
-            ui.strong("Transform");
+            ui.horizontal(|ui| {
+                ui.colored_label(
+                    crate::theme::ACCENT,
+                    egui_phosphor::regular::ARROWS_OUT_CARDINAL,
+                );
+                ui.colored_label(crate::theme::TEXT, "Transform");
+            });
             let mut pos_changed = false;
             ui.horizontal(|ui| {
                 ui.label("Pos");
@@ -142,7 +148,10 @@ impl EditorPanel for InspectorPanel {
         }
 
         // Tags
-        ui.strong("Tags");
+        ui.horizontal(|ui| {
+            ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::TAG);
+            ui.colored_label(crate::theme::TEXT, "Tags");
+        });
         ui.horizontal_wrapped(|ui| {
             for tag in &sel_info.tags {
                 ui.horizontal(|ui| {
@@ -169,7 +178,10 @@ impl EditorPanel for InspectorPanel {
         ui.separator();
 
         // Script
-        ui.strong("Script");
+        ui.horizontal(|ui| {
+            ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::CODE);
+            ui.colored_label(crate::theme::TEXT, "Script");
+        });
         ui.horizontal(|ui| {
             ui.text_edit_singleline(&mut insp.edit_script_path);
             if ui.button("Attach").clicked() && !insp.edit_script_path.is_empty() {
@@ -187,7 +199,10 @@ impl EditorPanel for InspectorPanel {
         ui.separator();
 
         // Mesh
-        ui.strong("Mesh");
+        ui.horizontal(|ui| {
+            ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::CUBE);
+            ui.colored_label(crate::theme::TEXT, "Mesh");
+        });
         ui.horizontal(|ui| {
             let current_label = sel_info.primitive.as_deref().unwrap_or("None");
             let mut chosen: Option<&str> = None;
@@ -214,7 +229,10 @@ impl EditorPanel for InspectorPanel {
         ui.separator();
 
         // Add Component
-        ui.strong("Add Component");
+        ui.horizontal(|ui| {
+            ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::PLUS);
+            ui.colored_label(crate::theme::TEXT, "Add Component");
+        });
         ui.horizontal(|ui| {
             if light_type.is_none() && ui.button("Point Light").clicked() {
                 insp.cmd_queue
@@ -227,7 +245,10 @@ impl EditorPanel for InspectorPanel {
 
         if let Some(registry) = ctx.type_registry {
             ui.separator();
-            ui.strong("Add Component (reflected)");
+            ui.horizontal(|ui| {
+                ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::PLUS);
+                ui.colored_label(crate::theme::TEXT, "Add Component (reflected)");
+            });
             let mut to_attach: Option<String> = None;
             egui::ComboBox::from_id_salt("reflect_add_component")
                 .selected_text("Select type...")
@@ -255,7 +276,10 @@ impl EditorPanel for InspectorPanel {
 
         if !insp.reflected_components.is_empty() {
             ui.separator();
-            ui.strong("Reflected Fields");
+            ui.horizontal(|ui| {
+                ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::LIST);
+                ui.colored_label(crate::theme::TEXT, "Reflected Fields");
+            });
             let type_registry = ctx.type_registry;
             let mut to_apply: Vec<(String, Box<dyn bevy_reflect::Reflect>)> = Vec::new();
             let mut to_remove: Option<String> = None;
@@ -267,10 +291,13 @@ impl EditorPanel for InspectorPanel {
                     true,
                 )
                 .show_header(ui, |ui| {
-                    ui.strong(type_path.as_str());
-                    if ui.small_button("✕").clicked() {
-                        to_remove = Some(type_path.clone());
-                    }
+                    ui.colored_label(crate::theme::TEXT, type_path.as_str());
+                    ui.menu_button(egui_phosphor::regular::DOTS_THREE, |ui| {
+                        if ui.button("Remove Component").clicked() {
+                            to_remove = Some(type_path.clone());
+                            ui.close_menu();
+                        }
+                    });
                 })
                 .body(|ui| {
                     if draw_reflect_ui(ui, value.as_mut()) {

--- a/crates/bsengine-rhi-wgpu/src/panels/mod.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/mod.rs
@@ -5,6 +5,7 @@ pub mod inspector;
 pub mod reflect_ui;
 pub mod viewport;
 
+pub use asset_browser::{AssetBrowserPanel, AssetDragPayload, AssetKind};
 pub use dock::{
     default_dock_state, ensure_builtin_panels, layout_path, load_dock_state, save_dock_state,
     window_menu_ui, BseTabViewer,

--- a/crates/bsengine-rhi-wgpu/src/panels/mod.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/mod.rs
@@ -1,3 +1,4 @@
+pub mod asset_browser;
 pub mod dock;
 pub mod hierarchy;
 pub mod inspector;

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -21,10 +21,8 @@ impl EditorPanel for ViewportPanel {
         insp.viewport_contains_cursor = panel_rect.contains(egui::Pos2::new(cursor_x, cursor_y));
         let response = ui.allocate_rect(panel_rect, egui::Sense::click_and_drag());
 
-        if let Some(payload) =
-            response.dnd_release_payload::<crate::panels::asset_browser::AssetDragPayload>()
-        {
-            if payload.kind == crate::panels::asset_browser::AssetKind::Mesh {
+        if let Some(payload) = response.dnd_release_payload::<crate::panels::AssetDragPayload>() {
+            if payload.kind == crate::panels::AssetKind::Mesh {
                 let name = payload
                     .path
                     .file_stem()

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -21,6 +21,22 @@ impl EditorPanel for ViewportPanel {
         insp.viewport_contains_cursor = panel_rect.contains(egui::Pos2::new(cursor_x, cursor_y));
         let response = ui.allocate_rect(panel_rect, egui::Sense::click_and_drag());
 
+        if let Some(payload) =
+            response.dnd_release_payload::<crate::panels::asset_browser::AssetDragPayload>()
+        {
+            if payload.kind == crate::panels::asset_browser::AssetKind::Mesh {
+                let name = payload
+                    .path
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "Mesh".to_string());
+                insp.cmd_queue.push(InspectorCmd::SpawnMeshAsset {
+                    name,
+                    path: payload.path.to_string_lossy().to_string(),
+                });
+            }
+        }
+
         // Gizmo overlays only make sense while editing: once Play starts,
         // the viewport shows the game's own Camera entity feed (see
         // bsengine-render's render_frame), which the editor-orbit-relative

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -27,6 +27,13 @@ impl EditorPanel for ViewportPanel {
         // view_proj no longer matches.
         let is_stopped = insp.play_state == bsengine_core::EditorPlayState::Stopped;
 
+        if is_stopped && insp.show_grid {
+            if let Some(view_proj) = insp.editor_view_proj {
+                let lines = crate::gizmo::ground_grid_lines(&view_proj, panel_rect, 1.0, 10);
+                crate::gizmo::draw_ground_grid(ui.painter(), &lines);
+            }
+        }
+
         if is_stopped {
             if let Some(view_proj) = insp.editor_view_proj {
                 for info in entities_snapshot {
@@ -204,5 +211,53 @@ impl EditorPanel for ViewportPanel {
                 }
             }
         }
+
+        egui::Area::new(egui::Id::new("viewport_mini_toolbar"))
+            .fixed_pos(panel_rect.min + egui::vec2(8.0, 8.0))
+            .show(ui.ctx(), |ui| {
+                egui::Frame::menu(ui.style()).show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        if ui
+                            .selectable_label(
+                                insp.gizmo_mode == bsengine_core::GizmoMode::Translate,
+                                egui_phosphor::regular::ARROWS_OUT_CARDINAL,
+                            )
+                            .on_hover_text("Move (W)")
+                            .clicked()
+                        {
+                            insp.gizmo_mode = bsengine_core::GizmoMode::Translate;
+                        }
+                        if ui
+                            .selectable_label(
+                                insp.gizmo_mode == bsengine_core::GizmoMode::Rotate,
+                                egui_phosphor::regular::ARROWS_CLOCKWISE,
+                            )
+                            .on_hover_text("Rotate (E)")
+                            .clicked()
+                        {
+                            insp.gizmo_mode = bsengine_core::GizmoMode::Rotate;
+                        }
+                        if ui
+                            .selectable_label(insp.show_grid, egui_phosphor::regular::GRID_FOUR)
+                            .on_hover_text("Toggle Grid")
+                            .clicked()
+                        {
+                            insp.show_grid = !insp.show_grid;
+                        }
+                    });
+                });
+            });
+
+        egui::Area::new(egui::Id::new("viewport_stats_overlay"))
+            .fixed_pos(egui::Pos2::new(
+                panel_rect.max.x - 90.0,
+                panel_rect.min.y + 8.0,
+            ))
+            .show(ui.ctx(), |ui| {
+                egui::Frame::menu(ui.style()).show(ui, |ui| {
+                    let fps = 1.0 / ui.ctx().input(|i| i.stable_dt.max(1e-6));
+                    ui.colored_label(crate::theme::TEXT_DIM, format!("{fps:.0} FPS"));
+                });
+            });
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1686,13 +1686,6 @@ impl WgpuSurface {
                 // Runtime inspector panels / full editor layout
                 if let Some(insp) = inspector.as_deref_mut() {
                     if insp.editor_mode {
-                        let play_label =
-                            if insp.play_state == bsengine_core::EditorPlayState::Playing {
-                                "■  Stop"
-                            } else {
-                                "▶  Play"
-                            };
-
                         // Keyboard shortcuts. Ignored while an egui widget (e.g. a
                         // DragValue or text field) has focus, so Ctrl+Z etc. don't
                         // get stolen from in-progress text editing.
@@ -1761,59 +1754,90 @@ impl WgpuSurface {
 
                             egui::TopBottomPanel::top("bse_editor_toolbar").show(ctx, |ui| {
                                 ui.horizontal(|ui| {
-                                    if ui.button(play_label).clicked() {
-                                        insp.play_state = if insp.play_state
+                                    ui.horizontal(|ui| {
+                                        if ui
+                                            .button(format!(
+                                                "{} Play",
+                                                egui_phosphor::regular::PLAY
+                                            ))
+                                            .on_hover_text("Play (toggles editor/play mode)")
+                                            .clicked()
+                                        {
+                                            insp.play_state = if insp.play_state
+                                                == bsengine_core::EditorPlayState::Playing
+                                            {
+                                                bsengine_core::EditorPlayState::Stopped
+                                            } else {
+                                                bsengine_core::EditorPlayState::Playing
+                                            };
+                                        }
+                                        let mode_label = if insp.play_state
                                             == bsengine_core::EditorPlayState::Playing
                                         {
-                                            bsengine_core::EditorPlayState::Stopped
+                                            "● Playing"
                                         } else {
-                                            bsengine_core::EditorPlayState::Playing
+                                            "◆ Editor"
                                         };
-                                    }
+                                        ui.label(mode_label);
+                                    });
                                     ui.separator();
-                                    let mode_label = if insp.play_state
-                                        == bsengine_core::EditorPlayState::Playing
-                                    {
-                                        "● Playing"
-                                    } else {
-                                        "◆ Editor"
-                                    };
-                                    ui.label(mode_label);
+                                    ui.horizontal(|ui| {
+                                        if ui
+                                            .button(egui_phosphor::regular::ARROW_COUNTER_CLOCKWISE)
+                                            .on_hover_text("Undo (Ctrl+Z)")
+                                            .clicked()
+                                        {
+                                            insp.request_undo = true;
+                                        }
+                                        if ui
+                                            .button(egui_phosphor::regular::ARROW_CLOCKWISE)
+                                            .on_hover_text("Redo (Ctrl+Y)")
+                                            .clicked()
+                                        {
+                                            insp.request_redo = true;
+                                        }
+                                        let save_enabled = insp.current_scene_path.is_some();
+                                        if ui
+                                            .add_enabled(
+                                                save_enabled,
+                                                egui::Button::new(egui_phosphor::regular::FLOPPY_DISK),
+                                            )
+                                            .on_hover_text("Save Scene (Ctrl+S)")
+                                            .on_disabled_hover_text("No scene file loaded")
+                                            .clicked()
+                                        {
+                                            insp.cmd_queue.push(bsengine_core::InspectorCmd::SaveScene);
+                                        }
+                                    });
                                     ui.separator();
-                                    if ui.button("↩ Undo").clicked() {
-                                        insp.request_undo = true;
-                                    }
-                                    if ui.button("↪ Redo").clicked() {
-                                        insp.request_redo = true;
-                                    }
-                                    ui.separator();
-                                    let save_enabled = insp.current_scene_path.is_some();
-                                    if ui
-                                        .add_enabled(save_enabled, egui::Button::new("💾 Save"))
-                                        .on_disabled_hover_text("No scene file loaded")
-                                        .clicked()
-                                    {
-                                        insp.cmd_queue.push(bsengine_core::InspectorCmd::SaveScene);
-                                    }
-                                    ui.separator();
-                                    if ui
-                                        .selectable_label(
-                                            insp.gizmo_mode == bsengine_core::GizmoMode::Translate,
-                                            "Move (W)",
-                                        )
-                                        .clicked()
-                                    {
-                                        insp.gizmo_mode = bsengine_core::GizmoMode::Translate;
-                                    }
-                                    if ui
-                                        .selectable_label(
-                                            insp.gizmo_mode == bsengine_core::GizmoMode::Rotate,
-                                            "Rotate (E)",
-                                        )
-                                        .clicked()
-                                    {
-                                        insp.gizmo_mode = bsengine_core::GizmoMode::Rotate;
-                                    }
+                                    ui.horizontal(|ui| {
+                                        if ui
+                                            .selectable_label(
+                                                insp.gizmo_mode == bsengine_core::GizmoMode::Translate,
+                                                format!(
+                                                    "{} Move",
+                                                    egui_phosphor::regular::ARROWS_OUT_CARDINAL
+                                                ),
+                                            )
+                                            .on_hover_text("Move (W)")
+                                            .clicked()
+                                        {
+                                            insp.gizmo_mode = bsengine_core::GizmoMode::Translate;
+                                        }
+                                        if ui
+                                            .selectable_label(
+                                                insp.gizmo_mode == bsengine_core::GizmoMode::Rotate,
+                                                format!(
+                                                    "{} Rotate",
+                                                    egui_phosphor::regular::ARROWS_CLOCKWISE
+                                                ),
+                                            )
+                                            .on_hover_text("Rotate (E)")
+                                            .clicked()
+                                        {
+                                            insp.gizmo_mode = bsengine_core::GizmoMode::Rotate;
+                                        }
+                                    });
                                     ui.separator();
                                     crate::panels::window_menu_ui(ui, &mut dock_state, registry);
                                 });

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1800,20 +1800,24 @@ impl WgpuSurface {
                                         if ui
                                             .add_enabled(
                                                 save_enabled,
-                                                egui::Button::new(egui_phosphor::regular::FLOPPY_DISK),
+                                                egui::Button::new(
+                                                    egui_phosphor::regular::FLOPPY_DISK,
+                                                ),
                                             )
                                             .on_hover_text("Save Scene (Ctrl+S)")
                                             .on_disabled_hover_text("No scene file loaded")
                                             .clicked()
                                         {
-                                            insp.cmd_queue.push(bsengine_core::InspectorCmd::SaveScene);
+                                            insp.cmd_queue
+                                                .push(bsengine_core::InspectorCmd::SaveScene);
                                         }
                                     });
                                     ui.separator();
                                     ui.horizontal(|ui| {
                                         if ui
                                             .selectable_label(
-                                                insp.gizmo_mode == bsengine_core::GizmoMode::Translate,
+                                                insp.gizmo_mode
+                                                    == bsengine_core::GizmoMode::Translate,
                                                 format!(
                                                     "{} Move",
                                                     egui_phosphor::regular::ARROWS_OUT_CARDINAL

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -853,6 +853,7 @@ impl WgpuSurface {
         });
 
         let egui_ctx = egui::Context::default();
+        crate::theme::apply(&egui_ctx);
         let egui_renderer = egui_wgpu::Renderer::new(&device, format, None, 1, false);
 
         let post_process = crate::post_process::PostProcessState::new(

--- a/crates/bsengine-rhi-wgpu/src/theme.rs
+++ b/crates/bsengine-rhi-wgpu/src/theme.rs
@@ -1,0 +1,92 @@
+//! Single source of truth for the editor's color palette and `egui::Visuals`.
+//! Every panel/toolbar reads colors from here rather than hard-coding hex
+//! values at each call site.
+
+use egui::{Color32, Rounding, Stroke};
+
+/// Base panel/window background.
+pub const BG: Color32 = Color32::from_rgb(0x18, 0x1a, 0x1f);
+/// Toolbar, headers, overlays.
+pub const BG_RAISED: Color32 = Color32::from_rgb(0x20, 0x23, 0x2a);
+/// Viewport background.
+pub const BG_VIEWPORT: Color32 = Color32::from_rgb(0x20, 0x23, 0x29);
+/// Toolbar group separators / widget borders.
+pub const DIVIDER: Color32 = Color32::from_rgb(0x2c, 0x31, 0x3c);
+/// Primary text and field values.
+pub const TEXT: Color32 = Color32::from_rgb(0xe8, 0xea, 0xee);
+/// Secondary text, field labels.
+pub const TEXT_MUTED: Color32 = Color32::from_rgb(0xb8, 0xbc, 0xc4);
+/// Placeholder / disabled text.
+pub const TEXT_DIM: Color32 = Color32::from_rgb(0x6a, 0x6f, 0x7a);
+/// Selection state, Play button, active tool — reserved for state, not decoration.
+pub const ACCENT: Color32 = Color32::from_rgb(0xe0, 0x91, 0x3a);
+/// Selected-row background wash (accent at ~13% alpha).
+pub const ACCENT_WASH: Color32 = Color32::from_rgba_premultiplied(0xe0, 0x91, 0x3a, 0x22);
+
+/// Builds the editor's `egui::Visuals` from the palette above, starting from
+/// `Visuals::dark()` as a base so every field egui expects has a sane
+/// default before the hybrid-theme overrides below.
+pub fn build_visuals() -> egui::Visuals {
+    let mut visuals = egui::Visuals::dark();
+    visuals.panel_fill = BG;
+    visuals.window_fill = BG_RAISED;
+    visuals.extreme_bg_color = BG;
+    visuals.faint_bg_color = BG_RAISED;
+    visuals.override_text_color = Some(TEXT_MUTED);
+    visuals.selection.bg_fill = ACCENT_WASH;
+    visuals.selection.stroke = Stroke::new(1.0, ACCENT);
+
+    visuals.widgets.noninteractive.bg_fill = BG;
+    visuals.widgets.noninteractive.weak_bg_fill = BG;
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT_MUTED);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, DIVIDER);
+    visuals.widgets.noninteractive.rounding = Rounding::same(5.0);
+
+    visuals.widgets.inactive.bg_fill = BG_RAISED;
+    visuals.widgets.inactive.weak_bg_fill = BG_RAISED;
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, TEXT_MUTED);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, DIVIDER);
+    visuals.widgets.inactive.rounding = Rounding::same(5.0);
+
+    visuals.widgets.hovered.bg_fill = DIVIDER;
+    visuals.widgets.hovered.weak_bg_fill = DIVIDER;
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, TEXT);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, ACCENT);
+    visuals.widgets.hovered.rounding = Rounding::same(5.0);
+
+    visuals.widgets.active.bg_fill = ACCENT;
+    visuals.widgets.active.weak_bg_fill = ACCENT;
+    visuals.widgets.active.fg_stroke = Stroke::new(1.0, BG);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0, ACCENT);
+    visuals.widgets.active.rounding = Rounding::same(5.0);
+
+    visuals.widgets.open.bg_fill = DIVIDER;
+    visuals.widgets.open.weak_bg_fill = DIVIDER;
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0, TEXT);
+    visuals.widgets.open.rounding = Rounding::same(5.0);
+
+    visuals
+}
+
+/// Registers the Phosphor icon font and applies the hybrid dark theme to
+/// `ctx`. Call exactly once, right after the `egui::Context` is created.
+pub fn apply(ctx: &egui::Context) {
+    let mut fonts = egui::FontDefinitions::default();
+    egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
+    ctx.set_fonts(fonts);
+    ctx.set_visuals(build_visuals());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visuals_uses_the_hybrid_dark_palette() {
+        let visuals = build_visuals();
+        assert_eq!(visuals.panel_fill, BG);
+        assert_eq!(visuals.selection.bg_fill, ACCENT_WASH);
+        assert_eq!(visuals.selection.stroke.color, ACCENT);
+        assert!(visuals.dark_mode);
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/theme.rs
+++ b/crates/bsengine-rhi-wgpu/src/theme.rs
@@ -18,7 +18,10 @@ pub const TEXT: Color32 = Color32::from_rgb(0xe8, 0xea, 0xee);
 pub const TEXT_MUTED: Color32 = Color32::from_rgb(0xb8, 0xbc, 0xc4);
 /// Placeholder / disabled text.
 pub const TEXT_DIM: Color32 = Color32::from_rgb(0x6a, 0x6f, 0x7a);
-/// Selection state, Play button, active tool — reserved for state, not decoration.
+/// Selection state, Play button, active tool, and section-header icons —
+/// reserved for state and category accents, never for header/body label
+/// text (which stays `TEXT`, see Inspector's section headers for the
+/// icon-vs-label split this describes).
 pub const ACCENT: Color32 = Color32::from_rgb(0xe0, 0x91, 0x3a);
 /// Selected-row background wash (accent at ~13% alpha).
 ///
@@ -99,6 +102,9 @@ mod tests {
         assert_eq!(visuals.selection.bg_fill, ACCENT_WASH);
         assert_eq!(visuals.selection.stroke.color, ACCENT);
         assert_eq!(visuals.widgets.open.bg_stroke.color, ACCENT);
+        assert_eq!(visuals.widgets.noninteractive.fg_stroke.color, TEXT);
+        assert_eq!(visuals.widgets.inactive.fg_stroke.color, TEXT);
+        assert_eq!(visuals.widgets.hovered.fg_stroke.color, TEXT);
         assert!(visuals.dark_mode);
     }
 

--- a/crates/bsengine-rhi-wgpu/src/theme.rs
+++ b/crates/bsengine-rhi-wgpu/src/theme.rs
@@ -31,6 +31,9 @@ pub const ACCENT: Color32 = Color32::from_rgb(0xe0, 0x91, 0x3a);
 /// (0x1e, 0x13, 0x08).
 pub const ACCENT_WASH: Color32 = Color32::from_rgba_premultiplied(0x1e, 0x13, 0x08, 0x22);
 
+/// Corner rounding shared by every widget-state block below.
+const ROUNDING: Rounding = Rounding::same(5.0);
+
 /// Builds the editor's `egui::Visuals` from the palette above, starting from
 /// `Visuals::dark()` as a base so every field egui expects has a sane
 /// default before the hybrid-theme overrides below.
@@ -40,39 +43,38 @@ pub fn build_visuals() -> egui::Visuals {
     visuals.window_fill = BG_RAISED;
     visuals.extreme_bg_color = BG;
     visuals.faint_bg_color = BG_RAISED;
-    visuals.override_text_color = Some(TEXT_MUTED);
     visuals.selection.bg_fill = ACCENT_WASH;
     visuals.selection.stroke = Stroke::new(1.0, ACCENT);
 
     visuals.widgets.noninteractive.bg_fill = BG;
     visuals.widgets.noninteractive.weak_bg_fill = BG;
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT_MUTED);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT);
     visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, DIVIDER);
-    visuals.widgets.noninteractive.rounding = Rounding::same(5.0);
+    visuals.widgets.noninteractive.rounding = ROUNDING;
 
     visuals.widgets.inactive.bg_fill = BG_RAISED;
     visuals.widgets.inactive.weak_bg_fill = BG_RAISED;
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, TEXT_MUTED);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, TEXT);
     visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, DIVIDER);
-    visuals.widgets.inactive.rounding = Rounding::same(5.0);
+    visuals.widgets.inactive.rounding = ROUNDING;
 
     visuals.widgets.hovered.bg_fill = DIVIDER;
     visuals.widgets.hovered.weak_bg_fill = DIVIDER;
     visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, TEXT);
     visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, ACCENT);
-    visuals.widgets.hovered.rounding = Rounding::same(5.0);
+    visuals.widgets.hovered.rounding = ROUNDING;
 
     visuals.widgets.active.bg_fill = ACCENT;
     visuals.widgets.active.weak_bg_fill = ACCENT;
     visuals.widgets.active.fg_stroke = Stroke::new(1.0, BG);
     visuals.widgets.active.bg_stroke = Stroke::new(1.0, ACCENT);
-    visuals.widgets.active.rounding = Rounding::same(5.0);
+    visuals.widgets.active.rounding = ROUNDING;
 
     visuals.widgets.open.bg_fill = DIVIDER;
     visuals.widgets.open.bg_stroke = Stroke::new(1.0, ACCENT);
     visuals.widgets.open.weak_bg_fill = DIVIDER;
     visuals.widgets.open.fg_stroke = Stroke::new(1.0, TEXT);
-    visuals.widgets.open.rounding = Rounding::same(5.0);
+    visuals.widgets.open.rounding = ROUNDING;
 
     visuals
 }
@@ -98,5 +100,14 @@ mod tests {
         assert_eq!(visuals.selection.stroke.color, ACCENT);
         assert_eq!(visuals.widgets.open.bg_stroke.color, ACCENT);
         assert!(visuals.dark_mode);
+    }
+
+    #[test]
+    fn accent_wash_matches_hand_premultiplied_accent() {
+        let a = ACCENT_WASH.a() as u32;
+        let round_div = |c: u8| (c as u32 * a + 127) / 255;
+        assert_eq!(ACCENT_WASH.r() as u32, round_div(ACCENT.r()));
+        assert_eq!(ACCENT_WASH.g() as u32, round_div(ACCENT.g()));
+        assert_eq!(ACCENT_WASH.b() as u32, round_div(ACCENT.b()));
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/theme.rs
+++ b/crates/bsengine-rhi-wgpu/src/theme.rs
@@ -21,7 +21,15 @@ pub const TEXT_DIM: Color32 = Color32::from_rgb(0x6a, 0x6f, 0x7a);
 /// Selection state, Play button, active tool — reserved for state, not decoration.
 pub const ACCENT: Color32 = Color32::from_rgb(0xe0, 0x91, 0x3a);
 /// Selected-row background wash (accent at ~13% alpha).
-pub const ACCENT_WASH: Color32 = Color32::from_rgba_premultiplied(0xe0, 0x91, 0x3a, 0x22);
+///
+/// `Color32::from_rgba_unmultiplied` is not a `const fn` in this workspace's
+/// pinned `ecolor` version, so this can't be built with the unmultiplied
+/// constructor while staying a `const`. Instead the RGB channels are
+/// pre-multiplied by hand (`component * alpha / 255`, rounded) so the
+/// premultiplied-alpha invariant (r,g,b <= a) holds: this is accent orange
+/// (0xe0, 0x91, 0x3a) blended to ~13% alpha (0x22), premultiplied to
+/// (0x1e, 0x13, 0x08).
+pub const ACCENT_WASH: Color32 = Color32::from_rgba_premultiplied(0x1e, 0x13, 0x08, 0x22);
 
 /// Builds the editor's `egui::Visuals` from the palette above, starting from
 /// `Visuals::dark()` as a base so every field egui expects has a sane
@@ -61,6 +69,7 @@ pub fn build_visuals() -> egui::Visuals {
     visuals.widgets.active.rounding = Rounding::same(5.0);
 
     visuals.widgets.open.bg_fill = DIVIDER;
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0, ACCENT);
     visuals.widgets.open.weak_bg_fill = DIVIDER;
     visuals.widgets.open.fg_stroke = Stroke::new(1.0, TEXT);
     visuals.widgets.open.rounding = Rounding::same(5.0);
@@ -87,6 +96,7 @@ mod tests {
         assert_eq!(visuals.panel_fill, BG);
         assert_eq!(visuals.selection.bg_fill, ACCENT_WASH);
         assert_eq!(visuals.selection.stroke.color, ACCENT);
+        assert_eq!(visuals.widgets.open.bg_stroke.color, ACCENT);
         assert!(visuals.dark_mode);
     }
 }


### PR DESCRIPTION
## Summary

- **Theme/restyle (10 tasks)**: replaces egui's default grey theme and emoji icons with a hybrid dark palette (`bsengine-rhi-wgpu/src/theme.rs`) + `egui-phosphor` icon font. Toolbar regrouped with tooltips, Hierarchy gets a name-filter search box + per-kind row icons, Inspector section headers get icon+neutral-label styling with a `⋯` overflow menu, Viewport gets a ground-reference grid + floating mini-toolbar + FPS overlay.
- **Asset Browser (8 tasks)**: new 4th dockable panel (Unity Project panel / Unreal Content Browser equivalent) that scans `./assets/`, categorizes files (Scene/.ron, Script/.js, Mesh/.glb+.gltf, Texture/.png+.jpg+.jpeg), shows a breadcrumb + folder tree + tile grid with real decoded-image thumbnails for textures, and supports drag-and-drop (Script → Hierarchy row attaches it, Mesh → Viewport spawns a glTF entity) plus double-click-to-load for scenes. Reuses existing `EditorCommand::LoadScene`/`bsengine-gltf`'s async loader rather than adding new engine capability.
- Three real bugs found and fixed during implementation via per-task spec/code review (premultiplied-alpha misuse in `ACCENT_WASH`, a missing `widgets.open.bg_stroke`, and `TEXT`/`TEXT_MUTED` wired backwards from their own doc comments), plus four whole-branch-only issues caught by a final cross-task review (ACCENT doc-comment completeness, a module re-export inconsistency, a missing regression test for the fixed text-color bug, and a per-frame filesystem rescan in the Asset Browser's folder tree) — all fixed and verified.
- Design spec: `docs/superpowers/specs/2026-07-23-editor-ui-redesign-design.md`. Implementation plans: `docs/superpowers/plans/2026-07-23-editor-ui-redesign-theme-restyle.md`, `docs/superpowers/plans/2026-07-23-editor-ui-redesign-asset-browser.md` (not committed — `docs/` is gitignored in this repo, kept locally per existing project convention).

**Explicit non-goals** (documented, not silently missing): Scale gizmo mode (`GizmoMode` only has Translate/Rotate), a triangle/draw-call stat (FPS only), rendered 3D mesh thumbnails (fixed icon for now — flagged as a follow-up needing renderer-pipeline research), on-disk thumbnail cache, a filesystem watcher, and texture drag-and-drop onto meshes/materials (no material-asset pipeline exists yet).

## Test plan

- [x] `cargo build --workspace` — clean, only pre-existing `missing_docs` warnings
- [x] `cargo test -p bsengine-core -p bsengine-rhi-wgpu -p bsengine-editor -p bsengine-gltf` — 177 + 75 + 803 + 11 = 1066 passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean across the whole workspace
- [ ] Manual smoke test in a running editor window (theme applied, toolbar/hierarchy/inspector/viewport restyle, Asset Browser navigation + drag-and-drop + scene double-click) — flagged as needing human verification, consistent with this project's established testing approach for UI/rendering code

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>