### PR TITLE
Fix viewport FPS jitter, Asset Browser divider, and invisible focused-tab text

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -177,9 +177,16 @@ impl EditorPanel for AssetBrowserPanel {
         ui.separator();
 
         let mut navigate_to: Option<PathBuf> = None;
+        let available_height = ui.available_height();
         ui.horizontal(|ui| {
+            // Force the row to claim the panel's full remaining height so
+            // the separator below draws as one unbroken line between the
+            // folder tree and the tile grid, instead of stopping wherever
+            // the shorter column's content happens to end.
+            ui.set_min_height(available_height);
             ui.vertical(|ui| {
                 ui.set_width(160.0);
+                ui.set_min_height(available_height);
                 self.draw_folder_tree(ui, self.root.clone(), &mut navigate_to);
             });
             ui.separator();

--- a/crates/bsengine-rhi-wgpu/src/panels/dock.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/dock.rs
@@ -47,8 +47,9 @@ pub fn ensure_builtin_panels(registry: &EditorPanelRegistry) {
         .or_insert_with(|| Box::new(crate::panels::HierarchyPanel) as Box<dyn EditorPanel>);
     map.entry("inspector".to_string())
         .or_insert_with(|| Box::new(crate::panels::InspectorPanel) as Box<dyn EditorPanel>);
-    map.entry("viewport".to_string())
-        .or_insert_with(|| Box::new(crate::panels::ViewportPanel) as Box<dyn EditorPanel>);
+    map.entry("viewport".to_string()).or_insert_with(|| {
+        Box::new(crate::panels::ViewportPanel::default()) as Box<dyn EditorPanel>
+    });
     map.entry("assets".to_string()).or_insert_with(|| {
         Box::new(crate::panels::AssetBrowserPanel::default()) as Box<dyn EditorPanel>
     });

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -1,7 +1,19 @@
 use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd};
 
 /// The Viewport panel: renders the editor gizmo/grid/frustum overlays on top of the 3D scene.
-pub struct ViewportPanel;
+pub struct ViewportPanel {
+    /// Exponential-moving-average of the instantaneous per-frame FPS
+    /// (`1.0 / stable_dt`), so the stats overlay doesn't visibly jitter —
+    /// raw per-frame dt varies enough, even at a steady refresh rate, that
+    /// displaying it unsmoothed makes the readout look like it's flickering.
+    smoothed_fps: f32,
+}
+
+impl Default for ViewportPanel {
+    fn default() -> Self {
+        Self { smoothed_fps: 60.0 }
+    }
+}
 
 impl EditorPanel for ViewportPanel {
     fn id(&self) -> &str {
@@ -263,16 +275,24 @@ impl EditorPanel for ViewportPanel {
                 });
             });
 
+        let instantaneous_fps = 1.0 / ui.ctx().input(|i| i.stable_dt.max(1e-6));
+        self.smoothed_fps += (instantaneous_fps - self.smoothed_fps) * 0.1;
+
         egui::Area::new(egui::Id::new("viewport_stats_overlay"))
             .fixed_pos(egui::Pos2::new(
-                panel_rect.max.x - 90.0,
+                panel_rect.max.x - 8.0,
                 panel_rect.min.y + 8.0,
             ))
+            .pivot(egui::Align2::RIGHT_TOP)
             .show(ui.ctx(), |ui| {
-                egui::Frame::menu(ui.style()).show(ui, |ui| {
-                    let fps = 1.0 / ui.ctx().input(|i| i.stable_dt.max(1e-6));
-                    ui.colored_label(crate::theme::TEXT_DIM, format!("{fps:.0} FPS"));
-                });
+                ui.add(
+                    egui::Label::new(
+                        egui::RichText::new(format!("{:.0} FPS", self.smoothed_fps))
+                            .size(11.0)
+                            .color(crate::theme::ACCENT),
+                    )
+                    .extend(),
+                );
             });
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1887,8 +1887,22 @@ impl WgpuSurface {
                                 panels: &mut panels_guard,
                                 type_registry: type_registry_guard.as_deref(),
                             };
+                            let mut dock_style = egui_dock::Style::from_egui(ctx.style().as_ref());
+                            // `Style::from_egui` derives the tab-bar's "focused"/"hovered"/
+                            // "*_with_kb_focus" text colors from `Visuals::strong_text_color()`,
+                            // which resolves to `widgets.active.fg_stroke` — this theme
+                            // deliberately makes that near-black (dark text on the bright
+                            // accent-colored Play/active-button background), which egui_dock's
+                            // reuse of the same field turns into near-invisible dark-on-dark
+                            // text for whichever tab is currently focused or hovered. Override
+                            // just those tab-text colors back to the theme's normal bright text.
+                            dock_style.tab.focused.text_color = crate::theme::TEXT;
+                            dock_style.tab.focused_with_kb_focus.text_color = crate::theme::TEXT;
+                            dock_style.tab.hovered.text_color = crate::theme::TEXT;
+                            dock_style.tab.active_with_kb_focus.text_color = crate::theme::TEXT;
+                            dock_style.tab.inactive_with_kb_focus.text_color = crate::theme::TEXT;
                             egui_dock::DockArea::new(&mut dock_state)
-                                .style(egui_dock::Style::from_egui(ctx.style().as_ref()))
+                                .style(dock_style)
                                 .show(ctx, &mut tab_viewer);
                             drop(panels_guard);
 

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1887,7 +1887,9 @@ impl WgpuSurface {
                                 panels: &mut panels_guard,
                                 type_registry: type_registry_guard.as_deref(),
                             };
-                            egui_dock::DockArea::new(&mut dock_state).show(ctx, &mut tab_viewer);
+                            egui_dock::DockArea::new(&mut dock_state)
+                                .style(egui_dock::Style::from_egui(ctx.style().as_ref()))
+                                .show(ctx, &mut tab_viewer);
                             drop(panels_guard);
 
                             let layout_json =


### PR DESCRIPTION
## Summary

Post-merge polish fixes reported after manually running the editor UI from PR #1720/#1721:

- **Viewport FPS overlay flickered/jittered.** It displayed the raw instantaneous `1.0 / stable_dt` every frame, which varies enough frame-to-frame to look unstable even at a steady framerate. Smoothed with an exponential moving average (`ViewportPanel` now holds `smoothed_fps` state).
- **FPS overlay restyle.** Per feedback: single line (`Label::extend()` disables wrapping), smaller text, background box removed, right-aligned via `Area::pivot` (so position doesn't depend on knowing the text's width up front) with an accent color standing in for the removed background.
- **Asset Browser's folder-tree/tile-grid divider only spanned partial height**, looking visually disconnected from the panel edges. Now the row claims the panel's full remaining height so the divider reads as one unbroken line.
- **The Asset Browser's dock tab title was rendering invisible** (or a newly-focused tab's title in general). Root cause: `egui_dock::Style::from_egui` derives its "focused"/"hovered"/"*_with_kb_focus" tab-text colors from `egui::Visuals::strong_text_color()`, which resolves to `widgets.active.fg_stroke` — deliberately near-black in this theme (dark text on the bright accent-colored Play/active-button background from the PR #1720 theme work). egui_dock's reuse of that same field for tab text made whichever tab is currently focused or hovered render as near-invisible dark-on-dark. Overrides just those tab-style text colors back to the theme's normal bright text.

## Test plan

- [x] `cargo build -p bsengine-rhi-wgpu` — clean
- [x] `cargo test -p bsengine-rhi-wgpu` — 75 passed, 0 failed (unchanged, no new test surface — all four fixes are UI-rendering/styling only)
- [x] `cargo fmt -p bsengine-rhi-wgpu -- --check` — clean
- [x] Manually verified in the running editor by the user: FPS overlay now renders as one stable line, tab title now visible

## Known follow-up (not in this PR)

While testing this fix, the user found that clicking an entity row in the Hierarchy panel does nothing (no selection highlight, no Inspector update). Confirmed this reproduces identically on `master`, before any of this PR's changes — it's a pre-existing, unrelated bug, being tracked/investigated separately.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>