### PR TITLE
fix: Hierarchy row clicks not registering (drag-sense hit-test bug)

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -368,8 +368,17 @@ impl AssetBrowserPanel {
                     }
                 }
                 AssetKind::Mesh | AssetKind::Script => {
+                    // Sense::click_and_drag() here, not Sense::drag() alone:
+                    // this interact is registered after (on top of, in
+                    // hit-test z-order) `response`'s own click-sensing
+                    // widget, on the exact same rect. egui's hit-test nulls
+                    // out the click hit whenever the topmost of two
+                    // perfectly-overlapping widgets senses only drag (see
+                    // the identical bug fixed in hierarchy.rs's draw_row) —
+                    // click_and_drag() keeps this tile clickable too.
                     let drag_id = ui.id().with(("asset_tile_drag", &entry.path));
-                    let drag_response = ui.interact(response.rect, drag_id, egui::Sense::drag());
+                    let drag_response =
+                        ui.interact(response.rect, drag_id, egui::Sense::click_and_drag());
                     let combined = drag_response | response;
                     combined.dnd_set_drag_payload(AssetDragPayload {
                         path: entry.path.clone(),
@@ -449,5 +458,78 @@ mod tests {
         let tmp = std::env::temp_dir().join("bse_asset_browser_scan_test_missing");
         std::fs::remove_dir_all(&tmp).ok();
         assert!(scan_dir(&tmp).is_empty());
+    }
+
+    /// Regression test mirroring `hierarchy.rs`'s
+    /// `row_click_registers_despite_unioned_drag_sense_interact`: a same-rect
+    /// `ui.interact(.., Sense::drag())` registered after (topmost over) a
+    /// click-sensing widget nulls out that widget's click hit entirely (see
+    /// egui's `hit_test_on_close`), regardless of `Response::union`. Two
+    /// `Context::run` passes are required because egui hit-tests against the
+    /// *previous* frame's widget rects.
+    #[test]
+    fn asset_tile_click_registers_despite_unioned_drag_sense_interact() {
+        let ctx = egui::Context::default();
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let mut tile_rect = egui::Rect::NOTHING;
+        let _ = ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                ..Default::default()
+            },
+            |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    let response = ui.button("tile");
+                    let drag_id = ui.id().with("asset_tile_drag");
+                    let _drag_response =
+                        ui.interact(response.rect, drag_id, egui::Sense::click_and_drag());
+                    tile_rect = response.rect;
+                });
+            },
+        );
+
+        let pos = tile_rect.center();
+        let click_events = vec![
+            egui::Event::PointerMoved(pos),
+            egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::default(),
+            },
+            egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::default(),
+            },
+        ];
+
+        let mut clicked = false;
+        let _ = ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                events: click_events,
+                ..Default::default()
+            },
+            |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    let response = ui.button("tile");
+                    let drag_id = ui.id().with("asset_tile_drag");
+                    let drag_response =
+                        ui.interact(response.rect, drag_id, egui::Sense::click_and_drag());
+                    let combined = drag_response | response;
+                    if combined.clicked() {
+                        clicked = true;
+                    }
+                });
+            },
+        );
+
+        assert!(
+            clicked,
+            "asset tile click must register even with a same-rect drag-sense interact unioned in"
+        );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -402,8 +402,22 @@ impl HierarchyPanel {
             // becomes an actual DnD source without disturbing its existing
             // click/double-click behavior (`Response::union` ORs
             // `clicked`/`double_clicked`/`drag_started`/`dragged`).
+            //
+            // This second interact MUST also sense `click` (not `Sense::drag()`
+            // alone): it's added after (i.e. on top of, in hit-test z-order)
+            // the row's own click-sensing widget on the *exact same rect*.
+            // egui's hit-test (`hit_test_on_close` in egui's `hit_test.rs`)
+            // deliberately nulls out the click hit whenever the topmost of two
+            // perfectly-overlapping widgets senses only drag — "the top thing
+            // senses only drags, so we ignore the click-widget below it" — so
+            // with `Sense::drag()` here, every row's click was permanently
+            // swallowed regardless of `Response::union`'s own (correct) OR
+            // logic. `Sense::click_and_drag()` keeps this topmost widget's
+            // click hit intact, since egui special-cases "topmost widget
+            // senses both" to report both hits.
             let drag_id = ui.id().with(("hierarchy_row_drag", info.id));
-            let drag_response = ui.interact(row_response.rect, drag_id, egui::Sense::drag());
+            let drag_response =
+                ui.interact(row_response.rect, drag_id, egui::Sense::click_and_drag());
             let row_response = drag_response | row_response;
 
             if row_response.clicked() {
@@ -597,6 +611,89 @@ mod tests {
         assert_eq!(
             HierarchyPanel::icon_for(&info),
             egui_phosphor::regular::TREE_STRUCTURE
+        );
+    }
+
+    /// Regression test for the tree-view row click failing to register.
+    ///
+    /// egui hit-tests using the *previous* frame's widget rects
+    /// (`Context::begin_pass` reads `viewport.prev_pass.widgets`), so this
+    /// needs two `Context::run` passes: the first establishes the row's
+    /// rect, the second delivers a press+release at that rect and observes
+    /// whether `.clicked()` fires.
+    ///
+    /// `draw_row` unions a same-rect `ui.interact(.., Sense::drag())` onto
+    /// the row's own click-sensing response to enable DnD-reparent. Per
+    /// egui's `hit_test_on_close` (Some click hit, Some drag hit branch),
+    /// when the *topmost* of two perfectly-overlapping widgets senses only
+    /// drag, egui deliberately reports `click: None` for the pair ("the top
+    /// thing senses only drags, so we ignore the click-widget below it") —
+    /// so `.clicked()` never fires, regardless of `Response::union`'s
+    /// otherwise-correct OR-merge. Using `Sense::click_and_drag()` for the
+    /// unioned interact keeps that topmost widget's own click hit intact.
+    #[test]
+    fn row_click_registers_despite_unioned_drag_sense_interact() {
+        let ctx = egui::Context::default();
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let mut row_rect = egui::Rect::NOTHING;
+        let _ = ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                ..Default::default()
+            },
+            |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    let row_response = ui.selectable_label(false, "row");
+                    let drag_id = ui.id().with("row_drag");
+                    let _drag_response =
+                        ui.interact(row_response.rect, drag_id, egui::Sense::click_and_drag());
+                    row_rect = row_response.rect;
+                });
+            },
+        );
+
+        let pos = row_rect.center();
+        let click_events = vec![
+            egui::Event::PointerMoved(pos),
+            egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::default(),
+            },
+            egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::default(),
+            },
+        ];
+
+        let mut clicked = false;
+        let _ = ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                events: click_events,
+                ..Default::default()
+            },
+            |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    let row_response = ui.selectable_label(false, "row");
+                    let drag_id = ui.id().with("row_drag");
+                    let drag_response =
+                        ui.interact(row_response.rect, drag_id, egui::Sense::click_and_drag());
+                    let row_response = drag_response | row_response;
+                    if row_response.clicked() {
+                        clicked = true;
+                    }
+                });
+            },
+        );
+
+        assert!(
+            clicked,
+            "row click must register even with a same-rect drag-sense interact unioned in"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Root cause: `hierarchy.rs`'s `draw_row` unioned a same-rect `Sense::drag()`-only `ui.interact()` *after* the row's own click-sensing widget. egui's hit-test (`hit_test_on_close`) nulls out the click hit whenever the topmost of two perfectly-overlapping widgets senses only drag ("ignore the click-widget below it"), so no row could ever register a click regardless of `Response::union`'s otherwise-correct OR-merge.
- Fix: use `Sense::click_and_drag()` for the unioned interact instead of `Sense::drag()`, so egui reports both hits when the topmost widget senses both.
- Found and fixed the identical latent pattern in `asset_browser.rs`'s Mesh/Script tile DnD interact (no visible symptom yet, but same root cause).
- Added regression tests for both (two-frame `egui::Context::run` harness simulating a press+release at the row/tile rect), confirmed red before the fix and green after.

## Test plan
- [x] `cargo test -p bsengine-rhi-wgpu` — 77 passed, 0 failed
- [x] `cargo +nightly fmt -p bsengine-rhi-wgpu --check`
- [ ] Manual verification in the running editor: click a Hierarchy row in tree view and confirm selection + Inspector update

🤖 Generated with [Claude Code](https://claude.com/claude-code)