### PR TITLE
Resolve all missing_docs warnings across the workspace (17 crates)

### DIFF
--- a/crates/bsengine-app/src/angular_velocity.rs
+++ b/crates/bsengine-app/src/angular_velocity.rs
@@ -3,6 +3,7 @@ use bsengine_core::{AngularVelocity, Time, Transform};
 use bsengine_ecs::{Query, Res};
 use glam::Quat;
 
+/// Rotates entities each frame based on their `AngularVelocity` component.
 pub struct AngularVelocityPlugin;
 
 impl Plugin for AngularVelocityPlugin {

--- a/crates/bsengine-app/src/animation_player.rs
+++ b/crates/bsengine-app/src/animation_player.rs
@@ -3,6 +3,7 @@ use bsengine_core::{AnimationPlayer, Time};
 use bsengine_ecs::Query;
 use bsengine_ecs::Res;
 
+/// Advances every `AnimationPlayer`'s clip time each frame by `Time::delta_seconds`.
 pub struct AnimationPlugin;
 
 impl Plugin for AnimationPlugin {

--- a/crates/bsengine-app/src/animation_state_machine.rs
+++ b/crates/bsengine-app/src/animation_state_machine.rs
@@ -2,6 +2,8 @@ use bevy_app::{App, Plugin, PostUpdate};
 use bsengine_core::{AnimationPlayer, AnimationStateMachine, Time, TransitionCondition};
 use bsengine_ecs::{Query, Res};
 
+/// Evaluates `AnimationStateMachine` transitions in `PostUpdate` and drives the
+/// entity's `AnimationPlayer` (clip, speed, looping) and crossfade blend weight.
 pub struct AnimationStateMachinePlugin;
 
 impl Plugin for AnimationStateMachinePlugin {

--- a/crates/bsengine-app/src/app.rs
+++ b/crates/bsengine-app/src/app.rs
@@ -4,6 +4,7 @@ pub use bevy_app::App;
 pub use bevy_app::Plugin as BsPlugin;
 pub use bevy_app::{Last, PostUpdate, PreUpdate, Startup, Update};
 
+/// Initializes engine logging and constructs a fresh, empty `bevy_app::App`.
 pub fn new_app() -> App {
     init_logging();
     App::new()

--- a/crates/bsengine-app/src/damping.rs
+++ b/crates/bsengine-app/src/damping.rs
@@ -2,6 +2,7 @@ use bevy_app::{App, Plugin, Update};
 use bsengine_core::{Damping, Time, Velocity};
 use bsengine_ecs::{Query, Res};
 
+/// Exponentially decays entity `Velocity` toward zero based on its `Damping` factor.
 pub struct DampingPlugin;
 
 impl Plugin for DampingPlugin {

--- a/crates/bsengine-app/src/external_impulse.rs
+++ b/crates/bsengine-app/src/external_impulse.rs
@@ -2,6 +2,8 @@ use bevy_app::{App, Plugin, Update};
 use bsengine_core::{AngularVelocity, ExternalImpulse, Mass, Velocity};
 use bsengine_ecs::Query;
 
+/// Applies each entity's pending `ExternalImpulse` to its `Velocity`/`AngularVelocity`
+/// (scaled by inverse mass) once per frame, then clears the impulse.
 pub struct ExternalImpulsePlugin;
 
 impl Plugin for ExternalImpulsePlugin {

--- a/crates/bsengine-app/src/follow.rs
+++ b/crates/bsengine-app/src/follow.rs
@@ -3,6 +3,8 @@ use bsengine_core::{Follow, GlobalTransform, LookAt, Time, Transform};
 use bsengine_ecs::{Query, Res};
 use glam::{Mat3, Quat, Vec3};
 
+/// Moves entities with a `Follow` component toward their target's position and
+/// orients entities with a `LookAt` component toward their target, each frame.
 pub struct FollowPlugin;
 
 impl Plugin for FollowPlugin {

--- a/crates/bsengine-app/src/gravity.rs
+++ b/crates/bsengine-app/src/gravity.rs
@@ -2,6 +2,8 @@ use bevy_app::{App, Plugin, Update};
 use bsengine_core::{Gravity, GravityScale, Time, Velocity};
 use bsengine_ecs::{Query, Res};
 
+/// Inserts the global `Gravity` resource and applies its acceleration (scaled by
+/// each entity's optional `GravityScale`) to `Velocity` every frame.
 pub struct GravityPlugin;
 
 impl Plugin for GravityPlugin {

--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -7,20 +7,35 @@
 //! `new_app()`/`BsPlugin` entry points.
 #![warn(missing_docs)]
 
+/// `AngularVelocityPlugin`: rotates entities each frame by their `AngularVelocity`.
 pub mod angular_velocity;
+/// `AnimationPlugin`: advances `AnimationPlayer` clip time each frame.
 pub mod animation_player;
+/// `AnimationStateMachinePlugin`: evaluates ASM transitions and drives the `AnimationPlayer`.
 pub mod animation_state_machine;
+/// `new_app()`/`BsPlugin` entry points and re-exported `bevy_app` schedule labels.
 pub mod app;
+/// `DampingPlugin`: exponentially decays entity `Velocity` over time.
 pub mod damping;
+/// `ExternalImpulsePlugin`: applies one-shot linear/angular impulses to velocity.
 pub mod external_impulse;
+/// `FollowPlugin`: moves/orients entities toward a target entity (`Follow`, `LookAt`).
 pub mod follow;
+/// `GravityPlugin`: applies a global `Gravity` acceleration to entity velocities.
 pub mod gravity;
+/// `LifetimePlugin`: despawns entities once their `Lifetime` expires.
 pub mod lifetime;
+/// `NavMeshPlugin`: paths and moves `NavMeshAgent` entities across a `NavMesh`.
 pub mod nav_mesh;
+/// `ShieldPlugin`: recharges `Shield` components over time.
 pub mod shield;
+/// `TimePlugin`: ticks the `Time` resource once per frame.
 pub mod time;
+/// `TimerPlugin`: ticks `Timer` components once per frame.
 pub mod timer;
+/// `TweenPlugin`: advances `Tween` components and applies them to `Transform`.
 pub mod tween;
+/// `VelocityPlugin`: integrates entity `Transform` by `Velocity` each frame.
 pub mod velocity;
 
 pub use angular_velocity::AngularVelocityPlugin;

--- a/crates/bsengine-app/src/lifetime.rs
+++ b/crates/bsengine-app/src/lifetime.rs
@@ -2,6 +2,7 @@ use bevy_app::{App, Plugin, Update};
 use bsengine_core::{Lifetime, Time};
 use bsengine_ecs::{Commands, Entity, Query, Res};
 
+/// Counts down each entity's `Lifetime` and despawns it once the remaining time hits zero.
 pub struct LifetimePlugin;
 
 impl Plugin for LifetimePlugin {

--- a/crates/bsengine-app/src/nav_mesh.rs
+++ b/crates/bsengine-app/src/nav_mesh.rs
@@ -5,6 +5,8 @@ use bsengine_core::{NavAgentState, NavMesh, NavMeshAgent, Time, Transform};
 use bsengine_ecs::{Entity, Query, Res, ResMut, Resource};
 use glam::Vec3;
 
+/// Paths `NavMeshAgent` entities across the `NavMesh` resource, moving them toward
+/// their destination each frame with basic separation-based obstacle avoidance.
 pub struct NavMeshPlugin;
 
 /// Per-entity cached A* path. Keyed by Entity; value is (waypoints, index, destination_it_was_computed_for).

--- a/crates/bsengine-app/src/shield.rs
+++ b/crates/bsengine-app/src/shield.rs
@@ -3,6 +3,7 @@ use bsengine_core::{Shield, Time};
 use bsengine_ecs::Query;
 use bsengine_ecs::Res;
 
+/// Recharges every entity's `Shield` component (after its cooldown elapses) each frame.
 pub struct ShieldPlugin;
 
 impl Plugin for ShieldPlugin {

--- a/crates/bsengine-app/src/time.rs
+++ b/crates/bsengine-app/src/time.rs
@@ -2,6 +2,8 @@ use bevy_app::prelude::*;
 use bsengine_core::Time;
 use bsengine_ecs::ResMut;
 
+/// Inserts the `Time` resource and ticks it in `PreUpdate` so every other system
+/// sees an up-to-date `delta_seconds` for the current frame.
 pub struct TimePlugin;
 
 impl Plugin for TimePlugin {

--- a/crates/bsengine-app/src/timer.rs
+++ b/crates/bsengine-app/src/timer.rs
@@ -2,6 +2,7 @@ use bevy_app::{App, Plugin, Update};
 use bsengine_core::{Time, Timer};
 use bsengine_ecs::{Query, Res};
 
+/// Ticks every entity's `Timer` component by the frame's `delta_seconds`.
 pub struct TimerPlugin;
 
 impl Plugin for TimerPlugin {

--- a/crates/bsengine-app/src/tween.rs
+++ b/crates/bsengine-app/src/tween.rs
@@ -2,6 +2,8 @@ use bevy_app::{App, Plugin, Update};
 use bsengine_core::{Time, Transform, Tween, TweenTarget};
 use bsengine_ecs::{Query, Res};
 
+/// Advances each entity's `Tween` and applies the eased value to its `Transform`,
+/// handling `RepeatMode::Once`/`Loop`/`PingPong` once the tween completes.
 pub struct TweenPlugin;
 
 impl Plugin for TweenPlugin {

--- a/crates/bsengine-app/src/velocity.rs
+++ b/crates/bsengine-app/src/velocity.rs
@@ -2,6 +2,7 @@ use bevy_app::{App, Plugin, Update};
 use bsengine_core::{Time, Transform, Velocity};
 use bsengine_ecs::{Query, Res};
 
+/// Integrates each entity's `Transform` translation by its `Velocity` every frame.
 pub struct VelocityPlugin;
 
 impl Plugin for VelocityPlugin {

--- a/crates/bsengine-asset/src/handle.rs
+++ b/crates/bsengine-asset/src/handle.rs
@@ -1,17 +1,20 @@
 use std::marker::PhantomData;
 
+/// A lightweight, typed reference to an asset stored elsewhere (e.g. in an `AssetServer`).
 pub struct Handle<T> {
     id: u64,
     _phantom: PhantomData<T>,
 }
 
 impl<T> Handle<T> {
+    /// Wraps a raw asset id in a typed handle.
     pub fn new(id: u64) -> Self {
         Self {
             id,
             _phantom: PhantomData,
         }
     }
+    /// Returns the raw id this handle refers to.
     pub fn id(&self) -> u64 {
         self.id
     }

--- a/crates/bsengine-asset/src/lib.rs
+++ b/crates/bsengine-asset/src/lib.rs
@@ -5,9 +5,13 @@
 //! as the `AssetServerResource`.
 #![warn(missing_docs)]
 
+/// Typed, cloneable references to loaded assets.
 pub mod handle;
+/// Wires the asset server into the app as a resource.
 pub mod plugin;
+/// Loads and caches raw asset bytes from disk.
 pub mod server;
+/// Concrete asset data types (textures, meshes).
 pub mod types;
 
 pub use handle::Handle;

--- a/crates/bsengine-asset/src/plugin.rs
+++ b/crates/bsengine-asset/src/plugin.rs
@@ -2,9 +2,11 @@ use crate::server::AssetServer;
 use bevy_app::{App, Plugin};
 use bsengine_ecs::Resource;
 
+/// ECS resource wrapper exposing the shared `AssetServer` to systems.
 #[derive(Resource, Clone)]
 pub struct AssetServerResource(pub AssetServer);
 
+/// App plugin that installs an `AssetServerResource` for asset loading.
 pub struct AssetPlugin;
 
 impl Plugin for AssetPlugin {

--- a/crates/bsengine-asset/src/server.rs
+++ b/crates/bsengine-asset/src/server.rs
@@ -1,18 +1,22 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+/// Loads asset bytes from disk, caching results by path for reuse across loads.
 #[derive(Clone)]
 pub struct AssetServer {
     cache: Arc<Mutex<HashMap<String, Vec<u8>>>>,
 }
 
 impl AssetServer {
+    /// Creates an `AssetServer` with an empty cache.
     pub fn new() -> Self {
         Self {
             cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
+    /// Returns the raw bytes at `path`, reading from disk on first access and
+    /// serving from the cache on subsequent calls.
     pub fn load_bytes(&self, path: &str) -> Result<Vec<u8>, String> {
         let mut cache = self.cache.lock().unwrap();
         if let Some(cached) = cache.get(path) {

--- a/crates/bsengine-asset/src/types.rs
+++ b/crates/bsengine-asset/src/types.rs
@@ -1,11 +1,18 @@
+/// Decoded texture pixel data, ready to be uploaded to the GPU.
 pub struct TextureAsset {
+    /// Width in pixels.
     pub width: u32,
+    /// Height in pixels.
     pub height: u32,
+    /// Raw pixel data, laid out row by row.
     pub data: Vec<u8>,
 }
 
+/// A raw mesh's geometry: flat vertex attributes and triangle indices.
 pub struct MeshAsset {
+    /// Flattened per-vertex attribute data (e.g. positions).
     pub vertices: Vec<f32>,
+    /// Indices into `vertices` describing triangle winding.
     pub indices: Vec<u32>,
 }
 

--- a/crates/bsengine-audio/src/components.rs
+++ b/crates/bsengine-audio/src/components.rs
@@ -4,10 +4,12 @@ use kira::sound::static_sound::StaticSoundData;
 /// Holds pre-loaded audio data.  Attach together with [`AudioPlayer`] to trigger playback.
 #[derive(Component, Clone)]
 pub struct AudioSource {
+    /// The decoded/streamed sound data to be played.
     pub data: StaticSoundData,
 }
 
 impl AudioSource {
+    /// Wraps pre-loaded sound data in an [`AudioSource`] component.
     pub fn new(data: StaticSoundData) -> Self {
         Self { data }
     }
@@ -36,20 +38,24 @@ impl Default for AudioPlayer {
 }
 
 impl AudioPlayer {
+    /// Creates an [`AudioPlayer`] with the default volume, looping, and playback rate.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the linear volume multiplier (1.0 = full, 0.0 = silent).
     pub fn with_volume(mut self, volume: f64) -> Self {
         self.volume = volume;
         self
     }
 
+    /// Enables looping playback.
     pub fn with_looping(mut self) -> Self {
         self.looping = true;
         self
     }
 
+    /// Sets the playback rate multiplier (1.0 = normal speed).
     pub fn with_playback_rate(mut self, rate: f64) -> Self {
         self.playback_rate = rate;
         self
@@ -59,9 +65,12 @@ impl AudioPlayer {
 /// Current playback state — written by the audio system after each update.
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PlaybackState {
+    /// The sound is actively producing output.
     #[default]
     Playing,
+    /// Playback is suspended and can be resumed from the current position.
     Paused,
+    /// Playback has ended, either naturally or because it was stopped explicitly.
     Stopped,
 }
 

--- a/crates/bsengine-audio/src/lib.rs
+++ b/crates/bsengine-audio/src/lib.rs
@@ -5,8 +5,11 @@
 //! `PlaybackState` tracking whether a sound is playing, paused, or stopped.
 #![warn(missing_docs)]
 
+/// ECS components for attaching and configuring audio playback on entities.
 pub mod components;
+/// The Bevy [`AudioPlugin`] and the systems that drive playback each frame.
 pub mod plugin;
+/// The [`AudioWorld`] resource wrapping the underlying `kira` audio manager.
 pub mod world;
 
 pub use components::{AudioPlayer, AudioSource, PlaybackState};

--- a/crates/bsengine-audio/src/plugin.rs
+++ b/crates/bsengine-audio/src/plugin.rs
@@ -7,6 +7,7 @@ use crate::{
     world::AudioWorld,
 };
 
+/// Registers the [`AudioWorld`] resource and the systems that start and track sound playback.
 pub struct AudioPlugin;
 
 impl Plugin for AudioPlugin {

--- a/crates/bsengine-audio/src/world.rs
+++ b/crates/bsengine-audio/src/world.rs
@@ -4,6 +4,7 @@ use kira::{
     AudioManager, AudioManagerSettings, DefaultBackend,
 };
 
+/// ECS resource wrapping the `kira` audio manager; `None` if audio backend init failed.
 #[derive(Resource)]
 pub struct AudioWorld {
     manager: Option<AudioManager<DefaultBackend>>,
@@ -24,10 +25,13 @@ impl Default for AudioWorld {
 }
 
 impl AudioWorld {
+    /// Returns whether the audio backend initialized successfully and can play sounds.
     pub fn is_available(&self) -> bool {
         self.manager.is_some()
     }
 
+    /// Starts playing the given sound data, returning a handle to it, or `None` if the audio
+    /// backend is unavailable or playback failed to start.
     pub fn play(&mut self, data: StaticSoundData) -> Option<StaticSoundHandle> {
         self.manager.as_mut()?.play(data).ok()
     }

--- a/crates/bsengine-core/src/ambient_occlusion.rs
+++ b/crates/bsengine-core/src/ambient_occlusion.rs
@@ -15,34 +15,41 @@ pub struct AmbientOcclusion {
     pub intensity: f32,
     /// Number of hemisphere samples per pixel. Higher = quality; lower = performance.
     pub sample_count: u32,
+    /// Whether the effect is applied at all.
     pub enabled: bool,
 }
 
 impl AmbientOcclusion {
+    /// Creates an ambient occlusion setting with the default radius, bias, intensity, and sample count.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the occluder sampling radius, clamped to be non-negative.
     pub fn with_radius(mut self, radius: f32) -> Self {
         self.radius = radius.max(0.0);
         self
     }
 
+    /// Sets the depth bias, clamped to be non-negative.
     pub fn with_bias(mut self, bias: f32) -> Self {
         self.bias = bias.max(0.0);
         self
     }
 
+    /// Sets the effect intensity, clamped to `[0, 1]`.
     pub fn with_intensity(mut self, intensity: f32) -> Self {
         self.intensity = intensity.clamp(0.0, 1.0);
         self
     }
 
+    /// Sets the hemisphere sample count, clamped to at least 1.
     pub fn with_sample_count(mut self, count: u32) -> Self {
         self.sample_count = count.max(1);
         self
     }
 
+    /// Turns the effect off while keeping its other settings.
     pub fn disabled(mut self) -> Self {
         self.enabled = false;
         self

--- a/crates/bsengine-core/src/angular_velocity.rs
+++ b/crates/bsengine-core/src/angular_velocity.rs
@@ -10,6 +10,7 @@ use glam::Vec3;
 #[derive(Component, Debug, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct AngularVelocity {
+    /// Per-axis angular rate in radians per second (pitch, yaw, roll).
     pub angular: ReflectVec3,
 }
 
@@ -22,12 +23,14 @@ impl Default for AngularVelocity {
 }
 
 impl AngularVelocity {
+    /// Creates an angular velocity from per-axis rates in radians per second.
     pub fn new(pitch: f32, yaw: f32, roll: f32) -> Self {
         Self {
             angular: Vec3::new(pitch, yaw, roll).into(),
         }
     }
 
+    /// Creates an angular velocity from a `glam::Vec3` of Euler rates.
     pub fn from_vec3(angular: Vec3) -> Self {
         Self {
             angular: angular.into(),

--- a/crates/bsengine-core/src/animation_player.rs
+++ b/crates/bsengine-core/src/animation_player.rs
@@ -2,18 +2,27 @@ use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 
+/// Plays a single named animation clip on an entity, advancing its own
+/// playback time each frame via [`AnimationPlayer::tick`].
 #[derive(Component, Debug, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct AnimationPlayer {
+    /// Name/identifier of the clip currently assigned to this player.
     pub clip: String,
+    /// Current playback position, in seconds since the clip started.
     pub time: f32,
+    /// Playback rate multiplier (1.0 = normal speed).
     pub speed: f32,
+    /// Total length of the clip, in seconds.
     pub duration: f32,
+    /// Whether playback wraps back to the start after reaching `duration`.
     pub looping: bool,
+    /// Whether playback is currently advancing.
     pub playing: bool,
 }
 
 impl AnimationPlayer {
+    /// Creates a player for the given clip, starting at time 0, playing, and looping.
     pub fn new(clip: impl Into<String>) -> Self {
         Self {
             clip: clip.into(),
@@ -25,42 +34,51 @@ impl AnimationPlayer {
         }
     }
 
+    /// Sets the playback rate multiplier.
     pub fn with_speed(mut self, speed: f32) -> Self {
         self.speed = speed;
         self
     }
 
+    /// Sets whether the clip loops when it reaches the end.
     pub fn with_looping(mut self, looping: bool) -> Self {
         self.looping = looping;
         self
     }
 
+    /// Starts the player in a paused state.
     pub fn paused(mut self) -> Self {
         self.playing = false;
         self
     }
 
+    /// Sets the clip duration, clamped to be non-negative.
     pub fn with_duration(mut self, duration: f32) -> Self {
         self.duration = duration.max(0.0);
         self
     }
 
+    /// Resumes playback.
     pub fn play(&mut self) {
         self.playing = true;
     }
 
+    /// Halts playback without resetting the current time.
     pub fn pause(&mut self) {
         self.playing = false;
     }
 
+    /// Rewinds playback to the start of the clip.
     pub fn reset(&mut self) {
         self.time = 0.0;
     }
 
+    /// Returns true once a non-looping clip has played through to its end.
     pub fn is_finished(&self) -> bool {
         !self.looping && self.duration > 0.0 && self.time >= self.duration
     }
 
+    /// Returns the current playback position as a fraction of `duration`, clamped to `[0, 1]`.
     pub fn normalized_time(&self) -> f32 {
         if self.duration <= 0.0 {
             0.0

--- a/crates/bsengine-core/src/animation_state_machine.rs
+++ b/crates/bsengine-core/src/animation_state_machine.rs
@@ -4,15 +4,22 @@ use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 
+/// A single named animation state within an [`AnimationStateMachine`], describing
+/// which clip plays and how, while that state is active.
 #[derive(Debug, Clone, Reflect)]
 pub struct AsmState {
+    /// Name/identifier of the animation clip this state plays.
     pub clip: String,
+    /// Whether the clip wraps back to the start after reaching `duration`.
     pub looping: bool,
+    /// Playback rate multiplier (1.0 = normal speed).
     pub speed: f32,
+    /// Length of the clip, in seconds.
     pub duration: f32,
 }
 
 impl AsmState {
+    /// Creates a state for the given clip, looping at normal speed with zero duration.
     pub fn new(clip: impl Into<String>) -> Self {
         Self {
             clip: clip.into(),
@@ -22,38 +29,64 @@ impl AsmState {
         }
     }
 
+    /// Sets whether the clip loops when it reaches the end.
     pub fn with_looping(mut self, looping: bool) -> Self {
         self.looping = looping;
         self
     }
 
+    /// Sets the playback rate multiplier.
     pub fn with_speed(mut self, speed: f32) -> Self {
         self.speed = speed;
         self
     }
 
+    /// Sets the clip duration, clamped to be non-negative.
     pub fn with_duration(mut self, duration: f32) -> Self {
         self.duration = duration.max(0.0);
         self
     }
 }
 
+/// Predicate evaluated against an [`AnimationStateMachine`]'s parameters to decide
+/// whether an [`AsmTransition`] should fire.
 #[derive(Debug, Clone, PartialEq, Reflect)]
 pub enum TransitionCondition {
+    /// Fires once when the named trigger parameter has been set, then clears it.
     Trigger(String),
-    FloatGreater { param: String, threshold: f32 },
-    FloatLess { param: String, threshold: f32 },
+    /// Fires while the named float parameter is greater than `threshold`.
+    FloatGreater {
+        /// Name of the float parameter to compare.
+        param: String,
+        /// Value the parameter must exceed.
+        threshold: f32,
+    },
+    /// Fires while the named float parameter is less than `threshold`.
+    FloatLess {
+        /// Name of the float parameter to compare.
+        param: String,
+        /// Value the parameter must fall below.
+        threshold: f32,
+    },
+    /// Fires while the named bool parameter is `true`.
     BoolTrue(String),
+    /// Fires while the named bool parameter is `false`.
     BoolFalse(String),
+    /// Fires once the current state's clip has finished playing.
     Finished,
 }
 
+/// A directed edge in the state machine graph: when `condition` holds while
+/// in state `from`, playback crossfades to state `to` over `blend_duration`.
 #[derive(Debug, Clone, Reflect)]
 pub struct AsmTransition {
     /// Source state name, or `"*"` to match any state.
     pub from: String,
+    /// Destination state name to transition into.
     pub to: String,
+    /// Predicate that must hold for this transition to fire.
     pub condition: TransitionCondition,
+    /// Crossfade duration, in seconds, when this transition fires.
     pub blend_duration: f32,
 }
 
@@ -65,17 +98,25 @@ pub struct AsmTransition {
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct AnimationStateMachine {
+    /// All named states in this machine's graph.
     pub states: HashMap<String, AsmState>,
+    /// Edges evaluated, in order, to decide when to change state.
     pub transitions: Vec<AsmTransition>,
+    /// Name of the state currently driving playback.
     pub current_state: String,
+    /// Float parameters read by `FloatGreater`/`FloatLess` conditions.
     pub params_float: HashMap<String, f32>,
+    /// Bool parameters read by `BoolTrue`/`BoolFalse` conditions.
     pub params_bool: HashMap<String, bool>,
+    /// Trigger parameters pending consumption by a `Trigger` condition.
     pub triggers: HashSet<String>,
     /// The state being blended *out* during a crossfade (None when not blending).
     pub blend_from: Option<String>,
     /// 0.0 = fully `blend_from`, 1.0 = fully `current_state`.
     pub blend_weight: f32,
+    /// Total duration of the in-progress crossfade, in seconds.
     pub blend_duration: f32,
+    /// Time elapsed since the in-progress crossfade began, in seconds.
     pub blend_elapsed: f32,
 }
 
@@ -86,6 +127,7 @@ impl Default for AnimationStateMachine {
 }
 
 impl AnimationStateMachine {
+    /// Creates a state machine with no states or transitions, starting in `initial_state`.
     pub fn new(initial_state: impl Into<String>) -> Self {
         Self {
             states: HashMap::new(),
@@ -101,11 +143,13 @@ impl AnimationStateMachine {
         }
     }
 
+    /// Registers a named state in the graph, replacing any existing state of the same name.
     pub fn add_state(&mut self, name: impl Into<String>, state: AsmState) -> &mut Self {
         self.states.insert(name.into(), state);
         self
     }
 
+    /// Registers a transition edge from `from` to `to`, evaluated when `condition` holds.
     pub fn add_transition(
         &mut self,
         from: impl Into<String>,
@@ -122,18 +166,22 @@ impl AnimationStateMachine {
         self
     }
 
+    /// Arms the named trigger parameter so a `Trigger` condition can consume it.
     pub fn set_trigger(&mut self, name: impl Into<String>) {
         self.triggers.insert(name.into());
     }
 
+    /// Sets the named float parameter, read by `FloatGreater`/`FloatLess` conditions.
     pub fn set_float(&mut self, name: impl Into<String>, value: f32) {
         self.params_float.insert(name.into(), value);
     }
 
+    /// Sets the named bool parameter, read by `BoolTrue`/`BoolFalse` conditions.
     pub fn set_bool(&mut self, name: impl Into<String>, value: bool) {
         self.params_bool.insert(name.into(), value);
     }
 
+    /// Returns true while a crossfade between two states is in progress.
     pub fn is_blending(&self) -> bool {
         self.blend_from.is_some()
     }

--- a/crates/bsengine-core/src/bloom.rs
+++ b/crates/bsengine-core/src/bloom.rs
@@ -16,10 +16,12 @@ pub struct Bloom {
     /// Controls the softness of the threshold knee.
     /// 0.0 = hard cutoff, 1.0 = smooth transition.
     pub softness: f32,
+    /// Whether the effect is applied at all.
     pub enabled: bool,
 }
 
 impl Bloom {
+    /// Creates a bloom setting with the given intensity (clamped to non-negative) and default threshold/radius/softness.
     pub fn new(intensity: f32) -> Self {
         Self {
             intensity: intensity.max(0.0),
@@ -30,21 +32,25 @@ impl Bloom {
         }
     }
 
+    /// Sets the luminance threshold, clamped to be non-negative.
     pub fn with_threshold(mut self, threshold: f32) -> Self {
         self.threshold = threshold.max(0.0);
         self
     }
 
+    /// Sets the bloom spread radius in screen pixels, clamped to be non-negative.
     pub fn with_radius(mut self, radius: f32) -> Self {
         self.radius = radius.max(0.0);
         self
     }
 
+    /// Sets the threshold knee softness, clamped to `[0, 1]`.
     pub fn with_softness(mut self, softness: f32) -> Self {
         self.softness = softness.clamp(0.0, 1.0);
         self
     }
 
+    /// Turns the effect off while keeping its other settings.
     pub fn disabled(mut self) -> Self {
         self.enabled = false;
         self

--- a/crates/bsengine-core/src/camera.rs
+++ b/crates/bsengine-core/src/camera.rs
@@ -4,16 +4,23 @@ use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use glam::Mat4;
 
+/// Perspective camera component holding the field of view and clip planes
+/// used to build a right-handed projection matrix each frame.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct Camera {
+    /// Vertical field of view.
     pub fov_y_degrees: ReflectDegrees,
+    /// Viewport width divided by height.
     pub aspect_ratio: f32,
+    /// Distance to the near clip plane.
     pub near: f32,
+    /// Distance to the far clip plane.
     pub far: f32,
 }
 
 impl Camera {
+    /// Creates a perspective camera with the given vertical FOV and aspect ratio, and default near/far planes.
     pub fn perspective(fov_y_degrees: f32, aspect_ratio: f32) -> Self {
         Self {
             fov_y_degrees: fov_y_degrees.into(),
@@ -23,6 +30,7 @@ impl Camera {
         }
     }
 
+    /// Builds the right-handed perspective projection matrix for this camera.
     pub fn projection_matrix(&self) -> Mat4 {
         Mat4::perspective_rh(
             self.fov_y_degrees.to_radians(),
@@ -32,6 +40,7 @@ impl Camera {
         )
     }
 
+    /// Recomputes `aspect_ratio` from a viewport size, ignoring zero-height viewports.
     pub fn update_aspect_ratio(&mut self, width: u32, height: u32) {
         if height > 0 {
             self.aspect_ratio = width as f32 / height as f32;

--- a/crates/bsengine-core/src/cursor_config.rs
+++ b/crates/bsengine-core/src/cursor_config.rs
@@ -1,8 +1,12 @@
 use bevy_ecs::prelude::Resource;
 
+/// Resource controlling the OS cursor's visibility and whether it is locked
+/// (confined/grabbed) to the window, e.g. for mouse-look camera controls.
 #[derive(Resource, Clone, Copy, Debug)]
 pub struct CursorConfig {
+    /// Whether the OS cursor is shown.
     pub visible: bool,
+    /// Whether the cursor is confined/grabbed to the window.
     pub locked: bool,
 }
 

--- a/crates/bsengine-core/src/cursor_pos.rs
+++ b/crates/bsengine-core/src/cursor_pos.rs
@@ -4,6 +4,8 @@ use bevy_ecs::prelude::Resource;
 /// Updated every frame by the window event loop.
 #[derive(Resource, Default, Clone, Copy, Debug)]
 pub struct CursorPos {
+    /// Horizontal cursor position, in logical pixels from the window's left edge.
     pub x: f32,
+    /// Vertical cursor position, in logical pixels from the window's top edge.
     pub y: f32,
 }

--- a/crates/bsengine-core/src/custom_shader.rs
+++ b/crates/bsengine-core/src/custom_shader.rs
@@ -2,9 +2,11 @@ use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 
+/// Overrides the default material shader with a custom WGSL shader file.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct CustomShader {
+    /// Path to the WGSL shader source, relative to the project's shader directory.
     pub path: String,
 }
 

--- a/crates/bsengine-core/src/damping.rs
+++ b/crates/bsengine-core/src/damping.rs
@@ -8,6 +8,7 @@ use bevy_reflect::Reflect;
 #[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct Damping {
+    /// Per-second linear drag coefficient applied to `Velocity.linear`.
     pub linear: f32,
 }
 
@@ -18,6 +19,7 @@ impl Default for Damping {
 }
 
 impl Damping {
+    /// Creates a damping component with the given linear drag coefficient.
     pub fn new(linear: f32) -> Self {
         Self { linear }
     }

--- a/crates/bsengine-core/src/editor_panel.rs
+++ b/crates/bsengine-core/src/editor_panel.rs
@@ -13,15 +13,21 @@ pub trait EditorPanel: Send {
     /// persistence. Must not change across versions once shipped, or saved
     /// layouts referencing it silently drop the tab.
     fn id(&self) -> &str;
+    /// Human-readable label shown on the panel's dock tab.
     fn title(&self) -> String;
+    /// Draws the panel's contents for this frame.
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &mut EditorPanelContext);
 }
 
 /// Shared state every panel's `ui()` call gets access to.
 pub struct EditorPanelContext<'a> {
+    /// Mutable inspector state (selection, gizmo mode, pending commands, ...).
     pub insp: &'a mut InspectorState,
+    /// Read-only snapshot of all entities visible to the editor this frame.
     pub entities_snapshot: &'a [InspectorEntityInfo],
+    /// Current cursor position within the viewport, in logical pixels.
     pub cursor_pos: (f32, f32),
+    /// Reflection type registry, when available, for generic component editing.
     pub type_registry: Option<&'a bevy_reflect::TypeRegistry>,
 }
 

--- a/crates/bsengine-core/src/external_impulse.rs
+++ b/crates/bsengine-core/src/external_impulse.rs
@@ -13,11 +13,14 @@ use glam::Vec3;
 #[derive(Component, Debug, Clone, Copy, PartialEq, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct ExternalImpulse {
+    /// Pending linear impulse (kg·m/s), applied then cleared each physics step.
     pub linear: ReflectVec3,
+    /// Pending angular impulse (kg·m²/s), applied then cleared each physics step.
     pub angular: ReflectVec3,
 }
 
 impl ExternalImpulse {
+    /// Creates an impulse with only a linear component set.
     pub fn linear(linear: Vec3) -> Self {
         Self {
             linear: linear.into(),
@@ -25,6 +28,7 @@ impl ExternalImpulse {
         }
     }
 
+    /// Creates an impulse with only an angular component set.
     pub fn angular(angular: Vec3) -> Self {
         Self {
             linear: Vec3::ZERO.into(),
@@ -32,19 +36,23 @@ impl ExternalImpulse {
         }
     }
 
+    /// Accumulates an additional linear impulse onto the pending value.
     pub fn add_linear(&mut self, impulse: Vec3) {
         self.linear.0 += impulse;
     }
 
+    /// Accumulates an additional angular impulse onto the pending value.
     pub fn add_angular(&mut self, impulse: Vec3) {
         self.angular.0 += impulse;
     }
 
+    /// Resets both linear and angular impulses to zero.
     pub fn clear(&mut self) {
         self.linear = Vec3::ZERO.into();
         self.angular = Vec3::ZERO.into();
     }
 
+    /// Returns true if both linear and angular impulses are exactly zero.
     pub fn is_zero(&self) -> bool {
         self.linear.0 == Vec3::ZERO && self.angular.0 == Vec3::ZERO
     }

--- a/crates/bsengine-core/src/follow.rs
+++ b/crates/bsengine-core/src/follow.rs
@@ -9,6 +9,7 @@ use glam::Vec3;
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component)]
 pub struct Follow {
+    /// The entity whose position this entity moves toward.
     pub target: Entity,
     /// World-space offset added to the target's position before interpolation.
     pub offset: ReflectVec3,
@@ -17,6 +18,7 @@ pub struct Follow {
 }
 
 impl Follow {
+    /// Creates a `Follow` targeting `target` with no offset and instant snap speed.
     pub fn new(target: Entity) -> Self {
         Self {
             target,
@@ -25,11 +27,13 @@ impl Follow {
         }
     }
 
+    /// Sets the world-space offset added to the target's position.
     pub fn with_offset(mut self, offset: Vec3) -> Self {
         self.offset = offset.into();
         self
     }
 
+    /// Sets the maximum move speed, in units per second.
     pub fn with_speed(mut self, speed: f32) -> Self {
         self.speed = speed;
         self
@@ -41,12 +45,14 @@ impl Follow {
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component)]
 pub struct LookAt {
+    /// The entity this entity orients its rotation toward.
     pub target: Entity,
     /// World-space up vector used to compute the orientation.
     pub up: ReflectVec3,
 }
 
 impl LookAt {
+    /// Creates a `LookAt` targeting `target` with a default world-up of `Vec3::Y`.
     pub fn new(target: Entity) -> Self {
         Self {
             target,
@@ -54,6 +60,7 @@ impl LookAt {
         }
     }
 
+    /// Sets the up vector used to compute orientation, normalizing it.
     pub fn with_up(mut self, up: Vec3) -> Self {
         self.up = up.normalize().into();
         self

--- a/crates/bsengine-core/src/global_transform.rs
+++ b/crates/bsengine-core/src/global_transform.rs
@@ -4,6 +4,8 @@ use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use glam::Mat4;
 
+/// World-space transform matrix computed by [`crate::propagate_global_transforms`]
+/// from an entity's local [`crate::Transform`] and its parent chain.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct GlobalTransform(pub ReflectMat4);
@@ -15,6 +17,7 @@ impl Default for GlobalTransform {
 }
 
 impl GlobalTransform {
+    /// Returns the underlying world-space transform matrix.
     pub fn to_matrix(&self) -> Mat4 {
         self.0 .0
     }

--- a/crates/bsengine-core/src/gravity.rs
+++ b/crates/bsengine-core/src/gravity.rs
@@ -7,6 +7,7 @@ use glam::Vec3;
 /// Insert this resource to override the default (9.81 m/s² downward).
 #[derive(Resource, Debug, Clone, PartialEq)]
 pub struct Gravity {
+    /// World-space acceleration applied per second to entities with `Velocity`.
     pub acceleration: Vec3,
 }
 
@@ -19,10 +20,12 @@ impl Default for Gravity {
 }
 
 impl Gravity {
+    /// Creates a gravity resource with the given world-space acceleration.
     pub fn new(acceleration: Vec3) -> Self {
         Self { acceleration }
     }
 
+    /// Creates a gravity resource with zero acceleration.
     pub fn zero() -> Self {
         Self {
             acceleration: Vec3::ZERO,
@@ -43,10 +46,12 @@ impl Default for GravityScale {
 }
 
 impl GravityScale {
+    /// Creates a gravity scale with the given multiplier.
     pub fn new(scale: f32) -> Self {
         Self(scale)
     }
 
+    /// Returns the underlying multiplier value.
     pub fn value(self) -> f32 {
         self.0
     }

--- a/crates/bsengine-core/src/hud_texts.rs
+++ b/crates/bsengine-core/src/hud_texts.rs
@@ -2,5 +2,7 @@ use std::collections::HashMap;
 
 use bevy_ecs::prelude::Resource;
 
+/// Resource mapping named HUD text slots (e.g. "score", "health") to their
+/// current display strings, read by the HUD rendering system.
 #[derive(Resource, Default, Clone)]
 pub struct HudTexts(pub HashMap<String, String>);

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -8,30 +8,51 @@ use bevy_ecs::prelude::Resource;
 /// enum) must stay in sync with this list — see the doc comments there.
 pub const PRIMITIVE_KINDS: [&str; 4] = ["cube", "sphere", "plane", "capsule"];
 
+/// Flattened, read-only snapshot of one ECS entity's editor-relevant
+/// component data, rebuilt each frame for the Inspector/Hierarchy panels.
 #[derive(Clone, Default)]
 pub struct InspectorEntityInfo {
+    /// Stable numeric identifier for this entity, as shown/referenced in the editor UI.
     pub id: u64,
+    /// The entity's `Name` component value, if any.
     pub name: Option<String>,
+    /// World-space position from `Transform`, if the entity has one.
     pub position: Option<[f32; 3]>,
+    /// Euler rotation in degrees from `Transform`, if the entity has one.
     pub rotation: Option<[f32; 3]>,
+    /// Scale from `Transform`, if the entity has one.
     pub scale: Option<[f32; 3]>,
     // light
+    /// Kind of light attached ("point", "spot", "directional"), if any.
     pub light_type: Option<String>,
+    /// Light color, if a light component is attached.
     pub light_color: Option<[f32; 3]>,
+    /// Light intensity, if a light component is attached.
     pub light_intensity: Option<f32>,
+    /// Light falloff range, if a point/spot light is attached.
     pub light_range: Option<f32>,
+    /// Spot light inner cone angle in degrees, if a spot light is attached.
     pub spot_inner_angle: Option<f32>,
+    /// Spot light outer cone angle in degrees, if a spot light is attached.
     pub spot_outer_angle: Option<f32>,
     // camera
+    /// Vertical field of view in degrees, if a `Camera` is attached.
     pub camera_fov: Option<f32>,
     // material
+    /// Base (albedo) color, if a `Material` is attached.
     pub material_base_color: Option<[f32; 3]>,
+    /// Metallic factor, if a `Material` is attached.
     pub material_metallic: Option<f32>,
+    /// Roughness factor, if a `Material` is attached.
     pub material_roughness: Option<f32>,
+    /// Emissive color, if a `Material` is attached.
     pub material_emissive: Option<[f32; 3]>,
     // hierarchy / tags / script / mesh
+    /// Id of this entity's parent, if it has one.
     pub parent_id: Option<u64>,
+    /// User-assigned tags on this entity.
     pub tags: Vec<String>,
+    /// Path of the attached script asset, if any.
     pub script_path: Option<String>,
     /// One of [`PRIMITIVE_KINDS`], or `None` if no `PrimitiveMesh` is
     /// attached. A plain `String`, not `bsengine_scene::Primitive`, because
@@ -39,51 +60,86 @@ pub struct InspectorEntityInfo {
     /// depends on `bsengine-core`). Mirrors this same struct's
     /// `light_type: Option<String>` convention.
     pub primitive: Option<String>,
+    /// Whether the entity is currently visible in the scene.
     pub visible: bool,
+    /// Whether the entity is currently selected in the editor.
     pub selected: bool,
 }
 
+/// One queued edit request from the editor UI, drained and applied to the
+/// live ECS world by `apply_inspector_cmds` (`bsengine-editor`).
 pub enum InspectorCmd {
+    /// Set an entity's world-space position.
     SetPosition {
+        /// Target entity id.
         id: u64,
+        /// New X position.
         x: f32,
+        /// New Y position.
         y: f32,
+        /// New Z position.
         z: f32,
     },
+    /// Set an entity's Euler rotation, in degrees.
     SetRotation {
+        /// Target entity id.
         id: u64,
+        /// New rotation about X, in degrees.
         rx: f32,
+        /// New rotation about Y, in degrees.
         ry: f32,
+        /// New rotation about Z, in degrees.
         rz: f32,
     },
+    /// Set an entity's scale.
     SetScale {
+        /// Target entity id.
         id: u64,
+        /// New scale along X.
         sx: f32,
+        /// New scale along Y.
         sy: f32,
+        /// New scale along Z.
         sz: f32,
     },
+    /// Spawn a new empty entity with the given name.
     SpawnEntity {
+        /// Name to give the new entity.
         name: String,
     },
+    /// Despawn an entity and its children.
     Despawn {
+        /// Target entity id.
         id: u64,
     },
+    /// Toggle whether an entity is rendered.
     SetVisible {
+        /// Target entity id.
         id: u64,
+        /// New visibility state.
         visible: bool,
     },
+    /// Attach a default point light to an entity.
     AddPointLight {
+        /// Target entity id.
         id: u64,
     },
+    /// Attach a default camera to an entity.
     AddCamera {
+        /// Target entity id.
         id: u64,
     },
+    /// Replace the current editor selection.
     SetSelection {
+        /// Ids of the entities to select.
         ids: Vec<u64>,
     },
+    /// Clone an entity (and its component data) into a new entity.
     Duplicate {
+        /// Id of the entity to duplicate.
         id: u64,
     },
+    /// Save the current scene to its existing path.
     SaveScene,
     /// Replace the current scene by loading and parsing a `.ron` file at
     /// `path`. Mirrors `EditorCommand::LoadScene`, which already does the
@@ -91,6 +147,7 @@ pub enum InspectorCmd {
     /// (the Asset Browser) can request it through the same `InspectorCmd`
     /// pipeline every other UI-driven command goes through.
     LoadScene {
+        /// Path to the `.ron` scene file to load.
         path: String,
     },
     /// Spawn a new named entity with a `GltfAsset { path }` component
@@ -99,44 +156,73 @@ pub enum InspectorCmd {
     /// and asynchronously replaces it with the loaded mesh's
     /// `MeshRenderer`/`Material`. Always spawns as a root entity.
     SpawnMeshAsset {
+        /// Name to give the new entity.
         name: String,
+        /// Path to the glTF asset to load.
         path: String,
     },
+    /// Attach a reflected component to an entity by its type path.
     AttachComponentByType {
+        /// Target entity id.
         id: u64,
+        /// Fully qualified reflected type path of the component to attach.
         type_path: String,
     },
+    /// Remove a reflected component from an entity by its type path.
     RemoveComponentByType {
+        /// Target entity id.
         id: u64,
+        /// Fully qualified reflected type path of the component to remove.
         type_path: String,
     },
+    /// Rename an entity's `Name` component.
     RenameEntity {
+        /// Target entity id.
         id: u64,
+        /// New name.
         name: String,
     },
+    /// Reparent an entity under another entity.
     SetParent {
+        /// Target entity id.
         id: u64,
+        /// Id of the new parent entity.
         parent_id: u64,
     },
+    /// Remove an entity's parent, making it a root entity.
     RemoveParent {
+        /// Target entity id.
         id: u64,
     },
+    /// Add a tag to an entity.
     TagEntity {
+        /// Target entity id.
         id: u64,
+        /// Tag to add.
         tag: String,
     },
+    /// Remove a tag from an entity.
     UntagEntity {
+        /// Target entity id.
         id: u64,
+        /// Tag to remove.
         tag: String,
     },
+    /// Attach a script asset to an entity.
     AttachScript {
+        /// Target entity id.
         id: u64,
+        /// Path to the script asset.
         path: String,
     },
+    /// Remove the attached script asset from an entity.
     DetachScript {
+        /// Target entity id.
         id: u64,
     },
+    /// Attach a primitive mesh to an entity.
     AttachPrimitiveMesh {
+        /// Target entity id.
         id: u64,
         /// One of [`PRIMITIVE_KINDS`] — a plain `String`, not
         /// `bsengine_scene::Primitive`, for the same circular-dependency
@@ -145,7 +231,9 @@ pub enum InspectorCmd {
         /// `bsengine_scene` is already in scope.
         primitive: String,
     },
+    /// Remove the attached primitive mesh from an entity.
     DetachPrimitiveMesh {
+        /// Target entity id.
         id: u64,
     },
     /// Apply an edited clone of a reflected component's value back onto the
@@ -157,30 +245,44 @@ pub enum InspectorCmd {
     /// `RemoveComponentByType` already use, not the plain `EditorCommand`
     /// queue — see `apply_inspector_cmds`.
     ApplyReflectedComponent {
+        /// Target entity id.
         id: u64,
+        /// Fully qualified reflected type path of the component being updated.
         type_path: String,
+        /// Edited component value to write back.
         value: Box<dyn bevy_reflect::Reflect>,
     },
 }
 
+/// Whether the editor is showing the static scene or running gameplay.
 #[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
 pub enum EditorPlayState {
+    /// Gameplay systems are not running; the scene is being edited.
     #[default]
     Stopped,
+    /// Gameplay systems are running as they would at runtime.
     Playing,
 }
 
+/// Which viewport manipulation gizmo is active for the selected entity.
 #[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
 pub enum GizmoMode {
+    /// Drag handles move the entity along an axis.
     #[default]
     Translate,
+    /// Drag rings rotate the entity about an axis.
     Rotate,
 }
 
+/// Editor-side resource holding the current entity snapshot, selection,
+/// pending edit commands, and all viewport/gizmo/camera UI state.
 #[derive(Resource)]
 pub struct InspectorState {
+    /// Snapshot of every entity visible to the editor this frame.
     pub entities: Vec<InspectorEntityInfo>,
+    /// Id of the currently selected entity, if any.
     pub selected_id: Option<u64>,
+    /// Edit commands queued by the UI this frame, drained by `apply_inspector_cmds`.
     pub cmd_queue: Vec<InspectorCmd>,
     /// Cloned reflected components currently attached to `selected_id`,
     /// repopulated every frame by `populate_reflected_component_snapshot`
@@ -191,10 +293,15 @@ pub struct InspectorState {
     /// format already used by `AttachComponentByType`/`RemoveComponentByType`
     /// (e.g. `"bsengine_core::camera::Camera"`).
     pub reflected_components: Vec<(String, Box<dyn bevy_reflect::Reflect>)>,
+    /// Editable position buffer for the Transform section, synced from the selected entity.
     pub edit_pos: [f32; 3],
+    /// Editable rotation buffer for the Transform section, synced from the selected entity.
     pub edit_rot: [f32; 3],
+    /// Editable scale buffer for the Transform section, synced from the selected entity.
     pub edit_scale: [f32; 3],
+    /// Live text in the "add tag" input box.
     pub edit_new_tag: String,
+    /// Editable script path buffer for the selected entity.
     pub edit_script_path: String,
     /// Live text in the Hierarchy panel's search box. Empty means "show the
     /// full tree"; non-empty switches Hierarchy to a flat, name-filtered
@@ -203,51 +310,73 @@ pub struct InspectorState {
     /// Whether the viewport draws the ground-plane reference grid. Toggled
     /// by the viewport overlay's grid button.
     pub show_grid: bool,
+    /// Editable visibility buffer for the selected entity.
     pub edit_visible: bool,
     prev_selected_id: Option<u64>,
 
     // Editor mode toggle and play state
+    /// Whether the app is running as the editor (vs. a plain game runtime).
     pub editor_mode: bool,
+    /// Whether gameplay systems are currently running.
     pub play_state: EditorPlayState,
 
     // Editor orbit camera parameters
+    /// World-space point the orbit camera looks at.
     pub cam_target: [f32; 3],
+    /// Distance from the orbit camera to `cam_target`.
     pub cam_distance: f32,
+    /// Orbit camera yaw, in radians.
     pub cam_yaw: f32,
+    /// Orbit camera pitch, in radians.
     pub cam_pitch: f32,
 
     // Set by the egui viewport panel each frame; read by the camera system
+    /// Whether the mouse cursor is currently over the viewport panel.
     pub viewport_contains_cursor: bool,
+    /// Current size of the viewport panel, in logical pixels.
     pub viewport_size: [f32; 2],
 
     // Override view_proj computed by EditorPlugin from orbit state; read by RenderPlugin
+    /// Editor-computed view-projection matrix override for the renderer, when in editor mode.
     pub editor_view_proj: Option<[[f32; 4]; 4]>,
+    /// Editor orbit camera's projection matrix.
     pub editor_proj: [[f32; 4]; 4],
+    /// Editor orbit camera's world-space position.
     pub editor_cam_pos: [f32; 3],
 
     // Which viewport gizmo is active for the selected entity.
+    /// Which viewport gizmo (translate/rotate) is currently active.
     pub gizmo_mode: GizmoMode,
 
     // Translate-gizmo drag state (viewport panel). `gizmo_drag_axis` is
     // 0=X, 1=Y, 2=Z while a handle is being dragged.
+    /// Axis (0=X, 1=Y, 2=Z) of the translate-gizmo handle currently being dragged, if any.
     pub gizmo_drag_axis: Option<u8>,
+    /// World-space position of the selected entity when the current translate drag began.
     pub gizmo_drag_start_world: [f32; 3],
+    /// Screen-space mouse position when the current translate drag began.
     pub gizmo_drag_start_mouse: [f32; 2],
 
     // Rotate-gizmo drag state. `gizmo_rotate_axis` is 0=X, 1=Y, 2=Z (world
     // axis) while a ring is being dragged; the angle fields are radians of
     // the mouse's angle around the gizmo's screen-space center.
+    /// World axis (0=X, 1=Y, 2=Z) of the rotate-gizmo ring currently being dragged, if any.
     pub gizmo_rotate_axis: Option<u8>,
+    /// Entity's Euler rotation, in degrees, when the current rotate drag began.
     pub gizmo_rotate_start_deg: [f32; 3],
+    /// Mouse angle, in radians, around the gizmo's screen-space center when the current rotate drag began.
     pub gizmo_rotate_start_angle: f32,
 
     // Set by the toolbar/keyboard to request an undo/redo; consumed and
     // cleared by EditorPlugin's history system the same frame.
+    /// Set to request an undo of the last edit; cleared once processed.
     pub request_undo: bool,
+    /// Set to request a redo of the last undone edit; cleared once processed.
     pub request_redo: bool,
 
     // Path the scene was loaded from / last saved to, used by Ctrl+S / the
     // Save toolbar button to save in place without prompting for a path.
+    /// Path the current scene was loaded from / last saved to.
     pub current_scene_path: Option<String>,
 }
 
@@ -293,6 +422,7 @@ impl Default for InspectorState {
 }
 
 impl InspectorState {
+    /// Creates an `InspectorState` with `editor_mode` set, otherwise using defaults.
     pub fn editor() -> Self {
         Self {
             editor_mode: true,
@@ -300,6 +430,7 @@ impl InspectorState {
         }
     }
 
+    /// Refreshes the `edit_*` buffers from the newly selected entity, if the selection changed.
     pub fn sync_selection(&mut self) {
         if self.selected_id != self.prev_selected_id {
             self.prev_selected_id = self.selected_id;

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -8,49 +8,93 @@
 //! and editor-facing infrastructure (`InspectorState`, `EditorPanelRegistry`).
 #![warn(missing_docs)]
 
+/// Screen-space ambient occlusion post-process settings.
 pub mod ambient_occlusion;
+/// Angular (rotational) velocity component for physics-driven entities.
 pub mod angular_velocity;
+/// Simple single-clip skeletal/sprite animation playback component.
 pub mod animation_player;
+/// Graph-based animation state machine with parameterized transitions.
 pub mod animation_state_machine;
+/// HDR bloom post-process settings.
 pub mod bloom;
+/// Perspective camera component and projection math.
 pub mod camera;
+/// Cursor visibility/lock configuration resource.
 pub mod cursor_config;
+/// Current cursor position resource, in window space.
 pub mod cursor_pos;
+/// Custom shader override component for materials.
 pub mod custom_shader;
+/// Linear/angular velocity damping (drag) component.
 pub mod damping;
+/// Editor-side dockable panel trait and registry.
 pub mod editor_panel;
+/// One-shot linear/angular impulse component consumed by the physics step.
 pub mod external_impulse;
+/// Components that make an entity's transform track another entity.
 pub mod follow;
+/// World-space transform resulting from local transform + parent hierarchy.
 pub mod global_transform;
+/// Gravitational acceleration resource and per-entity gravity scale.
 pub mod gravity;
+/// Named on-screen HUD text overlay resource.
 pub mod hud_texts;
+/// Editor inspector state, entity snapshots, and inspector command protocol.
 pub mod inspector;
+/// Countdown-to-despawn component for temporary entities.
 pub mod lifetime;
+/// Directional, point, and spot light components.
 pub mod light;
+/// Engine-wide logging initialization.
 pub mod logging;
+/// Physical mass component used by the physics integrator.
 pub mod mass;
+/// PBR material properties component.
 pub mod material;
+/// Human-readable entity name component.
 pub mod name;
+/// Baked navigation mesh resource used for pathfinding.
 pub mod nav_mesh;
+/// Nav-mesh-driven pathing agent component and its runtime state.
 pub mod nav_mesh_agent;
+/// Networked entity identity and authority components.
 pub mod network_id;
+/// Parent-entity reference for building transform hierarchies.
 pub mod parent;
+/// `bevy_reflect`-friendly wrapper for RGBA color values.
 pub mod reflect_color;
+/// `bevy_reflect`-friendly wrapper for angles expressed in degrees.
 pub mod reflect_degrees;
+/// `bevy_reflect`-friendly wrappers for `glam` vector and quaternion types.
 pub mod reflect_glam;
+/// `bevy_reflect`-friendly wrapper for a `glam::Mat4`.
 pub mod reflect_mat4;
+/// Validation trait for reflected component field values.
 pub mod reflect_validate;
+/// Serializable save-game data resource.
 pub mod save_data;
+/// Current window/render-target size resource.
 pub mod screen_size;
+/// Depletable shield/absorb-damage component.
 pub mod shield;
+/// Skybox background component and its projection mode.
 pub mod skybox;
+/// Frame and elapsed-time resource driven by the app's main loop.
 pub mod time;
+/// Simple countdown timer component.
 pub mod timer;
+/// HDR-to-LDR tone mapping post-process settings.
 pub mod tone_map;
+/// Local position/rotation/scale transform component.
 pub mod transform;
+/// Time-driven property tween/animation component.
 pub mod tween;
+/// Immediate-mode UI widget tree and state resource.
 pub mod ui_state;
+/// Linear velocity component consumed by the physics integrator.
 pub mod velocity;
+/// Visibility toggle component controlling whether an entity is rendered.
 pub mod visible;
 
 pub use ambient_occlusion::AmbientOcclusion;
@@ -102,6 +146,8 @@ pub use ui_state::{UiState, UiWidget};
 pub use velocity::Velocity;
 pub use visible::Visible;
 
+/// Recomputes every entity's [`GlobalTransform`] from its local [`Transform`]
+/// and [`Parent`] chain, iterating a fixed number of passes to settle deep hierarchies.
 pub fn propagate_global_transforms(world: &mut bevy_ecs::world::World) {
     use bevy_ecs::prelude::Entity;
     use glam::Mat4;

--- a/crates/bsengine-core/src/lifetime.rs
+++ b/crates/bsengine-core/src/lifetime.rs
@@ -7,16 +7,19 @@ use bevy_reflect::Reflect;
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct Lifetime {
+    /// Time left before this entity despawns, in seconds.
     pub remaining: f32,
 }
 
 impl Lifetime {
+    /// Creates a lifetime counting down from `seconds`, clamped to be non-negative.
     pub fn from_seconds(seconds: f32) -> Self {
         Self {
             remaining: seconds.max(0.0),
         }
     }
 
+    /// Returns true once `remaining` has counted down to zero or below.
     pub fn is_expired(&self) -> bool {
         self.remaining <= 0.0
     }

--- a/crates/bsengine-core/src/light.rs
+++ b/crates/bsengine-core/src/light.rs
@@ -12,10 +12,14 @@ use glam::Vec3;
 // for "which way is this thing facing" across all light/entity types, so
 // the existing move/rotate gizmos, Inspector Rot fields, and undo/redo all
 // work on directional lights for free.
+/// Parallel-ray light source (e.g. sunlight) with no position or falloff;
+/// its direction comes from the entity's `Transform` rotation.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct DirectionalLight {
+    /// Light color, applied to all surfaces facing the light direction.
     pub color: ReflectColor,
+    /// Constant ambient light color added regardless of surface orientation.
     pub ambient: ReflectColor,
 }
 
@@ -28,11 +32,16 @@ impl Default for DirectionalLight {
     }
 }
 
+/// Omnidirectional light source radiating equally in all directions from the
+/// entity's position, falling off to zero at `range`.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct PointLight {
+    /// Light color.
     pub color: ReflectColor,
+    /// Overall brightness multiplier.
     pub intensity: f32,
+    /// Distance at which the light's contribution falls off to zero.
     pub range: f32,
 }
 
@@ -46,11 +55,17 @@ impl Default for PointLight {
     }
 }
 
+/// Cone-shaped light source radiating from the entity's position in the
+/// direction of its `Transform` rotation, falling off between the inner and
+/// outer cone angles and to zero at `range`.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default, Validate)]
 pub struct SpotLight {
+    /// Light color.
     pub color: ReflectColor,
+    /// Overall brightness multiplier.
     pub intensity: f32,
+    /// Distance at which the light's contribution falls off to zero.
     pub range: f32,
     /// Inner cone half-angle (degrees) — full brightness inside.
     pub inner_angle_degrees: ReflectDegrees,

--- a/crates/bsengine-core/src/logging.rs
+++ b/crates/bsengine-core/src/logging.rs
@@ -2,6 +2,10 @@ use std::sync::OnceLock;
 
 static LOGGING_INIT: OnceLock<()> = OnceLock::new();
 
+/// Initializes the global `tracing` subscriber for the engine, writing to
+/// stderr with a `bsengine=debug,warn` default filter (overridable via the
+/// standard `RUST_LOG` env var). Safe to call more than once; only the first
+/// call takes effect.
 pub fn init_logging() {
     LOGGING_INIT.get_or_init(|| {
         use tracing_subscriber::{fmt, EnvFilter};

--- a/crates/bsengine-core/src/mass.rs
+++ b/crates/bsengine-core/src/mass.rs
@@ -8,12 +8,14 @@ use bevy_reflect::Reflect;
 #[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct Mass {
+    /// Mass in kilograms, clamped away from zero to avoid division by zero.
     pub value: f32,
 }
 
 impl Mass {
     const MIN: f32 = 1e-6;
 
+    /// Creates a mass from a kilogram value, clamped to a small positive minimum.
     pub fn new(kg: f32) -> Self {
         Self {
             value: kg.max(Self::MIN),

--- a/crates/bsengine-core/src/material.rs
+++ b/crates/bsengine-core/src/material.rs
@@ -4,13 +4,19 @@ use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use glam::Vec3;
 
+/// PBR (physically-based rendering) surface material properties.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct Material {
+    /// Id of the base color texture asset, or `None` for a flat-colored surface.
     pub texture_id: Option<u64>,
+    /// How metallic the surface is, from 0 (dielectric) to 1 (metal).
     pub metallic: f32,
+    /// Surface microfacet roughness, from 0 (mirror-smooth) to 1 (fully diffuse).
     pub roughness: f32,
+    /// Self-emitted light color, added regardless of scene lighting.
     pub emissive: ReflectColor,
+    /// Base (albedo) color of the surface.
     pub base_color: ReflectColor,
 }
 

--- a/crates/bsengine-core/src/name.rs
+++ b/crates/bsengine-core/src/name.rs
@@ -5,10 +5,12 @@ use bevy_ecs::prelude::Component;
 pub struct Name(pub String);
 
 impl Name {
+    /// Creates a name from any string-like value.
     pub fn new(name: impl Into<String>) -> Self {
         Self(name.into())
     }
 
+    /// Returns the name as a string slice.
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/crates/bsengine-core/src/nav_mesh.rs
+++ b/crates/bsengine-core/src/nav_mesh.rs
@@ -6,9 +6,13 @@ use glam::Vec3;
 /// Uniform-grid navigation mesh for A* pathfinding. Cells lie in the XZ plane.
 #[derive(Resource, Debug, Clone)]
 pub struct NavMesh {
+    /// Number of cells along the X axis.
     pub width: u32,
+    /// Number of cells along the Z axis.
     pub depth: u32,
+    /// World-space size of one grid cell, along both axes.
     pub cell_size: f32,
+    /// World-space position of the grid's cell (0, 0) corner.
     pub origin: Vec3,
     walkable: Vec<bool>,
 }
@@ -20,6 +24,7 @@ impl Default for NavMesh {
 }
 
 impl NavMesh {
+    /// Creates a `width` x `depth` grid of the given cell size at `origin`, all cells walkable.
     pub fn new(width: u32, depth: u32, cell_size: f32, origin: Vec3) -> Self {
         let total = (width as usize).saturating_mul(depth as usize);
         Self {
@@ -31,12 +36,14 @@ impl NavMesh {
         }
     }
 
+    /// Marks a grid cell as walkable or blocked. Out-of-bounds coordinates are ignored.
     pub fn set_walkable(&mut self, x: u32, z: u32, walkable: bool) {
         if x < self.width && z < self.depth {
             self.walkable[(z * self.width + x) as usize] = walkable;
         }
     }
 
+    /// Returns whether the given cell is walkable; out-of-bounds coordinates are never walkable.
     pub fn is_walkable(&self, x: i32, z: i32) -> bool {
         if x < 0 || z < 0 || x as u32 >= self.width || z as u32 >= self.depth {
             return false;
@@ -44,6 +51,7 @@ impl NavMesh {
         self.walkable[(z as u32 * self.width + x as u32) as usize]
     }
 
+    /// Converts a world-space position to its containing grid cell coordinates.
     pub fn world_to_cell(&self, pos: Vec3) -> (i32, i32) {
         let dx = pos.x - self.origin.x;
         let dz = pos.z - self.origin.z;
@@ -53,6 +61,7 @@ impl NavMesh {
         )
     }
 
+    /// Returns the world-space center of the given grid cell.
     pub fn cell_center(&self, x: i32, z: i32) -> Vec3 {
         Vec3::new(
             self.origin.x + x as f32 * self.cell_size + self.cell_size * 0.5,

--- a/crates/bsengine-core/src/nav_mesh_agent.rs
+++ b/crates/bsengine-core/src/nav_mesh_agent.rs
@@ -44,10 +44,12 @@ pub struct NavMeshAgent {
     pub height: f32,
     /// Current state written back by the navigation system each frame.
     pub state: NavAgentState,
+    /// Whether the navigation system processes this agent at all.
     pub enabled: bool,
 }
 
 impl NavMeshAgent {
+    /// Creates an agent with the given max speed (clamped to non-negative) and default tuning.
     pub fn new(speed: f32) -> Self {
         Self {
             destination: None,
@@ -62,35 +64,42 @@ impl NavMeshAgent {
         }
     }
 
+    /// Sets the maximum rotation speed, in radians per second (clamped to non-negative).
     pub fn with_angular_speed(mut self, radians_per_second: f32) -> Self {
         self.angular_speed = radians_per_second.max(0.0);
         self
     }
 
+    /// Sets the arrival distance threshold, clamped to non-negative.
     pub fn with_stopping_distance(mut self, distance: f32) -> Self {
         self.stopping_distance = distance.max(0.0);
         self
     }
 
+    /// Sets the avoidance capsule radius, clamped to non-negative.
     pub fn with_radius(mut self, radius: f32) -> Self {
         self.radius = radius.max(0.0);
         self
     }
 
+    /// Sets the target destination the agent should path toward.
     pub fn with_destination(mut self, destination: Vec3) -> Self {
         self.destination = Some(destination.into());
         self
     }
 
+    /// Clears the current destination and resets state to idle.
     pub fn clear_destination(&mut self) {
         self.destination = None;
         self.state = NavAgentState::Idle;
     }
 
+    /// Returns true if the agent is currently moving toward its destination.
     pub fn is_moving(&self) -> bool {
         self.state == NavAgentState::Moving
     }
 
+    /// Returns true if the agent has reached its destination.
     pub fn has_arrived(&self) -> bool {
         self.state == NavAgentState::Arrived
     }

--- a/crates/bsengine-core/src/network_id.rs
+++ b/crates/bsengine-core/src/network_id.rs
@@ -9,7 +9,10 @@ pub enum NetworkAuthority {
     #[default]
     Server,
     /// A specific client (by peer ID) owns simulation authority.
-    Client { peer_id: u64 },
+    Client {
+        /// Id of the peer that owns this entity.
+        peer_id: u64,
+    },
     /// No network replication — local-only entity.
     Local,
 }
@@ -22,6 +25,7 @@ pub enum NetworkAuthority {
 pub struct NetworkId {
     /// Globally unique, stable identifier assigned at spawn time.
     pub id: u64,
+    /// Who currently owns simulation authority over this entity.
     pub authority: NetworkAuthority,
 }
 

--- a/crates/bsengine-core/src/parent.rs
+++ b/crates/bsengine-core/src/parent.rs
@@ -1,6 +1,8 @@
 use bevy_ecs::prelude::{Component, Entity, ReflectComponent};
 use bevy_reflect::Reflect;
 
+/// Reference to this entity's parent, used to build transform hierarchies
+/// consumed by [`crate::propagate_global_transforms`].
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component)]
 pub struct Parent(pub Entity);

--- a/crates/bsengine-core/src/reflect_color.rs
+++ b/crates/bsengine-core/src/reflect_color.rs
@@ -14,6 +14,7 @@
 //! the type alone is what tells the UI which widget to use.
 use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
 
+/// Reflectable RGB color wrapper around a `glam::Vec3` (linear space, 0.0-1.0 per channel).
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct ReflectColor(pub glam::Vec3);
 

--- a/crates/bsengine-core/src/reflect_degrees.rs
+++ b/crates/bsengine-core/src/reflect_degrees.rs
@@ -21,6 +21,8 @@
 //! degrees internally.
 use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
 
+/// Reflectable `f32` wrapper representing an angle in degrees, used to signal
+/// to the generic reflected-field editor that a field should render as an angle.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct ReflectDegrees(pub f32);
 

--- a/crates/bsengine-core/src/reflect_glam.rs
+++ b/crates/bsengine-core/src/reflect_glam.rs
@@ -22,7 +22,8 @@
 use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
 
 macro_rules! reflect_glam_wrapper {
-    ($wrapper:ident, $inner:ty) => {
+    ($doc:expr, $wrapper:ident, $inner:ty) => {
+        #[doc = $doc]
         #[derive(Debug, Clone, Copy, PartialEq, Default)]
         pub struct $wrapper(pub $inner);
 
@@ -54,10 +55,26 @@ macro_rules! reflect_glam_wrapper {
     };
 }
 
-reflect_glam_wrapper!(ReflectVec2, glam::Vec2);
-reflect_glam_wrapper!(ReflectVec3, glam::Vec3);
-reflect_glam_wrapper!(ReflectVec4, glam::Vec4);
-reflect_glam_wrapper!(ReflectQuat, glam::Quat);
+reflect_glam_wrapper!(
+    "Reflectable wrapper around a `glam::Vec2`.",
+    ReflectVec2,
+    glam::Vec2
+);
+reflect_glam_wrapper!(
+    "Reflectable wrapper around a `glam::Vec3`.",
+    ReflectVec3,
+    glam::Vec3
+);
+reflect_glam_wrapper!(
+    "Reflectable wrapper around a `glam::Vec4`.",
+    ReflectVec4,
+    glam::Vec4
+);
+reflect_glam_wrapper!(
+    "Reflectable wrapper around a `glam::Quat`.",
+    ReflectQuat,
+    glam::Quat
+);
 
 impl_reflect_value!((in bsengine_core::reflect_glam) ReflectVec2(Debug, PartialEq, Default));
 impl_reflect_value!((in bsengine_core::reflect_glam) ReflectVec3(Debug, PartialEq, Default));

--- a/crates/bsengine-core/src/reflect_mat4.rs
+++ b/crates/bsengine-core/src/reflect_mat4.rs
@@ -8,6 +8,7 @@
 //! directly.
 use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
 
+/// Reflectable wrapper around a `glam::Mat4`.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct ReflectMat4(pub glam::Mat4);
 

--- a/crates/bsengine-core/src/reflect_validate.rs
+++ b/crates/bsengine-core/src/reflect_validate.rs
@@ -16,8 +16,11 @@
 //! `format!("Reflect{name}")`, not an allowlist of built-in names).
 use bevy_reflect::reflect_trait;
 
+/// Reflected hook for components with cross-field invariants that must be
+/// re-enforced after any generic field edit in the Inspector.
 #[reflect_trait]
 pub trait Validate {
+    /// Re-enforces this component's invariants across its fields.
     fn validate(&mut self);
 }
 

--- a/crates/bsengine-core/src/save_data.rs
+++ b/crates/bsengine-core/src/save_data.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 /// Values are stored as raw bytes; higher-level systems serialize/deserialize them.
 #[derive(Component, Debug, Clone, PartialEq)]
 pub struct SaveData {
+    /// Which save slot this data belongs to.
     pub slot: u32,
     /// Named fields — key = field name, value = raw serialised bytes.
     pub fields: HashMap<String, Vec<u8>>,
@@ -12,10 +13,12 @@ pub struct SaveData {
     pub last_saved_at: u64,
     /// Whether there are unsaved changes since the last flush.
     pub dirty: bool,
+    /// Whether this save slot is active and should be persisted.
     pub enabled: bool,
 }
 
 impl SaveData {
+    /// Creates an empty, enabled save slot with the given slot number.
     pub fn new(slot: u32) -> Self {
         Self {
             slot,
@@ -26,6 +29,7 @@ impl SaveData {
         }
     }
 
+    /// Turns this save slot off.
     pub fn disabled(mut self) -> Self {
         self.enabled = false;
         self
@@ -57,6 +61,7 @@ impl SaveData {
         self.dirty = false;
     }
 
+    /// Returns the number of fields currently stored.
     pub fn field_count(&self) -> usize {
         self.fields.len()
     }

--- a/crates/bsengine-core/src/screen_size.rs
+++ b/crates/bsengine-core/src/screen_size.rs
@@ -1,8 +1,11 @@
 use bevy_ecs::prelude::Resource;
 
+/// Current window/render-target size, in pixels, kept in sync with the OS window.
 #[derive(Resource, Clone, Copy, Debug)]
 pub struct ScreenSize {
+    /// Width in pixels.
     pub width: u32,
+    /// Height in pixels.
     pub height: u32,
 }
 

--- a/crates/bsengine-core/src/shield.rs
+++ b/crates/bsengine-core/src/shield.rs
@@ -2,10 +2,13 @@ use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 
+/// Depletable damage-absorbing shield that recharges over time.
 #[derive(Component, Debug, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct Shield {
+    /// Current shield charge.
     pub current: f32,
+    /// Maximum shield charge.
     pub max: f32,
     /// HP per second restored while recharging.
     pub recharge_rate: f32,
@@ -16,6 +19,7 @@ pub struct Shield {
 }
 
 impl Shield {
+    /// Creates a full shield with the given maximum charge (clamped to non-negative) and no recharge.
     pub fn new(max: f32) -> Self {
         let max = max.max(0.0);
         Self {
@@ -27,20 +31,24 @@ impl Shield {
         }
     }
 
+    /// Sets the recharge rate (HP/s) and the delay (seconds) before recharging resumes after damage.
     pub fn with_recharge(mut self, rate: f32, delay: f32) -> Self {
         self.recharge_rate = rate.max(0.0);
         self.recharge_delay = delay.max(0.0);
         self
     }
 
+    /// Returns true if the shield has no charge remaining.
     pub fn is_depleted(&self) -> bool {
         self.current <= 0.0
     }
 
+    /// Returns true if the shield is at maximum charge.
     pub fn is_full(&self) -> bool {
         self.current >= self.max
     }
 
+    /// Returns the current charge as a fraction of max, clamped to `[0, 1]`.
     pub fn fraction(&self) -> f32 {
         if self.max <= 0.0 {
             0.0

--- a/crates/bsengine-core/src/skybox.rs
+++ b/crates/bsengine-core/src/skybox.rs
@@ -28,11 +28,14 @@ pub struct Skybox {
     pub intensity: f32,
     /// Y-axis rotation of the skybox in radians.
     pub rotation: f32,
+    /// How the texture at `path` is laid out.
     pub projection: SkyboxProjection,
+    /// Whether the skybox is rendered at all.
     pub enabled: bool,
 }
 
 impl Skybox {
+    /// Creates an enabled skybox from the given texture path with default intensity/rotation.
     pub fn new(path: impl Into<String>) -> Self {
         Self {
             path: path.into(),
@@ -43,21 +46,25 @@ impl Skybox {
         }
     }
 
+    /// Sets the brightness multiplier, clamped to non-negative.
     pub fn with_intensity(mut self, intensity: f32) -> Self {
         self.intensity = intensity.max(0.0);
         self
     }
 
+    /// Sets the Y-axis rotation, in radians.
     pub fn with_rotation(mut self, radians: f32) -> Self {
         self.rotation = radians;
         self
     }
 
+    /// Sets how the skybox texture is laid out.
     pub fn with_projection(mut self, projection: SkyboxProjection) -> Self {
         self.projection = projection;
         self
     }
 
+    /// Turns the skybox off while keeping its other settings.
     pub fn disabled(mut self) -> Self {
         self.enabled = false;
         self

--- a/crates/bsengine-core/src/time.rs
+++ b/crates/bsengine-core/src/time.rs
@@ -2,9 +2,12 @@ use std::time::Instant;
 
 use bevy_ecs::prelude::Resource;
 
+/// Frame timing resource updated once per frame by the app's main loop.
 #[derive(Resource)]
 pub struct Time {
+    /// Seconds elapsed since the previous `tick()` call.
     pub delta_seconds: f32,
+    /// Total seconds elapsed since the app started.
     pub elapsed_seconds: f32,
     startup: Instant,
     last_tick: Instant,
@@ -23,6 +26,7 @@ impl Default for Time {
 }
 
 impl Time {
+    /// Advances the clock, recomputing `delta_seconds` and `elapsed_seconds` from the current instant.
     pub fn tick(&mut self) {
         let now = Instant::now();
         self.delta_seconds = now.duration_since(self.last_tick).as_secs_f32();

--- a/crates/bsengine-core/src/timer.rs
+++ b/crates/bsengine-core/src/timer.rs
@@ -79,14 +79,17 @@ impl Timer {
         (self.elapsed / self.duration).clamp(0.0, 1.0)
     }
 
+    /// Returns the time accumulated since the timer last started (or last looped, if repeating).
     pub fn elapsed(&self) -> f32 {
         self.elapsed
     }
 
+    /// Returns the configured duration, in seconds.
     pub fn duration(&self) -> f32 {
         self.duration
     }
 
+    /// Returns true if this timer loops instead of stopping when it finishes.
     pub fn is_repeating(&self) -> bool {
         self.repeating
     }

--- a/crates/bsengine-core/src/tone_map.rs
+++ b/crates/bsengine-core/src/tone_map.rs
@@ -23,13 +23,16 @@ pub enum ToneMappingMode {
 #[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct ToneMap {
+    /// Which HDR-to-LDR mapping curve is applied.
     pub mode: ToneMappingMode,
     /// Camera exposure in EV (exposure value). 0.0 = no change; positive = brighter.
     pub exposure: f32,
+    /// Whether the effect is applied at all.
     pub enabled: bool,
 }
 
 impl ToneMap {
+    /// Creates an enabled tone mapper using the given mode with zero exposure adjustment.
     pub fn new(mode: ToneMappingMode) -> Self {
         Self {
             mode,
@@ -38,11 +41,13 @@ impl ToneMap {
         }
     }
 
+    /// Sets the exposure adjustment, in EV.
     pub fn with_exposure(mut self, ev: f32) -> Self {
         self.exposure = ev;
         self
     }
 
+    /// Turns the effect off while keeping its other settings.
     pub fn disabled(mut self) -> Self {
         self.enabled = false;
         self

--- a/crates/bsengine-core/src/transform.rs
+++ b/crates/bsengine-core/src/transform.rs
@@ -4,11 +4,15 @@ use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use glam::{Mat4, Quat, Vec3};
 
+/// Local position, rotation, and scale of an entity, relative to its parent (if any).
 #[derive(Component, Debug, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct Transform {
+    /// Local-space position.
     pub translation: ReflectVec3,
+    /// Local-space rotation.
     pub rotation: ReflectQuat,
+    /// Local-space scale.
     pub scale: ReflectVec3,
 }
 
@@ -23,6 +27,7 @@ impl Default for Transform {
 }
 
 impl Transform {
+    /// Creates a transform at the given position with identity rotation and unit scale.
     pub fn from_translation(translation: Vec3) -> Self {
         Self {
             translation: translation.into(),
@@ -30,6 +35,7 @@ impl Transform {
         }
     }
 
+    /// Rotates this transform so it faces `target`, using `up` to determine the roll axis.
     pub fn looking_at(mut self, target: Vec3, up: Vec3) -> Self {
         let dir = (target - self.translation.0).normalize();
         let right = up.cross(dir).normalize();
@@ -38,10 +44,12 @@ impl Transform {
         self
     }
 
+    /// Builds the local-to-world transform matrix (scale, then rotate, then translate).
     pub fn to_matrix(&self) -> Mat4 {
         Mat4::from_scale_rotation_translation(self.scale.0, self.rotation.0, self.translation.0)
     }
 
+    /// Builds the world-to-view matrix, i.e. the inverse of `to_matrix()`.
     pub fn view_matrix(&self) -> Mat4 {
         self.to_matrix().inverse()
     }

--- a/crates/bsengine-core/src/tween.rs
+++ b/crates/bsengine-core/src/tween.rs
@@ -2,15 +2,21 @@ use crate::{ReflectQuat, ReflectVec3};
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::Reflect;
 
+/// Easing curve applied to a tween's normalized progress before interpolating.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 pub enum EasingFn {
+    /// Constant rate of change; no easing.
     Linear,
+    /// Starts slow, accelerates toward the end.
     EaseInQuad,
+    /// Starts fast, decelerates toward the end.
     EaseOutQuad,
+    /// Starts slow, speeds up through the middle, ends slow.
     EaseInOutQuad,
 }
 
 impl EasingFn {
+    /// Maps a linear progress value `t` in `[0, 1]` through this easing curve.
     pub fn apply(self, t: f32) -> f32 {
         match self {
             EasingFn::Linear => t,
@@ -27,33 +33,65 @@ impl EasingFn {
     }
 }
 
+/// How a tween behaves once it reaches the end of its duration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 pub enum RepeatMode {
+    /// Play once and stop.
     Once,
+    /// Restart from the beginning each time it finishes.
     Loop,
+    /// Reverse direction each time it finishes, bouncing between start and end.
     PingPong,
 }
 
+/// The property being animated and its start/end values.
 #[derive(Debug, Clone, Reflect)]
 pub enum TweenTarget {
-    Translation { from: ReflectVec3, to: ReflectVec3 },
-    Rotation { from: ReflectQuat, to: ReflectQuat },
-    Scale { from: ReflectVec3, to: ReflectVec3 },
+    /// Animates `Transform.translation`.
+    Translation {
+        /// Starting position.
+        from: ReflectVec3,
+        /// Ending position.
+        to: ReflectVec3,
+    },
+    /// Animates `Transform.rotation`.
+    Rotation {
+        /// Starting rotation.
+        from: ReflectQuat,
+        /// Ending rotation.
+        to: ReflectQuat,
+    },
+    /// Animates `Transform.scale`.
+    Scale {
+        /// Starting scale.
+        from: ReflectVec3,
+        /// Ending scale.
+        to: ReflectVec3,
+    },
 }
 
+/// Animates a `Transform` property from one value to another over time.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component)]
 pub struct Tween {
+    /// Which property is being animated, and its start/end values.
     pub target: TweenTarget,
+    /// Total time the tween takes to go from start to end, in seconds.
     pub duration: f32,
+    /// Easing curve applied to progress before interpolating.
     pub easing: EasingFn,
+    /// Behavior once the tween reaches the end.
     pub repeat: RepeatMode,
+    /// Whether a non-repeating tween has completed.
     pub finished: bool,
+    /// Time accumulated since the tween started, in seconds.
     pub elapsed: f32,
+    /// Whether the tween is currently playing back-to-front (used by `PingPong`).
     pub reversed: bool,
 }
 
 impl Tween {
+    /// Creates a linear, non-repeating tween for `target` over `duration` seconds.
     pub fn new(target: TweenTarget, duration: f32) -> Self {
         Self {
             target,
@@ -66,11 +104,13 @@ impl Tween {
         }
     }
 
+    /// Sets the easing curve applied to progress.
     pub fn with_easing(mut self, easing: EasingFn) -> Self {
         self.easing = easing;
         self
     }
 
+    /// Sets the behavior once the tween reaches the end.
     pub fn with_repeat(mut self, repeat: RepeatMode) -> Self {
         self.repeat = repeat;
         self

--- a/crates/bsengine-core/src/ui_state.rs
+++ b/crates/bsengine-core/src/ui_state.rs
@@ -2,49 +2,84 @@ use std::collections::{HashMap, HashSet};
 
 use bevy_ecs::prelude::Resource;
 
+/// A single immediate-mode UI element rendered by the HUD/UI system.
 #[derive(Clone, Debug)]
 pub enum UiWidget {
+    /// A static or dynamic text label.
     Label {
+        /// Unique widget identifier.
         id: String,
+        /// Text content to display.
         text: String,
+        /// X position, in screen-space pixels.
         x: f32,
+        /// Y position, in screen-space pixels.
         y: f32,
+        /// Font size, in pixels.
         font_size: f32,
     },
+    /// A clickable button.
     Button {
+        /// Unique widget identifier.
         id: String,
+        /// Text shown on the button.
         label: String,
+        /// X position, in screen-space pixels.
         x: f32,
+        /// Y position, in screen-space pixels.
         y: f32,
+        /// Button width, in pixels.
         width: f32,
+        /// Button height, in pixels.
         height: f32,
     },
+    /// A rectangular container with a title bar.
     Panel {
+        /// Unique widget identifier.
         id: String,
+        /// Text shown in the panel's title bar.
         title: String,
+        /// X position, in screen-space pixels.
         x: f32,
+        /// Y position, in screen-space pixels.
         y: f32,
+        /// Panel width, in pixels.
         width: f32,
+        /// Panel height, in pixels.
         height: f32,
     },
+    /// An editable single-line text field.
     TextInput {
+        /// Unique widget identifier.
         id: String,
+        /// Placeholder text shown when the field is empty.
         hint: String,
+        /// X position, in screen-space pixels.
         x: f32,
+        /// Y position, in screen-space pixels.
         y: f32,
+        /// Field width, in pixels.
         width: f32,
     },
+    /// A texture displayed at a fixed screen position.
     Image {
+        /// Unique widget identifier.
         id: String,
+        /// Path to the texture asset to display.
         texture_path: String,
+        /// X position, in screen-space pixels.
         x: f32,
+        /// Y position, in screen-space pixels.
         y: f32,
+        /// Image width, in pixels.
         width: f32,
+        /// Image height, in pixels.
         height: f32,
     },
 }
 
 impl UiWidget {
+    /// Returns this widget's unique identifier, regardless of its variant.
     pub fn id(&self) -> &str {
         match self {
             Self::Label { id, .. }
@@ -56,8 +91,11 @@ impl UiWidget {
     }
 }
 
+/// Resource holding the current tree of immediate-mode UI widgets and their
+/// per-frame interaction state.
 #[derive(Resource, Default, Clone)]
 pub struct UiState {
+    /// All widgets currently registered for rendering.
     pub widgets: Vec<UiWidget>,
     /// Buttons whose click was registered this frame (cleared next render).
     pub clicked: HashSet<String>,
@@ -66,6 +104,7 @@ pub struct UiState {
 }
 
 impl UiState {
+    /// Inserts a widget, or replaces the existing widget with the same id.
     pub fn set_widget(&mut self, widget: UiWidget) {
         let id = widget.id().to_string();
         if let Some(pos) = self.widgets.iter().position(|w| w.id() == id) {
@@ -75,11 +114,13 @@ impl UiState {
         }
     }
 
+    /// Removes the widget with the given id, along with any stored text input value.
     pub fn remove_widget(&mut self, id: &str) {
         self.widgets.retain(|w| w.id() != id);
         self.text_values.remove(id);
     }
 
+    /// Removes all widgets and clears click/text-input state.
     pub fn clear(&mut self) {
         self.widgets.clear();
         self.text_values.clear();

--- a/crates/bsengine-core/src/velocity.rs
+++ b/crates/bsengine-core/src/velocity.rs
@@ -10,6 +10,7 @@ use glam::Vec3;
 #[derive(Component, Debug, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct Velocity {
+    /// World-space linear velocity, in units per second.
     pub linear: ReflectVec3,
 }
 
@@ -22,12 +23,14 @@ impl Default for Velocity {
 }
 
 impl Velocity {
+    /// Creates a velocity from individual X/Y/Z components, in units per second.
     pub fn new(x: f32, y: f32, z: f32) -> Self {
         Self {
             linear: Vec3::new(x, y, z).into(),
         }
     }
 
+    /// Creates a velocity from a `glam::Vec3`.
     pub fn from_vec3(linear: Vec3) -> Self {
         Self {
             linear: linear.into(),

--- a/crates/bsengine-core/src/visible.rs
+++ b/crates/bsengine-core/src/visible.rs
@@ -7,6 +7,7 @@ use bevy_reflect::Reflect;
 #[derive(Component, Debug, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Component, Default)]
 pub struct Visible {
+    /// Whether the entity is currently drawn.
     pub is_visible: bool,
 }
 
@@ -17,6 +18,7 @@ impl Default for Visible {
 }
 
 impl Visible {
+    /// Creates a `Visible` component that hides the entity.
     pub fn hidden() -> Self {
         Self { is_visible: false }
     }

--- a/crates/bsengine-editor/src/lib.rs
+++ b/crates/bsengine-editor/src/lib.rs
@@ -12,7 +12,11 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
 
+/// Registers the editor's ECS systems, resources, and the `EditorCommand`/
+/// `ReflectCommand` processing loop into a Bevy `App`.
 pub mod plugin;
+/// The MCP-facing data model: `EditorSnapshot`, `EntityInfo`, `EditorCommand`,
+/// `ReflectCommand`, and the shared resources the editor bridge reads/writes.
 pub mod snapshot;
 
 pub use plugin::EditorPlugin;

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1491,6 +1491,9 @@ fn apply_inspector_cmds(
     }
 }
 
+/// Bevy `Plugin` that wires the editor bridge into an `App`: inserts the
+/// shared snapshot/command-queue/selection/history resources and registers
+/// the systems that process `EditorCommand`s and `ReflectCommand`s each frame.
 pub struct EditorPlugin;
 
 impl Plugin for EditorPlugin {

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -3,9 +3,12 @@ use bsengine_ecs::Resource;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
+/// Free-form string labels attached to an entity, set/cleared via
+/// `EditorCommand::TagEntity`/`UntagEntity` and used for selection/filtering.
 #[derive(Component, Clone, Default)]
 pub struct Tags(pub Vec<String>);
 
+/// Whether an entity is rendered; toggled via `EditorCommand::SetVisible`.
 #[derive(Component, Clone)]
 pub struct Visible(pub bool);
 
@@ -15,194 +18,350 @@ impl Default for Visible {
     }
 }
 
+/// Flattened, per-entity view of the ECS world used to build an
+/// `EditorSnapshot`; every field is `Option`/absent when the entity has no
+/// corresponding component, so the MCP layer can serialize it directly.
 #[derive(Clone, Default, Debug)]
 pub struct EntityInfo {
+    /// Entity id, as assigned by the ECS.
     pub id: u64,
+    /// Display name, if the entity has a `Name` component.
     pub name: Option<String>,
+    /// World-space translation, if the entity has a `Transform`.
     pub position: Option<[f32; 3]>,
+    /// Id of the attached mesh asset, if the entity has a `MeshRenderer`.
     pub mesh_id: Option<u64>,
+    /// Procedural primitive shape attached to the entity, if any.
     pub primitive: Option<bsengine_scene::Primitive>,
+    /// Path to the attached gameplay script, if the entity has one.
     pub script_path: Option<String>,
+    /// Euler rotation in degrees, if the entity has a `Transform`.
     pub rotation: Option<[f32; 3]>,
+    /// Per-axis scale, if the entity has a `Transform`.
     pub scale: Option<[f32; 3]>,
+    /// Kind of light attached (e.g. "point", "directional", "spot"), if any.
     pub light_type: Option<String>,
+    /// Light color, if the entity has a light component.
     pub light_color: Option<[f32; 3]>,
+    /// Light intensity, if the entity has a point or spot light.
     pub light_intensity: Option<f32>,
+    /// Light falloff range, if the entity has a point or spot light.
     pub light_range: Option<f32>,
+    /// Ambient color contribution, if the entity has a directional light.
     pub light_ambient: Option<[f32; 3]>,
+    /// Inner cone angle in degrees, if the entity has a spot light.
     pub spot_inner_angle: Option<f32>,
+    /// Outer cone angle in degrees, if the entity has a spot light.
     pub spot_outer_angle: Option<f32>,
+    /// Vertical field of view in degrees, if the entity has a `Camera`.
     pub camera_fov: Option<f32>,
+    /// PBR base color, if the entity has a `Material`.
     pub material_base_color: Option<[f32; 3]>,
+    /// PBR metallic factor, if the entity has a `Material`.
     pub material_metallic: Option<f32>,
+    /// PBR roughness factor, if the entity has a `Material`.
     pub material_roughness: Option<f32>,
+    /// Emissive color, if the entity has a `Material`.
     pub material_emissive: Option<[f32; 3]>,
+    /// Id of the parent entity, if this entity is attached to one.
     pub parent_id: Option<u64>,
+    /// Tags currently attached via `Tags`.
     pub tags: Vec<String>,
+    /// Whether the entity is currently rendered (mirrors `Visible`).
     pub visible: bool,
+    /// Whether the entity is in the editor's current selection set.
     pub selected: bool,
 }
 
+/// Full flattened capture of every tracked entity in the world, taken once
+/// per frame and read by the MCP layer/UI without needing ECS access.
 #[derive(Clone, Default)]
 pub struct EditorSnapshot {
+    /// Per-entity info captured this frame.
     pub entities: Vec<EntityInfo>,
 }
 
+/// Editor mutation commands, queued via `EditorCommandQueueResource` and
+/// drained/applied to the world once per frame by `process_editor_commands`.
 pub enum EditorCommand {
+    /// Spawn a new named, empty entity at the origin.
     SpawnNamed(String),
+    /// Set an entity's world-space translation.
     SetPosition {
+        /// Entity to move.
         entity_id: u64,
+        /// New X coordinate.
         x: f32,
+        /// New Y coordinate.
         y: f32,
+        /// New Z coordinate.
         z: f32,
     },
+    /// Remove an entity from the world entirely.
     Despawn {
+        /// Entity to despawn.
         entity_id: u64,
     },
+    /// Replace the current world contents with the scene at this path.
     LoadScene(String),
     /// Spawn a named entity with a `GltfAsset` component so the existing
     /// `bsengine-gltf` async loader picks it up. See
     /// `InspectorCmd::SpawnMeshAsset`'s doc comment for the full rationale.
     SpawnMeshAsset {
+        /// Name for the new entity.
         name: String,
+        /// Path to the glTF asset to load.
         path: String,
     },
+    /// Serialize the current scene to disk at this path.
     SaveScene {
+        /// Destination file path.
         path: String,
     },
+    /// Attach a `MeshRenderer` referencing an already-loaded mesh asset.
     AttachMeshRenderer {
+        /// Entity to attach the renderer to.
         entity_id: u64,
+        /// Id of the mesh asset to reference.
         mesh_id: u64,
     },
+    /// Remove an entity's `MeshRenderer`, if any.
     DetachMeshRenderer {
+        /// Entity to detach the renderer from.
         entity_id: u64,
     },
+    /// Spawn a new point light entity.
     SpawnPointLight {
+        /// Light color.
         color: [f32; 3],
+        /// Light intensity.
         intensity: f32,
+        /// Falloff range.
         range: f32,
+        /// World-space position to spawn at.
         position: [f32; 3],
     },
+    /// Spawn a new directional light entity.
     SpawnDirectionalLight {
+        /// Light direction vector.
         direction: [f32; 3],
+        /// Light color.
         color: [f32; 3],
+        /// Ambient color contribution.
         ambient: [f32; 3],
     },
+    /// Remove whichever light component is attached to an entity.
     RemoveLight {
+        /// Entity to remove the light from.
         entity_id: u64,
     },
+    /// Patch fields on an entity's existing `PointLight`; absent fields are
+    /// left unchanged.
     UpdatePointLight {
+        /// Entity whose point light to update.
         entity_id: u64,
+        /// New color, if changed.
         color: Option<[f32; 3]>,
+        /// New intensity, if changed.
         intensity: Option<f32>,
+        /// New falloff range, if changed.
         range: Option<f32>,
     },
+    /// Patch fields on an entity's existing `DirectionalLight`; absent
+    /// fields are left unchanged.
     UpdateDirectionalLight {
+        /// Entity whose directional light to update.
         entity_id: u64,
+        /// New direction, if changed.
         direction: Option<[f32; 3]>,
+        /// New color, if changed.
         color: Option<[f32; 3]>,
+        /// New ambient contribution, if changed.
         ambient: Option<[f32; 3]>,
     },
+    /// Set (or add) an entity's `Name` component.
     RenameEntity {
+        /// Entity to rename.
         entity_id: u64,
+        /// New display name.
         name: String,
     },
+    /// Despawn every entity in the world.
     ClearScene,
+    /// Toggle an entity's `Visible` component.
     SetVisible {
+        /// Entity to update.
         entity_id: u64,
+        /// New visibility state.
         visible: bool,
     },
+    /// Add a tag to an entity's `Tags` component.
     TagEntity {
+        /// Entity to tag.
         entity_id: u64,
+        /// Tag to add.
         tag: String,
     },
+    /// Remove a tag from an entity's `Tags` component.
     UntagEntity {
+        /// Entity to untag.
         entity_id: u64,
+        /// Tag to remove.
         tag: String,
     },
+    /// Attach an entity as a child of another entity.
     SetParent {
+        /// Child entity.
         entity_id: u64,
+        /// Entity to parent to.
         parent_id: u64,
     },
+    /// Detach an entity from its parent, if any.
     RemoveParent {
+        /// Entity to unparent.
         entity_id: u64,
     },
+    /// Set an entity's Euler rotation, in degrees.
     SetRotation {
+        /// Entity to rotate.
         entity_id: u64,
+        /// New rotation around X.
         rx: f32,
+        /// New rotation around Y.
         ry: f32,
+        /// New rotation around Z.
         rz: f32,
     },
+    /// Set an entity's per-axis scale.
     SetScale {
+        /// Entity to scale.
         entity_id: u64,
+        /// New scale on X.
         sx: f32,
+        /// New scale on Y.
         sy: f32,
+        /// New scale on Z.
         sz: f32,
     },
+    /// Patch an entity's `Transform`; absent fields are left unchanged.
     SetEntityTransform {
+        /// Entity to update.
         entity_id: u64,
+        /// New position, if changed.
         position: Option<[f32; 3]>,
+        /// New rotation, if changed.
         rotation: Option<[f32; 3]>,
+        /// New scale, if changed.
         scale: Option<[f32; 3]>,
     },
+    /// Offset an entity's position by a relative delta.
     MoveEntity {
+        /// Entity to move.
         entity_id: u64,
+        /// Delta along X.
         dx: f32,
+        /// Delta along Y.
         dy: f32,
+        /// Delta along Z.
         dz: f32,
     },
+    /// Clone an entity and all of its tracked components.
     DuplicateEntity {
+        /// Entity to duplicate.
         entity_id: u64,
     },
+    /// Spawn a new camera entity.
     SpawnCamera {
+        /// Vertical field of view, in degrees.
         fov_y_degrees: f32,
+        /// World-space position to spawn at.
         position: [f32; 3],
     },
+    /// Patch fields on an entity's existing `Camera`; absent fields are
+    /// left unchanged.
     UpdateCamera {
+        /// Entity whose camera to update.
         entity_id: u64,
+        /// New vertical field of view, if changed.
         fov_y_degrees: Option<f32>,
     },
+    /// Spawn multiple named entities in one batch, each with an optional
+    /// initial position.
     BatchSpawn {
+        /// `(name, position)` pairs to spawn.
         entries: Vec<(String, Option<[f32; 3]>)>,
     },
+    /// Spawn a new spot light entity.
     SpawnSpotLight {
+        /// Light color.
         color: [f32; 3],
+        /// Light intensity.
         intensity: f32,
+        /// Falloff range.
         range: f32,
+        /// Inner cone angle, in degrees.
         inner_angle: f32,
+        /// Outer cone angle, in degrees.
         outer_angle: f32,
+        /// World-space position to spawn at.
         position: [f32; 3],
     },
+    /// Patch fields on an entity's existing spot light; absent fields are
+    /// left unchanged.
     UpdateSpotLight {
+        /// Entity whose spot light to update.
         entity_id: u64,
+        /// New color, if changed.
         color: Option<[f32; 3]>,
+        /// New intensity, if changed.
         intensity: Option<f32>,
+        /// New falloff range, if changed.
         range: Option<f32>,
+        /// New inner cone angle, if changed.
         inner_angle: Option<f32>,
+        /// New outer cone angle, if changed.
         outer_angle: Option<f32>,
     },
+    /// Attach a point light component directly to an existing entity.
     AttachPointLight {
+        /// Entity to attach the light to.
         entity_id: u64,
+        /// Light color.
         color: [f32; 3],
+        /// Light intensity.
         intensity: f32,
+        /// Falloff range.
         range: f32,
     },
+    /// Attach a camera component directly to an existing entity.
     AttachCamera {
+        /// Entity to attach the camera to.
         entity_id: u64,
+        /// Vertical field of view, in degrees.
         fov_y_degrees: f32,
     },
+    /// Attach a gameplay script to an entity.
     AttachScript {
+        /// Entity to attach the script to.
         entity_id: u64,
+        /// Path to the script file.
         path: String,
     },
+    /// Remove an entity's attached gameplay script, if any.
     DetachScript {
+        /// Entity to detach the script from.
         entity_id: u64,
     },
+    /// Attach a procedural primitive mesh to an entity.
     AttachPrimitiveMesh {
+        /// Entity to attach the primitive to.
         entity_id: u64,
+        /// Primitive shape to attach.
         primitive: bsengine_scene::Primitive,
     },
+    /// Remove an entity's attached primitive mesh, if any.
     DetachPrimitiveMesh {
+        /// Entity to detach the primitive from.
         entity_id: u64,
     },
 }
@@ -213,7 +372,9 @@ pub enum EditorCommand {
 /// replaying inverse commands.
 #[derive(Default)]
 pub struct EditorHistory {
+    /// Snapshots to restore on undo, most recent last.
     pub undo_stack: Vec<EditorSnapshot>,
+    /// Snapshots to restore on redo, most recent last.
     pub redo_stack: Vec<EditorSnapshot>,
 }
 
@@ -223,12 +384,20 @@ pub struct EditorHistory {
 /// because `ReflectComponent::insert`/`remove` need `&mut EntityWorldMut`,
 /// which `process_editor_commands`'s typed system params can't provide.
 pub enum ReflectCommand {
+    /// Attach a default-constructed instance of the named type as a
+    /// component, via `ReflectComponent::insert`.
     AttachComponentByType {
+        /// Entity to attach the component to.
         entity_id: u64,
+        /// Fully-qualified reflected type path to attach.
         type_path: String,
     },
+    /// Remove the named component type from an entity, via
+    /// `ReflectComponent::remove`.
     RemoveComponentByType {
+        /// Entity to remove the component from.
         entity_id: u64,
+        /// Fully-qualified reflected type path to remove.
         type_path: String,
     },
     /// Apply an edited reflected value onto an already-attached component.
@@ -238,30 +407,50 @@ pub enum ReflectCommand {
     /// here — this command only ever originates from editing an
     /// already-cloned, already-attached component's fields).
     ApplyComponentValue {
+        /// Entity whose component to update.
         entity_id: u64,
+        /// Fully-qualified reflected type path of the component.
         type_path: String,
+        /// Edited reflected value to apply onto the component.
         value: Box<dyn bevy_reflect::Reflect>,
     },
 }
 
+/// Shared handle to the current frame's `EditorSnapshot`, read by the MCP
+/// layer and written once per frame by the editor's snapshot system.
 pub type SharedSnapshot = Arc<Mutex<EditorSnapshot>>;
+/// Shared handle to the pending `EditorCommand` queue, pushed to by the MCP
+/// layer/UI and drained each frame by `process_editor_commands`.
 pub type SharedCommandQueue = Arc<Mutex<Vec<EditorCommand>>>;
+/// Shared handle to the pending `ReflectCommand` queue, drained each frame
+/// by `process_reflect_commands`.
 pub type SharedReflectCommandQueue = Arc<Mutex<Vec<ReflectCommand>>>;
+/// Shared handle to the set of currently-selected entity ids.
 pub type SharedSelection = Arc<Mutex<HashSet<u64>>>;
+/// Shared handle to the undo/redo checkpoint stacks.
 pub type SharedHistory = Arc<Mutex<EditorHistory>>;
 
+/// Bevy resource exposing the shared snapshot to systems inside the `App`.
 #[derive(Resource)]
 pub struct EditorSnapshotResource(pub SharedSnapshot);
 
+/// Bevy resource exposing the shared `EditorCommand` queue to systems
+/// inside the `App`.
 #[derive(Resource)]
 pub struct EditorCommandQueueResource(pub SharedCommandQueue);
 
+/// Bevy resource exposing the shared `ReflectCommand` queue to systems
+/// inside the `App`.
 #[derive(Resource)]
 pub struct ReflectCommandQueueResource(pub SharedReflectCommandQueue);
 
+/// Bevy resource exposing the shared selection set to systems inside the
+/// `App`.
 #[derive(Resource)]
 pub struct EditorSelectionResource(pub SharedSelection);
 
+/// Bevy resource exposing the shared undo/redo history to systems inside
+/// the `App`.
 #[derive(Resource)]
 pub struct EditorHistoryResource(pub SharedHistory);
 

--- a/crates/bsengine-gltf/src/animation.rs
+++ b/crates/bsengine-gltf/src/animation.rs
@@ -1,8 +1,11 @@
 /// How keyframe values are interpolated between keyframe times.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Interpolation {
+    /// Straight-line interpolation between adjacent keyframes.
     Linear,
+    /// Hold the previous keyframe's value until the next keyframe time.
     Step,
+    /// Cubic Hermite spline interpolation using in/out tangents.
     CubicSpline,
 }
 
@@ -12,8 +15,11 @@ pub enum Interpolation {
 /// Rotations are `[x, y, z, w]` (quaternion).
 #[derive(Debug, Clone)]
 pub enum KeyframeValues {
+    /// Per-keyframe translation vectors.
     Translations(Vec<[f32; 3]>),
+    /// Per-keyframe rotation quaternions.
     Rotations(Vec<[f32; 4]>),
+    /// Per-keyframe scale vectors.
     Scales(Vec<[f32; 3]>),
 }
 
@@ -24,14 +30,18 @@ pub struct AnimationChannel {
     pub node_index: usize,
     /// Keyframe timestamps in seconds.
     pub times: Vec<f32>,
+    /// The animated values, one per keyframe time.
     pub values: KeyframeValues,
+    /// How to interpolate between the keyframe values.
     pub interpolation: Interpolation,
 }
 
 /// A named sequence of animation channels loaded from a GLTF file.
 #[derive(Debug, Clone)]
 pub struct AnimationClip {
+    /// The clip's name, as given in the GLTF file (or a fallback if unnamed).
     pub name: String,
+    /// The animated channels that make up this clip.
     pub channels: Vec<AnimationChannel>,
     /// Duration in seconds (= time of the last keyframe across all channels).
     pub duration: f32,

--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -6,8 +6,11 @@
 //! `GltfAsset` is the resulting ECS-facing handle.
 #![warn(missing_docs)]
 
+/// Animation clip/channel/interpolation types for skeletal animation data.
 pub mod animation;
+/// GLTF/GLB file parsing into mesh, image, and animation data.
 pub mod loader;
+/// The Bevy plugin that spawns loaded GLTF assets into the ECS world.
 pub mod plugin;
 
 pub use animation::{AnimationChannel, AnimationClip, Interpolation, KeyframeValues};

--- a/crates/bsengine-gltf/src/loader.rs
+++ b/crates/bsengine-gltf/src/loader.rs
@@ -3,32 +3,51 @@ use gltf::image::Format as GltfFormat;
 
 use crate::animation::{AnimationChannel, AnimationClip, Interpolation, KeyframeValues};
 
+/// A single mesh primitive extracted from a GLTF file, ready for GPU upload.
 pub struct MeshData {
+    /// The mesh's name, as given in the GLTF file (or a fallback if unnamed).
     pub name: String,
+    /// Vertex buffer data (position, color, normal, uv).
     pub vertices: Vec<Vertex>,
+    /// Index buffer data, referencing into `vertices`.
     pub indices: Vec<u32>,
 }
 
+/// A decoded texture image, converted to raw RGBA8 pixel data.
 pub struct GltfImageData {
+    /// Image width in pixels.
     pub width: u32,
+    /// Image height in pixels.
     pub height: u32,
+    /// Raw pixel data in RGBA8 order, `width * height * 4` bytes.
     pub rgba: Vec<u8>,
 }
 
+/// The full result of loading a GLTF/GLB file: meshes, images, and animations.
 pub struct LoadedGltf {
+    /// All mesh primitives found in the file, in document order.
     pub meshes: Vec<MeshData>,
+    /// All decoded images found in the file, in document order.
     pub images: Vec<GltfImageData>,
+    /// For each entry in `meshes`, the index into `images` of its base color
+    /// texture, if any.
     pub mesh_tex_indices: Vec<Option<usize>>,
+    /// All animation clips found in the file.
     pub animations: Vec<AnimationClip>,
 }
 
+/// Loads GLTF/GLB files from disk into engine-native mesh and animation data.
 pub struct GltfLoader;
 
 impl GltfLoader {
+    /// Loads a GLTF/GLB file and returns just its meshes, discarding images
+    /// and animations.
     pub fn load(path: &str) -> Result<Vec<MeshData>, String> {
         Ok(Self::load_full(path)?.meshes)
     }
 
+    /// Loads a GLTF/GLB file, parsing its meshes, textures, and animations
+    /// into engine-native data.
     pub fn load_full(path: &str) -> Result<LoadedGltf, String> {
         let (doc, buffers, raw_images) = gltf::import(path).map_err(|e| format!("gltf: {e}"))?;
 

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -7,17 +7,22 @@ use tracing::warn;
 
 use crate::loader::GltfLoader;
 
+/// Marker component requesting that a GLTF/GLB file be loaded onto this
+/// entity; replaced by `MeshRenderer`/`Material` once loading completes.
 #[derive(Component, Clone, Debug)]
 pub struct GltfAsset {
+    /// Filesystem path to the GLTF/GLB file to load.
     pub path: String,
 }
 
 impl GltfAsset {
+    /// Creates a new `GltfAsset` pointing at the given file path.
     pub fn new(path: impl Into<String>) -> Self {
         Self { path: path.into() }
     }
 }
 
+/// Bevy plugin that loads `GltfAsset` entities into renderable meshes each frame.
 pub struct GltfPlugin;
 
 impl Plugin for GltfPlugin {

--- a/crates/bsengine-input/src/convert.rs
+++ b/crates/bsengine-input/src/convert.rs
@@ -2,6 +2,8 @@ use crate::types::{ElementState, KeyCode};
 use winit::event::ElementState as WinitState;
 use winit::keyboard::{KeyCode as WinitKeyCode, PhysicalKey};
 
+/// Maps a winit physical key code to BSEngine's `KeyCode`, returning `KeyCode::Unknown`
+/// for unmapped or unidentified keys.
 pub fn convert_key_code(key: PhysicalKey) -> KeyCode {
     match key {
         PhysicalKey::Code(code) => match code {
@@ -69,6 +71,7 @@ pub fn convert_key_code(key: PhysicalKey) -> KeyCode {
     }
 }
 
+/// Maps a winit `ElementState` (pressed/released) to BSEngine's own `ElementState`.
 pub fn convert_element_state(state: WinitState) -> ElementState {
     match state {
         WinitState::Pressed => ElementState::Pressed,

--- a/crates/bsengine-input/src/lib.rs
+++ b/crates/bsengine-input/src/lib.rs
@@ -6,9 +6,13 @@
 //! ECS resources.
 #![warn(missing_docs)]
 
+/// Translates platform (winit/gilrs) input events into BSEngine's own input types.
 pub mod convert;
+/// The `InputPlugin` bevy plugin and the per-frame `MouseState` resource.
 pub mod plugin;
+/// The generic `Input<T>` press/release tracking resource.
 pub mod state;
+/// Input event and resource type definitions (keys, buttons, cursor, gamepad).
 pub mod types;
 
 pub use plugin::{InputPlugin, MouseState};

--- a/crates/bsengine-input/src/plugin.rs
+++ b/crates/bsengine-input/src/plugin.rs
@@ -10,6 +10,7 @@ use crate::{
     },
 };
 
+/// Non-send ECS resource wrapping the `gilrs` gamepad context, so it can be polled each frame.
 pub struct GilrsResource(gilrs::Gilrs);
 
 /// Per-frame mouse position, raw movement delta, and scroll wheel delta.
@@ -18,11 +19,15 @@ pub struct GilrsResource(gilrs::Gilrs);
 /// `scroll_delta` accumulates scroll wheel input for the current frame and resets each frame.
 #[derive(Resource, Default, Clone)]
 pub struct MouseState {
+    /// Last known cursor position in window pixels, top-left origin.
     pub position: (f64, f64),
+    /// Raw mouse movement accumulated this frame; reset to zero every frame.
     pub delta: (f64, f64),
+    /// Scroll wheel delta accumulated this frame; reset to zero every frame.
     pub scroll_delta: f64,
 }
 
+/// Bevy plugin that wires up keyboard, mouse, and gamepad polling as `PreUpdate` systems.
 pub struct InputPlugin;
 
 impl Plugin for InputPlugin {

--- a/crates/bsengine-input/src/state.rs
+++ b/crates/bsengine-input/src/state.rs
@@ -25,14 +25,17 @@ impl<T: Eq + Hash> Default for Input<T> {
 }
 
 impl<T: Eq + Hash + Clone> Input<T> {
+    /// Returns `true` if `key` is currently held down.
     pub fn is_pressed(&self, key: &T) -> bool {
         self.pressed.contains(key)
     }
 
+    /// Returns `true` if `key` transitioned to pressed on this frame.
     pub fn just_pressed(&self, key: &T) -> bool {
         self.just_pressed.contains(key)
     }
 
+    /// Returns `true` if `key` transitioned to released on this frame.
     pub fn just_released(&self, key: &T) -> bool {
         self.just_released.contains(key)
     }

--- a/crates/bsengine-input/src/types.rs
+++ b/crates/bsengine-input/src/types.rs
@@ -1,78 +1,144 @@
 use bevy_ecs::prelude::Resource;
 use bsengine_ecs::Event;
 
+/// Platform-independent physical keyboard key, translated from winit key codes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum KeyCode {
+    /// The "A" key.
     A,
+    /// The "B" key.
     B,
+    /// The "C" key.
     C,
+    /// The "D" key.
     D,
+    /// The "E" key.
     E,
+    /// The "F" key.
     F,
+    /// The "G" key.
     G,
+    /// The "H" key.
     H,
+    /// The "I" key.
     I,
+    /// The "J" key.
     J,
+    /// The "K" key.
     K,
+    /// The "L" key.
     L,
+    /// The "M" key.
     M,
+    /// The "N" key.
     N,
+    /// The "O" key.
     O,
+    /// The "P" key.
     P,
+    /// The "Q" key.
     Q,
+    /// The "R" key.
     R,
+    /// The "S" key.
     S,
+    /// The "T" key.
     T,
+    /// The "U" key.
     U,
+    /// The "V" key.
     V,
+    /// The "W" key.
     W,
+    /// The "X" key.
     X,
+    /// The "Y" key.
     Y,
+    /// The "Z" key.
     Z,
+    /// The spacebar.
     Space,
+    /// The Enter/Return key.
     Enter,
+    /// The Escape key.
     Escape,
+    /// The Backspace key.
     Backspace,
+    /// The Tab key.
     Tab,
+    /// The left arrow key.
     Left,
+    /// The right arrow key.
     Right,
+    /// The up arrow key.
     Up,
+    /// The down arrow key.
     Down,
+    /// The "0" digit key.
     Key0,
+    /// The "1" digit key.
     Key1,
+    /// The "2" digit key.
     Key2,
+    /// The "3" digit key.
     Key3,
+    /// The "4" digit key.
     Key4,
+    /// The "5" digit key.
     Key5,
+    /// The "6" digit key.
     Key6,
+    /// The "7" digit key.
     Key7,
+    /// The "8" digit key.
     Key8,
+    /// The "9" digit key.
     Key9,
+    /// The Delete key.
     Delete,
+    /// The "-" (minus/hyphen) key.
     Minus,
+    /// The "=" (equals) key.
     Equals,
+    /// The "." (period) key.
     Period,
+    /// The "," (comma) key.
     Comma,
+    /// The Home key.
     Home,
+    /// The End key.
     End,
+    /// The left Control key.
     ControlLeft,
+    /// The right Control key.
     ControlRight,
+    /// The left Shift key.
     ShiftLeft,
+    /// The right Shift key.
     ShiftRight,
+    /// The left Alt key.
     AltLeft,
+    /// The right Alt key.
     AltRight,
+    /// A key that could not be mapped to a known `KeyCode` variant.
     Unknown,
 }
 
+/// Press/release state shared by keyboard and mouse button events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ElementState {
+    /// The key or button was pressed down.
     Pressed,
+    /// The key or button was released.
     Released,
 }
 
+/// Event fired when a keyboard key changes state (pressed or released).
 #[derive(Event, Debug, Clone)]
 pub struct KeyInput {
+    /// The physical key that changed state.
     pub key_code: KeyCode,
+    /// Whether the key was pressed or released.
     pub state: ElementState,
     /// Text produced by this key press, accounting for shift/keyboard layout
     /// (e.g. "1", ".", "-"), as reported by the OS/windowing layer. `None`
@@ -81,23 +147,34 @@ pub struct KeyInput {
     pub text: Option<String>,
 }
 
+/// A mouse button, as reported by the platform windowing layer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MouseButton {
+    /// The primary (left) mouse button.
     Left,
+    /// The secondary (right) mouse button.
     Right,
+    /// The middle mouse button (often the scroll wheel click).
     Middle,
+    /// Any other mouse button, identified by its platform-reported index.
     Other(u16),
 }
 
+/// Event fired when a mouse button changes state (pressed or released).
 #[derive(Event, Debug, Clone)]
 pub struct MouseInput {
+    /// The mouse button that changed state.
     pub button: MouseButton,
+    /// Whether the button was pressed or released.
     pub state: ElementState,
 }
 
+/// Event fired with the cursor's absolute position whenever it moves within the window.
 #[derive(Event, Debug, Clone)]
 pub struct CursorMoved {
+    /// Cursor x position in window pixels, measured from the left edge.
     pub x: f64,
+    /// Cursor y position in window pixels, measured from the top edge.
     pub y: f64,
 }
 
@@ -106,7 +183,9 @@ pub struct CursorMoved {
 /// Use this for FPS-style camera rotation.
 #[derive(Event, Debug, Clone)]
 pub struct MouseMotion {
+    /// Raw horizontal movement delta since the last frame, in device units.
     pub dx: f64,
+    /// Raw vertical movement delta since the last frame, in device units.
     pub dy: f64,
 }
 
@@ -115,36 +194,57 @@ pub struct MouseMotion {
 /// Line deltas are passed as-is; pixel deltas are normalised by 40 px/line.
 #[derive(Event, Debug, Clone)]
 pub struct MouseWheel {
+    /// Scroll amount for this event; positive scrolls up/zooms in, negative scrolls down/zooms out.
     pub delta: f64,
 }
 
 /// Gamepad face and shoulder buttons. Bit indices match the scripting API (0=South..15=DPadRight).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GamepadButton {
-    South,      // 0: A / Cross
-    East,       // 1: B / Circle
-    West,       // 2: X / Square
-    North,      // 3: Y / Triangle
-    LB,         // 4: L1 / LeftBumper
-    RB,         // 5: R1 / RightBumper
-    LT,         // 6: L2 / LeftTrigger (digital)
-    RT,         // 7: R2 / RightTrigger (digital)
-    Select,     // 8
-    Start,      // 9
-    LeftStick,  // 10: L3
+    /// Bit 0: bottom face button (A / Cross).
+    South, // 0: A / Cross
+    /// Bit 1: right face button (B / Circle).
+    East, // 1: B / Circle
+    /// Bit 2: left face button (X / Square).
+    West, // 2: X / Square
+    /// Bit 3: top face button (Y / Triangle).
+    North, // 3: Y / Triangle
+    /// Bit 4: left shoulder bumper (L1 / LeftBumper).
+    LB, // 4: L1 / LeftBumper
+    /// Bit 5: right shoulder bumper (R1 / RightBumper).
+    RB, // 5: R1 / RightBumper
+    /// Bit 6: left shoulder trigger, digital press (L2 / LeftTrigger).
+    LT, // 6: L2 / LeftTrigger (digital)
+    /// Bit 7: right shoulder trigger, digital press (R2 / RightTrigger).
+    RT, // 7: R2 / RightTrigger (digital)
+    /// Bit 8: select/back button.
+    Select, // 8
+    /// Bit 9: start/menu button.
+    Start, // 9
+    /// Bit 10: left stick click (L3).
+    LeftStick, // 10: L3
+    /// Bit 11: right stick click (R3).
     RightStick, // 11: R3
-    DPadUp,     // 12
-    DPadDown,   // 13
-    DPadLeft,   // 14
-    DPadRight,  // 15
+    /// Bit 12: D-pad up.
+    DPadUp, // 12
+    /// Bit 13: D-pad down.
+    DPadDown, // 13
+    /// Bit 14: D-pad left.
+    DPadLeft, // 14
+    /// Bit 15: D-pad right.
+    DPadRight, // 15
 }
 
 /// Analog stick and trigger values from the first connected gamepad.
 #[derive(Resource, Default, Clone)]
 pub struct GamepadSticks {
+    /// Left analog stick axes as `(x, y)`, each in the range -1.0..=1.0.
     pub left: (f32, f32),
+    /// Right analog stick axes as `(x, y)`, each in the range -1.0..=1.0.
     pub right: (f32, f32),
+    /// Left analog trigger pressure, in the range 0.0..=1.0.
     pub left_trigger: f32,
+    /// Right analog trigger pressure, in the range 0.0..=1.0.
     pub right_trigger: f32,
 }
 

--- a/crates/bsengine-mcp/src/game_tools.rs
+++ b/crates/bsengine-mcp/src/game_tools.rs
@@ -111,6 +111,8 @@ Notes:
 - Each entity's script is isolated — multiple entities can each have their own script
 - path is relative to game root (e.g. "assets/scripts/player.js")"#;
 
+/// Builds the `game_create`/`scene_write`/`script_write`/`game_validate` tools,
+/// each scoped to game projects under `root/games/`.
 pub fn game_tools(root: PathBuf) -> Vec<McpTool> {
     let r1 = root.clone();
     let r2 = root.clone();

--- a/crates/bsengine-mcp/src/lib.rs
+++ b/crates/bsengine-mcp/src/lib.rs
@@ -7,12 +7,17 @@
 //! here rather than reimplementing a protocol server itself.
 #![warn(missing_docs)]
 
+/// MCP tools for scaffolding, writing, and validating BSEngine game projects.
 pub mod game_tools;
+/// Wires `McpToolRegistry` into a Bevy `App` as an `McpPlugin`.
 pub mod plugin;
+/// Stores and dispatches the set of `McpTool`s available to a server.
 pub mod registry;
+/// JSON-RPC server loop that exposes registered tools over stdio.
 pub mod server;
 pub mod session;
 pub mod test_tools;
+/// Core `McpTool`/`McpToolOutput` types shared by every tool implementation.
 pub mod tool;
 pub use game_tools::game_tools;
 pub use plugin::{McpPlugin, McpRegistryResource};

--- a/crates/bsengine-mcp/src/plugin.rs
+++ b/crates/bsengine-mcp/src/plugin.rs
@@ -5,9 +5,13 @@ use bsengine_ecs::Resource;
 use serde_json::json;
 use std::sync::{Arc, Mutex};
 
+/// ECS resource wrapping the shared `McpToolRegistry`, giving systems access
+/// to the tools registered by `McpPlugin`.
 #[derive(Resource, Clone)]
 pub struct McpRegistryResource(pub Arc<Mutex<McpToolRegistry>>);
 
+/// Bevy plugin that builds an `McpToolRegistry` with the built-in engine
+/// tools and inserts it into the `App` as an `McpRegistryResource`.
 pub struct McpPlugin;
 
 impl Plugin for McpPlugin {

--- a/crates/bsengine-mcp/src/registry.rs
+++ b/crates/bsengine-mcp/src/registry.rs
@@ -2,25 +2,32 @@ use crate::tool::{McpTool, McpToolOutput};
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// Holds `McpTool`s keyed by name and dispatches calls to them by name.
 pub struct McpToolRegistry {
     tools: HashMap<String, McpTool>,
 }
 
 impl McpToolRegistry {
+    /// Creates an empty registry with no tools registered.
     pub fn new() -> Self {
         Self {
             tools: HashMap::new(),
         }
     }
 
+    /// Adds a tool to the registry, replacing any existing tool with the same name.
     pub fn register(&mut self, tool: McpTool) {
         self.tools.insert(tool.name.clone(), tool);
     }
 
+    /// Returns all currently registered tools, in arbitrary order.
     pub fn list_tools(&self) -> Vec<&McpTool> {
         self.tools.values().collect()
     }
 
+    /// Looks up the tool by name and runs its handler on `input`.
+    ///
+    /// Returns `Err` if no tool with that name is registered.
     pub fn execute(&self, name: &str, input: Value) -> Result<McpToolOutput, String> {
         let tool = self
             .tools

--- a/crates/bsengine-mcp/src/server.rs
+++ b/crates/bsengine-mcp/src/server.rs
@@ -3,11 +3,14 @@ use serde_json::{json, Value};
 use std::io::{BufRead, Write};
 use std::sync::{Arc, Mutex};
 
+/// JSON-RPC 2.0 MCP server that dispatches `initialize`/`tools/list`/`tools/call`
+/// requests against a shared `McpToolRegistry`.
 pub struct McpServer {
     registry: Arc<Mutex<McpToolRegistry>>,
 }
 
 impl McpServer {
+    /// Creates a server that serves the tools in the given registry.
     pub fn new(registry: Arc<Mutex<McpToolRegistry>>) -> Self {
         Self { registry }
     }
@@ -44,6 +47,9 @@ impl McpServer {
         }))
     }
 
+    /// Reads newline-delimited JSON-RPC requests from stdin, dispatches each
+    /// through `handle_message`, and writes any response to stdout. Runs
+    /// until stdin is closed.
     pub fn run_stdio(&self) {
         let stdin = std::io::stdin();
         let mut stdout = std::io::stdout();

--- a/crates/bsengine-mcp/src/session.rs
+++ b/crates/bsengine-mcp/src/session.rs
@@ -37,6 +37,8 @@ pub struct SessionRegistry {
 }
 
 impl SessionRegistry {
+    /// Creates a registry with no active sessions, using `runtime_bin` to
+    /// spawn `bsengine-runtime` and resolving game paths under `games_root`.
     pub fn new(runtime_bin: PathBuf, games_root: PathBuf) -> Self {
         Self {
             runtime_bin,

--- a/crates/bsengine-mcp/src/tool.rs
+++ b/crates/bsengine-mcp/src/tool.rs
@@ -1,12 +1,17 @@
 use serde_json::Value;
 
+/// Result of running an `McpTool`'s handler: either success content or an
+/// error message, never both.
 #[derive(Debug)]
 pub struct McpToolOutput {
+    /// The tool's return value on success (`Value::Null` on error).
     pub content: Value,
+    /// The failure message, present only when the tool call failed.
     pub error: Option<String>,
 }
 
 impl McpToolOutput {
+    /// Builds a successful output wrapping the given content.
     pub fn success(content: Value) -> Self {
         Self {
             content,
@@ -14,6 +19,7 @@ impl McpToolOutput {
         }
     }
 
+    /// Builds a failed output carrying the given error message.
     pub fn error(msg: &str) -> Self {
         Self {
             content: Value::Null,
@@ -21,15 +27,22 @@ impl McpToolOutput {
         }
     }
 
+    /// Returns true if the tool call succeeded (no error message set).
     pub fn is_ok(&self) -> bool {
         self.error.is_none()
     }
 }
 
+/// A single MCP tool: its name/description/input schema for discovery, plus
+/// the handler that executes it.
 pub struct McpTool {
+    /// Unique tool name, used to look it up and to invoke it via `tools/call`.
     pub name: String,
+    /// Human-readable description shown to MCP clients via `tools/list`.
     pub description: String,
+    /// JSON Schema describing the handler's expected input, if any.
     pub input_schema: Option<Value>,
+    /// The function invoked with the call's input to produce an `McpToolOutput`.
     pub handler: Box<dyn Fn(Value) -> McpToolOutput + Send + Sync>,
 }
 

--- a/crates/bsengine-network/src/plugin.rs
+++ b/crates/bsengine-network/src/plugin.rs
@@ -10,6 +10,7 @@ use crate::{
     session::{NetworkRole, NetworkSession},
 };
 
+/// Bevy plugin that wires up the UDP send/receive systems for entity transform replication.
 pub struct NetworkPlugin;
 
 impl Plugin for NetworkPlugin {

--- a/crates/bsengine-network/src/session.rs
+++ b/crates/bsengine-network/src/session.rs
@@ -4,14 +4,21 @@ use std::net::{SocketAddr, UdpSocket};
 /// Whether this process acts as a server or client.
 #[derive(Debug)]
 pub enum NetworkRole {
+    /// Authoritative host: accepts client connections and broadcasts entity state.
     Server,
-    Client { server_addr: SocketAddr },
+    /// Connects to a remote server and sends only its own client-authoritative transforms.
+    Client {
+        /// Address of the server this client is connected (or connecting) to.
+        server_addr: SocketAddr,
+    },
 }
 
 /// Live network session — inserted as a Bevy Resource when networking is active.
 #[derive(Resource)]
 pub struct NetworkSession {
+    /// Whether this session is acting as the server or as a client.
     pub role: NetworkRole,
+    /// Non-blocking UDP socket used for all send/receive traffic.
     pub socket: UdpSocket,
     /// Server: list of connected client addresses. Client: [server_addr].
     pub peers: Vec<SocketAddr>,
@@ -24,6 +31,7 @@ pub struct NetworkSession {
 }
 
 impl NetworkSession {
+    /// Binds a non-blocking UDP socket on all interfaces at `port` and starts a server session.
     pub fn new_server(port: u16) -> Result<Self, std::io::Error> {
         let socket = UdpSocket::bind(format!("0.0.0.0:{port}"))?;
         socket.set_nonblocking(true)?;
@@ -38,6 +46,7 @@ impl NetworkSession {
         })
     }
 
+    /// Binds an ephemeral local UDP socket, sends a HELLO to `host:port`, and starts a client session.
     pub fn new_client(host: &str, port: u16) -> Result<Self, std::io::Error> {
         let server_addr: SocketAddr = format!("{host}:{port}").parse().map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid server address")
@@ -56,10 +65,12 @@ impl NetworkSession {
         })
     }
 
+    /// Returns true if this session is acting as the server.
     pub fn is_server(&self) -> bool {
         matches!(self.role, NetworkRole::Server)
     }
 
+    /// Number of known peers (connected clients for a server, or the server itself for a client).
     pub fn peer_count(&self) -> u32 {
         self.peers.len() as u32
     }

--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -2,28 +2,41 @@ use bevy_ecs::prelude::{Component, Entity, Event};
 use glam::{Quat, Vec3};
 use rapier3d::prelude::{ColliderHandle, RigidBodyHandle};
 
+/// Fired when two colliders start or stop touching; `started` distinguishes the two cases.
 #[derive(Event, Debug, Clone, Copy)]
 pub struct CollisionEvent {
+    /// The first entity in the contact pair.
     pub entity_a: Entity,
+    /// The second entity in the contact pair.
     pub entity_b: Entity,
+    /// `true` when contact began this step, `false` when it ended.
     pub started: bool,
 }
 
+/// How a `RigidBody` is simulated: affected by forces, fixed in place, or driven by code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RigidBodyType {
+    /// Moved by forces, impulses, and gravity.
     Dynamic,
+    /// Immovable; never affected by forces or collisions.
     Static,
+    /// Moved only by explicitly setting its position (e.g. via `PhysicsInput`); ignores forces.
     KinematicPosition,
 }
 
+/// ECS component marking an entity as a physics body; paired with a `Collider` for shape/material.
 #[derive(Component, Debug, Clone)]
 pub struct RigidBody {
+    /// Whether the body is dynamic, static, or kinematic.
     pub body_type: RigidBodyType,
+    /// Damping applied to linear velocity each step, slowing translation over time.
     pub linear_damping: f32,
+    /// Damping applied to angular velocity each step, slowing rotation over time.
     pub angular_damping: f32,
 }
 
 impl RigidBody {
+    /// Creates a dynamic body with no damping, free to move under forces and gravity.
     pub fn dynamic() -> Self {
         Self {
             body_type: RigidBodyType::Dynamic,
@@ -32,6 +45,7 @@ impl RigidBody {
         }
     }
 
+    /// Creates a static body that never moves, e.g. for ground or walls.
     pub fn fixed() -> Self {
         Self {
             body_type: RigidBodyType::Static,
@@ -40,6 +54,7 @@ impl RigidBody {
         }
     }
 
+    /// Creates a kinematic body driven by explicit position updates rather than physics forces.
     pub fn kinematic() -> Self {
         Self {
             body_type: RigidBodyType::KinematicPosition,
@@ -49,23 +64,45 @@ impl RigidBody {
     }
 }
 
+/// The geometric shape a `Collider` uses for contact and raycast queries.
 #[derive(Debug, Clone)]
 pub enum ColliderShape {
-    Box { half_extents: Vec3 },
-    Sphere { radius: f32 },
-    Capsule { half_height: f32, radius: f32 },
+    /// An axis-aligned box, defined by its half-extents along each axis.
+    Box {
+        /// Half the box's size along each axis (x, y, z).
+        half_extents: Vec3,
+    },
+    /// A sphere, defined by its radius.
+    Sphere {
+        /// The sphere's radius.
+        radius: f32,
+    },
+    /// A capsule (cylinder with rounded caps) aligned along the Y axis.
+    Capsule {
+        /// Half the height of the capsule's cylindrical body, excluding the rounded caps.
+        half_height: f32,
+        /// The radius of the capsule's rounded caps and cylindrical body.
+        radius: f32,
+    },
 }
 
+/// ECS component describing the physical shape and surface material of a `RigidBody`.
 #[derive(Component, Debug, Clone)]
 pub struct Collider {
+    /// The collider's geometric shape.
     pub shape: ColliderShape,
+    /// Bounciness of collisions; 0 absorbs all energy, 1 is a perfectly elastic bounce.
     pub restitution: f32,
+    /// Surface friction coefficient used when resolving contacts.
     pub friction: f32,
+    /// Mass per unit volume, used with the shape's volume to compute the body's mass.
     pub density: f32,
+    /// When `true`, the collider detects overlaps but generates no physical response.
     pub sensor: bool,
 }
 
 impl Collider {
+    /// Creates a box collider with the given half-extents and default material properties.
     pub fn cuboid(hx: f32, hy: f32, hz: f32) -> Self {
         Self {
             shape: ColliderShape::Box {
@@ -78,6 +115,7 @@ impl Collider {
         }
     }
 
+    /// Creates a sphere collider with the given radius and default material properties.
     pub fn ball(radius: f32) -> Self {
         Self {
             shape: ColliderShape::Sphere { radius },
@@ -88,6 +126,7 @@ impl Collider {
         }
     }
 
+    /// Creates a capsule collider with the given half-height and radius and default material properties.
     pub fn capsule(half_height: f32, radius: f32) -> Self {
         Self {
             shape: ColliderShape::Capsule {
@@ -101,16 +140,19 @@ impl Collider {
         }
     }
 
+    /// Sets the restitution (bounciness) and returns `self` for chaining.
     pub fn with_restitution(mut self, restitution: f32) -> Self {
         self.restitution = restitution;
         self
     }
 
+    /// Sets the friction coefficient and returns `self` for chaining.
     pub fn with_friction(mut self, friction: f32) -> Self {
         self.friction = friction;
         self
     }
 
+    /// Sets whether this collider is a sensor (no physical response) and returns `self` for chaining.
     pub fn with_sensor(mut self, sensor: bool) -> Self {
         self.sensor = sensor;
         self
@@ -120,23 +162,31 @@ impl Collider {
 /// Result of a raycast query.
 #[derive(Debug, Clone)]
 pub struct RaycastHit {
+    /// The entity whose collider was hit, if the hit collider maps to a known entity.
     pub entity: Option<Entity>,
+    /// The world-space point where the ray hit the collider.
     pub point: Vec3,
+    /// The surface normal at the hit point.
     pub normal: Vec3,
+    /// The distance from the ray origin to the hit point.
     pub distance: f32,
 }
 
 /// Written by the physics system after each step — read this to get simulated position/rotation.
 #[derive(Component, Debug, Clone, Default)]
 pub struct PhysicsTransform {
+    /// The body's simulated world-space position.
     pub translation: Vec3,
+    /// The body's simulated world-space rotation.
     pub rotation: Quat,
 }
 
 /// Input transform for the physics system — set this to teleport or drive kinematic bodies.
 #[derive(Component, Debug, Clone)]
 pub struct PhysicsInput {
+    /// The position to spawn at, or to drive a kinematic body toward.
     pub translation: Vec3,
+    /// The rotation to spawn at, or to drive a kinematic body toward.
     pub rotation: Quat,
 }
 

--- a/crates/bsengine-physics/src/lib.rs
+++ b/crates/bsengine-physics/src/lib.rs
@@ -7,8 +7,11 @@
 //! `Transform` component.
 #![warn(missing_docs)]
 
+/// ECS components exchanged between the engine and the physics simulation.
 pub mod components;
+/// The Bevy plugin that drives spawning, stepping, and syncing physics bodies.
 pub mod plugin;
+/// The Rapier-backed physics world resource and its query/mutation API.
 pub mod world;
 
 pub use components::{

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -15,6 +15,7 @@ use crate::{
     world::PhysicsWorld,
 };
 
+/// Bevy plugin that inserts a `PhysicsWorld` and steps spawn/simulate/sync systems each frame.
 pub struct PhysicsPlugin;
 
 impl Plugin for PhysicsPlugin {

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -7,6 +7,7 @@ use rapier3d::prelude::*;
 
 use crate::components::RaycastHit;
 
+/// The Rapier simulation state: rigid bodies, colliders, and the pipeline that steps them.
 #[derive(Resource)]
 pub struct PhysicsWorld {
     pub(crate) rigid_body_set: RigidBodySet,
@@ -31,6 +32,7 @@ impl Default for PhysicsWorld {
 }
 
 impl PhysicsWorld {
+    /// Creates a new empty world with downward gravity of the given magnitude (m/s²).
     pub fn new(gravity_magnitude: f32) -> Self {
         Self {
             rigid_body_set: RigidBodySet::new(),
@@ -49,6 +51,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Advances the simulation by one timestep, reporting contact events via `event_handler`.
     pub fn step(&mut self, event_handler: &dyn EventHandler) {
         self.physics_pipeline.step(
             self.gravity,
@@ -75,10 +78,12 @@ impl PhysicsWorld {
             .insert_with_parent(coll, body_handle, &mut self.rigid_body_set)
     }
 
+    /// Returns the current gravity magnitude (m/s²), always pointing down along -Y.
     pub fn gravity(&self) -> f32 {
         -self.gravity.y
     }
 
+    /// Sets the gravity magnitude (m/s²), applied downward along -Y.
     pub fn set_gravity(&mut self, magnitude: f32) {
         self.gravity = Vector::new(0.0, -magnitude, 0.0);
     }
@@ -87,6 +92,7 @@ impl PhysicsWorld {
         self.entity_body_map.insert(entity, handle);
     }
 
+    /// Returns the entity's linear velocity, or `None` if it has no physics body.
     pub fn get_linvel(&self, entity: Entity) -> Option<Vec3> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
@@ -94,6 +100,7 @@ impl PhysicsWorld {
         Some(Vec3::new(v.x, v.y, v.z))
     }
 
+    /// Sets the entity's linear velocity directly, waking the body if it was asleep.
     pub fn set_linvel(&mut self, entity: Entity, vel: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -102,6 +109,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Applies an instantaneous linear impulse to the entity's body, waking it if asleep.
     pub fn apply_impulse(&mut self, entity: Entity, impulse: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -110,6 +118,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Applies a linear impulse at a specific world-space point, inducing torque if off-center.
     pub fn apply_impulse_at_point(&mut self, entity: Entity, impulse: Vec3, point: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -122,6 +131,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Applies a continuous force to the entity's body for the current step, waking it if asleep.
     pub fn apply_force(&mut self, entity: Entity, force: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -130,6 +140,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Applies a continuous force at a specific world-space point, inducing torque if off-center.
     pub fn apply_force_at_point(&mut self, entity: Entity, force: Vec3, point: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -142,6 +153,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Returns the entity's angular velocity, or `None` if it has no physics body.
     pub fn get_angvel(&self, entity: Entity) -> Option<Vec3> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
@@ -149,6 +161,7 @@ impl PhysicsWorld {
         Some(Vec3::new(v.x, v.y, v.z))
     }
 
+    /// Sets the entity's angular velocity directly, waking the body if it was asleep.
     pub fn set_angvel(&mut self, entity: Entity, vel: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -157,6 +170,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Applies an instantaneous angular impulse (torque) to the entity's body.
     pub fn apply_torque_impulse(&mut self, entity: Entity, impulse: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -165,6 +179,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Applies a continuous torque to the entity's body for the current step, waking it if asleep.
     pub fn add_torque(&mut self, entity: Entity, torque: Vec3) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -173,6 +188,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Enables or disables continuous collision detection, preventing fast bodies from tunneling.
     pub fn set_ccd_enabled(&mut self, entity: Entity, enabled: bool) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -181,6 +197,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Sets how quickly the entity's linear velocity decays over time.
     pub fn set_linear_damping(&mut self, entity: Entity, damping: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -189,6 +206,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Sets how quickly the entity's angular velocity decays over time.
     pub fn set_angular_damping(&mut self, entity: Entity, damping: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -197,24 +215,28 @@ impl PhysicsWorld {
         }
     }
 
+    /// Returns the entity's linear velocity damping factor, or `None` if it has no physics body.
     pub fn get_linear_damping(&self, entity: Entity) -> Option<f32> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
         Some(body.linear_damping())
     }
 
+    /// Returns the entity's angular velocity damping factor, or `None` if it has no physics body.
     pub fn get_angular_damping(&self, entity: Entity) -> Option<f32> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
         Some(body.angular_damping())
     }
 
+    /// Returns the entity's total mass, or `None` if it has no physics body.
     pub fn get_mass(&self, entity: Entity) -> Option<f32> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
         Some(body.mass())
     }
 
+    /// Overrides the entity's mass, replacing what its colliders' density would otherwise compute.
     pub fn set_mass(&mut self, entity: Entity, mass: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -223,6 +245,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Locks or unlocks rotation of the entity's body around each world axis.
     pub fn lock_rotations(&mut self, entity: Entity, lock_x: bool, lock_y: bool, lock_z: bool) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -231,6 +254,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Locks or unlocks translation of the entity's body along each world axis.
     pub fn lock_translations(&mut self, entity: Entity, lock_x: bool, lock_y: bool, lock_z: bool) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -239,12 +263,14 @@ impl PhysicsWorld {
         }
     }
 
+    /// Returns whether the entity's body is currently asleep (excluded from active simulation).
     pub fn is_sleeping(&self, entity: Entity) -> Option<bool> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
         Some(body.is_sleeping())
     }
 
+    /// Forces the entity's body to wake up if it was sleeping.
     pub fn wake_up(&mut self, entity: Entity) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -253,6 +279,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Forces the entity's body to sleep immediately, excluding it from active simulation.
     pub fn put_to_sleep(&mut self, entity: Entity) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -261,6 +288,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Returns the restitution (bounciness) of the entity's first collider, or `None` if absent.
     pub fn get_restitution(&self, entity: Entity) -> Option<f32> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
@@ -269,6 +297,7 @@ impl PhysicsWorld {
         Some(collider.restitution())
     }
 
+    /// Sets the restitution (bounciness) on every collider attached to the entity's body.
     pub fn set_restitution(&mut self, entity: Entity, restitution: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get(handle) {
@@ -281,6 +310,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Returns the friction coefficient of the entity's first collider, or `None` if absent.
     pub fn get_friction(&self, entity: Entity) -> Option<f32> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
@@ -289,6 +319,7 @@ impl PhysicsWorld {
         Some(collider.friction())
     }
 
+    /// Sets the friction coefficient on every collider attached to the entity's body.
     pub fn set_friction(&mut self, entity: Entity, friction: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get(handle) {
@@ -301,6 +332,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Sets sensor mode (overlap detection without physical response) on every collider on the entity's body.
     pub fn set_collider_sensor(&mut self, entity: Entity, sensor: bool) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get(handle) {
@@ -313,18 +345,21 @@ impl PhysicsWorld {
         }
     }
 
+    /// Returns the entity's per-body gravity multiplier, or `None` if it has no physics body.
     pub fn get_gravity_scale(&self, entity: Entity) -> Option<f32> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
         Some(body.gravity_scale())
     }
 
+    /// Returns whether the entity's body is kinematic (position-driven, not force-driven).
     pub fn is_kinematic(&self, entity: Entity) -> Option<bool> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
         Some(body.is_kinematic())
     }
 
+    /// Returns whether the entity's first collider is a sensor, or `None` if absent.
     pub fn is_collider_sensor(&self, entity: Entity) -> Option<bool> {
         let handle = self.entity_body_map.get(&entity)?;
         let body = self.rigid_body_set.get(*handle)?;
@@ -333,6 +368,7 @@ impl PhysicsWorld {
         Some(collider.is_sensor())
     }
 
+    /// Sets the entity's per-body gravity multiplier (1.0 = normal gravity, 0.0 = unaffected).
     pub fn set_gravity_scale(&mut self, entity: Entity, scale: f32) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
@@ -341,6 +377,7 @@ impl PhysicsWorld {
         }
     }
 
+    /// Switches the entity's body between dynamic and kinematic-position-based simulation.
     pub fn set_body_type(&mut self, entity: Entity, kinematic: bool) {
         if let Some(&handle) = self.entity_body_map.get(&entity) {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {

--- a/crates/bsengine-plugin/src/descriptor.rs
+++ b/crates/bsengine-plugin/src/descriptor.rs
@@ -1,10 +1,15 @@
 use serde::{Deserialize, Serialize};
 
+/// Plugin manifest metadata, parsed from a plugin's `plugin.toml` file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginDescriptor {
+    /// Unique plugin name, used as its registry key.
     pub name: String,
+    /// Plugin version string (e.g. semver).
     pub version: String,
+    /// Optional human-readable description of the plugin.
     pub description: Option<String>,
+    /// Optional path, relative to the plugin directory, to its entry script.
     pub entry_script: Option<String>,
 }
 

--- a/crates/bsengine-plugin/src/lib.rs
+++ b/crates/bsengine-plugin/src/lib.rs
@@ -6,9 +6,13 @@
 //! the app.
 #![warn(missing_docs)]
 
+/// Defines `PluginDescriptor`, the manifest format parsed from `plugin.toml`.
 pub mod descriptor;
+/// Discovers and reads plugin manifests from disk.
 pub mod loader;
+/// Wires the plugin registry into the Bevy `App` as a resource.
 pub mod plugin;
+/// In-memory tracking of loaded plugin descriptors, keyed by name.
 pub mod registry;
 pub use descriptor::PluginDescriptor;
 pub use loader::PluginLoader;

--- a/crates/bsengine-plugin/src/loader.rs
+++ b/crates/bsengine-plugin/src/loader.rs
@@ -1,9 +1,11 @@
 use crate::descriptor::PluginDescriptor;
 use std::path::Path;
 
+/// Stateless helper for reading plugin manifests from the filesystem.
 pub struct PluginLoader;
 
 impl PluginLoader {
+    /// Reads and parses the `plugin.toml` manifest inside `dir`.
     pub fn load_from_dir(dir: &Path) -> Result<PluginDescriptor, String> {
         let toml_path = dir.join("plugin.toml");
         let content = std::fs::read_to_string(&toml_path)
@@ -11,6 +13,8 @@ impl PluginLoader {
         toml::from_str(&content).map_err(|e| format!("Parse error in {}: {e}", toml_path.display()))
     }
 
+    /// Scans immediate subdirectories of `root`, loading a descriptor from
+    /// each one that contains a valid `plugin.toml`; invalid entries are skipped.
     pub fn scan_directory(root: &Path) -> Result<Vec<PluginDescriptor>, String> {
         let mut plugins = Vec::new();
         let entries = std::fs::read_dir(root)

--- a/crates/bsengine-plugin/src/plugin.rs
+++ b/crates/bsengine-plugin/src/plugin.rs
@@ -2,9 +2,11 @@ use crate::registry::PluginRegistry;
 use bevy_app::{App, Plugin};
 use bsengine_ecs::Resource;
 
+/// ECS resource wrapper exposing the `PluginRegistry` to Bevy systems.
 #[derive(Resource)]
 pub struct PluginRegistryResource(pub PluginRegistry);
 
+/// Bevy plugin that inserts an empty `PluginRegistryResource` into the app.
 pub struct PluginSystemPlugin;
 
 impl Plugin for PluginSystemPlugin {

--- a/crates/bsengine-plugin/src/registry.rs
+++ b/crates/bsengine-plugin/src/registry.rs
@@ -1,25 +1,30 @@
 use crate::descriptor::PluginDescriptor;
 use std::collections::HashMap;
 
+/// In-memory table of loaded plugin descriptors, keyed by plugin name.
 pub struct PluginRegistry {
     plugins: HashMap<String, PluginDescriptor>,
 }
 
 impl PluginRegistry {
+    /// Creates an empty registry.
     pub fn new() -> Self {
         Self {
             plugins: HashMap::new(),
         }
     }
 
+    /// Registers a plugin descriptor, overwriting any existing entry with the same name.
     pub fn register(&mut self, desc: PluginDescriptor) {
         self.plugins.insert(desc.name.clone(), desc);
     }
 
+    /// Looks up a registered plugin descriptor by name.
     pub fn get(&self, name: &str) -> Option<&PluginDescriptor> {
         self.plugins.get(name)
     }
 
+    /// Returns all registered plugin descriptors, in arbitrary order.
     pub fn all(&self) -> Vec<&PluginDescriptor> {
         self.plugins.values().collect()
     }

--- a/crates/bsengine-render/src/components.rs
+++ b/crates/bsengine-render/src/components.rs
@@ -1,7 +1,9 @@
 use bevy_ecs::prelude::Component;
 
+/// Marks an entity as drawable and identifies which mesh asset to render it with.
 #[derive(Component, Debug, Clone)]
 pub struct MeshRenderer {
+    /// Id of the mesh asset to draw, as registered with the mesh/asset store.
     pub mesh_id: u64,
 }
 

--- a/crates/bsengine-render/src/lib.rs
+++ b/crates/bsengine-render/src/lib.rs
@@ -11,7 +11,9 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
 
+/// ECS components describing renderable entities (currently `MeshRenderer`).
 pub mod components;
+/// The Bevy `Plugin` wiring transform propagation and frame rendering into the app schedule.
 pub mod plugin;
 
 pub use components::MeshRenderer;

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -372,6 +372,8 @@ fn update_camera_aspect(mut events: EventReader<WindowResized>, mut cameras: Que
     }
 }
 
+/// Bevy plugin that registers the render-related resources, events, and per-frame
+/// systems (transform propagation, camera aspect updates, frame rendering).
 pub struct RenderPlugin;
 
 impl Plugin for RenderPlugin {

--- a/crates/bsengine-rhi-wgpu/src/gizmo.rs
+++ b/crates/bsengine-rhi-wgpu/src/gizmo.rs
@@ -5,8 +5,11 @@
 use egui::{Color32, Painter, Pos2, Rect, Stroke, Vec2};
 use glam::{Mat4, Quat, Vec3};
 
+/// Gizmo axis id for the X axis.
 pub const AXIS_X: u8 = 0;
+/// Gizmo axis id for the Y axis.
 pub const AXIS_Y: u8 = 1;
+/// Gizmo axis id for the Z axis.
 pub const AXIS_Z: u8 = 2;
 
 const HANDLE_HIT_RADIUS: f32 = 8.0;
@@ -18,6 +21,7 @@ const HANDLE_LENGTH_FRACTION: f32 = 0.15;
 const FRUSTUM_VIZ_DISTANCE: f32 = 1.2;
 const FRUSTUM_DEFAULT_ASPECT: f32 = 16.0 / 9.0;
 
+/// Maps a gizmo axis id to its unit direction vector in world space.
 pub fn axis_dir(axis: u8) -> Vec3 {
     match axis {
         AXIS_X => Vec3::X,

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -13,13 +13,21 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
 
+/// Screen-space translate/rotate gizmo math and drawing.
 pub mod gizmo;
+/// GPU mesh generation and the mesh registry.
 pub mod mesh;
+/// Editor-only egui panels (asset browser, dock, hierarchy, inspector, viewport).
 pub mod panels;
+/// The Bevy plugin that wires the wgpu RHI into the app.
 pub mod plugin;
+/// Post-processing render passes (bloom, tonemapping, etc).
 pub mod post_process;
+/// The `WgpuRHI` implementation of the abstract RHI traits.
 pub mod rhi;
+/// Swapchain/frame lifecycle and the main scene render pass.
 pub mod surface;
+/// GPU texture loading and the texture registry.
 pub mod texture;
 pub mod theme;
 pub use mesh::{

--- a/crates/bsengine-rhi-wgpu/src/mesh.rs
+++ b/crates/bsengine-rhi-wgpu/src/mesh.rs
@@ -6,10 +6,16 @@ use wgpu::util::DeviceExt;
 
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+/// A single GPU mesh vertex: position, vertex color, normal, and UV, packed
+/// for direct upload via `bytemuck`.
 pub struct Vertex {
+    /// Local-space position.
     pub position: [f32; 3],
+    /// Per-vertex RGB tint, multiplied with material color at render time.
     pub color: [f32; 3],
+    /// Local-space surface normal.
     pub normal: [f32; 3],
+    /// Texture coordinates.
     pub uv: [f32; 2],
 }
 
@@ -30,14 +36,19 @@ pub fn compute_bounding_sphere(vertices: &[Vertex]) -> (Vec3, f32) {
     (center, radius)
 }
 
+/// A mesh's GPU-resident buffers plus its precomputed bounding sphere.
 pub struct GpuMesh {
+    /// GPU buffer holding this mesh's `Vertex` data.
     pub vertex_buffer: wgpu::Buffer,
+    /// GPU buffer holding this mesh's triangle indices.
     pub index_buffer: wgpu::Buffer,
+    /// Number of indices to draw.
     pub index_count: u32,
     /// Local-space bounding sphere (center, radius).
     pub bounds: (Vec3, f32),
 }
 
+/// Owns every GPU mesh uploaded for the running app, keyed by a registry-assigned id.
 #[derive(Resource)]
 pub struct GpuMeshRegistry {
     device: Arc<wgpu::Device>,
@@ -46,6 +57,7 @@ pub struct GpuMeshRegistry {
 }
 
 impl GpuMeshRegistry {
+    /// Creates an empty registry bound to the given wgpu device.
     pub fn new(device: Arc<wgpu::Device>) -> Self {
         Self {
             device,
@@ -54,6 +66,7 @@ impl GpuMeshRegistry {
         }
     }
 
+    /// Uploads vertex/index data as a new GPU mesh and returns its assigned id.
     pub fn register(&mut self, vertices: &[Vertex], indices: &[u32]) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
@@ -86,15 +99,18 @@ impl GpuMeshRegistry {
         id
     }
 
+    /// Looks up a previously registered mesh by id.
     pub fn get(&self, id: u64) -> Option<&GpuMesh> {
         self.meshes.get(&id)
     }
 
+    /// Looks up a previously registered mesh's local-space bounding sphere by id.
     pub fn get_bounds(&self, id: u64) -> Option<(Vec3, f32)> {
         self.meshes.get(&id).map(|m| m.bounds)
     }
 }
 
+/// Vertices/indices for a single centered, unit-sized triangle.
 pub fn triangle_vertices() -> (Vec<Vertex>, Vec<u32>) {
     let vertices = vec![
         Vertex {
@@ -120,6 +136,8 @@ pub fn triangle_vertices() -> (Vec<Vertex>, Vec<u32>) {
     (vertices, indices)
 }
 
+/// Vertices/indices for a unit cube, with one distinctly colored face per axis
+/// direction and per-face (non-shared) normals/UVs.
 pub fn cube_vertices() -> (Vec<Vertex>, Vec<u32>) {
     let v = |pos: [f32; 3], col: [f32; 3], normal: [f32; 3], uv: [f32; 2]| Vertex {
         position: pos,
@@ -170,6 +188,7 @@ pub fn cube_vertices() -> (Vec<Vertex>, Vec<u32>) {
     (vertices, indices)
 }
 
+/// Vertices/indices for a UV sphere of unit diameter, built as a stack/slice grid.
 pub fn sphere_vertices() -> (Vec<Vertex>, Vec<u32>) {
     const STACKS: u32 = 16;
     const SLICES: u32 = 32;
@@ -207,6 +226,7 @@ pub fn sphere_vertices() -> (Vec<Vertex>, Vec<u32>) {
     (verts, idx)
 }
 
+/// Vertices/indices for a flat unit-sized quad in the XZ plane, facing +Y.
 pub fn plane_vertices() -> (Vec<Vertex>, Vec<u32>) {
     let verts = vec![
         Vertex {
@@ -238,6 +258,8 @@ pub fn plane_vertices() -> (Vec<Vertex>, Vec<u32>) {
     (verts, idx)
 }
 
+/// Vertices/indices for a capsule: a cylindrical body capped with two
+/// hemispheres, built as stacked rings of vertices.
 pub fn capsule_vertices() -> (Vec<Vertex>, Vec<u32>) {
     const SLICES: u32 = 24;
     const CAP_STACKS: u32 = 8;

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -13,11 +13,17 @@ use std::path::{Path, PathBuf};
 /// category with no attach target in this plan.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AssetKind {
+    /// A subdirectory to navigate into.
     Directory,
+    /// A `.ron` scene file, double-click loads it.
     Scene,
+    /// A `.js` script file, draggable onto an entity to attach it.
     Script,
+    /// A `.glb`/`.gltf` model file, draggable into the viewport to spawn it.
     Mesh,
+    /// A `.png`/`.jpg`/`.jpeg` image file, shown with a decoded thumbnail.
     Texture,
+    /// Any file extension not recognized as one of the other kinds.
     Other,
 }
 
@@ -46,16 +52,22 @@ fn categorize_by_extension(path: &Path) -> AssetKind {
 /// drop targets by payload type, so both can coexist on the same rows.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssetDragPayload {
+    /// Filesystem path of the dragged asset.
     pub path: PathBuf,
+    /// Category of the dragged asset, used by the drop target to decide how to handle it.
     pub kind: AssetKind,
 }
 
 /// One row in the Asset Browser's tile grid or folder tree.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssetEntry {
+    /// File or directory name, as shown under its tile.
     pub name: String,
+    /// Full filesystem path.
     pub path: PathBuf,
+    /// Category derived from the file extension (or `Directory`).
     pub kind: AssetKind,
+    /// Whether this entry is a directory rather than a file.
     pub is_dir: bool,
 }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/dock.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/dock.rs
@@ -68,6 +68,7 @@ pub fn load_dock_state(path: &Path) -> Option<DockState<String>> {
     }
 }
 
+/// Serializes and writes the dock layout to `path`; failures are logged as warnings, not propagated.
 pub fn save_dock_state(path: &Path, state: &DockState<String>) {
     match serde_json::to_string(state) {
         Ok(json) => {
@@ -85,10 +86,15 @@ pub fn save_dock_state(path: &Path, state: &DockState<String>) {
 /// panel type that's no longer registered) renders a placeholder instead
 /// of panicking.
 pub struct BseTabViewer<'a> {
+    /// Shared editor/inspector state (selection, edit buffers, command queue).
     pub insp: &'a mut InspectorState,
+    /// This frame's snapshot of every entity's inspectable info.
     pub entities_snapshot: &'a [InspectorEntityInfo],
+    /// Current mouse position in window space, forwarded to panels for hit-testing.
     pub cursor_pos: (f32, f32),
+    /// Registered panel instances, keyed by tab id.
     pub panels: &'a mut HashMap<String, Box<dyn EditorPanel>>,
+    /// Reflection type registry, used to render/edit reflected components.
     pub type_registry: Option<&'a bevy_reflect::TypeRegistry>,
 }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -1,5 +1,6 @@
 use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd, InspectorEntityInfo};
 
+/// The Hierarchy panel: shows the entity tree with selection, drag-to-reparent, and inline rename.
 pub struct HierarchyPanel;
 
 /// Which row is currently being renamed inline (double-click target), and

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -1,6 +1,7 @@
 use crate::panels::reflect_ui::draw_reflect_ui;
 use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd, PRIMITIVE_KINDS};
 
+/// The Inspector panel: shows and edits the selected entity's transform, tags, and components.
 pub struct InspectorPanel;
 
 /// Looks up the `ReflectValidate` type data for `type_path` (if the

--- a/crates/bsengine-rhi-wgpu/src/panels/mod.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/mod.rs
@@ -1,8 +1,14 @@
+/// The Assets panel: scans and browses the project's asset directory.
 pub mod asset_browser;
+/// Dock layout state, persistence, and the `egui_dock` tab viewer.
 pub mod dock;
+/// The Hierarchy panel: entity tree view with selection, reparenting, and rename.
 pub mod hierarchy;
+/// The Inspector panel: displays and edits the selected entity's components.
 pub mod inspector;
+/// Generic egui widgets for editing `bevy_reflect`-reflected component fields.
 pub mod reflect_ui;
+/// The Viewport panel: renders the 3D scene plus gizmo overlays.
 pub mod viewport;
 
 pub use asset_browser::{AssetBrowserPanel, AssetDragPayload, AssetKind};

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -1,5 +1,6 @@
 use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd};
 
+/// The Viewport panel: renders the editor gizmo/grid/frustum overlays on top of the 3D scene.
 pub struct ViewportPanel;
 
 impl EditorPanel for ViewportPanel {

--- a/crates/bsengine-rhi-wgpu/src/plugin.rs
+++ b/crates/bsengine-rhi-wgpu/src/plugin.rs
@@ -9,9 +9,12 @@ use bsengine_rhi::RHI;
 use bsengine_window::{WindowHandle, WindowResized};
 use std::sync::Arc;
 
+/// ECS resource wrapping the app's shared `RHI` implementation.
 #[derive(Resource)]
 pub struct RhiResource(pub Arc<dyn RHI>);
 
+/// Bevy plugin that initializes the wgpu RHI, creates the swapchain surface,
+/// and wires up window-resize handling.
 pub struct WgpuRHIPlugin;
 
 impl Plugin for WgpuRHIPlugin {

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -1,3 +1,4 @@
+/// Texture format used for the HDR scene-color render target, before tonemapping.
 pub const HDR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
 const BLOOM_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
 const AO_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
@@ -222,31 +223,53 @@ fn fs_composite(in: FullscreenOut) -> @location(0) vec4<f32> {
 }
 "#;
 
+/// GPU-uniform-buffer layout for bloom/tonemap/SSAO settings, matching the
+/// `PostProcessConfig` struct declared in the WGSL shaders above.
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct PostProcessConfigGpu {
+    /// Luminance level above which pixels start contributing to bloom.
     pub bloom_threshold: f32,
+    /// Width of the soft knee around `bloom_threshold`.
     pub bloom_softness: f32,
+    /// Multiplier applied to the bloom contribution during composite.
     pub bloom_intensity: f32,
+    /// Blur sample radius in pixels for the bloom pass.
     pub bloom_radius: f32,
+    /// Nonzero to enable the bloom pass; zero disables it.
     pub bloom_enabled: u32,
+    /// Selects the tonemap curve (0=clamp, 1=Reinhard, 2=Reinhard-luminance, 4=filmic, else ACES).
     pub tonemap_mode: u32,
+    /// Exposure adjustment (stops, applied as `2^exposure`) before tonemapping.
     pub tonemap_exposure: f32,
+    /// Nonzero to enable tonemapping; zero passes color through clamped but linear.
     pub tonemap_enabled: u32,
+    /// World/view-space sample radius for SSAO occlusion checks.
     pub ssao_radius: f32,
+    /// Depth bias added to avoid SSAO self-occlusion artifacts.
     pub ssao_bias: f32,
+    /// Multiplier applied to the computed occlusion amount.
     pub ssao_intensity: f32,
+    /// Number of hemisphere samples to take per pixel (capped at 8 in the shader).
     pub ssao_sample_count: u32,
+    /// Nonzero to enable the SSAO pass; zero always returns full visibility.
     pub ssao_enabled: u32,
+    /// Padding to satisfy uniform buffer alignment; unused.
     pub _pad0: f32,
+    /// Padding to satisfy uniform buffer alignment; unused.
     pub _pad1: f32,
+    /// Padding to satisfy uniform buffer alignment; unused.
     pub _pad2: f32,
 }
 
+/// GPU-uniform-buffer layout for the camera matrices the SSAO pass needs to
+/// reconstruct view-space position from depth.
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct SsaoCameraGpu {
+    /// Camera projection matrix.
     pub proj: [[f32; 4]; 4],
+    /// Inverse of `proj`, used to unproject depth back to view space.
     pub inv_proj: [[f32; 4]; 4],
 }
 
@@ -263,7 +286,10 @@ struct PostProcessTargets {
     depth_bg: wgpu::BindGroup,
 }
 
+/// Owns the render targets, bind groups, and pipelines for the post-process
+/// chain (bloom -> SSAO -> tonemapped composite onto the swapchain).
 pub struct PostProcessState {
+    /// View of the HDR scene-color render target the main pass writes into.
     pub hdr_view: wgpu::TextureView,
     _hdr_texture: wgpu::Texture,
     bloom_view: wgpu::TextureView,
@@ -279,14 +305,19 @@ pub struct PostProcessState {
     config_bg: wgpu::BindGroup,
     ssao_cam_buffer: wgpu::Buffer,
     ssao_cam_bg: wgpu::BindGroup,
+    /// Pipeline for the bright-pass bloom extraction shader.
     pub bloom_pipeline: wgpu::RenderPipeline,
+    /// Pipeline for the SSAO occlusion shader.
     pub ssao_pipeline: wgpu::RenderPipeline,
+    /// Pipeline for the final composite (HDR + bloom + AO, tonemapped) shader.
     pub composite_pipeline: wgpu::RenderPipeline,
     tex2d_bgl: wgpu::BindGroupLayout,
     depth_bgl: wgpu::BindGroupLayout,
 }
 
 impl PostProcessState {
+    /// Builds every pipeline, bind group layout, and sized render target needed
+    /// for the post-process chain at the given resolution.
     pub fn new(
         device: &wgpu::Device,
         width: u32,
@@ -634,6 +665,8 @@ impl PostProcessState {
         })
     }
 
+    /// Recreates the sized render targets (HDR/bloom/AO/depth bind group) for
+    /// a new surface resolution, leaving pipelines and samplers untouched.
     pub fn resize_targets(
         &mut self,
         device: &wgpu::Device,
@@ -662,14 +695,18 @@ impl PostProcessState {
         self.depth_bg = t.depth_bg;
     }
 
+    /// Uploads new bloom/tonemap/SSAO settings to the config uniform buffer.
     pub fn update_config(&self, queue: &wgpu::Queue, config: PostProcessConfigGpu) {
         queue.write_buffer(&self.config_buffer, 0, bytemuck::cast_slice(&[config]));
     }
 
+    /// Uploads the current frame's camera projection matrices for SSAO depth reconstruction.
     pub fn update_ssao_camera(&self, queue: &wgpu::Queue, cam: SsaoCameraGpu) {
         queue.write_buffer(&self.ssao_cam_buffer, 0, bytemuck::cast_slice(&[cam]));
     }
 
+    /// Runs the bloom, SSAO, and composite passes in sequence, writing the
+    /// final tonemapped result into `surface_view`.
     pub fn apply(&self, encoder: &mut wgpu::CommandEncoder, surface_view: &wgpu::TextureView) {
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {

--- a/crates/bsengine-rhi-wgpu/src/rhi.rs
+++ b/crates/bsengine-rhi-wgpu/src/rhi.rs
@@ -1,6 +1,9 @@
 use bsengine_rhi::{RHIMesh, RHIShader, RHITexture, RHI};
 use wgpu::{Device, Queue};
 
+/// The `wgpu`-backed `RHI` implementation, holding the GPU device/queue used
+/// for headless (surfaceless) rendering — e.g. tests and tooling that don't
+/// need an on-screen swapchain.
 #[allow(dead_code)]
 pub struct WgpuRHI {
     pub(crate) device: Device,
@@ -8,6 +11,7 @@ pub struct WgpuRHI {
 }
 
 impl WgpuRHI {
+    /// Creates a `WgpuRHI` with no window surface, requesting any available adapter.
     pub async fn new_headless() -> Result<Self, String> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -290,9 +290,13 @@ struct CameraUniformData {
 
 /// Material parameters uploaded per draw call.
 pub struct MaterialParams {
+    /// 0 = fully dielectric, 1 = fully metallic, PBR-style.
     pub metallic: f32,
+    /// Surface microfacet roughness, 0 = mirror-smooth, 1 = fully rough.
     pub roughness: f32,
+    /// Self-illumination color added regardless of lighting.
     pub emissive: Vec3,
+    /// Base albedo color multiplied with the surface texture (if any).
     pub base_color: Vec3,
 }
 
@@ -323,29 +327,45 @@ struct ModelUniformData {
 
 /// A single point light entry for the GPU buffer.
 pub struct PointLightEntry {
+    /// World-space position of the light.
     pub position: Vec3,
+    /// Light color (linear RGB, unclamped so intensity can exceed 1.0 per channel).
     pub color: Vec3,
+    /// Brightness multiplier applied to `color`.
     pub intensity: f32,
+    /// Distance at which the light's contribution falls off to zero.
     pub range: f32,
 }
 
 /// A single spot light entry for the GPU buffer.
 pub struct SpotLightEntry {
+    /// World-space position of the light.
     pub position: Vec3,
+    /// World-space direction the cone points toward.
     pub direction: Vec3,
+    /// Light color (linear RGB, unclamped so intensity can exceed 1.0 per channel).
     pub color: Vec3,
+    /// Brightness multiplier applied to `color`.
     pub intensity: f32,
+    /// Distance at which the light's contribution falls off to zero.
     pub range: f32,
+    /// Half-angle (radians) of the cone's fully-lit inner core.
     pub inner_angle: f32,
+    /// Half-angle (radians) of the cone's outer falloff edge.
     pub outer_angle: f32,
 }
 
 /// Light parameters passed per frame.
 pub struct LightData {
+    /// Directional (sun) light's world-space direction.
     pub direction: Vec3,
+    /// Directional (sun) light's color.
     pub color: Vec3,
+    /// Flat ambient light added to every surface regardless of direction.
     pub ambient: Vec3,
+    /// Active point lights this frame (uploaded up to a fixed GPU-side cap).
     pub point_lights: Vec<PointLightEntry>,
+    /// Active spot lights this frame (uploaded up to a fixed GPU-side cap).
     pub spot_lights: Vec<SpotLightEntry>,
 }
 
@@ -491,6 +511,8 @@ fn map_keycode_to_egui(code: bsengine_input::KeyCode) -> Option<egui::Key> {
     })
 }
 
+/// Owns the wgpu swapchain, all GPU pipelines/buffers for the main scene and
+/// shadow passes, the egui renderer, and per-frame render state for one window.
 pub struct WgpuSurface {
     _window: Arc<winit::window::Window>,
     pub(crate) surface: wgpu::Surface<'static>,
@@ -526,6 +548,8 @@ pub struct WgpuSurface {
 }
 
 impl WgpuSurface {
+    /// Initializes the wgpu adapter/device/swapchain for `window` and builds
+    /// every pipeline, buffer, and bind group the main render loop needs.
     pub async fn new(window: Arc<winit::window::Window>) -> Result<Self, String> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
@@ -1183,19 +1207,25 @@ impl WgpuSurface {
         Ok(())
     }
 
+    /// Unloads the current skybox, if any, reverting to no skybox rendering.
     pub fn clear_skybox(&mut self) {
         self.skybox = None;
         self.loaded_skybox_path = None;
     }
 
+    /// Whether a skybox is currently loaded and will be rendered.
     pub fn has_skybox(&self) -> bool {
         self.skybox.is_some()
     }
 
+    /// Path of the currently loaded skybox texture, if any.
     pub fn loaded_skybox_path(&self) -> Option<&str> {
         self.loaded_skybox_path.as_deref()
     }
 
+    /// Renders one full frame: shadow map, main scene pass, post-processing,
+    /// skybox, and the game/editor UI overlay, then presents the swapchain.
+    /// Returns the ids of any `UiWidget::Button`s clicked this frame.
     #[allow(clippy::too_many_arguments)] // one frame's worth of render inputs; splitting into a struct is a larger refactor
     pub fn render_frame(
         &mut self,
@@ -2065,6 +2095,8 @@ impl WgpuSurface {
         Ok(clicked)
     }
 
+    /// Reconfigures the swapchain and depth/post-process targets for a new
+    /// window size; a no-op if either dimension is zero (e.g. minimized).
     pub fn resize(&mut self, width: u32, height: u32) {
         if width == 0 || height == 0 {
             return;
@@ -2079,6 +2111,8 @@ impl WgpuSurface {
             .resize_targets(&self.device, &self.depth_view, width, height);
     }
 
+    /// Compiles a WGSL custom shader and stores it as a render pipeline keyed
+    /// by `path`, replacing any previously compiled pipeline for that path.
     pub fn compile_and_store_shader(&mut self, path: &str, wgsl: &str) {
         let shader = self
             .device
@@ -2154,10 +2188,13 @@ impl WgpuSurface {
         self.custom_pipelines.insert(path.to_string(), pipeline);
     }
 
+    /// Whether a custom shader has already been compiled and stored for `path`.
     pub fn has_custom_shader(&self, path: &str) -> bool {
         self.custom_pipelines.contains_key(path)
     }
 
+    /// Compiles a standalone WGSL source string into a shader module, without
+    /// building a pipeline or storing it.
     pub fn compile_shader(device: &wgpu::Device, src: &str) -> wgpu::ShaderModule {
         device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("wgsl shader"),
@@ -2166,6 +2203,7 @@ impl WgpuSurface {
     }
 }
 
+/// ECS resource wrapping the app's [`WgpuSurface`].
 #[derive(Resource)]
 pub struct WgpuSurfaceResource(pub WgpuSurface);
 

--- a/crates/bsengine-rhi-wgpu/src/texture.rs
+++ b/crates/bsengine-rhi-wgpu/src/texture.rs
@@ -8,6 +8,7 @@ struct GpuTexture {
     bind_group: wgpu::BindGroup,
 }
 
+/// Owns every GPU texture uploaded for the running app, keyed by a registry-assigned id.
 #[derive(Resource)]
 pub struct GpuTextureRegistry {
     device: Arc<wgpu::Device>,
@@ -19,6 +20,7 @@ pub struct GpuTextureRegistry {
 }
 
 impl GpuTextureRegistry {
+    /// Creates an empty registry bound to the given wgpu device/queue.
     pub fn new(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> Self {
         let bgl = Self::create_bgl(&device);
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
@@ -63,6 +65,8 @@ impl GpuTextureRegistry {
         })
     }
 
+    /// Decodes an in-memory image file (PNG, JPEG, etc), uploads it as an
+    /// RGBA8 texture, and returns its assigned id.
     pub fn load_from_bytes(&mut self, bytes: &[u8]) -> Result<u64, String> {
         let img = image::load_from_memory(bytes).map_err(|e| format!("image decode: {e}"))?;
         let rgba = img.to_rgba8();
@@ -70,6 +74,7 @@ impl GpuTextureRegistry {
         Ok(self.upload_rgba(width, height, &rgba))
     }
 
+    /// Uploads already-decoded RGBA8 pixel data as a new texture and returns its assigned id.
     pub fn load_from_rgba(&mut self, width: u32, height: u32, rgba: &[u8]) -> u64 {
         self.upload_rgba(width, height, rgba)
     }
@@ -131,6 +136,7 @@ impl GpuTextureRegistry {
         id
     }
 
+    /// Looks up a previously loaded texture's bind group by id.
     pub fn get_bind_group(&self, id: u64) -> Option<&wgpu::BindGroup> {
         self.textures.get(&id).map(|t| &t.bind_group)
     }

--- a/crates/bsengine-rhi/src/lib.rs
+++ b/crates/bsengine-rhi/src/lib.rs
@@ -5,5 +5,6 @@
 //! current implementation, built on `wgpu`.
 #![warn(missing_docs)]
 
+/// Core RHI trait definitions (`RHI`, `RHIMesh`, `RHIShader`, `RHITexture`).
 pub mod traits;
 pub use traits::{RHIMesh, RHIShader, RHITexture, RHI};

--- a/crates/bsengine-rhi/src/traits.rs
+++ b/crates/bsengine-rhi/src/traits.rs
@@ -1,11 +1,18 @@
+/// Entry point a concrete GPU backend implements to create RHI resources.
 pub trait RHI: Send + Sync {
+    /// Creates a new, backend-specific mesh resource.
     fn create_mesh(&self) -> Box<dyn RHIMesh>;
+    /// Compiles `src` into a backend-specific shader resource.
     fn create_shader(&self, src: &str) -> Box<dyn RHIShader>;
+    /// Creates a new, backend-specific texture resource.
     fn create_texture(&self) -> Box<dyn RHITexture>;
 }
 
+/// Opaque handle to a GPU mesh resource owned by a backend implementation.
 pub trait RHIMesh: Send + Sync {}
+/// Opaque handle to a compiled GPU shader resource owned by a backend implementation.
 pub trait RHIShader: Send + Sync {}
+/// Opaque handle to a GPU texture resource owned by a backend implementation.
 pub trait RHITexture: Send + Sync {}
 
 #[cfg(test)]

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -6,7 +6,9 @@
 //! (`PointLightDescriptor`, `RigidBodyDesc`, `TransformDescriptor`, ...).
 #![warn(missing_docs)]
 
+/// `ScenePlugin` and the entity-spawning logic that turns a `SceneDescriptor` into ECS entities.
 pub mod plugin;
+/// Serde/RON descriptor types that make up the on-disk scene file format.
 pub mod types;
 
 pub use plugin::{spawn_scene_entities, Name, ScenePlugin};

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -8,14 +8,17 @@ use bsengine_core::{
 use bsengine_gltf::GltfAsset;
 use glam::{Quat, Vec3};
 
+/// Human-readable name assigned to a spawned scene entity, taken from `EntityDescriptor::name`.
 #[derive(Component, Debug, Clone)]
 pub struct Name(pub String);
 
+/// Bevy plugin that loads a scene file at startup and spawns its entities into the world.
 pub struct ScenePlugin {
     path: String,
 }
 
 impl ScenePlugin {
+    /// Creates a plugin that will load and spawn the scene at `path` when added to an `App`.
     pub fn from_file(path: &str) -> Self {
         Self {
             path: path.to_string(),

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -1,8 +1,10 @@
 use bevy_ecs::prelude::{Component, Resource};
 use serde::{Deserialize, Serialize};
 
+/// Root of a scene file: the list of entities to spawn plus scene-wide settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SceneDescriptor {
+    /// Entities to spawn into the world, in file order.
     pub entities: Vec<EntityDescriptor>,
     /// Optional equirectangular skybox image path (relative to the scene file).
     #[serde(default)]
@@ -12,9 +14,13 @@ pub struct SceneDescriptor {
 /// Built-in primitive mesh shapes that the runtime can spawn without an asset file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Primitive {
+    /// Unit cube.
     Cube,
+    /// Unit sphere.
     Sphere,
+    /// Flat ground plane.
     Plane,
+    /// Cylinder with hemispherical caps.
     Capsule,
 }
 
@@ -33,26 +39,36 @@ pub struct ScriptPath(pub String);
 /// required.  The legacy `components` field is kept for compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntityDescriptor {
+    /// Name assigned to the spawned entity's `Name` component.
     pub name: String,
+    /// Initial position/rotation/scale. Absent means no `Transform` component is added.
     #[serde(default)]
     pub transform: Option<TransformDescriptor>,
+    /// Path to a glTF asset to load as this entity's mesh.
     #[serde(default)]
     pub gltf: Option<String>,
+    /// Whether this entity should get a `Camera` component.
     #[serde(default)]
     pub camera: bool,
     /// Camera-only: vertical field of view in degrees. Defaults to 60 if absent.
     #[serde(default)]
     pub camera_fov: Option<f32>,
+    /// Directional (sun-like) light to attach to this entity.
     #[serde(default)]
     pub directional_light: Option<DirectionalLightDescriptor>,
+    /// Point light to attach to this entity.
     #[serde(default)]
     pub point_light: Option<PointLightDescriptor>,
+    /// Spot light to attach to this entity.
     #[serde(default)]
     pub spot_light: Option<SpotLightDescriptor>,
+    /// Built-in primitive mesh shape to spawn, if not using a glTF asset.
     #[serde(default)]
     pub primitive: Option<Primitive>,
+    /// Path to a JS script to attach via `ScriptPath`.
     #[serde(default)]
     pub script: Option<String>,
+    /// Emissive color as [r, g, b], added on top of the base color.
     #[serde(default)]
     pub emissive: Option<[f32; 3]>,
     /// Albedo/base color as [r, g, b] in linear 0–1. Multiplies the mesh vertex color and texture.
@@ -61,21 +77,27 @@ pub struct EntityDescriptor {
     /// Camera-only: point in world space the camera should face. Overrides the transform rotation.
     #[serde(default)]
     pub look_at: Option<[f32; 3]>,
+    /// Physics body type; requires `collider` to also be set to take effect.
     #[serde(default)]
     pub rigidbody: Option<RigidBodyDesc>,
+    /// Collision shape and material; requires `rigidbody` to also be set to take effect.
     #[serde(default)]
     pub collider: Option<ColliderDesc>,
+    /// Legacy (name, json) component pairs, kept for backwards compatibility.
     #[serde(default)]
     pub components: Vec<(String, String)>,
 }
 
+/// Position, rotation, and scale for a scene entity, as written in a scene file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransformDescriptor {
+    /// World-space position as [x, y, z]. Defaults to the origin.
     #[serde(default)]
     pub translation: [f32; 3],
     /// Quaternion as [x, y, z, w].  Defaults to identity.
     #[serde(default = "default_rotation")]
     pub rotation: [f32; 4],
+    /// Per-axis scale as [x, y, z]. Defaults to uniform scale of 1.
     #[serde(default = "default_scale")]
     pub scale: [f32; 3],
 }
@@ -90,31 +112,43 @@ impl Default for TransformDescriptor {
     }
 }
 
+/// Sun-like light that shines uniformly along `direction`, with no falloff over distance.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DirectionalLightDescriptor {
+    /// Direction the light travels in, as [x, y, z]. Does not need to be normalized.
     pub direction: [f32; 3],
+    /// Light color as [r, g, b] in linear 0-1. Defaults to white.
     #[serde(default = "default_white")]
     pub color: [f32; 3],
+    /// Ambient light color added uniformly to unlit surfaces, as [r, g, b].
     #[serde(default = "default_ambient")]
     pub ambient: [f32; 3],
 }
 
+/// Omnidirectional light that falls off with distance from the entity's position.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PointLightDescriptor {
+    /// Light color as [r, g, b] in linear 0-1. Defaults to white.
     #[serde(default = "default_white")]
     pub color: [f32; 3],
+    /// Brightness multiplier. Defaults to 1.
     #[serde(default = "default_intensity")]
     pub intensity: f32,
+    /// Maximum distance the light reaches, in world units.
     #[serde(default = "default_range")]
     pub range: f32,
 }
 
+/// Cone-shaped light that falls off with distance and angle from the entity's forward direction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpotLightDescriptor {
+    /// Light color as [r, g, b] in linear 0-1. Defaults to white.
     #[serde(default = "default_white")]
     pub color: [f32; 3],
+    /// Brightness multiplier. Defaults to 1.
     #[serde(default = "default_intensity")]
     pub intensity: f32,
+    /// Maximum distance the light reaches, in world units.
     #[serde(default = "default_range")]
     pub range: f32,
     /// Inner cone half-angle in degrees — full brightness inside.
@@ -128,27 +162,52 @@ pub struct SpotLightDescriptor {
 /// Rigid body type for physics descriptors in scene files.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum RigidBodyDesc {
+    /// Fully simulated body, affected by forces, gravity, and collisions.
     Dynamic,
+    /// Immovable body that other bodies can collide with but that never moves itself.
     Static,
+    /// Body moved directly by code/animation rather than by the physics simulation.
     Kinematic,
 }
 
 /// Collider shape descriptor for scene files.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ColliderShapeDesc {
-    Box { hx: f32, hy: f32, hz: f32 },
-    Sphere { radius: f32 },
-    Capsule { half_height: f32, radius: f32 },
+    /// Axis-aligned box collider defined by its half-extents.
+    Box {
+        /// Half-extent along the x axis.
+        hx: f32,
+        /// Half-extent along the y axis.
+        hy: f32,
+        /// Half-extent along the z axis.
+        hz: f32,
+    },
+    /// Spherical collider.
+    Sphere {
+        /// Sphere radius.
+        radius: f32,
+    },
+    /// Capsule collider: a cylinder with hemispherical caps, aligned to the local y axis.
+    Capsule {
+        /// Half the height of the cylindrical section, excluding the end caps.
+        half_height: f32,
+        /// Radius of the cylindrical section and end caps.
+        radius: f32,
+    },
 }
 
 /// Full collider descriptor for scene files.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ColliderDesc {
+    /// Collision geometry.
     pub shape: ColliderShapeDesc,
+    /// Bounciness, from 0 (no bounce) to 1 (fully elastic).
     #[serde(default)]
     pub restitution: f32,
+    /// Surface friction coefficient. Defaults to 0.5.
     #[serde(default = "default_friction")]
     pub friction: f32,
+    /// If true, this collider detects overlaps but does not physically collide.
     #[serde(default)]
     pub sensor: bool,
 }
@@ -157,13 +216,16 @@ pub struct ColliderDesc {
 /// The runtime resolves this into actual physics components.
 #[derive(Component, Debug, Clone)]
 pub struct PhysicsBodyDesc {
+    /// Physics simulation type for this body.
     pub rigidbody: RigidBodyDesc,
+    /// Collision shape and material for this body.
     pub collider: ColliderDesc,
 }
 
 /// Signals a runtime scene transition was requested via script.
 #[derive(Resource)]
 pub struct PendingSceneLoad {
+    /// Path to the scene file to load next.
     pub path: String,
 }
 

--- a/crates/bsengine-scripting/src/lib.rs
+++ b/crates/bsengine-scripting/src/lib.rs
@@ -12,9 +12,13 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
 // bsengine-scripting
+/// Deno ops exposing ECS state and mutations to JS scripts as `Bsengine.*` calls.
 pub mod ops;
+/// The `ScriptingPlugin` Bevy plugin and its supporting components/resources.
 pub mod plugin;
+/// The `ScriptRuntime` V8 isolate wrapper used to execute script source.
 pub mod runtime;
+/// Script-driven save-game serialization to/from JSON.
 pub mod save;
 pub use plugin::{
     load_scripts, ProjectDir, Script, ScriptRuntimeResource, ScriptingPlugin, SoundHandles,

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -1,3 +1,18 @@
+// `#[op2]` rewrites every annotated `pub fn` into a `pub const fn ... -> OpDecl`;
+// any `///` doc comment (or other non-special attribute) written above the
+// `#[op2]` line is forwarded only to a private helper struct/method nested
+// inside that generated function body, never to the actual public item the
+// macro emits. `missing_docs` therefore always fires on op2-annotated
+// functions no matter what doc comment precedes them — see
+// `deno_ops::op2::generate_op2` (attrs are only spliced into the inner
+// `#rust_name` struct/`call` impl, never onto the outer `#vis const fn`).
+// Each op below still has a `///` comment for readers of this source file;
+// this allow only accounts for the lint's inability to see it.
+#![allow(
+    missing_docs,
+    reason = "see comment above: #[op2] never forwards doc comments to the public item it generates"
+)]
+
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
@@ -5,296 +20,512 @@ use deno_core::op2;
 use glam::{Quat, Vec3};
 use serde::{Deserialize, Serialize};
 
+/// JS-provided parameters for spawning a new entity via `Bsengine.spawn`.
 #[derive(Clone, Deserialize)]
 pub struct SpawnParams {
+    /// Name to assign the spawned entity.
     pub name: String,
+    /// Primitive mesh shape to spawn (e.g. "Cube", "Sphere"); defaults to "Cube".
     #[serde(default = "default_primitive")]
     pub primitive: String,
+    /// Initial X position.
     #[serde(default)]
     pub x: f32,
+    /// Initial Y position.
     #[serde(default)]
     pub y: f32,
+    /// Initial Z position.
     #[serde(default)]
     pub z: f32,
+    /// Initial rotation quaternion X component.
     #[serde(default)]
     pub rx: f32,
+    /// Initial rotation quaternion Y component.
     #[serde(default)]
     pub ry: f32,
+    /// Initial rotation quaternion Z component.
     #[serde(default)]
     pub rz: f32,
+    /// Initial rotation quaternion W component; defaults to 1 (identity).
     #[serde(default = "default_one")]
     pub rw: f32,
+    /// Initial X scale; defaults to 1.
     #[serde(default = "default_one")]
     pub sx: f32,
+    /// Initial Y scale; defaults to 1.
     #[serde(default = "default_one")]
     pub sy: f32,
+    /// Initial Z scale; defaults to 1.
     #[serde(default = "default_one")]
     pub sz: f32,
+    /// Optional base material color as `[r, g, b]`.
     pub color: Option<[f32; 3]>,
+    /// Optional emissive material color as `[r, g, b]`.
     pub emissive: Option<[f32; 3]>,
+    /// Optional path to a script to attach to the spawned entity.
     pub script: Option<String>,
 }
 
+/// Default primitive shape used by `SpawnParams` when none is specified.
 fn default_primitive() -> String {
     "Cube".to_string()
 }
+/// Default value (`1.0`) used for `SpawnParams` scale/rotation-w fields.
 fn default_one() -> f32 {
     1.0
 }
 
+/// Deferred world-mutating command produced by a `Bsengine.*` script call; queued and applied to the ECS world on the next update.
 #[derive(Clone)]
 pub enum ScriptCommand {
+    /// Set an entity's absolute world position.
     SetTransform {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// New absolute Z position.
         z: f32,
     },
+    /// Set an entity's absolute rotation, as a quaternion.
     SetRotation {
+        /// Name of the entity to modify.
         name: String,
+        /// Rotation quaternion X component.
         rx: f32,
+        /// Rotation quaternion Y component.
         ry: f32,
+        /// Rotation quaternion Z component.
         rz: f32,
+        /// Rotation quaternion W component.
         rw: f32,
     },
+    /// Set an entity's absolute scale.
     SetScale {
+        /// Name of the entity to modify.
         name: String,
+        /// New X scale factor.
         sx: f32,
+        /// New Y scale factor.
         sy: f32,
+        /// New Z scale factor.
         sz: f32,
     },
+    /// Add a world-space offset to an entity's position.
     AddPosition {
+        /// Name of the entity to modify.
         name: String,
+        /// Position delta along X.
         dx: f32,
+        /// Position delta along Y.
         dy: f32,
+        /// Position delta along Z.
         dz: f32,
     },
+    /// Add a local-space (entity-relative) offset to an entity's position.
     AddPositionLocal {
+        /// Name of the entity to modify.
         name: String,
+        /// Position delta along X.
         dx: f32,
+        /// Position delta along Y.
         dy: f32,
+        /// Position delta along Z.
         dz: f32,
     },
+    /// Set an entity's emissive material color.
     SetEmissive {
+        /// Name of the entity to modify.
         name: String,
+        /// Red channel (0-1).
         r: f32,
+        /// Green channel (0-1).
         g: f32,
+        /// Blue channel (0-1).
         b: f32,
     },
+    /// Set an entity's base material color.
     SetColor {
+        /// Name of the entity to modify.
         name: String,
+        /// Red channel (0-1).
         r: f32,
+        /// Green channel (0-1).
         g: f32,
+        /// Blue channel (0-1).
         b: f32,
     },
+    /// Set an entity's material metallic factor.
     SetMetallic {
+        /// Name of the entity to modify.
         name: String,
+        /// New metallic factor (0 = dielectric, 1 = fully metallic).
         value: f32,
     },
+    /// Set an entity's material roughness factor.
     SetRoughness {
+        /// Name of the entity to modify.
         name: String,
+        /// New roughness factor (0 = mirror-smooth, 1 = fully rough).
         value: f32,
     },
+    /// Set a point light's color.
     SetPointLightColor {
+        /// Name of the entity to modify.
         name: String,
+        /// Red channel (0-1).
         r: f32,
+        /// Green channel (0-1).
         g: f32,
+        /// Blue channel (0-1).
         b: f32,
     },
+    /// Set a point light's intensity.
     SetPointLightIntensity {
+        /// Name of the entity to modify.
         name: String,
+        /// New light intensity.
         value: f32,
     },
+    /// Set a point light's maximum range.
     SetPointLightRange {
+        /// Name of the entity to modify.
         name: String,
+        /// New maximum light range, in world units.
         value: f32,
     },
+    /// Set a spot light's color.
     SetSpotLightColor {
+        /// Name of the entity to modify.
         name: String,
+        /// Red channel (0-1).
         r: f32,
+        /// Green channel (0-1).
         g: f32,
+        /// Blue channel (0-1).
         b: f32,
     },
+    /// Set a spot light's intensity.
     SetSpotLightIntensity {
+        /// Name of the entity to modify.
         name: String,
+        /// New light intensity.
         value: f32,
     },
+    /// Set a spot light's maximum range.
     SetSpotLightRange {
+        /// Name of the entity to modify.
         name: String,
+        /// New maximum light range, in world units.
         value: f32,
     },
+    /// Set a spot light's inner cone angle.
     SetSpotLightInnerAngle {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Set a spot light's outer cone angle.
     SetSpotLightOuterAngle {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Set a directional light's color.
     SetDirectionalLightColor {
+        /// Name of the entity to modify.
         name: String,
+        /// Red channel (0-1).
         r: f32,
+        /// Green channel (0-1).
         g: f32,
+        /// Blue channel (0-1).
         b: f32,
     },
+    /// Set a directional light's ambient color contribution.
     SetDirectionalLightAmbient {
+        /// Name of the entity to modify.
         name: String,
+        /// Red channel (0-1).
         r: f32,
+        /// Green channel (0-1).
         g: f32,
+        /// Blue channel (0-1).
         b: f32,
     },
+    /// Set a directional light's direction vector.
     SetDirectionalLightDirection {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// New absolute Z position.
         z: f32,
     },
+    /// Set a camera's vertical field of view.
     SetCameraFov {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Set a camera's near clip plane distance.
     SetCameraNear {
+        /// Name of the entity to modify.
         name: String,
+        /// New near clip plane distance.
         value: f32,
     },
+    /// Set a camera's far clip plane distance.
     SetCameraFar {
+        /// Name of the entity to modify.
         name: String,
+        /// New far clip plane distance.
         value: f32,
     },
+    /// Set a generic damping coefficient on an entity.
     SetDamping {
+        /// Name of the entity to modify.
         name: String,
+        /// New damping coefficient.
         value: f32,
     },
+    /// Subtract damage from an entity's shield value.
     DamageShield {
+        /// Name of the entity to modify.
         name: String,
+        /// Amount of damage to subtract from the shield.
         amount: f32,
     },
+    /// Restore some of an entity's shield value.
     RestoreShield {
+        /// Name of the entity to modify.
         name: String,
+        /// Amount of shield to restore.
         amount: f32,
     },
+    /// Set an entity's maximum shield capacity.
     SetMaxShield {
+        /// Name of the entity to modify.
         name: String,
+        /// New maximum shield capacity.
         value: f32,
     },
+    /// Reset a named entity's gameplay timer back to zero.
     ResetTimer {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Set the destination point for an entity's nav-mesh agent.
     SetNavDestination {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// New absolute Z position.
         z: f32,
     },
+    /// Clear an entity's current nav-mesh destination, halting movement.
     ClearNavDestination {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Set an entity's nav-mesh agent movement speed.
     SetNavSpeed {
+        /// Name of the entity to modify.
         name: String,
+        /// New speed value.
         speed: f32,
     },
+    /// Set an entity's nav-mesh agent turning speed.
     SetNavAngularSpeed {
+        /// Name of the entity to modify.
         name: String,
+        /// New speed value.
         speed: f32,
     },
+    /// Set how close an entity's nav-mesh agent must get before it stops.
     SetNavStoppingDistance {
+        /// Name of the entity to modify.
         name: String,
+        /// Stopping distance from the destination, in world units.
         distance: f32,
     },
+    /// Enable or disable an entity's nav-mesh agent.
     SetNavEnabled {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the effect is enabled.
         enabled: bool,
     },
+    /// Set the bloom post-process effect intensity.
     SetBloomIntensity {
+        /// Name of the entity to modify.
         name: String,
+        /// New intensity/strength value.
         intensity: f32,
     },
+    /// Set the brightness threshold above which bloom is applied.
     SetBloomThreshold {
+        /// Name of the entity to modify.
         name: String,
+        /// New threshold value.
         threshold: f32,
     },
+    /// Set the blur radius of the bloom effect.
     SetBloomRadius {
+        /// Name of the entity to modify.
         name: String,
+        /// New radius, in world units.
         radius: f32,
     },
+    /// Set the softness of the bloom threshold falloff.
     SetBloomSoftness {
+        /// Name of the entity to modify.
         name: String,
+        /// New softness of the falloff.
         softness: f32,
     },
+    /// Enable or disable the bloom post-process effect.
     SetBloomEnabled {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the effect is enabled.
         enabled: bool,
     },
+    /// Set the sampling radius of the ambient occlusion effect.
     SetAoRadius {
+        /// Name of the entity to modify.
         name: String,
+        /// New radius, in world units.
         radius: f32,
     },
+    /// Set the ambient occlusion bias, used to reduce self-shadowing artifacts.
     SetAoBias {
+        /// Name of the entity to modify.
         name: String,
+        /// New bias value, used to reduce artifacts.
         bias: f32,
     },
+    /// Set the strength of the ambient occlusion effect.
     SetAoIntensity {
+        /// Name of the entity to modify.
         name: String,
+        /// New intensity/strength value.
         intensity: f32,
     },
+    /// Set the number of samples used by the ambient occlusion effect.
     SetAoSampleCount {
+        /// Name of the entity to modify.
         name: String,
+        /// Number of samples to take per pixel.
         count: u32,
     },
+    /// Enable or disable the ambient occlusion effect.
     SetAoEnabled {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the effect is enabled.
         enabled: bool,
     },
+    /// Set the tone-mapping operator used by the render pipeline.
     SetToneMapMode {
+        /// Name of the entity to modify.
         name: String,
+        /// Tone-mapping mode, encoded as an integer.
         mode: u32,
     },
+    /// Set the exposure applied before tone mapping.
     SetToneMapExposure {
+        /// Name of the entity to modify.
         name: String,
+        /// New exposure value.
         exposure: f32,
     },
+    /// Enable or disable tone mapping.
     SetToneMapEnabled {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the effect is enabled.
         enabled: bool,
     },
+    /// Set the duration of a running tween.
     SetTweenDuration {
+        /// Name of the entity to modify.
         name: String,
+        /// New duration, in seconds.
         duration: f32,
     },
+    /// Set the easing function used by a running tween.
     SetTweenEasing {
+        /// Name of the entity to modify.
         name: String,
+        /// Easing function, encoded as an integer.
         easing: u32,
     },
+    /// Set the repeat count of a running tween.
     SetTweenRepeat {
+        /// Name of the entity to modify.
         name: String,
+        /// Number of times the tween should repeat.
         repeat: u32,
     },
+    /// Set the elapsed time of a running tween.
     SetTweenElapsed {
+        /// Name of the entity to modify.
         name: String,
+        /// New elapsed time, in seconds.
         elapsed: f32,
     },
+    /// Set the entity a camera/follow-behavior should track.
     SetFollowTarget {
+        /// Name of the entity to modify.
         name: String,
+        /// Name of the entity to target.
         target: String,
     },
+    /// Set the offset a follow-behavior maintains from its target.
     SetFollowOffset {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// New absolute Z position.
         z: f32,
     },
+    /// Set how quickly a follow-behavior catches up to its target.
     SetFollowSpeed {
+        /// Name of the entity to modify.
         name: String,
+        /// New speed value.
         speed: f32,
     },
+    /// Set the entity a look-at behavior should aim towards.
     SetLookAtTarget {
+        /// Name of the entity to modify.
         name: String,
+        /// Name of the entity to target.
         target: String,
     },
+    /// Set the up vector used by a look-at behavior.
     SetLookAtUp {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// New absolute Z position.
         z: f32,
     },
     // ── Scald ────────────────────────────────────────────────────────────────
@@ -491,434 +722,768 @@ pub enum ScriptCommand {
     // ── Rot ──────────────────────────────────────────────────────────────────
     // ── Rout ─────────────────────────────────────────────────────────────────
     // ── Rupture ──────────────────────────────────────────────────────────────
+    /// Play an animation clip on an entity.
     PlayAnimation {
+        /// Name of the entity to modify.
         name: String,
+        /// Name of the animation clip to play.
         clip: String,
     },
+    /// Pause an entity's currently playing animation.
     PauseAnimation {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Resume an entity's paused animation.
     ResumeAnimation {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Reset an entity's animation back to its first frame.
     ResetAnimation {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Set the playback speed multiplier of an entity's animation.
     SetAnimationSpeed {
+        /// Name of the entity to modify.
         name: String,
+        /// New speed value.
         speed: f32,
     },
+    /// Set whether an entity's animation loops.
     SetAnimationLooping {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the animation should loop.
         looping: bool,
     },
+    /// Fire a trigger on an entity's animation state machine.
     AsmSetTrigger {
+        /// Name of the entity to modify.
         name: String,
+        /// Name of the animation-state-machine trigger to fire.
         trigger: String,
     },
+    /// Set a float parameter on an entity's animation state machine.
     AsmSetFloat {
+        /// Name of the entity to modify.
         name: String,
+        /// Name of the animation-state-machine parameter to set.
         param: String,
+        /// New float value for the parameter.
         value: f32,
     },
+    /// Set a boolean parameter on an entity's animation state machine.
     AsmSetBool {
+        /// Name of the entity to modify.
         name: String,
+        /// Name of the animation-state-machine parameter to set.
         param: String,
+        /// New boolean value for the parameter.
         value: bool,
     },
+    /// Set a countdown after which the entity is automatically destroyed.
     SetLifetime {
+        /// Name of the entity to modify.
         name: String,
+        /// Remaining lifetime, in seconds, before the entity is destroyed.
         seconds: f32,
     },
+    /// Spawn a new entity from the given parameters.
     Spawn(SpawnParams),
+    /// Destroy a named entity.
     Destroy {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Show or hide an entity.
     SetVisible {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the entity is visible.
         visible: bool,
     },
+    /// Start playing a sound.
     PlaySound {
+        /// Identifier of the sound or UI widget to target.
         id: u32,
+        /// Filesystem path of the resource to load.
         path: String,
+        /// Playback volume (0-1).
         volume: f32,
+        /// Whether the sound should loop.
         loop_: bool,
     },
+    /// Stop a playing sound.
     StopSound {
+        /// Identifier of the sound or UI widget to target.
         id: u32,
     },
+    /// Pause a playing sound.
     PauseSound {
+        /// Identifier of the sound or UI widget to target.
         id: u32,
     },
+    /// Resume a paused sound.
     ResumeSound {
+        /// Identifier of the sound or UI widget to target.
         id: u32,
     },
+    /// Set the volume of a playing sound.
     SetSoundVolume {
+        /// Identifier of the sound or UI widget to target.
         id: u32,
+        /// Volume, in decibels.
         db: f32,
     },
+    /// Set the stereo pan of a playing sound.
     SetSoundPanning {
+        /// Identifier of the sound or UI widget to target.
         id: u32,
+        /// Stereo pan position, from -1 (left) to 1 (right).
         panning: f32,
     },
+    /// Set the playback rate (pitch/speed) of a playing sound.
     SetSoundPlaybackRate {
+        /// Identifier of the sound or UI widget to target.
         id: u32,
+        /// Playback rate multiplier (1 = normal speed).
         rate: f32,
     },
+    /// Seek a playing sound to a specific position.
     SeekSound {
+        /// Identifier of the sound or UI widget to target.
         id: u32,
+        /// Playback position, in seconds, to seek to.
         position: f64,
     },
+    /// Set the text content of a HUD element.
     SetHudText {
+        /// Identifier of the sound or UI widget to target.
         id: String,
+        /// Text content to display.
         text: String,
     },
+    /// Remove a HUD text element.
     ClearHudText {
+        /// Identifier of the sound or UI widget to target.
         id: String,
     },
+    /// Create or update a UI text label.
     SetUiLabel {
+        /// Identifier of the sound or UI widget to target.
         id: String,
+        /// Text content to display.
         text: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// Font size, in points.
         font_size: f32,
     },
+    /// Create or update a UI button.
     SetUiButton {
+        /// Identifier of the sound or UI widget to target.
         id: String,
+        /// Button label text.
         label: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// Widget width, in pixels.
         width: f32,
+        /// Widget height, in pixels.
         height: f32,
     },
+    /// Create or update a UI panel.
     SetUiPanel {
+        /// Identifier of the sound or UI widget to target.
         id: String,
+        /// Panel title text.
         title: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// Widget width, in pixels.
         width: f32,
+        /// Widget height, in pixels.
         height: f32,
     },
+    /// Create or update a UI text input field.
     SetUiTextInput {
+        /// Identifier of the sound or UI widget to target.
         id: String,
+        /// Placeholder hint text shown when the input is empty.
         hint: String,
+        /// New absolute X position.
         x: f32,
+        /// New absolute Y position.
         y: f32,
+        /// Widget width, in pixels.
         width: f32,
     },
+    /// Remove a UI widget by id.
     RemoveUiWidget {
+        /// Identifier of the sound or UI widget to target.
         id: String,
     },
+    /// Remove all UI widgets.
     ClearUiWidgets,
+    /// Load a scene from a file, replacing the current world.
     LoadScene {
+        /// Filesystem path of the resource to load.
         path: String,
     },
+    /// Set the skybox texture used for the background/environment.
     SetSkybox {
+        /// Filesystem path of the resource to load.
         path: String,
     },
+    /// Attach an entity as the child of another entity.
     SetParent {
+        /// Name of the child entity.
         child: String,
+        /// Name of the new parent entity.
         parent: String,
     },
+    /// Detach an entity from its parent.
     ClearParent {
+        /// Name of the child entity.
         child: String,
     },
+    /// Show or hide the mouse cursor.
     SetCursorVisible {
+        /// Whether the entity is visible.
         visible: bool,
     },
+    /// Lock or unlock the mouse cursor to the window.
     SetCursorLocked {
+        /// Whether the cursor is locked to the window.
         locked: bool,
     },
+    /// Apply an instantaneous impulse to a rigid body's center of mass.
     AddImpulse {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the force/impulse.
         fx: f32,
+        /// Y component of the force/impulse.
         fy: f32,
+        /// Z component of the force/impulse.
         fz: f32,
     },
+    /// Apply an instantaneous impulse to a rigid body at a specific world point.
     AddImpulseAtPoint {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the force/impulse.
         fx: f32,
+        /// Y component of the force/impulse.
         fy: f32,
+        /// Z component of the force/impulse.
         fz: f32,
+        /// X coordinate of the point the force/impulse is applied at.
         px: f32,
+        /// Y coordinate of the point the force/impulse is applied at.
         py: f32,
+        /// Z coordinate of the point the force/impulse is applied at.
         pz: f32,
     },
+    /// Apply a continuous force to a rigid body's center of mass.
     AddForce {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the force/impulse.
         fx: f32,
+        /// Y component of the force/impulse.
         fy: f32,
+        /// Z component of the force/impulse.
         fz: f32,
     },
+    /// Apply a continuous force to a rigid body at a specific world point.
     AddForceAtPoint {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the force/impulse.
         fx: f32,
+        /// Y component of the force/impulse.
         fy: f32,
+        /// Z component of the force/impulse.
         fz: f32,
+        /// X coordinate of the point the force/impulse is applied at.
         px: f32,
+        /// Y coordinate of the point the force/impulse is applied at.
         py: f32,
+        /// Z coordinate of the point the force/impulse is applied at.
         pz: f32,
     },
+    /// Set a rigid body's linear velocity.
     SetVelocity {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the velocity.
         vx: f32,
+        /// Y component of the velocity.
         vy: f32,
+        /// Z component of the velocity.
         vz: f32,
     },
+    /// Set the X component of a rigid body's linear velocity.
     SetVelocityX {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the velocity.
         vx: f32,
     },
+    /// Set the Y component of a rigid body's linear velocity.
     SetVelocityY {
+        /// Name of the entity to modify.
         name: String,
+        /// Y component of the velocity.
         vy: f32,
     },
+    /// Set the Z component of a rigid body's linear velocity.
     SetVelocityZ {
+        /// Name of the entity to modify.
         name: String,
+        /// Z component of the velocity.
         vz: f32,
     },
+    /// Set the world's global gravity magnitude.
     SetGravity {
+        /// World gravity magnitude.
         magnitude: f32,
     },
+    /// Set a rigid body's angular velocity.
     SetAngularVelocity {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the velocity.
         vx: f32,
+        /// Y component of the velocity.
         vy: f32,
+        /// Z component of the velocity.
         vz: f32,
     },
+    /// Set the X component of a rigid body's angular velocity.
     SetAngularVelocityX {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the velocity.
         vx: f32,
     },
+    /// Set the Y component of a rigid body's angular velocity.
     SetAngularVelocityY {
+        /// Name of the entity to modify.
         name: String,
+        /// Y component of the velocity.
         vy: f32,
     },
+    /// Set the Z component of a rigid body's angular velocity.
     SetAngularVelocityZ {
+        /// Name of the entity to modify.
         name: String,
+        /// Z component of the velocity.
         vz: f32,
     },
+    /// Add to a rigid body's linear velocity.
     AddVelocity {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the velocity.
         vx: f32,
+        /// Y component of the velocity.
         vy: f32,
+        /// Z component of the velocity.
         vz: f32,
     },
+    /// Add to a rigid body's angular velocity.
     AddAngularVelocity {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the velocity.
         vx: f32,
+        /// Y component of the velocity.
         vy: f32,
+        /// Z component of the velocity.
         vz: f32,
     },
+    /// Apply an instantaneous angular impulse to a rigid body.
     AddAngularImpulse {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the velocity.
         vx: f32,
+        /// Y component of the velocity.
         vy: f32,
+        /// Z component of the velocity.
         vz: f32,
     },
+    /// Apply a continuous torque to a rigid body.
     AddTorque {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the velocity.
         vx: f32,
+        /// Y component of the velocity.
         vy: f32,
+        /// Z component of the velocity.
         vz: f32,
     },
+    /// Enable or disable continuous collision detection on a rigid body.
     SetCCDEnabled {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the effect is enabled.
         enabled: bool,
     },
+    /// Set a rigid body's linear damping (velocity decay over time).
     SetLinearDamping {
+        /// Name of the entity to modify.
         name: String,
+        /// New damping coefficient.
         damping: f32,
     },
+    /// Set a rigid body's angular damping (angular velocity decay over time).
     SetAngularDamping {
+        /// Name of the entity to modify.
         name: String,
+        /// New damping coefficient.
         damping: f32,
     },
+    /// Set a rigid body's mass.
     SetMass {
+        /// Name of the entity to modify.
         name: String,
+        /// New mass, in kilograms.
         mass: f32,
     },
+    /// Set whether a rigid body is kinematic.
     SetKinematic {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the body is kinematic (unaffected by physics forces).
         kinematic: bool,
     },
+    /// Set a rigid body's gravity scale multiplier.
     SetGravityScale {
+        /// Name of the entity to modify.
         name: String,
+        /// Gravity scale multiplier applied to the body.
         scale: f32,
     },
+    /// Set whether an entity's collider acts as a sensor.
     SetColliderSensor {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the collider acts as a sensor (detects overlap without a physical response).
         sensor: bool,
     },
+    /// Set a collider's restitution (bounciness).
     SetRestitution {
+        /// Name of the entity to modify.
         name: String,
+        /// Bounciness of the collider (0 = no bounce, 1 = perfectly elastic).
         restitution: f32,
     },
+    /// Set a collider's surface friction.
     SetFriction {
+        /// Name of the entity to modify.
         name: String,
+        /// Surface friction coefficient.
         friction: f32,
     },
+    /// Lock a rigid body's rotation on one or more axes.
     LockRotation {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the X axis is locked.
         lock_x: bool,
+        /// Whether the Y axis is locked.
         lock_y: bool,
+        /// Whether the Z axis is locked.
         lock_z: bool,
     },
+    /// Lock a rigid body's translation on one or more axes.
     LockTranslation {
+        /// Name of the entity to modify.
         name: String,
+        /// Whether the X axis is locked.
         lock_x: bool,
+        /// Whether the Y axis is locked.
         lock_y: bool,
+        /// Whether the Z axis is locked.
         lock_z: bool,
     },
+    /// Wake a sleeping rigid body so physics resumes simulating it.
     WakeUp {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Force a rigid body to sleep, pausing physics simulation for it.
     PutToSleep {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Set the X component of an entity's position.
     SetPositionX {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute X position.
         x: f32,
     },
+    /// Set the Y component of an entity's position.
     SetPositionY {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute Y position.
         y: f32,
     },
+    /// Set the Z component of an entity's position.
     SetPositionZ {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute Z position.
         z: f32,
     },
+    /// Add to the X component of an entity's position.
     AddPositionX {
+        /// Name of the entity to modify.
         name: String,
+        /// Position delta along X.
         dx: f32,
     },
+    /// Add to the Y component of an entity's position.
     AddPositionY {
+        /// Name of the entity to modify.
         name: String,
+        /// Position delta along Y.
         dy: f32,
     },
+    /// Add to the Z component of an entity's position.
     AddPositionZ {
+        /// Name of the entity to modify.
         name: String,
+        /// Position delta along Z.
         dz: f32,
     },
+    /// Compose an additional rotation onto an entity's current rotation.
     RotateBy {
+        /// Name of the entity to modify.
         name: String,
+        /// Rotation quaternion X component.
         rx: f32,
+        /// Rotation quaternion Y component.
         ry: f32,
+        /// Rotation quaternion Z component.
         rz: f32,
+        /// Rotation quaternion W component.
         rw: f32,
     },
+    /// Rotate an entity around an arbitrary axis by an angle.
     RotateAroundAxis {
+        /// Name of the entity to modify.
         name: String,
+        /// X component of the rotation axis.
         ax: f32,
+        /// Y component of the rotation axis.
         ay: f32,
+        /// Z component of the rotation axis.
         az: f32,
+        /// Rotation angle, in degrees.
         angle_deg: f32,
     },
+    /// Add Euler-angle rotation deltas (in degrees) to an entity.
     AddRotationEuler {
+        /// Name of the entity to modify.
         name: String,
+        /// Pitch delta, in degrees.
         pitch: f32,
+        /// Yaw delta, in degrees.
         yaw: f32,
+        /// Roll delta, in degrees.
         roll: f32,
     },
+    /// Add a rotation delta around the X axis, in degrees.
     AddRotationEulerX {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Add a rotation delta around the Y axis, in degrees.
     AddRotationEulerY {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Add a rotation delta around the Z axis, in degrees.
     AddRotationEulerZ {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Set the X component of an entity's scale.
     SetScaleX {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute X position.
         x: f32,
     },
+    /// Set the Y component of an entity's scale.
     SetScaleY {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute Y position.
         y: f32,
     },
+    /// Set the Z component of an entity's scale.
     SetScaleZ {
+        /// Name of the entity to modify.
         name: String,
+        /// New absolute Z position.
         z: f32,
     },
+    /// Add to the X component of an entity's scale.
     AddScaleX {
+        /// Name of the entity to modify.
         name: String,
+        /// Position delta along X.
         dx: f32,
     },
+    /// Add to the Y component of an entity's scale.
     AddScaleY {
+        /// Name of the entity to modify.
         name: String,
+        /// Position delta along Y.
         dy: f32,
     },
+    /// Add to the Z component of an entity's scale.
     AddScaleZ {
+        /// Name of the entity to modify.
         name: String,
+        /// Position delta along Z.
         dz: f32,
     },
+    /// Set an entity's absolute rotation from Euler angles, in degrees.
     SetRotationEuler {
+        /// Name of the entity to modify.
         name: String,
+        /// Absolute pitch angle, in degrees.
         pitch_deg: f32,
+        /// Absolute yaw angle, in degrees.
         yaw_deg: f32,
+        /// Absolute roll angle, in degrees.
         roll_deg: f32,
     },
+    /// Add to all three components of an entity's scale.
     AddScale {
+        /// Name of the entity to modify.
         name: String,
+        /// New X scale factor.
         sx: f32,
+        /// New Y scale factor.
         sy: f32,
+        /// New Z scale factor.
         sz: f32,
     },
+    /// Set the pitch component of an entity's rotation, in degrees.
     SetRotationEulerX {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Set the yaw component of an entity's rotation, in degrees.
     SetRotationEulerY {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Set the roll component of an entity's rotation, in degrees.
     SetRotationEulerZ {
+        /// Name of the entity to modify.
         name: String,
+        /// Angle, in degrees.
         deg: f32,
     },
+    /// Multiply an entity's current scale by the given factors.
     MultiplyScale {
+        /// Name of the entity to modify.
         name: String,
+        /// New X scale factor.
         sx: f32,
+        /// New Y scale factor.
         sy: f32,
+        /// New Z scale factor.
         sz: f32,
     },
+    /// (Re)initialize the nav-mesh grid used for pathfinding.
     NavmeshInit {
+        /// Grid width, in cells.
         width: u32,
+        /// Grid depth, in cells.
         depth: u32,
+        /// Size of one grid cell, in world units.
         cell_size: f32,
+        /// World-space X coordinate of the grid origin.
         origin_x: f32,
+        /// World-space Y coordinate of the grid origin.
         origin_y: f32,
+        /// World-space Z coordinate of the grid origin.
         origin_z: f32,
     },
+    /// Mark a nav-mesh grid cell as walkable or blocked.
     NavmeshSetWalkable {
+        /// Grid cell X coordinate.
         x: u32,
+        /// Grid cell Z coordinate.
         z: u32,
+        /// Whether the navmesh cell is walkable.
         walkable: bool,
     },
+    /// Serialize the current world state to a save file.
     SaveGame {
+        /// Filesystem path of the resource to load.
         path: String,
     },
+    /// Load world state from a save file.
     LoadGame {
+        /// Filesystem path of the resource to load.
         path: String,
     },
+    /// Assign a custom shader to an entity's material.
     SetCustomShader {
+        /// Name of the entity to modify.
         name: String,
+        /// Filesystem path of the resource to load.
         path: String,
     },
+    /// Remove an entity's custom shader, reverting to the default.
     ClearCustomShader {
+        /// Name of the entity to modify.
         name: String,
     },
+    /// Start hosting a network server on the given port.
     NetworkStartServer {
+        /// Network port number.
         port: u16,
     },
+    /// Connect to a network server as a client.
     NetworkConnect {
+        /// Hostname or IP address to connect to.
         host: String,
+        /// Network port number.
         port: u16,
     },
+    /// Disconnect from the current network session.
     NetworkDisconnect,
 }
 
@@ -1655,17 +2220,20 @@ struct RaycastHitJson {
     distance: f32,
 }
 
+/// Write a message to the engine log at info level, tagged as coming from a script.
 #[op2(fast)]
 pub fn bsengine_log(#[string] msg: String) {
     tracing::info!("[script] {}", msg);
 }
 
+/// Get the scripting API version string.
 #[op2]
 #[string]
 pub fn bsengine_version() -> String {
     "0.1.0".to_string()
 }
 
+/// Get an entity's local position, rotation, and scale, or `None` if it doesn't exist.
 #[op2]
 #[serde]
 pub fn bsengine_get_transform(#[string] name: String) -> Option<TransformJson> {
@@ -1687,6 +2255,7 @@ pub fn bsengine_get_transform(#[string] name: String) -> Option<TransformJson> {
     })
 }
 
+/// Get the world-space forward direction vector of an entity's rotation.
 #[op2]
 #[serde]
 pub fn bsengine_get_forward_vector(#[string] name: String) -> Option<Vec<f32>> {
@@ -1698,6 +2267,7 @@ pub fn bsengine_get_forward_vector(#[string] name: String) -> Option<Vec<f32>> {
     })
 }
 
+/// Get the world-space right direction vector of an entity's rotation.
 #[op2]
 #[serde]
 pub fn bsengine_get_right_vector(#[string] name: String) -> Option<Vec<f32>> {
@@ -1709,6 +2279,7 @@ pub fn bsengine_get_right_vector(#[string] name: String) -> Option<Vec<f32>> {
     })
 }
 
+/// Get the world-space up direction vector of an entity's rotation.
 #[op2]
 #[serde]
 pub fn bsengine_get_up_vector(#[string] name: String) -> Option<Vec<f32>> {
@@ -1720,6 +2291,7 @@ pub fn bsengine_get_up_vector(#[string] name: String) -> Option<Vec<f32>> {
     })
 }
 
+/// Get an entity's world-space position, rotation, and scale, or `None` if it doesn't exist.
 #[op2]
 #[serde]
 pub fn bsengine_get_world_transform(#[string] name: String) -> Option<TransformJson> {
@@ -1741,6 +2313,7 @@ pub fn bsengine_get_world_transform(#[string] name: String) -> Option<TransformJ
     })
 }
 
+/// Get the distance between two named entities.
 #[op2(fast)]
 pub fn bsengine_distance_to(#[string] name_a: String, #[string] name_b: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| {
@@ -1754,6 +2327,7 @@ pub fn bsengine_distance_to(#[string] name_a: String, #[string] name_b: String) 
     })
 }
 
+/// Get the distance from a named entity to a world-space point.
 #[op2(fast)]
 pub fn bsengine_distance_to_point(#[string] name: String, x: f32, y: f32, z: f32) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| {
@@ -1764,6 +2338,7 @@ pub fn bsengine_distance_to_point(#[string] name: String, x: f32, y: f32, z: f32
     })
 }
 
+/// Queue setting an entity's absolute position.
 #[op2(fast)]
 pub fn bsengine_set_transform(#[string] name: String, x: f32, y: f32, z: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1772,6 +2347,7 @@ pub fn bsengine_set_transform(#[string] name: String, x: f32, y: f32, z: f32) {
     });
 }
 
+/// Queue setting an entity's absolute rotation, as a quaternion.
 #[op2(fast)]
 pub fn bsengine_set_rotation(#[string] name: String, rx: f32, ry: f32, rz: f32, rw: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1785,6 +2361,7 @@ pub fn bsengine_set_rotation(#[string] name: String, rx: f32, ry: f32, rz: f32, 
     });
 }
 
+/// Queue setting an entity's absolute rotation from Euler angles, in degrees.
 #[op2(fast)]
 pub fn bsengine_set_rotation_euler(
     #[string] name: String,
@@ -1802,6 +2379,7 @@ pub fn bsengine_set_rotation_euler(
     });
 }
 
+/// Queue setting an entity's absolute scale.
 #[op2(fast)]
 pub fn bsengine_set_scale(#[string] name: String, sx: f32, sy: f32, sz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1810,6 +2388,7 @@ pub fn bsengine_set_scale(#[string] name: String, sx: f32, sy: f32, sz: f32) {
     });
 }
 
+/// Queue a world-space position offset for an entity.
 #[op2(fast)]
 pub fn bsengine_add_position(#[string] name: String, dx: f32, dy: f32, dz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1818,6 +2397,7 @@ pub fn bsengine_add_position(#[string] name: String, dx: f32, dy: f32, dz: f32) 
     });
 }
 
+/// Queue composing an additional rotation onto an entity's current rotation.
 #[op2(fast)]
 pub fn bsengine_rotate_by(#[string] name: String, rx: f32, ry: f32, rz: f32, rw: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1831,6 +2411,7 @@ pub fn bsengine_rotate_by(#[string] name: String, rx: f32, ry: f32, rz: f32, rw:
     });
 }
 
+/// Queue a local-space (entity-relative) position offset for an entity.
 #[op2(fast)]
 pub fn bsengine_add_position_local(#[string] name: String, dx: f32, dy: f32, dz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1839,6 +2420,7 @@ pub fn bsengine_add_position_local(#[string] name: String, dx: f32, dy: f32, dz:
     });
 }
 
+/// Queue setting the X component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_set_position_x(#[string] name: String, x: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1846,6 +2428,7 @@ pub fn bsengine_set_position_x(#[string] name: String, x: f32) {
     });
 }
 
+/// Queue setting the Y component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_set_position_y(#[string] name: String, y: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1853,6 +2436,7 @@ pub fn bsengine_set_position_y(#[string] name: String, y: f32) {
     });
 }
 
+/// Queue setting the Z component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_set_position_z(#[string] name: String, z: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1860,6 +2444,7 @@ pub fn bsengine_set_position_z(#[string] name: String, z: f32) {
     });
 }
 
+/// Queue adding to the X component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_add_position_x(#[string] name: String, dx: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1868,6 +2453,7 @@ pub fn bsengine_add_position_x(#[string] name: String, dx: f32) {
     });
 }
 
+/// Queue adding to the Y component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_add_position_y(#[string] name: String, dy: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1876,6 +2462,7 @@ pub fn bsengine_add_position_y(#[string] name: String, dy: f32) {
     });
 }
 
+/// Queue adding to the Z component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_add_position_z(#[string] name: String, dz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1884,6 +2471,7 @@ pub fn bsengine_add_position_z(#[string] name: String, dz: f32) {
     });
 }
 
+/// Queue rotating an entity around an arbitrary axis by an angle, in degrees.
 #[op2(fast)]
 pub fn bsengine_rotate_around_axis(
     #[string] name: String,
@@ -1903,6 +2491,7 @@ pub fn bsengine_rotate_around_axis(
     });
 }
 
+/// Queue adding Euler-angle rotation deltas (in degrees) to an entity.
 #[op2(fast)]
 pub fn bsengine_add_rotation_euler(#[string] name: String, pitch: f32, yaw: f32, roll: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1915,6 +2504,7 @@ pub fn bsengine_add_rotation_euler(#[string] name: String, pitch: f32, yaw: f32,
     });
 }
 
+/// Queue a rotation delta around the X axis, in degrees.
 #[op2(fast)]
 pub fn bsengine_add_rotation_euler_x(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1923,6 +2513,7 @@ pub fn bsengine_add_rotation_euler_x(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue a rotation delta around the Y axis, in degrees.
 #[op2(fast)]
 pub fn bsengine_add_rotation_euler_y(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1931,6 +2522,7 @@ pub fn bsengine_add_rotation_euler_y(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue a rotation delta around the Z axis, in degrees.
 #[op2(fast)]
 pub fn bsengine_add_rotation_euler_z(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1939,6 +2531,7 @@ pub fn bsengine_add_rotation_euler_z(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue setting the X component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_set_scale_x(#[string] name: String, x: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1946,6 +2539,7 @@ pub fn bsengine_set_scale_x(#[string] name: String, x: f32) {
     });
 }
 
+/// Queue setting the Y component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_set_scale_y(#[string] name: String, y: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1953,6 +2547,7 @@ pub fn bsengine_set_scale_y(#[string] name: String, y: f32) {
     });
 }
 
+/// Queue setting the Z component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_set_scale_z(#[string] name: String, z: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1960,6 +2555,7 @@ pub fn bsengine_set_scale_z(#[string] name: String, z: f32) {
     });
 }
 
+/// Queue adding to the X component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_add_scale_x(#[string] name: String, dx: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1967,6 +2563,7 @@ pub fn bsengine_add_scale_x(#[string] name: String, dx: f32) {
     });
 }
 
+/// Queue adding to the Y component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_add_scale_y(#[string] name: String, dy: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1974,6 +2571,7 @@ pub fn bsengine_add_scale_y(#[string] name: String, dy: f32) {
     });
 }
 
+/// Queue adding to the Z component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_add_scale_z(#[string] name: String, dz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -1981,36 +2579,43 @@ pub fn bsengine_add_scale_z(#[string] name: String, dz: f32) {
     });
 }
 
+/// Get the X component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_get_position_x(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |t| t.0.x))
 }
 
+/// Get the Y component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_get_position_y(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |t| t.0.y))
 }
 
+/// Get the Z component of an entity's position.
 #[op2(fast)]
 pub fn bsengine_get_position_z(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |t| t.0.z))
 }
 
+/// Get the X component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_get_scale_x(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |t| t.2.x))
 }
 
+/// Get the Y component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_get_scale_y(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |t| t.2.y))
 }
 
+/// Get the Z component of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_get_scale_z(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |t| t.2.z))
 }
 
+/// Get the pitch component of an entity's rotation, in degrees.
 #[op2(fast)]
 pub fn bsengine_get_rotation_euler_x(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| {
@@ -2021,6 +2626,7 @@ pub fn bsengine_get_rotation_euler_x(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the yaw component of an entity's rotation, in degrees.
 #[op2(fast)]
 pub fn bsengine_get_rotation_euler_y(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| {
@@ -2031,6 +2637,7 @@ pub fn bsengine_get_rotation_euler_y(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the roll component of an entity's rotation, in degrees.
 #[op2(fast)]
 pub fn bsengine_get_rotation_euler_z(#[string] name: String) -> f32 {
     TRANSFORM_SNAPSHOT.with(|s| {
@@ -2041,6 +2648,7 @@ pub fn bsengine_get_rotation_euler_z(#[string] name: String) -> f32 {
     })
 }
 
+/// Queue adding to all three components of an entity's scale.
 #[op2(fast)]
 pub fn bsengine_add_scale(#[string] name: String, sx: f32, sy: f32, sz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2049,6 +2657,7 @@ pub fn bsengine_add_scale(#[string] name: String, sx: f32, sy: f32, sz: f32) {
     });
 }
 
+/// Queue setting the pitch component of an entity's rotation, in degrees.
 #[op2(fast)]
 pub fn bsengine_set_rotation_euler_x(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2057,6 +2666,7 @@ pub fn bsengine_set_rotation_euler_x(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue setting the yaw component of an entity's rotation, in degrees.
 #[op2(fast)]
 pub fn bsengine_set_rotation_euler_y(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2065,6 +2675,7 @@ pub fn bsengine_set_rotation_euler_y(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue setting the roll component of an entity's rotation, in degrees.
 #[op2(fast)]
 pub fn bsengine_set_rotation_euler_z(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2073,6 +2684,7 @@ pub fn bsengine_set_rotation_euler_z(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue multiplying an entity's current scale by the given factors.
 #[op2(fast)]
 pub fn bsengine_multiply_scale(#[string] name: String, sx: f32, sy: f32, sz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2081,21 +2693,25 @@ pub fn bsengine_multiply_scale(#[string] name: String, sx: f32, sy: f32, sz: f32
     });
 }
 
+/// Check whether a keyboard key was pressed this frame.
 #[op2(fast)]
 pub fn bsengine_is_key_pressed(#[string] key: String) -> bool {
     KEY_SNAPSHOT.with(|k| k.borrow().contains(&key))
 }
 
+/// Check whether a keyboard key is currently held down.
 #[op2(fast)]
 pub fn bsengine_is_key_down(#[string] key: String) -> bool {
     KEY_JUST_PRESSED_SNAPSHOT.with(|k| k.borrow().contains(&key))
 }
 
+/// Check whether a keyboard key was released this frame.
 #[op2(fast)]
 pub fn bsengine_is_key_up(#[string] key: String) -> bool {
     KEY_JUST_RELEASED_SNAPSHOT.with(|k| k.borrow().contains(&key))
 }
 
+/// Get the names of all named entities, as a JSON array string.
 #[op2]
 #[string]
 pub fn bsengine_get_entity_names() -> String {
@@ -2103,16 +2719,19 @@ pub fn bsengine_get_entity_names() -> String {
         .with(|s| serde_json::to_string(&*s.borrow()).unwrap_or_else(|_| "[]".to_string()))
 }
 
+/// Check whether a named entity currently exists.
 #[op2(fast)]
 pub fn bsengine_entity_exists(#[string] name: String) -> bool {
     ENTITY_NAMES_SNAPSHOT.with(|s| s.borrow().contains(&name))
 }
 
+/// Get the total number of named entities.
 #[op2(fast)]
 pub fn bsengine_get_entity_count() -> u32 {
     ENTITY_NAMES_SNAPSHOT.with(|s| s.borrow().len() as u32)
 }
 
+/// Get the names of all entities within a radius of a world-space point, as a JSON array string.
 #[op2]
 #[string]
 pub fn bsengine_get_entities_in_radius(x: f32, y: f32, z: f32, radius: f32) -> String {
@@ -2129,6 +2748,7 @@ pub fn bsengine_get_entities_in_radius(x: f32, y: f32, z: f32, radius: f32) -> S
     })
 }
 
+/// Get the name of the entity closest to a world-space point.
 #[op2]
 #[string]
 pub fn bsengine_get_closest_entity(x: f32, y: f32, z: f32) -> String {
@@ -2146,6 +2766,7 @@ pub fn bsengine_get_closest_entity(x: f32, y: f32, z: f32) -> String {
     })
 }
 
+/// Queue setting an entity's emissive material color.
 #[op2(fast)]
 pub fn bsengine_set_emissive(#[string] name: String, r: f32, g: f32, b: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2154,6 +2775,7 @@ pub fn bsengine_set_emissive(#[string] name: String, r: f32, g: f32, b: f32) {
     });
 }
 
+/// Queue setting an entity's base material color.
 #[op2(fast)]
 pub fn bsengine_set_color(#[string] name: String, r: f32, g: f32, b: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2162,16 +2784,19 @@ pub fn bsengine_set_color(#[string] name: String, r: f32, g: f32, b: f32) {
     });
 }
 
+/// Queue spawning a new entity from the given parameters.
 #[op2]
 pub fn bsengine_spawn(#[serde] params: SpawnParams) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::Spawn(params)));
 }
 
+/// Queue destroying a named entity.
 #[op2(fast)]
 pub fn bsengine_destroy(#[string] name: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::Destroy { name }));
 }
 
+/// Queue showing or hiding an entity.
 #[op2(fast)]
 pub fn bsengine_set_visible(#[string] name: String, visible: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -2180,23 +2805,27 @@ pub fn bsengine_set_visible(#[string] name: String, visible: bool) {
     });
 }
 
+/// Check whether an entity is currently visible.
 #[op2(fast)]
 pub fn bsengine_get_visible(#[string] name: String) -> bool {
     VISIBLE_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(true))
 }
 
+/// Get an entity's base material color as `[r, g, b]`, or `None` if it has no material.
 #[op2]
 #[serde]
 pub fn bsengine_get_material_color(#[string] name: String) -> Option<Vec<f32>> {
     MATERIAL_COLOR_SNAPSHOT.with(|s| s.borrow().get(&name).map(|c| c.to_vec()))
 }
 
+/// Get an entity's emissive material color as `[r, g, b]`, or `None` if it has no material.
 #[op2]
 #[serde]
 pub fn bsengine_get_material_emissive(#[string] name: String) -> Option<Vec<f32>> {
     MATERIAL_EMISSIVE_SNAPSHOT.with(|s| s.borrow().get(&name).map(|c| c.to_vec()))
 }
 
+/// Queue setting an entity's material metallic factor.
 #[op2(fast)]
 pub fn bsengine_set_metallic(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2205,11 +2834,13 @@ pub fn bsengine_set_metallic(#[string] name: String, value: f32) {
     });
 }
 
+/// Get an entity's material metallic factor.
 #[op2(fast)]
 pub fn bsengine_get_metallic(#[string] name: String) -> f32 {
     MATERIAL_METALLIC_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(f32::NAN))
 }
 
+/// Queue setting an entity's material roughness factor.
 #[op2(fast)]
 pub fn bsengine_set_roughness(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2218,11 +2849,13 @@ pub fn bsengine_set_roughness(#[string] name: String, value: f32) {
     });
 }
 
+/// Get an entity's material roughness factor.
 #[op2(fast)]
 pub fn bsengine_get_roughness(#[string] name: String) -> f32 {
     MATERIAL_ROUGHNESS_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(f32::NAN))
 }
 
+/// Queue setting a point light's color.
 #[op2(fast)]
 pub fn bsengine_set_point_light_color(#[string] name: String, r: f32, g: f32, b: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2231,6 +2864,7 @@ pub fn bsengine_set_point_light_color(#[string] name: String, r: f32, g: f32, b:
     });
 }
 
+/// Queue setting a point light's intensity.
 #[op2(fast)]
 pub fn bsengine_set_point_light_intensity(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2239,6 +2873,7 @@ pub fn bsengine_set_point_light_intensity(#[string] name: String, value: f32) {
     });
 }
 
+/// Queue setting a point light's maximum range.
 #[op2(fast)]
 pub fn bsengine_set_point_light_range(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2247,6 +2882,7 @@ pub fn bsengine_set_point_light_range(#[string] name: String, value: f32) {
     });
 }
 
+/// Queue setting a spot light's color.
 #[op2(fast)]
 pub fn bsengine_set_spot_light_color(#[string] name: String, r: f32, g: f32, b: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2255,6 +2891,7 @@ pub fn bsengine_set_spot_light_color(#[string] name: String, r: f32, g: f32, b: 
     });
 }
 
+/// Queue setting a spot light's intensity.
 #[op2(fast)]
 pub fn bsengine_set_spot_light_intensity(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2263,6 +2900,7 @@ pub fn bsengine_set_spot_light_intensity(#[string] name: String, value: f32) {
     });
 }
 
+/// Queue setting a spot light's maximum range.
 #[op2(fast)]
 pub fn bsengine_set_spot_light_range(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2271,6 +2909,7 @@ pub fn bsengine_set_spot_light_range(#[string] name: String, value: f32) {
     });
 }
 
+/// Queue setting a spot light's inner cone angle.
 #[op2(fast)]
 pub fn bsengine_set_spot_light_inner_angle(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2279,6 +2918,7 @@ pub fn bsengine_set_spot_light_inner_angle(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue setting a spot light's outer cone angle.
 #[op2(fast)]
 pub fn bsengine_set_spot_light_outer_angle(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2287,6 +2927,7 @@ pub fn bsengine_set_spot_light_outer_angle(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue setting a directional light's color.
 #[op2(fast)]
 pub fn bsengine_set_directional_light_color(#[string] name: String, r: f32, g: f32, b: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2295,6 +2936,7 @@ pub fn bsengine_set_directional_light_color(#[string] name: String, r: f32, g: f
     });
 }
 
+/// Queue setting a directional light's ambient color contribution.
 #[op2(fast)]
 pub fn bsengine_set_directional_light_ambient(#[string] name: String, r: f32, g: f32, b: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2303,6 +2945,7 @@ pub fn bsengine_set_directional_light_ambient(#[string] name: String, r: f32, g:
     });
 }
 
+/// Queue setting a directional light's direction vector.
 #[op2(fast)]
 pub fn bsengine_set_directional_light_direction(#[string] name: String, x: f32, y: f32, z: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2311,6 +2954,7 @@ pub fn bsengine_set_directional_light_direction(#[string] name: String, x: f32, 
     });
 }
 
+/// Queue setting a camera's vertical field of view, in degrees.
 #[op2(fast)]
 pub fn bsengine_set_camera_fov(#[string] name: String, deg: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2319,6 +2963,7 @@ pub fn bsengine_set_camera_fov(#[string] name: String, deg: f32) {
     });
 }
 
+/// Queue setting a camera's near clip plane distance.
 #[op2(fast)]
 pub fn bsengine_set_camera_near(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2327,6 +2972,7 @@ pub fn bsengine_set_camera_near(#[string] name: String, value: f32) {
     });
 }
 
+/// Queue setting a camera's far clip plane distance.
 #[op2(fast)]
 pub fn bsengine_set_camera_far(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2335,6 +2981,7 @@ pub fn bsengine_set_camera_far(#[string] name: String, value: f32) {
     });
 }
 
+/// Queue setting a generic damping coefficient on an entity.
 #[op2(fast)]
 pub fn bsengine_set_damping(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2343,6 +2990,7 @@ pub fn bsengine_set_damping(#[string] name: String, value: f32) {
     });
 }
 
+/// Queue playing an animation clip on an entity.
 #[op2(fast)]
 pub fn bsengine_play_animation(#[string] name: String, #[string] clip: String) {
     COMMAND_BUFFER.with(|c| {
@@ -2351,21 +2999,25 @@ pub fn bsengine_play_animation(#[string] name: String, #[string] clip: String) {
     });
 }
 
+/// Queue pausing an entity's currently playing animation.
 #[op2(fast)]
 pub fn bsengine_pause_animation(#[string] name: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::PauseAnimation { name }));
 }
 
+/// Queue resuming an entity's paused animation.
 #[op2(fast)]
 pub fn bsengine_resume_animation(#[string] name: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResumeAnimation { name }));
 }
 
+/// Queue resetting an entity's animation back to its first frame.
 #[op2(fast)]
 pub fn bsengine_reset_animation(#[string] name: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResetAnimation { name }));
 }
 
+/// Queue setting the playback speed multiplier of an entity's animation.
 #[op2(fast)]
 pub fn bsengine_set_animation_speed(#[string] name: String, speed: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2374,6 +3026,7 @@ pub fn bsengine_set_animation_speed(#[string] name: String, speed: f32) {
     });
 }
 
+/// Queue setting whether an entity's animation loops.
 #[op2(fast)]
 pub fn bsengine_set_animation_looping(#[string] name: String, looping: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -2382,6 +3035,7 @@ pub fn bsengine_set_animation_looping(#[string] name: String, looping: bool) {
     });
 }
 
+/// Queue firing a trigger on an entity's animation state machine.
 #[op2(fast)]
 pub fn bsengine_anim_set_trigger(#[string] name: String, #[string] trigger: String) {
     COMMAND_BUFFER.with(|c| {
@@ -2390,6 +3044,7 @@ pub fn bsengine_anim_set_trigger(#[string] name: String, #[string] trigger: Stri
     });
 }
 
+/// Queue setting a float parameter on an entity's animation state machine.
 #[op2(fast)]
 pub fn bsengine_anim_set_float(#[string] name: String, #[string] param: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2398,6 +3053,7 @@ pub fn bsengine_anim_set_float(#[string] name: String, #[string] param: String, 
     });
 }
 
+/// Queue setting a boolean parameter on an entity's animation state machine.
 #[op2(fast)]
 pub fn bsengine_anim_set_bool(#[string] name: String, #[string] param: String, value: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -2406,12 +3062,14 @@ pub fn bsengine_anim_set_bool(#[string] name: String, #[string] param: String, v
     });
 }
 
+/// Get the current state name of an entity's animation state machine.
 #[op2]
 #[string]
 pub fn bsengine_anim_get_state(#[string] name: String) -> String {
     ASM_STATE_SNAPSHOT.with(|s| s.borrow().get(&name).cloned().unwrap_or_default())
 }
 
+/// Get the name of the animation clip currently playing on an entity.
 #[op2]
 #[string]
 pub fn bsengine_get_animation_clip(#[string] name: String) -> String {
@@ -2423,6 +3081,7 @@ pub fn bsengine_get_animation_clip(#[string] name: String) -> String {
     })
 }
 
+/// Get the current playback time of an entity's animation, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_animation_time(#[string] name: String) -> f32 {
     ANIMATION_SNAPSHOT.with(|s| {
@@ -2433,6 +3092,7 @@ pub fn bsengine_get_animation_time(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the playback speed multiplier of an entity's animation.
 #[op2(fast)]
 pub fn bsengine_get_animation_speed(#[string] name: String) -> f32 {
     ANIMATION_SNAPSHOT.with(|s| {
@@ -2443,6 +3103,7 @@ pub fn bsengine_get_animation_speed(#[string] name: String) -> f32 {
     })
 }
 
+/// Check whether an entity's animation is currently playing.
 #[op2(fast)]
 pub fn bsengine_is_animation_playing(#[string] name: String) -> bool {
     ANIMATION_SNAPSHOT.with(|s| {
@@ -2453,6 +3114,7 @@ pub fn bsengine_is_animation_playing(#[string] name: String) -> bool {
     })
 }
 
+/// Check whether an entity's animation is set to loop.
 #[op2(fast)]
 pub fn bsengine_is_animation_looping(#[string] name: String) -> bool {
     ANIMATION_SNAPSHOT.with(|s| {
@@ -2463,6 +3125,7 @@ pub fn bsengine_is_animation_looping(#[string] name: String) -> bool {
     })
 }
 
+/// Queue a countdown after which an entity is automatically destroyed.
 #[op2(fast)]
 pub fn bsengine_set_lifetime(#[string] name: String, seconds: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2471,11 +3134,13 @@ pub fn bsengine_set_lifetime(#[string] name: String, seconds: f32) {
     });
 }
 
+/// Get the remaining lifetime of an entity, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_lifetime(#[string] name: String) -> f32 {
     LIFETIME_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
 }
 
+/// Queue subtracting damage from an entity's shield value.
 #[op2(fast)]
 pub fn bsengine_damage_shield(#[string] name: String, amount: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2484,6 +3149,7 @@ pub fn bsengine_damage_shield(#[string] name: String, amount: f32) {
     });
 }
 
+/// Queue restoring some of an entity's shield value.
 #[op2(fast)]
 pub fn bsengine_restore_shield(#[string] name: String, amount: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2492,6 +3158,7 @@ pub fn bsengine_restore_shield(#[string] name: String, amount: f32) {
     });
 }
 
+/// Queue setting an entity's maximum shield capacity.
 #[op2(fast)]
 pub fn bsengine_set_max_shield(#[string] name: String, value: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2872,16 +3539,19 @@ pub fn bsengine_set_max_shield(#[string] name: String, value: f32) {
 // ── Smoke ────────────────────────────────────────────────────────────────────
 // ── Snare ────────────────────────────────────────────────────────────────────
 // ── Soak ─────────────────────────────────────────────────────────────────────
+/// Get an entity's current shield value.
 #[op2(fast)]
 pub fn bsengine_get_shield(#[string] name: String) -> f32 {
     SHIELD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(cur, _)| *cur).unwrap_or(0.0))
 }
 
+/// Get an entity's maximum shield capacity.
 #[op2(fast)]
 pub fn bsengine_get_max_shield(#[string] name: String) -> f32 {
     SHIELD_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(_, max)| *max).unwrap_or(0.0))
 }
 
+/// Get an entity's current shield value as a fraction of its maximum.
 #[op2(fast)]
 pub fn bsengine_get_shield_fraction(#[string] name: String) -> f32 {
     SHIELD_SNAPSHOT.with(|s| {
@@ -2898,6 +3568,7 @@ pub fn bsengine_get_shield_fraction(#[string] name: String) -> f32 {
     })
 }
 
+/// Check whether an entity's shield is fully depleted.
 #[op2(fast)]
 pub fn bsengine_is_shield_depleted(#[string] name: String) -> bool {
     SHIELD_SNAPSHOT.with(|s| {
@@ -2908,11 +3579,13 @@ pub fn bsengine_is_shield_depleted(#[string] name: String) -> bool {
     })
 }
 
+/// Queue resetting a named entity's gameplay timer back to zero.
 #[op2(fast)]
 pub fn bsengine_reset_timer(#[string] name: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResetTimer { name }));
 }
 
+/// Get the elapsed time of an entity's gameplay timer, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_timer_elapsed(#[string] name: String) -> f32 {
     TIMER_SNAPSHOT.with(|s| {
@@ -2923,6 +3596,7 @@ pub fn bsengine_get_timer_elapsed(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the configured duration of an entity's gameplay timer, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_timer_duration(#[string] name: String) -> f32 {
     TIMER_SNAPSHOT.with(|s| {
@@ -2933,6 +3607,7 @@ pub fn bsengine_get_timer_duration(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the elapsed fraction (0-1) of an entity's gameplay timer.
 #[op2(fast)]
 pub fn bsengine_get_timer_fraction(#[string] name: String) -> f32 {
     TIMER_SNAPSHOT.with(|s| {
@@ -2943,6 +3618,7 @@ pub fn bsengine_get_timer_fraction(#[string] name: String) -> f32 {
     })
 }
 
+/// Check whether an entity's gameplay timer has finished.
 #[op2(fast)]
 pub fn bsengine_is_timer_finished(#[string] name: String) -> bool {
     TIMER_SNAPSHOT.with(|s| {
@@ -2953,6 +3629,7 @@ pub fn bsengine_is_timer_finished(#[string] name: String) -> bool {
     })
 }
 
+/// Check whether an entity's gameplay timer finished on this exact frame.
 #[op2(fast)]
 pub fn bsengine_is_timer_just_finished(#[string] name: String) -> bool {
     TIMER_SNAPSHOT.with(|s| {
@@ -2963,6 +3640,7 @@ pub fn bsengine_is_timer_just_finished(#[string] name: String) -> bool {
     })
 }
 
+/// Queue setting the destination point for an entity's nav-mesh agent.
 #[op2(fast)]
 pub fn bsengine_set_nav_destination(#[string] name: String, x: f32, y: f32, z: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2971,6 +3649,7 @@ pub fn bsengine_set_nav_destination(#[string] name: String, x: f32, y: f32, z: f
     });
 }
 
+/// Queue clearing an entity's current nav-mesh destination, halting movement.
 #[op2(fast)]
 pub fn bsengine_clear_nav_destination(#[string] name: String) {
     COMMAND_BUFFER.with(|c| {
@@ -2979,6 +3658,7 @@ pub fn bsengine_clear_nav_destination(#[string] name: String) {
     });
 }
 
+/// Queue setting an entity's nav-mesh agent movement speed.
 #[op2(fast)]
 pub fn bsengine_set_nav_speed(#[string] name: String, speed: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2987,6 +3667,7 @@ pub fn bsengine_set_nav_speed(#[string] name: String, speed: f32) {
     });
 }
 
+/// Queue setting an entity's nav-mesh agent turning speed.
 #[op2(fast)]
 pub fn bsengine_set_nav_angular_speed(#[string] name: String, speed: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -2995,6 +3676,7 @@ pub fn bsengine_set_nav_angular_speed(#[string] name: String, speed: f32) {
     });
 }
 
+/// Queue setting how close an entity's nav-mesh agent must get before it stops.
 #[op2(fast)]
 pub fn bsengine_set_nav_stopping_distance(#[string] name: String, distance: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3003,6 +3685,7 @@ pub fn bsengine_set_nav_stopping_distance(#[string] name: String, distance: f32)
     });
 }
 
+/// Queue enabling or disabling an entity's nav-mesh agent.
 #[op2(fast)]
 pub fn bsengine_set_nav_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -3011,6 +3694,7 @@ pub fn bsengine_set_nav_enabled(#[string] name: String, enabled: bool) {
     });
 }
 
+/// Get an entity's nav-mesh agent movement speed.
 #[op2(fast)]
 pub fn bsengine_get_nav_speed(#[string] name: String) -> f32 {
     NAV_SNAPSHOT.with(|s| {
@@ -3021,6 +3705,7 @@ pub fn bsengine_get_nav_speed(#[string] name: String) -> f32 {
     })
 }
 
+/// Get an entity's nav-mesh agent turning speed.
 #[op2(fast)]
 pub fn bsengine_get_nav_angular_speed(#[string] name: String) -> f32 {
     NAV_SNAPSHOT.with(|s| {
@@ -3031,6 +3716,7 @@ pub fn bsengine_get_nav_angular_speed(#[string] name: String) -> f32 {
     })
 }
 
+/// Get an entity's nav-mesh agent stopping distance.
 #[op2(fast)]
 pub fn bsengine_get_nav_stopping_distance(#[string] name: String) -> f32 {
     NAV_SNAPSHOT.with(|s| {
@@ -3041,6 +3727,7 @@ pub fn bsengine_get_nav_stopping_distance(#[string] name: String) -> f32 {
     })
 }
 
+/// Check whether an entity's nav-mesh agent is currently moving.
 #[op2(fast)]
 pub fn bsengine_is_nav_moving(#[string] name: String) -> bool {
     NAV_SNAPSHOT.with(|s| {
@@ -3051,6 +3738,7 @@ pub fn bsengine_is_nav_moving(#[string] name: String) -> bool {
     })
 }
 
+/// Check whether an entity's nav-mesh agent has reached its destination.
 #[op2(fast)]
 pub fn bsengine_has_nav_arrived(#[string] name: String) -> bool {
     NAV_SNAPSHOT.with(|s| {
@@ -3061,6 +3749,7 @@ pub fn bsengine_has_nav_arrived(#[string] name: String) -> bool {
     })
 }
 
+/// Check whether an entity's nav-mesh agent has no destination set.
 #[op2(fast)]
 pub fn bsengine_is_nav_idle(#[string] name: String) -> bool {
     NAV_SNAPSHOT.with(|s| {
@@ -3071,6 +3760,7 @@ pub fn bsengine_is_nav_idle(#[string] name: String) -> bool {
     })
 }
 
+/// Check whether an entity's nav-mesh agent failed to find a path to its destination.
 #[op2(fast)]
 pub fn bsengine_nav_has_no_path(#[string] name: String) -> bool {
     NAV_SNAPSHOT.with(|s| {
@@ -3081,6 +3771,7 @@ pub fn bsengine_nav_has_no_path(#[string] name: String) -> bool {
     })
 }
 
+/// Check whether an entity's nav-mesh agent is enabled.
 #[op2(fast)]
 pub fn bsengine_is_nav_enabled(#[string] name: String) -> bool {
     NAV_SNAPSHOT.with(|s| {
@@ -3091,6 +3782,7 @@ pub fn bsengine_is_nav_enabled(#[string] name: String) -> bool {
     })
 }
 
+/// Queue (re)initializing the nav-mesh grid used for pathfinding.
 #[op2(fast)]
 pub fn bsengine_navmesh_init(width: u32, depth: u32, cell_size: f32, ox: f32, oy: f32, oz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3105,6 +3797,7 @@ pub fn bsengine_navmesh_init(width: u32, depth: u32, cell_size: f32, ox: f32, oy
     });
 }
 
+/// Queue marking a nav-mesh grid cell as walkable or blocked.
 #[op2(fast)]
 pub fn bsengine_navmesh_set_walkable(x: u32, z: u32, walkable: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -3113,6 +3806,7 @@ pub fn bsengine_navmesh_set_walkable(x: u32, z: u32, walkable: bool) {
     });
 }
 
+/// Get the current nav-mesh grid state, as a JSON string.
 #[op2]
 #[string]
 pub fn bsengine_navmesh_get_state(#[string] name: String) -> String {
@@ -3130,16 +3824,19 @@ pub fn bsengine_navmesh_get_state(#[string] name: String) -> String {
     })
 }
 
+/// Queue serializing the current world state to a save file.
 #[op2(fast)]
 pub fn bsengine_save_game(#[string] path: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SaveGame { path }));
 }
 
+/// Queue loading world state from a save file.
 #[op2(fast)]
 pub fn bsengine_load_game(#[string] path: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::LoadGame { path }));
 }
 
+/// Queue assigning a custom shader to an entity's material.
 #[op2(fast)]
 pub fn bsengine_material_set_shader(#[string] name: String, #[string] path: String) {
     COMMAND_BUFFER.with(|c| {
@@ -3148,6 +3845,7 @@ pub fn bsengine_material_set_shader(#[string] name: String, #[string] path: Stri
     });
 }
 
+/// Queue removing an entity's custom shader, reverting to the default.
 #[op2(fast)]
 pub fn bsengine_material_clear_shader(#[string] name: String) {
     COMMAND_BUFFER.with(|c| {
@@ -3156,6 +3854,7 @@ pub fn bsengine_material_clear_shader(#[string] name: String) {
     });
 }
 
+/// Queue setting the bloom post-process effect intensity.
 #[op2(fast)]
 pub fn bsengine_set_bloom_intensity(#[string] name: String, intensity: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3164,6 +3863,7 @@ pub fn bsengine_set_bloom_intensity(#[string] name: String, intensity: f32) {
     });
 }
 
+/// Queue setting the brightness threshold above which bloom is applied.
 #[op2(fast)]
 pub fn bsengine_set_bloom_threshold(#[string] name: String, threshold: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3172,6 +3872,7 @@ pub fn bsengine_set_bloom_threshold(#[string] name: String, threshold: f32) {
     });
 }
 
+/// Queue setting the blur radius of the bloom effect.
 #[op2(fast)]
 pub fn bsengine_set_bloom_radius(#[string] name: String, radius: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3180,6 +3881,7 @@ pub fn bsengine_set_bloom_radius(#[string] name: String, radius: f32) {
     });
 }
 
+/// Queue setting the softness of the bloom threshold falloff.
 #[op2(fast)]
 pub fn bsengine_set_bloom_softness(#[string] name: String, softness: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3188,6 +3890,7 @@ pub fn bsengine_set_bloom_softness(#[string] name: String, softness: f32) {
     });
 }
 
+/// Queue enabling or disabling the bloom post-process effect.
 #[op2(fast)]
 pub fn bsengine_set_bloom_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -3196,6 +3899,7 @@ pub fn bsengine_set_bloom_enabled(#[string] name: String, enabled: bool) {
     });
 }
 
+/// Get the current bloom post-process effect intensity.
 #[op2(fast)]
 pub fn bsengine_get_bloom_intensity(#[string] name: String) -> f32 {
     BLOOM_SNAPSHOT.with(|s| {
@@ -3206,6 +3910,7 @@ pub fn bsengine_get_bloom_intensity(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the current bloom brightness threshold.
 #[op2(fast)]
 pub fn bsengine_get_bloom_threshold(#[string] name: String) -> f32 {
     BLOOM_SNAPSHOT.with(|s| {
@@ -3216,6 +3921,7 @@ pub fn bsengine_get_bloom_threshold(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the current bloom blur radius.
 #[op2(fast)]
 pub fn bsengine_get_bloom_radius(#[string] name: String) -> f32 {
     BLOOM_SNAPSHOT.with(|s| {
@@ -3226,6 +3932,7 @@ pub fn bsengine_get_bloom_radius(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the current bloom threshold falloff softness.
 #[op2(fast)]
 pub fn bsengine_get_bloom_softness(#[string] name: String) -> f32 {
     BLOOM_SNAPSHOT.with(|s| {
@@ -3236,6 +3943,7 @@ pub fn bsengine_get_bloom_softness(#[string] name: String) -> f32 {
     })
 }
 
+/// Check whether the bloom post-process effect is enabled.
 #[op2(fast)]
 pub fn bsengine_is_bloom_enabled(#[string] name: String) -> bool {
     BLOOM_SNAPSHOT.with(|s| {
@@ -3246,6 +3954,7 @@ pub fn bsengine_is_bloom_enabled(#[string] name: String) -> bool {
     })
 }
 
+/// Queue setting the sampling radius of the ambient occlusion effect.
 #[op2(fast)]
 pub fn bsengine_set_ao_radius(#[string] name: String, radius: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3254,11 +3963,13 @@ pub fn bsengine_set_ao_radius(#[string] name: String, radius: f32) {
     });
 }
 
+/// Queue setting the ambient occlusion bias, used to reduce self-shadowing artifacts.
 #[op2(fast)]
 pub fn bsengine_set_ao_bias(#[string] name: String, bias: f32) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SetAoBias { name, bias }));
 }
 
+/// Queue setting the strength of the ambient occlusion effect.
 #[op2(fast)]
 pub fn bsengine_set_ao_intensity(#[string] name: String, intensity: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3267,6 +3978,7 @@ pub fn bsengine_set_ao_intensity(#[string] name: String, intensity: f32) {
     });
 }
 
+/// Queue setting the number of samples used by the ambient occlusion effect.
 #[op2(fast)]
 pub fn bsengine_set_ao_sample_count(#[string] name: String, count: u32) {
     COMMAND_BUFFER.with(|c| {
@@ -3275,6 +3987,7 @@ pub fn bsengine_set_ao_sample_count(#[string] name: String, count: u32) {
     });
 }
 
+/// Queue enabling or disabling the ambient occlusion effect.
 #[op2(fast)]
 pub fn bsengine_set_ao_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -3283,6 +3996,7 @@ pub fn bsengine_set_ao_enabled(#[string] name: String, enabled: bool) {
     });
 }
 
+/// Get the current ambient occlusion sampling radius.
 #[op2(fast)]
 pub fn bsengine_get_ao_radius(#[string] name: String) -> f32 {
     AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
@@ -3293,6 +4007,7 @@ pub fn bsengine_get_ao_radius(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the current ambient occlusion bias.
 #[op2(fast)]
 pub fn bsengine_get_ao_bias(#[string] name: String) -> f32 {
     AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
@@ -3303,6 +4018,7 @@ pub fn bsengine_get_ao_bias(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the current ambient occlusion strength.
 #[op2(fast)]
 pub fn bsengine_get_ao_intensity(#[string] name: String) -> f32 {
     AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
@@ -3313,6 +4029,7 @@ pub fn bsengine_get_ao_intensity(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the current ambient occlusion sample count.
 #[op2(fast)]
 pub fn bsengine_get_ao_sample_count(#[string] name: String) -> u32 {
     AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
@@ -3323,6 +4040,7 @@ pub fn bsengine_get_ao_sample_count(#[string] name: String) -> u32 {
     })
 }
 
+/// Check whether the ambient occlusion effect is enabled.
 #[op2(fast)]
 pub fn bsengine_is_ao_enabled(#[string] name: String) -> bool {
     AMBIENT_OCCLUSION_SNAPSHOT.with(|s| {
@@ -3333,6 +4051,7 @@ pub fn bsengine_is_ao_enabled(#[string] name: String) -> bool {
     })
 }
 
+/// Queue setting the tone-mapping operator used by the render pipeline.
 #[op2(fast)]
 pub fn bsengine_set_tone_map_mode(#[string] name: String, mode: u32) {
     COMMAND_BUFFER.with(|c| {
@@ -3341,6 +4060,7 @@ pub fn bsengine_set_tone_map_mode(#[string] name: String, mode: u32) {
     });
 }
 
+/// Queue setting the exposure applied before tone mapping.
 #[op2(fast)]
 pub fn bsengine_set_tone_map_exposure(#[string] name: String, exposure: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3349,6 +4069,7 @@ pub fn bsengine_set_tone_map_exposure(#[string] name: String, exposure: f32) {
     });
 }
 
+/// Queue enabling or disabling tone mapping.
 #[op2(fast)]
 pub fn bsengine_set_tone_map_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -3357,21 +4078,25 @@ pub fn bsengine_set_tone_map_enabled(#[string] name: String, enabled: bool) {
     });
 }
 
+/// Get the current tone-mapping operator, encoded as an integer.
 #[op2(fast)]
 pub fn bsengine_get_tone_map_mode(#[string] name: String) -> u32 {
     TONE_MAP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(m, _, _)| *m).unwrap_or(0))
 }
 
+/// Get the current tone-mapping exposure value.
 #[op2(fast)]
 pub fn bsengine_get_tone_map_exposure(#[string] name: String) -> f32 {
     TONE_MAP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(_, e, _)| *e).unwrap_or(0.0))
 }
 
+/// Check whether tone mapping is enabled.
 #[op2(fast)]
 pub fn bsengine_is_tone_map_enabled(#[string] name: String) -> bool {
     TONE_MAP_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(_, _, en)| *en).unwrap_or(true))
 }
 
+/// Queue setting the duration of a running tween.
 #[op2(fast)]
 pub fn bsengine_set_tween_duration(#[string] name: String, duration: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3380,6 +4105,7 @@ pub fn bsengine_set_tween_duration(#[string] name: String, duration: f32) {
     });
 }
 
+/// Queue setting the easing function used by a running tween.
 #[op2(fast)]
 pub fn bsengine_set_tween_easing(#[string] name: String, easing: u32) {
     COMMAND_BUFFER.with(|c| {
@@ -3388,6 +4114,7 @@ pub fn bsengine_set_tween_easing(#[string] name: String, easing: u32) {
     });
 }
 
+/// Queue setting the repeat count of a running tween.
 #[op2(fast)]
 pub fn bsengine_set_tween_repeat(#[string] name: String, repeat: u32) {
     COMMAND_BUFFER.with(|c| {
@@ -3396,6 +4123,7 @@ pub fn bsengine_set_tween_repeat(#[string] name: String, repeat: u32) {
     });
 }
 
+/// Queue setting the elapsed time of a running tween.
 #[op2(fast)]
 pub fn bsengine_set_tween_elapsed(#[string] name: String, elapsed: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -3404,6 +4132,7 @@ pub fn bsengine_set_tween_elapsed(#[string] name: String, elapsed: f32) {
     });
 }
 
+/// Get the kind of property a running tween is animating, encoded as an integer.
 #[op2(fast)]
 pub fn bsengine_get_tween_target_type(#[string] name: String) -> u32 {
     TWEEN_SNAPSHOT.with(|s| {
@@ -3414,6 +4143,7 @@ pub fn bsengine_get_tween_target_type(#[string] name: String) -> u32 {
     })
 }
 
+/// Get the duration of a running tween, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_tween_duration(#[string] name: String) -> f32 {
     TWEEN_SNAPSHOT.with(|s| {
@@ -3424,6 +4154,7 @@ pub fn bsengine_get_tween_duration(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the easing function of a running tween, encoded as an integer.
 #[op2(fast)]
 pub fn bsengine_get_tween_easing(#[string] name: String) -> u32 {
     TWEEN_SNAPSHOT.with(|s| {
@@ -3434,6 +4165,7 @@ pub fn bsengine_get_tween_easing(#[string] name: String) -> u32 {
     })
 }
 
+/// Get the repeat count of a running tween.
 #[op2(fast)]
 pub fn bsengine_get_tween_repeat(#[string] name: String) -> u32 {
     TWEEN_SNAPSHOT.with(|s| {
@@ -3444,6 +4176,7 @@ pub fn bsengine_get_tween_repeat(#[string] name: String) -> u32 {
     })
 }
 
+/// Get the elapsed time of a running tween, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_tween_elapsed(#[string] name: String) -> f32 {
     TWEEN_SNAPSHOT.with(|s| {
@@ -3454,6 +4187,7 @@ pub fn bsengine_get_tween_elapsed(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the elapsed fraction (0-1) of a running tween.
 #[op2(fast)]
 pub fn bsengine_get_tween_progress(#[string] name: String) -> f32 {
     TWEEN_SNAPSHOT.with(|s| {
@@ -3470,6 +4204,7 @@ pub fn bsengine_get_tween_progress(#[string] name: String) -> f32 {
     })
 }
 
+/// Check whether a running tween has finished.
 #[op2(fast)]
 pub fn bsengine_is_tween_finished(#[string] name: String) -> bool {
     TWEEN_SNAPSHOT.with(|s| {
@@ -3480,6 +4215,7 @@ pub fn bsengine_is_tween_finished(#[string] name: String) -> bool {
     })
 }
 
+/// Check whether a running tween is currently playing in reverse.
 #[op2(fast)]
 pub fn bsengine_is_tween_reversed(#[string] name: String) -> bool {
     TWEEN_SNAPSHOT.with(|s| {
@@ -3490,6 +4226,7 @@ pub fn bsengine_is_tween_reversed(#[string] name: String) -> bool {
     })
 }
 
+/// Queue setting the entity a camera/follow-behavior should track.
 #[op2(fast)]
 pub fn bsengine_set_follow_target(#[string] name: String, #[string] target: String) {
     COMMAND_BUFFER.with(|b| {
@@ -3498,6 +4235,7 @@ pub fn bsengine_set_follow_target(#[string] name: String, #[string] target: Stri
     });
 }
 
+/// Queue setting the offset a follow-behavior maintains from its target.
 #[op2(fast)]
 pub fn bsengine_set_follow_offset(#[string] name: String, x: f32, y: f32, z: f32) {
     COMMAND_BUFFER.with(|b| {
@@ -3506,6 +4244,7 @@ pub fn bsengine_set_follow_offset(#[string] name: String, x: f32, y: f32, z: f32
     });
 }
 
+/// Queue setting how quickly a follow-behavior catches up to its target.
 #[op2(fast)]
 pub fn bsengine_set_follow_speed(#[string] name: String, speed: f32) {
     COMMAND_BUFFER.with(|b| {
@@ -3514,6 +4253,7 @@ pub fn bsengine_set_follow_speed(#[string] name: String, speed: f32) {
     });
 }
 
+/// Get the name of the entity a follow-behavior is currently tracking.
 #[op2]
 #[string]
 pub fn bsengine_get_follow_target(#[string] name: String) -> String {
@@ -3525,6 +4265,7 @@ pub fn bsengine_get_follow_target(#[string] name: String) -> String {
     })
 }
 
+/// Get the X component of a follow-behavior's target offset.
 #[op2(fast)]
 pub fn bsengine_get_follow_offset_x(#[string] name: String) -> f32 {
     FOLLOW_SNAPSHOT.with(|s| {
@@ -3535,6 +4276,7 @@ pub fn bsengine_get_follow_offset_x(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the Y component of a follow-behavior's target offset.
 #[op2(fast)]
 pub fn bsengine_get_follow_offset_y(#[string] name: String) -> f32 {
     FOLLOW_SNAPSHOT.with(|s| {
@@ -3545,6 +4287,7 @@ pub fn bsengine_get_follow_offset_y(#[string] name: String) -> f32 {
     })
 }
 
+/// Get the Z component of a follow-behavior's target offset.
 #[op2(fast)]
 pub fn bsengine_get_follow_offset_z(#[string] name: String) -> f32 {
     FOLLOW_SNAPSHOT.with(|s| {
@@ -3555,6 +4298,7 @@ pub fn bsengine_get_follow_offset_z(#[string] name: String) -> f32 {
     })
 }
 
+/// Get a follow-behavior's catch-up speed.
 #[op2(fast)]
 pub fn bsengine_get_follow_speed(#[string] name: String) -> f32 {
     FOLLOW_SNAPSHOT.with(|s| {
@@ -3565,6 +4309,7 @@ pub fn bsengine_get_follow_speed(#[string] name: String) -> f32 {
     })
 }
 
+/// Queue setting the entity a look-at behavior should aim towards.
 #[op2(fast)]
 pub fn bsengine_set_look_at_target(#[string] name: String, #[string] target: String) {
     COMMAND_BUFFER.with(|b| {
@@ -3573,6 +4318,7 @@ pub fn bsengine_set_look_at_target(#[string] name: String, #[string] target: Str
     });
 }
 
+/// Queue setting the up vector used by a look-at behavior.
 #[op2(fast)]
 pub fn bsengine_set_look_at_up(#[string] name: String, x: f32, y: f32, z: f32) {
     COMMAND_BUFFER.with(|b| {
@@ -3581,6 +4327,7 @@ pub fn bsengine_set_look_at_up(#[string] name: String, x: f32, y: f32, z: f32) {
     });
 }
 
+/// Get the name of the entity a look-at behavior is aiming towards.
 #[op2]
 #[string]
 pub fn bsengine_get_look_at_target(#[string] name: String) -> String {
@@ -3592,16 +4339,19 @@ pub fn bsengine_get_look_at_target(#[string] name: String) -> String {
     })
 }
 
+/// Get the X component of a look-at behavior's up vector.
 #[op2(fast)]
 pub fn bsengine_get_look_at_up_x(#[string] name: String) -> f32 {
     LOOK_AT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(_, x, _, _)| *x).unwrap_or(0.0))
 }
 
+/// Get the Y component of a look-at behavior's up vector.
 #[op2(fast)]
 pub fn bsengine_get_look_at_up_y(#[string] name: String) -> f32 {
     LOOK_AT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(_, _, y, _)| *y).unwrap_or(1.0))
 }
 
+/// Get the Z component of a look-at behavior's up vector.
 #[op2(fast)]
 pub fn bsengine_get_look_at_up_z(#[string] name: String) -> f32 {
     LOOK_AT_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(_, _, _, z)| *z).unwrap_or(0.0))
@@ -3761,6 +4511,7 @@ pub fn bsengine_get_look_at_up_z(#[string] name: String) -> f32 {
 
 // ── NetworkId ─────────────────────────────────────────────────────────────────
 
+/// Get an entity's replicated network id string.
 #[op2]
 #[string]
 pub fn bsengine_get_network_id(#[string] name: String) -> String {
@@ -3772,11 +4523,13 @@ pub fn bsengine_get_network_id(#[string] name: String) -> String {
     })
 }
 
+/// Get the authority kind (server/client/local) that owns an entity, encoded as an integer.
 #[op2(fast)]
 pub fn bsengine_get_network_authority(#[string] name: String) -> u32 {
     NETWORK_ID_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(_, auth, _)| *auth).unwrap_or(0))
 }
 
+/// Get the peer id string that owns an entity over the network.
 #[op2]
 #[string]
 pub fn bsengine_get_network_peer_id(#[string] name: String) -> String {
@@ -3788,6 +4541,7 @@ pub fn bsengine_get_network_peer_id(#[string] name: String) -> String {
     })
 }
 
+/// Check whether an entity is replicated over the network.
 #[op2(fast)]
 pub fn bsengine_is_network_replicated(#[string] name: String) -> bool {
     NETWORK_ID_SNAPSHOT.with(|s| {
@@ -3800,6 +4554,7 @@ pub fn bsengine_is_network_replicated(#[string] name: String) -> bool {
 
 // ── Network session ───────────────────────────────────────────────────────────
 
+/// Queue starting a network server on the given port.
 #[op2(fast)]
 pub fn bsengine_network_start_server(port: u32) {
     COMMAND_BUFFER.with(|c| {
@@ -3808,6 +4563,7 @@ pub fn bsengine_network_start_server(port: u32) {
     });
 }
 
+/// Queue connecting to a network server as a client.
 #[op2(fast)]
 pub fn bsengine_network_connect(#[string] host: String, port: u32) {
     COMMAND_BUFFER.with(|c| {
@@ -3818,6 +4574,7 @@ pub fn bsengine_network_connect(#[string] host: String, port: u32) {
     });
 }
 
+/// Queue disconnecting from the current network session.
 #[op2(fast)]
 pub fn bsengine_network_disconnect() {
     COMMAND_BUFFER.with(|c| {
@@ -3825,22 +4582,26 @@ pub fn bsengine_network_disconnect() {
     });
 }
 
+/// Check whether this instance is currently hosting a network server.
 #[op2(fast)]
 pub fn bsengine_network_is_server() -> bool {
     NETWORK_STATE_SNAPSHOT.with(|s| s.borrow().0)
 }
 
+/// Check whether this instance is currently connected to a network session.
 #[op2(fast)]
 pub fn bsengine_network_is_connected() -> bool {
     NETWORK_STATE_SNAPSHOT.with(|s| s.borrow().1)
 }
 
+/// Get this instance's own network peer id.
 #[op2]
 #[string]
 pub fn bsengine_network_get_my_peer_id() -> String {
     NETWORK_STATE_SNAPSHOT.with(|s| s.borrow().2.to_string())
 }
 
+/// Get the number of connected network peers.
 #[op2(fast)]
 pub fn bsengine_network_get_peer_count() -> u32 {
     NETWORK_STATE_SNAPSHOT.with(|s| s.borrow().3)
@@ -3934,6 +4695,7 @@ pub fn bsengine_network_get_peer_count() -> u32 {
 
 // ── Rupture ───────────────────────────────────────────────────────────────────
 
+/// Get the world transform an entity would need to face a target point (query only; does not move the entity).
 #[op2(fast)]
 pub fn bsengine_look_at(#[string] name: String, tx: f32, ty: f32, tz: f32) {
     let origin = TRANSFORM_SNAPSHOT.with(|s| s.borrow().get(&name).map(|(pos, _, _)| *pos));
@@ -3955,16 +4717,19 @@ pub fn bsengine_look_at(#[string] name: String, tx: f32, ty: f32, tz: f32) {
     }
 }
 
+/// Get the total elapsed application time, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_time() -> f32 {
     TIME_ELAPSED_SNAPSHOT.with(|s| *s.borrow())
 }
 
+/// Get the duration of the last frame, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_delta_time() -> f32 {
     TIME_DELTA_SNAPSHOT.with(|s| *s.borrow())
 }
 
+/// Get the current window/render surface size, as `[width, height]`.
 #[op2]
 #[serde]
 pub fn bsengine_get_screen_size() -> Vec<u32> {
@@ -3974,6 +4739,7 @@ pub fn bsengine_get_screen_size() -> Vec<u32> {
     })
 }
 
+/// Queue attaching an entity as the child of another entity.
 #[op2(fast)]
 pub fn bsengine_set_parent(#[string] child: String, #[string] parent: String) {
     COMMAND_BUFFER.with(|c| {
@@ -3982,6 +4748,7 @@ pub fn bsengine_set_parent(#[string] child: String, #[string] parent: String) {
     });
 }
 
+/// Queue detaching an entity from its parent.
 #[op2(fast)]
 pub fn bsengine_clear_parent(#[string] child: String) {
     COMMAND_BUFFER.with(|c| {
@@ -3989,6 +4756,7 @@ pub fn bsengine_clear_parent(#[string] child: String) {
     });
 }
 
+/// Get the name of an entity's parent, or `None` if it has none.
 #[op2]
 #[string]
 pub fn bsengine_get_parent(#[string] name: String) -> String {
@@ -4001,6 +4769,7 @@ pub fn bsengine_get_parent(#[string] name: String) -> String {
     })
 }
 
+/// Get the names of an entity's children, as a JSON array string.
 #[op2]
 #[string]
 pub fn bsengine_get_children(#[string] name: String) -> String {
@@ -4010,33 +4779,39 @@ pub fn bsengine_get_children(#[string] name: String) -> String {
     })
 }
 
+/// Get a rigid body's linear velocity, as `[x, y, z]`.
 #[op2]
 #[serde]
 pub fn bsengine_get_velocity(#[string] name: String) -> Option<Vec<f32>> {
     VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| vec![v.x, v.y, v.z]))
 }
 
+/// Get the magnitude of a rigid body's linear velocity.
 #[op2]
 #[serde]
 pub fn bsengine_get_linear_speed(#[string] name: String) -> Option<Vec<f32>> {
     VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| vec![v.length()]))
 }
 
+/// Get the X component of a rigid body's linear velocity.
 #[op2(fast)]
 pub fn bsengine_get_velocity_x(#[string] name: String) -> f32 {
     VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |v| v.x))
 }
 
+/// Get the Y component of a rigid body's linear velocity.
 #[op2(fast)]
 pub fn bsengine_get_velocity_y(#[string] name: String) -> f32 {
     VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |v| v.y))
 }
 
+/// Get the Z component of a rigid body's linear velocity.
 #[op2(fast)]
 pub fn bsengine_get_velocity_z(#[string] name: String) -> f32 {
     VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |v| v.z))
 }
 
+/// Queue applying an instantaneous impulse to a rigid body's center of mass.
 #[op2(fast)]
 pub fn bsengine_add_impulse(#[string] name: String, fx: f32, fy: f32, fz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4045,6 +4820,7 @@ pub fn bsengine_add_impulse(#[string] name: String, fx: f32, fy: f32, fz: f32) {
     });
 }
 
+/// Queue applying an instantaneous impulse to a rigid body at a specific world point.
 #[op2(fast)]
 pub fn bsengine_apply_impulse_at_point(
     #[string] name: String,
@@ -4068,6 +4844,7 @@ pub fn bsengine_apply_impulse_at_point(
     });
 }
 
+/// Queue applying a continuous force to a rigid body's center of mass.
 #[op2(fast)]
 pub fn bsengine_add_force(#[string] name: String, fx: f32, fy: f32, fz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4076,6 +4853,7 @@ pub fn bsengine_add_force(#[string] name: String, fx: f32, fy: f32, fz: f32) {
     });
 }
 
+/// Queue applying a continuous force to a rigid body at a specific world point.
 #[op2(fast)]
 pub fn bsengine_add_force_at_point(
     #[string] name: String,
@@ -4099,6 +4877,7 @@ pub fn bsengine_add_force_at_point(
     });
 }
 
+/// Queue setting a rigid body's linear velocity.
 #[op2(fast)]
 pub fn bsengine_set_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4107,6 +4886,7 @@ pub fn bsengine_set_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) 
     });
 }
 
+/// Queue setting the X component of a rigid body's linear velocity.
 #[op2(fast)]
 pub fn bsengine_set_velocity_x(#[string] name: String, vx: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4115,6 +4895,7 @@ pub fn bsengine_set_velocity_x(#[string] name: String, vx: f32) {
     });
 }
 
+/// Queue setting the Y component of a rigid body's linear velocity.
 #[op2(fast)]
 pub fn bsengine_set_velocity_y(#[string] name: String, vy: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4123,6 +4904,7 @@ pub fn bsengine_set_velocity_y(#[string] name: String, vy: f32) {
     });
 }
 
+/// Queue setting the Z component of a rigid body's linear velocity.
 #[op2(fast)]
 pub fn bsengine_set_velocity_z(#[string] name: String, vz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4131,11 +4913,13 @@ pub fn bsengine_set_velocity_z(#[string] name: String, vz: f32) {
     });
 }
 
+/// Get the world's global gravity magnitude.
 #[op2(fast)]
 pub fn bsengine_get_gravity() -> f32 {
     GRAVITY_SNAPSHOT.with(|s| *s.borrow())
 }
 
+/// Queue setting the world's global gravity magnitude.
 #[op2(fast)]
 pub fn bsengine_set_gravity(magnitude: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4143,27 +4927,32 @@ pub fn bsengine_set_gravity(magnitude: f32) {
     });
 }
 
+/// Get a rigid body's angular velocity, as `[x, y, z]`.
 #[op2]
 #[serde]
 pub fn bsengine_get_angular_velocity(#[string] name: String) -> Option<Vec<f32>> {
     ANGULAR_VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map(|v| vec![v.x, v.y, v.z]))
 }
 
+/// Get the X component of a rigid body's angular velocity.
 #[op2(fast)]
 pub fn bsengine_get_angular_velocity_x(#[string] name: String) -> f32 {
     ANGULAR_VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |v| v.x))
 }
 
+/// Get the Y component of a rigid body's angular velocity.
 #[op2(fast)]
 pub fn bsengine_get_angular_velocity_y(#[string] name: String) -> f32 {
     ANGULAR_VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |v| v.y))
 }
 
+/// Get the Z component of a rigid body's angular velocity.
 #[op2(fast)]
 pub fn bsengine_get_angular_velocity_z(#[string] name: String) -> f32 {
     ANGULAR_VELOCITY_SNAPSHOT.with(|s| s.borrow().get(&name).map_or(f32::NAN, |v| v.z))
 }
 
+/// Queue setting a rigid body's angular velocity.
 #[op2(fast)]
 pub fn bsengine_set_angular_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4172,6 +4961,7 @@ pub fn bsengine_set_angular_velocity(#[string] name: String, vx: f32, vy: f32, v
     });
 }
 
+/// Queue setting the X component of a rigid body's angular velocity.
 #[op2(fast)]
 pub fn bsengine_set_angular_velocity_x(#[string] name: String, vx: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4180,6 +4970,7 @@ pub fn bsengine_set_angular_velocity_x(#[string] name: String, vx: f32) {
     });
 }
 
+/// Queue setting the Y component of a rigid body's angular velocity.
 #[op2(fast)]
 pub fn bsengine_set_angular_velocity_y(#[string] name: String, vy: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4188,6 +4979,7 @@ pub fn bsengine_set_angular_velocity_y(#[string] name: String, vy: f32) {
     });
 }
 
+/// Queue setting the Z component of a rigid body's angular velocity.
 #[op2(fast)]
 pub fn bsengine_set_angular_velocity_z(#[string] name: String, vz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4196,6 +4988,7 @@ pub fn bsengine_set_angular_velocity_z(#[string] name: String, vz: f32) {
     });
 }
 
+/// Queue adding to a rigid body's linear velocity.
 #[op2(fast)]
 pub fn bsengine_add_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4204,6 +4997,7 @@ pub fn bsengine_add_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) 
     });
 }
 
+/// Queue adding to a rigid body's angular velocity.
 #[op2(fast)]
 pub fn bsengine_add_angular_velocity(#[string] name: String, vx: f32, vy: f32, vz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4212,6 +5006,7 @@ pub fn bsengine_add_angular_velocity(#[string] name: String, vx: f32, vy: f32, v
     });
 }
 
+/// Queue applying an instantaneous angular impulse to a rigid body.
 #[op2(fast)]
 pub fn bsengine_add_angular_impulse(#[string] name: String, vx: f32, vy: f32, vz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4220,6 +5015,7 @@ pub fn bsengine_add_angular_impulse(#[string] name: String, vx: f32, vy: f32, vz
     });
 }
 
+/// Queue applying a continuous torque to a rigid body.
 #[op2(fast)]
 pub fn bsengine_add_torque(#[string] name: String, vx: f32, vy: f32, vz: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4228,6 +5024,7 @@ pub fn bsengine_add_torque(#[string] name: String, vx: f32, vy: f32, vz: f32) {
     });
 }
 
+/// Queue enabling or disabling continuous collision detection on a rigid body.
 #[op2(fast)]
 pub fn bsengine_set_ccd_enabled(#[string] name: String, enabled: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -4236,6 +5033,7 @@ pub fn bsengine_set_ccd_enabled(#[string] name: String, enabled: bool) {
     });
 }
 
+/// Queue setting a rigid body's linear damping (velocity decay over time).
 #[op2(fast)]
 pub fn bsengine_set_linear_damping(#[string] name: String, damping: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4244,6 +5042,7 @@ pub fn bsengine_set_linear_damping(#[string] name: String, damping: f32) {
     });
 }
 
+/// Queue setting a rigid body's angular damping (angular velocity decay over time).
 #[op2(fast)]
 pub fn bsengine_set_angular_damping(#[string] name: String, damping: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4252,56 +5051,67 @@ pub fn bsengine_set_angular_damping(#[string] name: String, damping: f32) {
     });
 }
 
+/// Get a rigid body's mass.
 #[op2(fast)]
 pub fn bsengine_get_mass(#[string] name: String) -> f32 {
     MASS_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
 }
 
+/// Get a rigid body's gravity scale multiplier.
 #[op2(fast)]
 pub fn bsengine_get_gravity_scale(#[string] name: String) -> f32 {
     GRAVITY_SCALE_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(1.0))
 }
 
+/// Check whether a rigid body is kinematic.
 #[op2(fast)]
 pub fn bsengine_is_kinematic(#[string] name: String) -> bool {
     BODY_TYPE_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(false))
 }
 
+/// Check whether a rigid body is currently asleep (not being simulated).
 #[op2(fast)]
 pub fn bsengine_is_sleeping(#[string] name: String) -> bool {
     SLEEP_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(false))
 }
 
+/// Queue waking a sleeping rigid body so physics resumes simulating it.
 #[op2(fast)]
 pub fn bsengine_wake_up(#[string] name: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::WakeUp { name }));
 }
 
+/// Queue forcing a rigid body to sleep, pausing physics simulation for it.
 #[op2(fast)]
 pub fn bsengine_sleep(#[string] name: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::PutToSleep { name }));
 }
 
+/// Check whether an entity's collider acts as a sensor.
 #[op2(fast)]
 pub fn bsengine_is_collider_sensor(#[string] name: String) -> bool {
     COLLIDER_SENSOR_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(false))
 }
 
+/// Get a rigid body's linear damping coefficient.
 #[op2(fast)]
 pub fn bsengine_get_linear_damping(#[string] name: String) -> f32 {
     LINEAR_DAMPING_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
 }
 
+/// Get a rigid body's angular damping coefficient.
 #[op2(fast)]
 pub fn bsengine_get_angular_damping(#[string] name: String) -> f32 {
     ANGULAR_DAMPING_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
 }
 
+/// Get a collider's restitution (bounciness).
 #[op2(fast)]
 pub fn bsengine_get_restitution(#[string] name: String) -> f32 {
     RESTITUTION_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
 }
 
+/// Queue setting a collider's restitution (bounciness).
 #[op2(fast)]
 pub fn bsengine_set_restitution(#[string] name: String, restitution: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4310,11 +5120,13 @@ pub fn bsengine_set_restitution(#[string] name: String, restitution: f32) {
     });
 }
 
+/// Get a collider's surface friction coefficient.
 #[op2(fast)]
 pub fn bsengine_get_friction(#[string] name: String) -> f32 {
     FRICTION_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(0.0))
 }
 
+/// Queue setting a collider's surface friction.
 #[op2(fast)]
 pub fn bsengine_set_friction(#[string] name: String, friction: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4323,6 +5135,7 @@ pub fn bsengine_set_friction(#[string] name: String, friction: f32) {
     });
 }
 
+/// Queue setting a rigid body's mass.
 #[op2(fast)]
 pub fn bsengine_set_mass(#[string] name: String, mass: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4330,6 +5143,7 @@ pub fn bsengine_set_mass(#[string] name: String, mass: f32) {
     });
 }
 
+/// Queue setting whether a rigid body is kinematic.
 #[op2(fast)]
 pub fn bsengine_set_kinematic(#[string] name: String, kinematic: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -4338,6 +5152,7 @@ pub fn bsengine_set_kinematic(#[string] name: String, kinematic: bool) {
     });
 }
 
+/// Queue setting a rigid body's gravity scale multiplier.
 #[op2(fast)]
 pub fn bsengine_set_gravity_scale(#[string] name: String, scale: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4346,6 +5161,7 @@ pub fn bsengine_set_gravity_scale(#[string] name: String, scale: f32) {
     });
 }
 
+/// Queue setting whether an entity's collider acts as a sensor.
 #[op2(fast)]
 pub fn bsengine_set_collider_sensor(#[string] name: String, sensor: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -4354,6 +5170,7 @@ pub fn bsengine_set_collider_sensor(#[string] name: String, sensor: bool) {
     });
 }
 
+/// Queue locking a rigid body's rotation on one or more axes.
 #[op2(fast)]
 pub fn bsengine_lock_rotation(#[string] name: String, lock_x: bool, lock_y: bool, lock_z: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -4366,6 +5183,7 @@ pub fn bsengine_lock_rotation(#[string] name: String, lock_x: bool, lock_y: bool
     });
 }
 
+/// Queue locking a rigid body's translation on one or more axes.
 #[op2(fast)]
 pub fn bsengine_lock_translation(#[string] name: String, lock_x: bool, lock_y: bool, lock_z: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -4378,6 +5196,7 @@ pub fn bsengine_lock_translation(#[string] name: String, lock_x: bool, lock_y: b
     });
 }
 
+/// Queue showing or hiding the mouse cursor.
 #[op2(fast)]
 pub fn bsengine_set_cursor_visible(visible: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -4386,6 +5205,7 @@ pub fn bsengine_set_cursor_visible(visible: bool) {
     });
 }
 
+/// Queue locking or unlocking the mouse cursor to the window.
 #[op2(fast)]
 pub fn bsengine_set_cursor_locked(locked: bool) {
     COMMAND_BUFFER.with(|c| {
@@ -4394,6 +5214,7 @@ pub fn bsengine_set_cursor_locked(locked: bool) {
     });
 }
 
+/// Queue starting playback of a sound.
 #[op2(fast)]
 pub fn bsengine_play_sound(#[string] path: String, volume: f32, loop_: bool) -> u32 {
     let id = SOUND_ID_COUNTER.with(|c| {
@@ -4412,21 +5233,25 @@ pub fn bsengine_play_sound(#[string] path: String, volume: f32, loop_: bool) -> 
     id
 }
 
+/// Queue stopping a playing sound.
 #[op2(fast)]
 pub fn bsengine_stop_sound(id: u32) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::StopSound { id }));
 }
 
+/// Queue pausing a playing sound.
 #[op2(fast)]
 pub fn bsengine_pause_sound(id: u32) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::PauseSound { id }));
 }
 
+/// Queue resuming a paused sound.
 #[op2(fast)]
 pub fn bsengine_resume_sound(id: u32) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ResumeSound { id }));
 }
 
+/// Queue setting the volume of a playing sound.
 #[op2(fast)]
 pub fn bsengine_set_sound_volume(id: u32, db: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4435,6 +5260,7 @@ pub fn bsengine_set_sound_volume(id: u32, db: f32) {
     });
 }
 
+/// Queue setting the stereo pan of a playing sound.
 #[op2(fast)]
 pub fn bsengine_set_sound_panning(id: u32, panning: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4443,6 +5269,7 @@ pub fn bsengine_set_sound_panning(id: u32, panning: f32) {
     });
 }
 
+/// Queue setting the playback rate (pitch/speed) of a playing sound.
 #[op2(fast)]
 pub fn bsengine_set_sound_playback_rate(id: u32, rate: f32) {
     COMMAND_BUFFER.with(|c| {
@@ -4451,6 +5278,7 @@ pub fn bsengine_set_sound_playback_rate(id: u32, rate: f32) {
     });
 }
 
+/// Queue seeking a playing sound to a specific position.
 #[op2(fast)]
 pub fn bsengine_seek_sound(id: u32, position: f64) {
     COMMAND_BUFFER.with(|c| {
@@ -4459,6 +5287,7 @@ pub fn bsengine_seek_sound(id: u32, position: f64) {
     });
 }
 
+/// Get a sound's playback state (e.g. playing/paused/stopped), encoded as an integer.
 #[op2]
 #[string]
 pub fn bsengine_get_sound_state(id: u32) -> String {
@@ -4467,16 +5296,19 @@ pub fn bsengine_get_sound_state(id: u32) -> String {
         .unwrap_or_default()
 }
 
+/// Get a sound's current playback position, in seconds.
 #[op2(fast)]
 pub fn bsengine_get_sound_position(id: u32) -> f64 {
     SOUND_POSITION_SNAPSHOT.with(|s| s.borrow().get(&id).copied().unwrap_or(0.0))
 }
 
+/// Queue setting the text content of a HUD element.
 #[op2(fast)]
 pub fn bsengine_set_hud_text(#[string] id: String, #[string] text: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SetHudText { id, text }));
 }
 
+/// Queue removing a HUD text element.
 #[op2(fast)]
 pub fn bsengine_clear_hud_text(#[string] id: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearHudText { id }));
@@ -4484,6 +5316,7 @@ pub fn bsengine_clear_hud_text(#[string] id: String) {
 
 // --- UI widget ops ---
 
+/// Queue creating or updating a UI text label.
 #[op2(fast)]
 pub fn bsengine_ui_set_label(
     #[string] id: String,
@@ -4503,6 +5336,7 @@ pub fn bsengine_ui_set_label(
     });
 }
 
+/// Queue creating or updating a UI button.
 #[op2(fast)]
 pub fn bsengine_ui_set_button(
     #[string] id: String,
@@ -4524,6 +5358,7 @@ pub fn bsengine_ui_set_button(
     });
 }
 
+/// Queue creating or updating a UI panel.
 #[op2(fast)]
 pub fn bsengine_ui_set_panel(
     #[string] id: String,
@@ -4545,6 +5380,7 @@ pub fn bsengine_ui_set_panel(
     });
 }
 
+/// Queue creating or updating a UI text input field.
 #[op2(fast)]
 pub fn bsengine_ui_set_text_input(
     #[string] id: String,
@@ -4564,26 +5400,31 @@ pub fn bsengine_ui_set_text_input(
     });
 }
 
+/// Queue removing a UI widget by id.
 #[op2(fast)]
 pub fn bsengine_ui_remove_widget(#[string] id: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::RemoveUiWidget { id }));
 }
 
+/// Queue removing all UI widgets.
 #[op2(fast)]
 pub fn bsengine_ui_clear() {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::ClearUiWidgets));
 }
 
+/// Check whether a UI widget was clicked this frame.
 #[op2(fast)]
 pub fn bsengine_ui_is_clicked(#[string] id: String) -> bool {
     UI_CLICKED_SNAPSHOT.with(|s| s.borrow().iter().any(|v| v == &id))
 }
 
+/// Queue loading a scene from a file, replacing the current world.
 #[op2(fast)]
 pub fn bsengine_load_scene(#[string] path: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::LoadScene { path }));
 }
 
+/// Queue setting the skybox texture used for the background/environment.
 #[op2(fast)]
 pub fn bsengine_set_skybox(#[string] path: String) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::SetSkybox { path }));
@@ -4591,6 +5432,7 @@ pub fn bsengine_set_skybox(#[string] path: String) {
 
 // --- Mouse ops ---
 
+/// Check whether a mouse button was pressed this frame.
 #[op2(fast)]
 pub fn bsengine_is_mouse_pressed(button: u32) -> bool {
     if button > 7 {
@@ -4599,6 +5441,7 @@ pub fn bsengine_is_mouse_pressed(button: u32) -> bool {
     MOUSE_PRESSED_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
 }
 
+/// Check whether a mouse button is currently held down.
 #[op2(fast)]
 pub fn bsengine_is_mouse_down(button: u32) -> bool {
     if button > 7 {
@@ -4607,6 +5450,7 @@ pub fn bsengine_is_mouse_down(button: u32) -> bool {
     MOUSE_JUST_PRESSED_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
 }
 
+/// Check whether a mouse button was released this frame.
 #[op2(fast)]
 pub fn bsengine_is_mouse_up(button: u32) -> bool {
     if button > 7 {
@@ -4615,6 +5459,7 @@ pub fn bsengine_is_mouse_up(button: u32) -> bool {
     MOUSE_JUST_RELEASED_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
 }
 
+/// Get the current mouse cursor position, as `[x, y]`.
 #[op2]
 #[serde]
 pub fn bsengine_get_mouse_pos() -> Vec<f64> {
@@ -4624,6 +5469,7 @@ pub fn bsengine_get_mouse_pos() -> Vec<f64> {
     })
 }
 
+/// Get the mouse movement delta since the last frame, as `[dx, dy]`.
 #[op2]
 #[serde]
 pub fn bsengine_get_mouse_delta() -> Vec<f64> {
@@ -4635,6 +5481,7 @@ pub fn bsengine_get_mouse_delta() -> Vec<f64> {
 
 // --- Raycast op ---
 
+/// Cast a ray into the world and return the closest hit, if any, as JSON.
 #[op2]
 #[serde]
 pub fn bsengine_raycast(
@@ -4674,6 +5521,7 @@ pub fn bsengine_raycast(
     })
 }
 
+/// Check whether a gamepad button was pressed this frame.
 #[op2(fast)]
 pub fn bsengine_is_gamepad_button(button: u32) -> bool {
     if button > 15 {
@@ -4682,6 +5530,7 @@ pub fn bsengine_is_gamepad_button(button: u32) -> bool {
     GAMEPAD_BUTTON_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
 }
 
+/// Check whether a gamepad button is currently held down.
 #[op2(fast)]
 pub fn bsengine_is_gamepad_button_down(button: u32) -> bool {
     if button > 15 {
@@ -4690,6 +5539,7 @@ pub fn bsengine_is_gamepad_button_down(button: u32) -> bool {
     GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
 }
 
+/// Check whether a gamepad button was released this frame.
 #[op2(fast)]
 pub fn bsengine_is_gamepad_button_up(button: u32) -> bool {
     if button > 15 {
@@ -4698,6 +5548,7 @@ pub fn bsengine_is_gamepad_button_up(button: u32) -> bool {
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT.with(|s| ((*s.borrow()) >> button) & 1 != 0)
 }
 
+/// Get the gamepad's left analog stick position, as `[x, y]`.
 #[op2]
 #[serde]
 pub fn bsengine_get_left_stick() -> Vec<f32> {
@@ -4707,6 +5558,7 @@ pub fn bsengine_get_left_stick() -> Vec<f32> {
     })
 }
 
+/// Get the gamepad's right analog stick position, as `[x, y]`.
 #[op2]
 #[serde]
 pub fn bsengine_get_right_stick() -> Vec<f32> {
@@ -4716,6 +5568,7 @@ pub fn bsengine_get_right_stick() -> Vec<f32> {
     })
 }
 
+/// Get the pull amount (0-1) of a gamepad analog trigger.
 #[op2(fast)]
 pub fn bsengine_get_gamepad_trigger(side: u32) -> f32 {
     GAMEPAD_STICKS_SNAPSHOT.with(|s| {
@@ -5022,6 +5875,8 @@ deno_core::extension!(
     ],
 );
 
+/// JS source injected into every script runtime that defines the `Bsengine` global,
+/// mapping its camelCase methods onto the `bsengine_*` ops registered above.
 pub const BOOTSTRAP_JS: &str = r#"
 const Bsengine = {
     log:            (msg)                  => Deno.core.ops.bsengine_log(msg),

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -41,10 +41,12 @@ pub struct ProjectDir(pub String);
 /// Loaded JS source for a scripted entity.
 #[derive(Component)]
 pub struct Script {
+    /// The full text of the entity's script file.
     pub source: String,
 }
 
-// Not Send/Sync — stored as a non-send resource via insert_non_send_resource.
+/// Non-Send wrapper around the entity's V8 isolate; stored as a non-send
+/// resource via `insert_non_send_resource` since `JsRuntime` isn't `Send`/`Sync`.
 pub struct ScriptRuntimeResource(pub ScriptRuntime);
 
 /// Stores kira sound handles by script-assigned id for stopSound support.
@@ -57,7 +59,10 @@ pub(crate) struct ScriptTimingState {
     last_frame: std::time::Instant,
 }
 
+/// Bevy plugin that wires up the JS scripting runtime: loads scripts, runs
+/// them each frame, and exposes ECS state to them via the `bsengine_ops` extension.
 pub struct ScriptingPlugin {
+    /// Root directory used to resolve relative script paths.
     pub project_dir: String,
 }
 
@@ -107,6 +112,8 @@ fn capture_collision_events(
     COLLISION_SNAPSHOT.with(|s| *s.borrow_mut() = collisions);
 }
 
+/// Read the JS source for every entity with a `ScriptPath` (resolved against
+/// `ProjectDir`) and attach it as a `Script` component.
 pub fn load_scripts(world: &mut World) {
     let project_dir = world
         .get_resource::<ProjectDir>()

--- a/crates/bsengine-scripting/src/runtime.rs
+++ b/crates/bsengine-scripting/src/runtime.rs
@@ -19,11 +19,15 @@ fn ensure_v8_flags() {
     });
 }
 
+/// A single V8 isolate wrapping a `deno_core::JsRuntime`, used to execute
+/// script-defined behavior for one entity or subsystem.
 pub struct ScriptRuntime {
     runtime: JsRuntime,
 }
 
 impl ScriptRuntime {
+    /// Create a bare runtime with no BSEngine ops registered (useful for
+    /// plain JS evaluation in tests).
     pub fn new() -> Self {
         ensure_v8_flags();
         let runtime = JsRuntime::new(RuntimeOptions {
@@ -32,6 +36,8 @@ impl ScriptRuntime {
         Self { runtime }
     }
 
+    /// Create a runtime with the full `bsengine_ops` extension registered,
+    /// exposing ECS operations to scripts.
     pub fn new_with_ops() -> Self {
         ensure_v8_flags();
         let runtime = JsRuntime::new(RuntimeOptions {
@@ -41,6 +47,7 @@ impl ScriptRuntime {
         Self { runtime }
     }
 
+    /// Evaluate a JS expression and return its result stringified.
     pub fn eval(&mut self, src: &str) -> Result<String, String> {
         let result = self
             .runtime

--- a/crates/bsengine-scripting/src/save.rs
+++ b/crates/bsengine-scripting/src/save.rs
@@ -7,31 +7,52 @@ use bsengine_core::{Name, SaveData, Transform};
 use glam::{Quat, Vec3};
 use serde::{Deserialize, Serialize};
 
+/// Root JSON structure of a save-game file: a format version plus the
+/// serialized state of every named, transform-bearing entity.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GameSaveFile {
+    /// Save-file format version, for future migration compatibility.
     pub version: String,
+    /// Serialized entities captured at save time.
     pub entities: Vec<EntitySave>,
 }
 
+/// Serialized state of a single entity: its identifying name, transform,
+/// and any script-defined `SaveData` fields.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct EntitySave {
+    /// The entity's `Name` component value, used to match it on load.
     pub name: String,
+    /// The entity's position, rotation, and scale at save time.
     pub transform: TransformSave,
+    /// Script-defined key/value fields from the entity's `SaveData`, stored as UTF-8 strings.
     #[serde(default)]
     pub fields: HashMap<String, String>,
 }
 
+/// Flat, JSON-friendly encoding of a `Transform` (translation, quaternion
+/// rotation, and scale) for save files.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TransformSave {
+    /// Translation X component.
     pub x: f32,
+    /// Translation Y component.
     pub y: f32,
+    /// Translation Z component.
     pub z: f32,
+    /// Rotation quaternion X component.
     pub rx: f32,
+    /// Rotation quaternion Y component.
     pub ry: f32,
+    /// Rotation quaternion Z component.
     pub rz: f32,
+    /// Rotation quaternion W component.
     pub rw: f32,
+    /// Scale X component.
     pub sx: f32,
+    /// Scale Y component.
     pub sy: f32,
+    /// Scale Z component.
     pub sz: f32,
 }
 

--- a/crates/bsengine-window/src/lib.rs
+++ b/crates/bsengine-window/src/lib.rs
@@ -5,8 +5,11 @@
 //! `WindowDescriptor` configures initial size/title.
 #![warn(missing_docs)]
 
+/// The Bevy plugin that owns window creation and lifecycle.
 pub mod plugin;
+/// The `winit` event loop runner that drives the ECS app per frame.
 pub mod runner;
+/// Window-related resources and events (handle, descriptor, resize/create/close).
 pub mod types;
 
 pub use plugin::WindowPlugin;

--- a/crates/bsengine-window/src/plugin.rs
+++ b/crates/bsengine-window/src/plugin.rs
@@ -5,8 +5,10 @@ use bevy_ecs::prelude::*;
 use bsengine_core::{CursorConfig, CursorPos};
 use winit::window::CursorGrabMode;
 
+/// Bevy plugin that creates the OS window and wires up cursor/window events.
 #[derive(Default)]
 pub struct WindowPlugin {
+    /// Initial size, title, and resizability of the window to create.
     pub descriptor: WindowDescriptor,
 }
 

--- a/crates/bsengine-window/src/runner.rs
+++ b/crates/bsengine-window/src/runner.rs
@@ -186,6 +186,8 @@ impl ApplicationHandler for BsWinitApp {
     }
 }
 
+/// Bevy `App` runner that drives a `winit` event loop, translating window and
+/// device events into ECS events and calling `app.update()` on each redraw.
 pub fn winit_runner(app: App) -> AppExit {
     let event_loop = EventLoop::new().expect("Failed to create event loop");
     event_loop.set_control_flow(ControlFlow::Poll);

--- a/crates/bsengine-window/src/types.rs
+++ b/crates/bsengine-window/src/types.rs
@@ -2,14 +2,20 @@ use bsengine_ecs::{Event, Resource};
 use std::sync::Arc;
 use winit::window::Window;
 
+/// ECS resource holding a shared handle to the OS window created by the runner.
 #[derive(Resource, Clone)]
 pub struct WindowHandle(pub Arc<Window>);
 
+/// Initial window configuration, inserted as a resource by `WindowPlugin`.
 #[derive(Resource, Debug, Clone)]
 pub struct WindowDescriptor {
+    /// Text shown in the OS window's title bar.
     pub title: String,
+    /// Initial window width, in logical pixels.
     pub width: u32,
+    /// Initial window height, in logical pixels.
     pub height: u32,
+    /// Whether the user can resize the window after creation.
     pub resizable: bool,
 }
 
@@ -24,15 +30,20 @@ impl Default for WindowDescriptor {
     }
 }
 
+/// Fired whenever the OS window is resized, with the new dimensions.
 #[derive(Event, Debug, Clone)]
 pub struct WindowResized {
+    /// New window width, in physical pixels.
     pub width: u32,
+    /// New window height, in physical pixels.
     pub height: u32,
 }
 
+/// Fired once the OS window has been created and its handle inserted as a resource.
 #[derive(Event, Debug, Clone)]
 pub struct WindowCreated;
 
+/// Fired when the user requests the window be closed (e.g. clicking the close button).
 #[derive(Event, Debug, Clone)]
 pub struct WindowClosed;
 


### PR DESCRIPTION
## Summary

- Silences `#![warn(missing_docs)]` across all 17 workspace crates (~2,069 warnings → 0), each crate documented in parallel by an independent agent, one crate per commit for easy review/revert.
- Every doc comment is a real, context-derived one-liner (not filler like "The X field.") — each agent read the surrounding code (constructors, call sites, sibling fields) before writing.
- Doc-comments only — no logic, signatures, field types, or test behavior changed anywhere. Verified per-crate and via a final full-workspace pass.
- One notable technical finding (not a bug): `bsengine-scripting`'s `#[op2]`-annotated ops functions can never receive rustdoc via a `///` comment — deno_core's `op2` proc-macro splices any attribute above `#[op2]` onto a private inner helper, never onto the actual public item it emits (traced in the vendored `deno_ops` source). Real one-line docs were still written for all 288 ops (useful for readers), and a file-scoped `#![allow(missing_docs, reason = "...")]` was added to `ops.rs` explaining exactly why, so it doesn't read as laziness later.
- `bsengine-core/src/reflect_glam.rs`'s wrapper-generating macro was extended to take a doc string as its first argument so each of its four generated types (`ReflectVec2/3/4`, `ReflectQuat`) gets a real doc comment — purely additive, no behavior change.

## Test plan

- [x] `cargo build --workspace` — 0 warnings anywhere (previously ~2,069 `missing_docs` warnings across 17 crates)
- [x] Every touched crate's test suite run individually — all pass with unchanged counts vs. pre-change baseline: bsengine-core 177, bsengine-scripting 276 (+1 ignored, pre-existing), bsengine-editor 803, bsengine-rhi-wgpu 75, bsengine-input 23, bsengine-physics 6, bsengine-scene 12, bsengine-app 72 (+12 integration), bsengine-gltf 11, bsengine-mcp 36, bsengine-plugin 12, bsengine-asset 7, bsengine-window 4, bsengine-audio 3 (+2 ignored, pre-existing/platform), bsengine-network 8, bsengine-rhi 1, bsengine-render 13
- [x] `cargo +nightly fmt --check` — clean across the whole workspace (this workspace's `bsengine-editor/src/plugin.rs` needs the nightly toolchain for its rustfmt ignore-list to apply — a known, pre-existing, documented quirk, unrelated to this change)
- [x] Spot-checked several diffs by hand (including the macro restructuring and the `#[op2]` allow-attribute) to confirm no accidental logic changes

Note: running many crates' test binaries concatenated in one `cargo test -p A -p B -p C ...` invocation triggers a `STATUS_STACK_OVERFLOW` in `bsengine-editor`'s test binary specifically — this is a pre-existing local resource-contention artifact (confirmed: the same crate's 803 tests pass cleanly every time it's run in isolation, both here and in the prior editor-UI-redesign PR), not a regression from this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>