### PR TITLE
feat: Inspector Phase 1 — generic reflect-driven component list foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ version = "0.1.0"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
+ "bevy_reflect",
  "bsengine-app",
  "bsengine-core",
  "bsengine-ecs",

--- a/crates/bsengine-core/src/tween.rs
+++ b/crates/bsengine-core/src/tween.rs
@@ -1,5 +1,6 @@
 use crate::{ReflectQuat, ReflectVec3};
 use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 
 /// Easing curve applied to a tween's normalized progress before interpolating.
@@ -72,7 +73,7 @@ pub enum TweenTarget {
 
 /// Animates a `Transform` property from one value to another over time.
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct Tween {
     /// Which property is being animated, and its start/end values.
     pub target: TweenTarget,
@@ -88,6 +89,23 @@ pub struct Tween {
     pub elapsed: f32,
     /// Whether the tween is currently playing back-to-front (used by `PingPong`).
     pub reversed: bool,
+}
+
+impl Default for Tween {
+    fn default() -> Self {
+        Self {
+            target: TweenTarget::Translation {
+                from: glam::Vec3::ZERO.into(),
+                to: glam::Vec3::ZERO.into(),
+            },
+            duration: 1.0,
+            easing: EasingFn::Linear,
+            repeat: RepeatMode::Once,
+            finished: false,
+            elapsed: 0.0,
+            reversed: false,
+        }
+    }
 }
 
 impl Tween {
@@ -176,5 +194,14 @@ mod tests {
         assert_eq!(tw.repeat, RepeatMode::Once);
         assert!(!tw.finished);
         assert!((tw.elapsed - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn tween_has_a_default_impl() {
+        let t = Tween::default();
+        assert_eq!(t.duration, 1.0);
+        assert!(!t.finished);
+        assert_eq!(t.elapsed, 0.0);
+        assert!(matches!(t.target, TweenTarget::Translation { .. }));
     }
 }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1155,6 +1155,57 @@ fn populate_reflected_component_snapshot(world: &mut World) {
     }
 }
 
+/// Recursively walks `value`'s reflect tree and, for every leaf field whose
+/// declared type is `bevy_ecs::Entity`, replaces it with the live entity
+/// that currently has the same `.index()` (if any still does). The
+/// Inspector UI (`reflect_ui.rs`) only ever knows a raw `u64` index for an
+/// `Entity`-typed field -- it edits a *detached clone*, with no `World`
+/// access to look up the entity's real generation -- so it writes
+/// `Entity::from_raw(index)` (generation 0) as a placeholder. Applying that
+/// as-is could silently target the wrong (or a since-despawned-and-reused)
+/// entity slot; this runs once, here, where `World` access is actually
+/// available, before the value is applied to a live component.
+fn fixup_entity_fields(value: &mut dyn bevy_reflect::Reflect, world: &World) {
+    if let Some(entity) = value.downcast_mut::<bevy_ecs::prelude::Entity>() {
+        let wanted_index = entity.index();
+        if let Some(live) = world.iter_entities().find(|e| e.id().index() == wanted_index) {
+            *entity = live.id();
+        }
+        return;
+    }
+    match value.reflect_mut() {
+        bevy_reflect::ReflectMut::Struct(s) => {
+            for i in 0..s.field_len() {
+                if let Some(field) = s.field_at_mut(i) {
+                    fixup_entity_fields(field, world);
+                }
+            }
+        }
+        bevy_reflect::ReflectMut::TupleStruct(ts) => {
+            for i in 0..ts.field_len() {
+                if let Some(field) = ts.field_mut(i) {
+                    fixup_entity_fields(field, world);
+                }
+            }
+        }
+        bevy_reflect::ReflectMut::Enum(e) => {
+            for i in 0..e.field_len() {
+                if let Some(field) = e.field_at_mut(i) {
+                    fixup_entity_fields(field, world);
+                }
+            }
+        }
+        bevy_reflect::ReflectMut::List(l) => {
+            for i in 0..l.len() {
+                if let Some(field) = l.get_mut(i) {
+                    fixup_entity_fields(field, world);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
 fn process_reflect_commands(world: &mut World) {
     let cmds: Vec<ReflectCommand> = {
         let Some(queue_res) = world.get_resource::<ReflectCommandQueueResource>() else {
@@ -1225,7 +1276,7 @@ fn process_reflect_commands(world: &mut World) {
                     reflect_component.remove(&mut entity_mut);
                 }
             }
-            ReflectCommand::ApplyComponentValue { entity_id, type_path, value } => {
+            ReflectCommand::ApplyComponentValue { entity_id, type_path, mut value } => {
                 let Some(registration) = registry.get_with_type_path(&type_path) else {
                     tracing::warn!("reflect: unknown type path '{type_path}'");
                     continue;
@@ -1235,6 +1286,7 @@ fn process_reflect_commands(world: &mut World) {
                     tracing::warn!("reflect: '{type_path}' is not a registered Component");
                     continue;
                 };
+                fixup_entity_fields(value.as_mut(), world);
                 let target = world.iter_entities().find(|e| e.id().index() as u64 == entity_id);
                 if let Some(entity) = target.map(|e| e.id()) {
                     let mut entity_mut = world.entity_mut(entity);
@@ -29103,6 +29155,63 @@ mod tests {
         assert!(
             (cam.fov_y_degrees.0 - 1.2345).abs() < f32::EPSILON,
             "Camera.fov_y_degrees should have been updated to the applied value"
+        );
+    }
+
+    #[test]
+    fn apply_component_value_fixes_up_a_stale_entity_field_generation() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+
+        // Spawn, despawn, and respawn at the same index so the live entity's
+        // generation is now > 0 -- Entity::from_raw(index) (generation 0)
+        // would NOT equal this live entity.
+        let throwaway = app.world_mut().spawn(Name("Throwaway".to_string())).id();
+        app.world_mut().despawn(throwaway);
+        let target = app
+            .world_mut()
+            .spawn(Name("Target".to_string()))
+            .id();
+        assert_eq!(
+            target.index(),
+            throwaway.index(),
+            "test setup requires the respawn to reuse the same index"
+        );
+        assert_ne!(
+            target,
+            bevy_ecs::prelude::Entity::from_raw(target.index()),
+            "test setup requires a nonzero generation to actually exercise the fixup"
+        );
+
+        let follower = app.world_mut().spawn(Name("Follower".to_string())).id();
+        app.update();
+
+        let stale_follow = bsengine_core::Follow::new(bevy_ecs::prelude::Entity::from_raw(target.index()));
+        {
+            let queue = app
+                .world()
+                .resource::<crate::snapshot::ReflectCommandQueueResource>();
+            queue
+                .0
+                .lock()
+                .unwrap()
+                .push(crate::snapshot::ReflectCommand::ApplyComponentValue {
+                    entity_id: follower.index() as u64,
+                    type_path: "bsengine_core::follow::Follow".to_string(),
+                    value: Box::new(stale_follow),
+                });
+        }
+        app.update();
+
+        let applied = app
+            .world()
+            .get::<bsengine_core::Follow>(follower)
+            .expect("Follow should have been applied");
+        assert_eq!(
+            applied.target, target,
+            "the applied Follow.target must be fixed up to the live entity's real generation, \
+             not the stale generation-0 placeholder the UI layer constructed"
         );
     }
 

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1606,6 +1606,9 @@ impl Plugin for EditorPlugin {
         app.register_type::<bsengine_scene::Primitive>();
         app.register_type::<bsengine_scene::PrimitiveMesh>();
         app.register_type::<bsengine_scene::ScriptPath>();
+        app.register_type::<String>();
+        app.register_type::<bsengine_core::ReflectVec3>();
+        app.register_type::<bsengine_core::ReflectQuat>();
         app.add_systems(Update, update_editor_snapshot);
         app.add_systems(Update, update_editor_camera);
         app.add_systems(Update, populate_inspector.after(update_editor_snapshot));
@@ -90942,5 +90945,37 @@ mod tests {
             .expect("expected one entity with Name + GltfAsset");
         assert_eq!(name.0, "Rock");
         assert_eq!(gltf_asset.path, "assets/models/rock.glb");
+    }
+
+    #[test]
+    fn app_type_registry_has_default_for_string_and_glam_wrappers() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        let registry = app
+            .world()
+            .resource::<bevy_ecs::reflect::AppTypeRegistry>()
+            .read();
+        for (type_id, label) in [
+            (std::any::TypeId::of::<String>(), "String"),
+            (
+                std::any::TypeId::of::<bsengine_core::ReflectVec3>(),
+                "ReflectVec3",
+            ),
+            (
+                std::any::TypeId::of::<bsengine_core::ReflectQuat>(),
+                "ReflectQuat",
+            ),
+        ] {
+            assert!(
+                registry
+                    .get_type_data::<bevy_reflect::std_traits::ReflectDefault>(type_id)
+                    .is_some(),
+                "{label} must have a registered ReflectDefault for the List-append and \
+                 enum-variant-switch UI features to work in the real app"
+            );
+        }
     }
 }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1603,6 +1603,9 @@ impl Plugin for EditorPlugin {
         app.register_type::<bsengine_core::AnimationStateMachine>();
         app.register_type::<bsengine_core::Tween>();
         app.register_type::<Tags>();
+        app.register_type::<bsengine_scene::Primitive>();
+        app.register_type::<bsengine_scene::PrimitiveMesh>();
+        app.register_type::<bsengine_scene::ScriptPath>();
         app.add_systems(Update, update_editor_snapshot);
         app.add_systems(Update, update_editor_camera);
         app.add_systems(Update, populate_inspector.after(update_editor_snapshot));
@@ -29373,6 +29376,40 @@ mod tests {
         assert!(
             app.world().resource::<InspectorState>().reflected_components.is_empty(),
             "reflected_components should clear once nothing is selected"
+        );
+    }
+
+    #[test]
+    fn populate_reflected_component_snapshot_includes_attached_primitive_mesh_and_script_path() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app
+            .world_mut()
+            .spawn((
+                Name("Target".to_string()),
+                bsengine_scene::PrimitiveMesh(bsengine_scene::Primitive::Capsule),
+                bsengine_scene::ScriptPath("assets/scripts/foo.js".to_string()),
+            ))
+            .id();
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.selected_id = Some(eid.index() as u64);
+        }
+        app.update();
+
+        let insp = app.world().resource::<InspectorState>();
+        assert!(
+            insp.reflected_components
+                .iter()
+                .any(|(p, _)| p == "bsengine_scene::types::PrimitiveMesh"),
+            "PrimitiveMesh must appear in Reflected Fields"
+        );
+        assert!(
+            insp.reflected_components
+                .iter()
+                .any(|(p, _)| p == "bsengine_scene::types::ScriptPath"),
+            "ScriptPath must appear in Reflected Fields"
         );
     }
 

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1606,6 +1606,15 @@ impl Plugin for EditorPlugin {
         app.register_type::<bsengine_scene::Primitive>();
         app.register_type::<bsengine_scene::PrimitiveMesh>();
         app.register_type::<bsengine_scene::ScriptPath>();
+        // Explicit, defensive registration -- as of this writing these three
+        // already get a ReflectDefault transitively (bevy_reflect's
+        // register_type_dependencies walks Transform's/ScriptPath's own
+        // fields), so this is currently redundant, not a fix for an active
+        // bug. Kept anyway so List-append/enum-variant-switch (which need
+        // ReflectDefault for these types in the real app registry, not just
+        // in reflect_ui.rs's own unit-test-local registries) don't silently
+        // regress if a future refactor to Transform/ScriptPath breaks that
+        // transitive path.
         app.register_type::<String>();
         app.register_type::<bsengine_core::ReflectVec3>();
         app.register_type::<bsengine_core::ReflectQuat>();
@@ -90947,6 +90956,16 @@ mod tests {
         assert_eq!(gltf_asset.path, "assets/models/rock.glb");
     }
 
+    /// Verifies the property List-append/enum-variant-switch actually
+    /// depend on -- these three types have a `ReflectDefault` in the real
+    /// app's registry, not just in reflect_ui.rs's own unit-test-local
+    /// registries. A pass here doesn't uniquely attribute to this file's
+    /// explicit `register_type` calls for these three types specifically:
+    /// bevy_reflect's `register_type_dependencies` already walks
+    /// `Transform`'s/`ScriptPath`'s own fields and would supply the same
+    /// `ReflectDefault`s transitively even without them (confirmed by
+    /// temporarily removing the explicit calls and re-running this test).
+    /// Both paths are acceptable; this test guards the end state either way.
     #[test]
     fn app_type_registry_has_default_for_string_and_glam_wrappers() {
         let mut app = new_app();

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -29196,6 +29196,57 @@ mod tests {
     }
 
     #[test]
+    fn reflect_command_apply_component_value_mutates_a_list_shaped_component() {
+        // `Tags` (a `Vec<String>`-wrapping tuple struct) is the best
+        // available `List`-shaped reflected component. `reflect_ui.rs`'s
+        // List tests exercise the UI-only rendering in isolation (no ECS),
+        // and the other `ApplyComponentValue` tests in this module only
+        // cover `Struct`-shaped components (`Camera`, `Follow`) -- nothing
+        // proves a `List`-shaped component round-trips through the full
+        // command pipeline. This does: InspectorCmd::ApplyReflectedComponent
+        // -> ReflectCommand::ApplyComponentValue ->
+        // ReflectComponent::apply_or_insert.
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app
+            .world_mut()
+            .spawn((Name("Target".to_string()), Tags(vec!["a".to_string()])))
+            .id();
+        app.update();
+
+        // Simulates what the List-editing UI's "+" button would produce:
+        // the existing value plus one appended element.
+        let edited = Tags(vec!["a".to_string(), "b".to_string()]);
+        {
+            let queue = app
+                .world()
+                .resource::<crate::snapshot::ReflectCommandQueueResource>();
+            queue
+                .0
+                .lock()
+                .unwrap()
+                .push(crate::snapshot::ReflectCommand::ApplyComponentValue {
+                    entity_id: eid.index() as u64,
+                    type_path: "bsengine_editor::snapshot::Tags".to_string(),
+                    value: Box::new(edited),
+                });
+        }
+        app.update();
+
+        let tags = app
+            .world()
+            .get::<Tags>(eid)
+            .expect("Tags should still be attached");
+        assert_eq!(
+            tags.0,
+            vec!["a".to_string(), "b".to_string()],
+            "Tags(Vec<String>) should round-trip through the full reflect command \
+             pipeline end-to-end, not just the UI-only or snapshot-only layers"
+        );
+    }
+
+    #[test]
     fn apply_component_value_fixes_up_a_stale_entity_field_generation() {
         let mut app = new_app();
         app.add_plugins(McpPlugin);

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1202,6 +1202,27 @@ fn fixup_entity_fields(value: &mut dyn bevy_reflect::Reflect, world: &World) {
                 }
             }
         }
+        bevy_reflect::ReflectMut::Array(a) => {
+            for i in 0..a.len() {
+                if let Some(field) = a.get_mut(i) {
+                    fixup_entity_fields(field, world);
+                }
+            }
+        }
+        bevy_reflect::ReflectMut::Map(m) => {
+            // `Map` only exposes a mutable reference to the *value* half of
+            // each entry (`get_at_mut`) -- keys are immutable through this
+            // trait, since mutating one in place would desync the map's
+            // internal hash bucket for it. That's fine here: recursing into
+            // the value covers the realistic shape (e.g. `HashMap<K,
+            // Entity>`); a key itself being an `Entity` is an unusual design
+            // this codebase doesn't use.
+            for i in 0..m.len() {
+                if let Some((_key, value)) = m.get_at_mut(i) {
+                    fixup_entity_fields(value, world);
+                }
+            }
+        }
         _ => {}
     }
 }
@@ -29228,6 +29249,90 @@ mod tests {
             applied.target, target,
             "the applied Follow.target must be fixed up to the live entity's real generation, \
              not the stale generation-0 placeholder the UI layer constructed"
+        );
+    }
+
+    #[test]
+    fn apply_component_value_fixes_up_stale_entity_generations_inside_array_and_map_fields() {
+        use bevy_ecs::prelude::{Component, ReflectComponent};
+        use bevy_reflect::Reflect;
+
+        // Test-only component whose reflect tree puts an `Entity` inside
+        // both an `Array` (`[Entity; 2]`) and a `Map`
+        // (`HashMap<String, Entity>`) field -- proving `fixup_entity_fields`'s
+        // `Array`/`Map` arms actually recurse into their elements, rather
+        // than silently falling through `_ => {}` like before this fix.
+        #[derive(Component, Clone, Debug, Reflect)]
+        #[reflect(Component)]
+        struct EntityCollections {
+            array: [bevy_ecs::prelude::Entity; 2],
+            map: std::collections::HashMap<String, bevy_ecs::prelude::Entity>,
+        }
+
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.register_type::<EntityCollections>();
+
+        // Spawn, despawn, and respawn at the same index so the live entity's
+        // generation is now > 0 -- Entity::from_raw(index) (generation 0)
+        // would NOT equal this live entity (same technique as
+        // `apply_component_value_fixes_up_a_stale_entity_field_generation`).
+        let throwaway = app.world_mut().spawn(Name("Throwaway".to_string())).id();
+        app.world_mut().despawn(throwaway);
+        let target = app.world_mut().spawn(Name("Target".to_string())).id();
+        assert_eq!(
+            target.index(),
+            throwaway.index(),
+            "test setup requires the respawn to reuse the same index"
+        );
+        assert_ne!(
+            target,
+            bevy_ecs::prelude::Entity::from_raw(target.index()),
+            "test setup requires a nonzero generation to actually exercise the fixup"
+        );
+
+        let holder = app.world_mut().spawn(Name("Holder".to_string())).id();
+        app.update();
+
+        let stale = bevy_ecs::prelude::Entity::from_raw(target.index());
+        let mut map = std::collections::HashMap::new();
+        map.insert("target".to_string(), stale);
+        let value = EntityCollections { array: [stale, stale], map };
+
+        let type_path = <EntityCollections as bevy_reflect::TypePath>::type_path().to_string();
+        {
+            let queue = app
+                .world()
+                .resource::<crate::snapshot::ReflectCommandQueueResource>();
+            queue
+                .0
+                .lock()
+                .unwrap()
+                .push(crate::snapshot::ReflectCommand::ApplyComponentValue {
+                    entity_id: holder.index() as u64,
+                    type_path,
+                    value: Box::new(value),
+                });
+        }
+        app.update();
+
+        let applied = app
+            .world()
+            .get::<EntityCollections>(holder)
+            .expect("EntityCollections should have been applied");
+        assert_eq!(
+            applied.array[0], target,
+            "Array element containing a stale Entity must be fixed up to the live generation"
+        );
+        assert_eq!(
+            applied.array[1], target,
+            "Array element containing a stale Entity must be fixed up to the live generation"
+        );
+        assert_eq!(
+            applied.map.get("target"),
+            Some(&target),
+            "Map value containing a stale Entity must be fixed up to the live generation"
         );
     }
 

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -29605,6 +29605,58 @@ mod tests {
     }
 
     #[test]
+    fn inspector_cmd_attach_component_by_type_inserts_a_real_default_primitive_mesh() {
+        // Full verification would confirm `resolve_primitives`
+        // (bsengine-runtime's system reacting to `Added<PrimitiveMesh>` by
+        // inserting a derived `MeshRenderer`) still fires when the component
+        // arrives via this reflected path rather than a typed
+        // `commands.insert()`. That's not reachable from this crate's test
+        // harness: `resolve_primitives` lives in `bsengine-runtime`, which
+        // is a binary-only crate (no `[lib]` target -- see its Cargo.toml,
+        // `[[bin]]` only) that itself depends on `bsengine-editor`, so there
+        // is no way to add its plugin here without an unresolvable cycle
+        // (and nothing to `use` even if there weren't one). See
+        // `editor_command_detach_primitive_mesh_also_removes_derived_mesh_renderer`
+        // above for the same limitation on the older typed-command path.
+        //
+        // This narrower test instead confirms the piece that *is* testable
+        // here: `InspectorCmd::AttachComponentByType` (the unified Add
+        // Component menu's mechanism) inserts a genuine, usable
+        // `PrimitiveMesh` component via `ReflectComponent::insert`+
+        // `ReflectDefault` -- not just a UI-only stub -- with its
+        // `#[default]` variant (`Primitive::Cube`), the same starting point
+        // a typed `commands.insert(PrimitiveMesh::default())` would produce.
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app.world_mut().spawn(Name("Target".to_string())).id();
+        app.update();
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.cmd_queue.push(InspectorCmd::AttachComponentByType {
+                id: eid.index() as u64,
+                type_path: "bsengine_scene::types::PrimitiveMesh".to_string(),
+            });
+        }
+        app.update();
+
+        let mesh = app
+            .world()
+            .get::<bsengine_scene::PrimitiveMesh>(eid)
+            .expect(
+                "PrimitiveMesh should have been attached via the reflected \
+                 AttachComponentByType path",
+            );
+        assert_eq!(
+            mesh.0,
+            bsengine_scene::Primitive::Cube,
+            "the default PrimitiveMesh attached via ReflectDefault should be \
+             Primitive::Cube per its #[default]"
+        );
+    }
+
+    #[test]
     fn editor_plugin_registers_reflected_component_types() {
         let mut app = new_app();
         app.add_plugins(McpPlugin);

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1602,6 +1602,7 @@ impl Plugin for EditorPlugin {
         app.register_type::<bsengine_core::Parent>();
         app.register_type::<bsengine_core::AnimationStateMachine>();
         app.register_type::<bsengine_core::Tween>();
+        app.register_type::<Tags>();
         app.add_systems(Update, update_editor_snapshot);
         app.add_systems(Update, update_editor_camera);
         app.add_systems(Update, populate_inspector.after(update_editor_snapshot));
@@ -29319,6 +29320,32 @@ mod tests {
             "cloned Camera's fov_y_degrees should be 60.0 (degrees) — proves the field is wired \
              through the real reflection pipeline with the correct unit, not just internally \
              self-consistent"
+        );
+    }
+
+    #[test]
+    fn populate_reflected_component_snapshot_includes_attached_tags() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app
+            .world_mut()
+            .spawn((Name("Target".to_string()), Tags(vec!["enemy".to_string()])))
+            .id();
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.selected_id = Some(eid.index() as u64);
+        }
+        app.update();
+
+        let insp = app.world().resource::<InspectorState>();
+        let found = insp
+            .reflected_components
+            .iter()
+            .find(|(type_path, _)| type_path == "bsengine_editor::snapshot::Tags");
+        assert!(
+            found.is_some(),
+            "Tags must appear in the Reflected Fields list once selected, now that it's a Reflect component"
         );
     }
 

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -1,11 +1,18 @@
-use bevy_ecs::prelude::Component;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
 use bsengine_ecs::Resource;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 /// Free-form string labels attached to an entity, set/cleared via
 /// `EditorCommand::TagEntity`/`UntagEntity` and used for selection/filtering.
-#[derive(Component, Clone, Default)]
+/// Also reflected so it appears in the Inspector's generic "Reflected
+/// Fields" list (via the List-editing UI added in reflect_ui.rs) -- the
+/// TagEntity/UntagEntity commands remain a second, equivalent entry point
+/// onto the same component.
+#[derive(Component, Clone, Default, Debug, Reflect)]
+#[reflect(Component, Default)]
 pub struct Tags(pub Vec<String>);
 
 /// Flattened, per-entity view of the ECS world used to build an

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -231,26 +231,14 @@ impl EditorPanel for InspectorPanel {
         });
         ui.separator();
 
-        // Add Component
-        ui.horizontal(|ui| {
-            ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::PLUS);
-            ui.colored_label(crate::theme::TEXT, "Add Component");
-        });
-        ui.horizontal(|ui| {
-            if light_type.is_none() && ui.button("Point Light").clicked() {
-                insp.cmd_queue
-                    .push(InspectorCmd::AddPointLight { id: sel_id });
-            }
-            if !has_camera && ui.button("Camera").clicked() {
-                insp.cmd_queue.push(InspectorCmd::AddCamera { id: sel_id });
-            }
-        });
-
+        // Add Component -- a single menu listing every registered,
+        // ReflectDefault-constructible component type not already attached
+        // to this entity (filtering prevents a confusing duplicate-attach).
         if let Some(registry) = ctx.type_registry {
             ui.separator();
             ui.horizontal(|ui| {
                 ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::PLUS);
-                ui.colored_label(crate::theme::TEXT, "Add Component (reflected)");
+                ui.colored_label(crate::theme::TEXT, "Add Component");
             });
             let mut to_attach: Option<String> = None;
             egui::ComboBox::from_id_salt("reflect_add_component")
@@ -263,7 +251,20 @@ impl EditorPanel for InspectorPanel {
                         {
                             continue;
                         }
+                        if registration
+                            .data::<bevy_reflect::std_traits::ReflectDefault>()
+                            .is_none()
+                        {
+                            continue;
+                        }
                         let type_path = registration.type_info().type_path().to_string();
+                        let already_attached = insp
+                            .reflected_components
+                            .iter()
+                            .any(|(existing_path, _)| existing_path == &type_path);
+                        if already_attached {
+                            continue;
+                        }
                         if ui.selectable_label(false, &type_path).clicked() {
                             to_attach = Some(type_path);
                         }
@@ -622,6 +623,210 @@ mod tests {
         assert!(
             (sl.inner_angle_degrees.0 - 20.0).abs() < 1e-6,
             "inner should have been clamped down to outer via the generic Validate hook"
+        );
+    }
+
+    #[test]
+    fn add_component_menu_filters_out_already_attached_types() {
+        let mut registry = bevy_reflect::TypeRegistry::default();
+        registry.register::<bsengine_core::Camera>();
+        registry.register::<bsengine_core::PointLight>();
+
+        let mut insp = InspectorState::default();
+        insp.selected_id = Some(1);
+        // Camera is already attached (present in reflected_components) --
+        // it must not also appear as a pickable entry in the Add Component
+        // menu, or picking it would be a confusing no-op duplicate-attach.
+        insp.reflected_components = vec![(
+            "bsengine_core::camera::Camera".to_string(),
+            Box::new(bsengine_core::Camera::default()) as Box<dyn bevy_reflect::Reflect>,
+        )];
+
+        let entities_snapshot: Vec<InspectorEntityInfo> = Vec::new();
+        let mut panel = InspectorPanel;
+
+        with_test_ui(|ui| {
+            let mut ctx = EditorPanelContext {
+                insp: &mut insp,
+                entities_snapshot: &entities_snapshot,
+                cursor_pos: (0.0, 0.0),
+                type_registry: Some(&registry),
+            };
+            panel.ui(ui, &mut ctx);
+        });
+
+        // No interaction was simulated (headless single frame), so this
+        // doesn't test clicking the menu -- it's a smoke test that the
+        // panel renders without panicking with a registry containing an
+        // already-attached type.
+        assert!(insp.cmd_queue.is_empty());
+    }
+
+    #[test]
+    fn add_component_menu_click_only_offers_the_not_yet_attached_type() {
+        // Regression test that genuinely drives `InspectorPanel::ui()`'s Add
+        // Component combo, mirroring the click-simulation technique in
+        // `reflect_ui.rs`'s `enum_variant_combo_switches_to_a_default_instance_
+        // of_the_chosen_variant` test (open combo, settle frame, click a row)
+        // adapted to `panel.ui(ui, &mut ctx)`'s call shape instead of
+        // `draw_reflect_ui(ui, value, &ctx)`.
+        //
+        // Camera is registered AND already attached (in reflected_components);
+        // PointLight is registered and NOT attached. With the real
+        // `already_attached` filter in place, the combo has exactly one
+        // candidate row (PointLight) -- clicking it must queue
+        // `AttachComponentByType` for PointLight, never Camera. If the filter
+        // were a no-op, Camera would also be offered as a row, which this
+        // test's row-count and type_path assertions below would catch.
+        let mut registry = bevy_reflect::TypeRegistry::default();
+        registry.register::<bsengine_core::Camera>();
+        registry.register::<bsengine_core::PointLight>();
+
+        let mut insp = InspectorState::default();
+        insp.selected_id = Some(1);
+        insp.reflected_components = vec![(
+            "bsengine_core::camera::Camera".to_string(),
+            Box::new(bsengine_core::Camera::default()) as Box<dyn bevy_reflect::Reflect>,
+        )];
+
+        let entities_snapshot: Vec<InspectorEntityInfo> = Vec::new();
+        let mut panel = InspectorPanel;
+
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let run_frame = |egui_ctx: &egui::Context,
+                         events: Vec<egui::Event>,
+                         insp: &mut InspectorState,
+                         entities_snapshot: &[InspectorEntityInfo],
+                         panel: &mut InspectorPanel| {
+            let _ = egui_ctx.run(
+                egui::RawInput {
+                    screen_rect: Some(screen_rect),
+                    events,
+                    ..Default::default()
+                },
+                |egui_ctx| {
+                    egui::CentralPanel::default().show(egui_ctx, |ui| {
+                        let mut ctx = EditorPanelContext {
+                            insp,
+                            entities_snapshot,
+                            cursor_pos: (0.0, 0.0),
+                            type_registry: Some(&registry),
+                        };
+                        panel.ui(ui, &mut ctx);
+                    });
+                },
+            );
+        };
+        let click_events = |pos: egui::Pos2| {
+            vec![
+                egui::Event::PointerMoved(pos),
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ]
+        };
+
+        // Frame 1: draw the panel once (combo closed) so its widgets exist
+        // in egui's id/layout cache before anything is clicked.
+        run_frame(&egui_ctx, vec![], &mut insp, &entities_snapshot, &mut panel);
+
+        // Frame 2: click the combo box to open its popup. Its position was
+        // found empirically for this exact scenario (fixed 800x800 headless
+        // screen rect, `FontDefinitions::empty()`, this panel's fixed
+        // section order up to "Add Component") by scanning candidate y
+        // values and observing `ctx.memory(|mem| mem.any_popup_open())`
+        // flip to true -- the closed combo box spans y=[240,268], so its
+        // vertical center (254) is used here.
+        let combo_pos = egui::Pos2::new(20.0, 254.0);
+        run_frame(
+            &egui_ctx,
+            click_events(combo_pos),
+            &mut insp,
+            &entities_snapshot,
+            &mut panel,
+        );
+
+        // Frame 3 ("settle"): redraw with no input so the popup's cached
+        // size/id sequence stabilizes before anything tries to click into
+        // it (see reflect_ui.rs's identical settle-frame comment for why
+        // this is needed).
+        run_frame(&egui_ctx, vec![], &mut insp, &entities_snapshot, &mut panel);
+
+        // Frame 4: click the popup's only row (y=278, likewise found
+        // empirically: with the real `already_attached` filter active,
+        // clicking anywhere in y=[269,287] queues PointLight, and nothing at
+        // all is queued for y >= 288 -- there is no second row).
+        let point_light_row_pos = egui::Pos2::new(30.0, 278.0);
+        run_frame(
+            &egui_ctx,
+            click_events(point_light_row_pos),
+            &mut insp,
+            &entities_snapshot,
+            &mut panel,
+        );
+
+        assert_eq!(
+            insp.cmd_queue.len(),
+            1,
+            "clicking the popup's only row should queue exactly one attach command; \
+             a queue of 0 means the click missed"
+        );
+        match &insp.cmd_queue[0] {
+            InspectorCmd::AttachComponentByType { id, type_path } => {
+                assert_eq!(*id, 1);
+                assert_eq!(
+                    type_path, "bsengine_core::light::PointLight",
+                    "the only clickable row must be PointLight -- Camera is already \
+                     attached and must never be offered again"
+                );
+            }
+            other => panic!(
+                "expected AttachComponentByType, got a different InspectorCmd variant instead: {:?}",
+                std::mem::discriminant(other)
+            ),
+        }
+
+        // Frame 5: reopen the combo and click y=298 -- the row position
+        // Camera would occupy as a second entry if the `already_attached`
+        // filter regressed to a no-op (measured the same way: with the
+        // filter genuinely disabled, y=[290,308] reliably queues
+        // `AttachComponentByType` for Camera). With the real filter active,
+        // there is no second row there, so this must add nothing to the
+        // queue: the length must stay at 1 from frame 4, not grow to 2.
+        run_frame(
+            &egui_ctx,
+            click_events(combo_pos),
+            &mut insp,
+            &entities_snapshot,
+            &mut panel,
+        );
+        run_frame(&egui_ctx, vec![], &mut insp, &entities_snapshot, &mut panel);
+        let camera_row_pos = egui::Pos2::new(30.0, 298.0);
+        run_frame(
+            &egui_ctx,
+            click_events(camera_row_pos),
+            &mut insp,
+            &entities_snapshot,
+            &mut panel,
+        );
+        assert_eq!(
+            insp.cmd_queue.len(),
+            1,
+            "clicking where Camera's row would sit if it weren't filtered out must not \
+             queue a second command -- a length of 2 here means the already_attached \
+             filter regressed and Camera became clickable again"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -58,8 +58,6 @@ impl EditorPanel for InspectorPanel {
         let label = sel_info.name.as_deref().unwrap_or("(unnamed)");
         let entity_name = format!("[{sel_id}] {label}");
         let has_transform = sel_info.position.is_some();
-        let light_type = sel_info.light_type.clone();
-        let has_camera = sel_info.camera_fov.is_some();
 
         ui.heading(&entity_name);
         ui.separator();

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -1,4 +1,4 @@
-use crate::panels::reflect_ui::draw_reflect_ui;
+use crate::panels::reflect_ui::{draw_reflect_ui, ReflectUiCtx};
 use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd, PRIMITIVE_KINDS};
 
 /// The Inspector panel: shows and edits the selected entity's transform, tags, and components.
@@ -284,6 +284,10 @@ impl EditorPanel for InspectorPanel {
                 ui.colored_label(crate::theme::TEXT, "Reflected Fields");
             });
             let type_registry = ctx.type_registry;
+            let reflect_ctx = ReflectUiCtx {
+                entities: ctx.entities_snapshot,
+                type_registry,
+            };
             let mut to_apply: Vec<(String, Box<dyn bevy_reflect::Reflect>)> = Vec::new();
             let mut to_remove: Option<String> = None;
             for (type_path, value) in insp.reflected_components.iter_mut() {
@@ -303,7 +307,7 @@ impl EditorPanel for InspectorPanel {
                     });
                 })
                 .body(|ui| {
-                    if draw_reflect_ui(ui, value.as_mut()) {
+                    if draw_reflect_ui(ui, value.as_mut(), &reflect_ctx) {
                         validate_after_edit(type_path, value.as_mut(), type_registry);
                         to_apply.push((type_path.clone(), value.clone_value()));
                     }

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -20,12 +20,21 @@ pub struct ReflectUiCtx<'a> {
 /// Recursively renders an egui editor for any `Reflect` value. Returns
 /// whether anything changed. Handles:
 /// - `Struct`: iterate fields, label + recurse.
+/// - `TupleStruct`: iterate fields and recurse, with no label wrapper
+///   (tuple struct fields have no name to show).
 /// - `Enum`: display the current variant's name (read-only — switching
 ///   variants generically is out of scope for this pass, see design doc)
 ///   and recurse into its fields.
+/// - `List`: one row per element (recursively-rendered widget + a remove
+///   button), plus an append row that pushes a `ReflectDefault`-constructed
+///   item via the type registry.
 /// - Opaque `Value`: glam Vec2/Vec3/Vec4/Quat get dedicated multi-DragValue
 ///   rows; everything else falls through to primitive widgets.
 pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &ReflectUiCtx) -> bool {
+    let list_item_type_id = match value.get_represented_type_info() {
+        Some(bevy_reflect::TypeInfo::List(list_info)) => Some(list_info.item_type_id()),
+        _ => None,
+    };
     match value.reflect_mut() {
         bevy_reflect::ReflectMut::Struct(s) => {
             let mut changed = false;
@@ -47,6 +56,39 @@ pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &Reflect
                     changed |= draw_reflect_ui(ui, field, ctx);
                 }
             }
+            changed
+        }
+        bevy_reflect::ReflectMut::List(l) => {
+            let mut changed = false;
+            let mut remove_at: Option<usize> = None;
+            for i in 0..l.len() {
+                if let Some(element) = l.get_mut(i) {
+                    ui.horizontal(|ui| {
+                        changed |= draw_reflect_ui(ui, element, ctx);
+                        if ui.small_button("×").clicked() {
+                            remove_at = Some(i);
+                        }
+                    });
+                }
+            }
+            if let Some(i) = remove_at {
+                l.remove(i);
+                changed = true;
+            }
+            ui.horizontal(|ui| {
+                if ui.small_button("+").clicked() {
+                    if let (Some(item_type_id), Some(registry)) =
+                        (list_item_type_id, ctx.type_registry)
+                    {
+                        if let Some(default) = registry
+                            .get_type_data::<bevy_reflect::std_traits::ReflectDefault>(item_type_id)
+                        {
+                            l.push(default.default());
+                            changed = true;
+                        }
+                    }
+                }
+            });
             changed
         }
         bevy_reflect::ReflectMut::Enum(e) => {
@@ -413,6 +455,113 @@ mod tests {
             "expected exactly 2 top-level widgets (one f32 DragValue, one bool checkbox) -- \
              a widget count of 1 would mean this fell through to the single fallback label \
              instead of iterating the tuple struct's fields"
+        );
+    }
+
+    #[test]
+    fn list_leaf_renders_one_row_per_element_plus_an_append_button() {
+        let mut tags: Vec<String> = vec!["enemy".to_string(), "boss".to_string()];
+        let (changed, widget_count) = with_test_ui(|_ctx, ui| {
+            let changed = draw_reflect_ui(ui, &mut tags, &empty_ctx());
+            let after = ui.next_auto_id();
+            (changed, after)
+        });
+        assert!(!changed, "no interaction happened, so nothing changed");
+        assert_eq!(tags, vec!["enemy".to_string(), "boss".to_string()]);
+        // One ui.horizontal group per existing element (text field + "x"
+        // button), plus one more group for the "+" append row: 2 elements
+        // + 1 append row = 3 top-level groups.
+        assert_eq!(
+            widget_count,
+            auto_id_after_n_top_level_widgets(3),
+            "expected 2 element rows + 1 append row"
+        );
+    }
+
+    #[test]
+    fn list_append_button_pushes_a_default_item_using_the_type_registry() {
+        let mut tags: Vec<String> = vec![];
+        let mut registry = bevy_reflect::TypeRegistry::default();
+        registry.register::<String>();
+        let ctx = ReflectUiCtx {
+            entities: &[],
+            type_registry: Some(&registry),
+        };
+
+        // Simulate a click on the append ("+") button by calling
+        // draw_reflect_ui inside a frame where the button's id is pressed.
+        // This mirrors the click-simulation pattern used in
+        // hierarchy.rs's `row_click_registers_despite_unioned_drag_sense_interact`
+        // test: two `Context::run` passes, since egui hit-tests against the
+        // *previous* frame's widget rects.
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let mut button_rect = egui::Rect::NOTHING;
+        let _ = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    draw_reflect_ui(ui, &mut tags, &ctx);
+                });
+            },
+        );
+        // Re-run once, capturing the actual button response this time.
+        let _ = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    let before = ui.next_auto_id();
+                    draw_reflect_ui(ui, &mut tags, &ctx);
+                    button_rect = ui
+                        .ctx()
+                        .read_response(before)
+                        .map(|r| r.rect)
+                        .unwrap_or(egui::Rect::NOTHING);
+                });
+            },
+        );
+
+        let pos = button_rect.center();
+        let click_events = vec![
+            egui::Event::PointerMoved(pos),
+            egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::default(),
+            },
+            egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::default(),
+            },
+        ];
+        let _ = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                events: click_events,
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    draw_reflect_ui(ui, &mut tags, &ctx);
+                });
+            },
+        );
+
+        assert_eq!(
+            tags,
+            vec!["".to_string()],
+            "clicking append should push one default (empty-string) item"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -1,5 +1,22 @@
 use bevy_reflect::Reflect;
 
+/// Read-only context threaded through every `draw_reflect_ui`/`draw_leaf_ui`
+/// call in a single Inspector frame — bundled into one struct rather than
+/// separate positional parameters, mirroring `hierarchy.rs`'s `TreeCtx` (same
+/// rationale: keeps the recursive calls' argument lists from growing every
+/// time a new leaf case needs more context).
+pub struct ReflectUiCtx<'a> {
+    /// Every entity in the current scene, for rendering an `Entity`-typed
+    /// field's current target and the picker's search list. Empty is a
+    /// valid, safe value (the picker just has nothing to show/pick).
+    pub entities: &'a [bsengine_core::InspectorEntityInfo],
+    /// Used to look up `ReflectDefault` for: (a) a `List`'s item type when
+    /// appending a new element, (b) an enum variant's field types when
+    /// switching to a variant that isn't currently active. `None` is a
+    /// valid, safe value (those two features just become no-ops).
+    pub type_registry: Option<&'a bevy_reflect::TypeRegistry>,
+}
+
 /// Recursively renders an egui editor for any `Reflect` value. Returns
 /// whether anything changed. Handles:
 /// - `Struct`: iterate fields, label + recurse.
@@ -8,7 +25,7 @@ use bevy_reflect::Reflect;
 ///   and recurse into its fields.
 /// - Opaque `Value`: glam Vec2/Vec3/Vec4/Quat get dedicated multi-DragValue
 ///   rows; everything else falls through to primitive widgets.
-pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect) -> bool {
+pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &ReflectUiCtx) -> bool {
     match value.reflect_mut() {
         bevy_reflect::ReflectMut::Struct(s) => {
             let mut changed = false;
@@ -17,7 +34,7 @@ pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect) -> bool {
                 if let Some(field) = s.field_at_mut(i) {
                     ui.horizontal(|ui| {
                         ui.label(&name);
-                        changed |= draw_reflect_ui(ui, field);
+                        changed |= draw_reflect_ui(ui, field, ctx);
                     });
                 }
             }
@@ -28,7 +45,7 @@ pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect) -> bool {
             let mut changed = false;
             for i in 0..e.field_len() {
                 if let Some(field) = e.field_at_mut(i) {
-                    changed |= draw_reflect_ui(ui, field);
+                    changed |= draw_reflect_ui(ui, field, ctx);
                 }
             }
             changed
@@ -125,8 +142,15 @@ fn draw_leaf_ui(ui: &mut egui::Ui, value: &mut dyn Reflect) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::draw_reflect_ui;
+    use super::{draw_reflect_ui, ReflectUiCtx};
     use bevy_reflect::Reflect;
+
+    fn empty_ctx() -> ReflectUiCtx<'static> {
+        ReflectUiCtx {
+            entities: &[],
+            type_registry: None,
+        }
+    }
 
     #[derive(Reflect, Debug, PartialEq, Clone)]
     struct SampleStruct {
@@ -197,7 +221,7 @@ mod tests {
         let mut speed: f32 = 3.5;
         let (changed, widget_count, is_focusable) = with_test_ui(|ctx, ui| {
             let before = ui.next_auto_id();
-            let changed = draw_reflect_ui(ui, &mut speed);
+            let changed = draw_reflect_ui(ui, &mut speed, &empty_ctx());
             let after = ui.next_auto_id();
             let is_focusable = top_level_response_exists_at(ctx, before)
                 .map(|r| r.sense.focusable)
@@ -230,7 +254,7 @@ mod tests {
         let mut offset: bsengine_core::ReflectVec3 = glam::Vec3::new(1.0, 2.0, 3.0).into();
         let (changed, widget_count, is_wrapped_group) = with_test_ui(|ctx, ui| {
             let before = ui.next_auto_id();
-            let changed = draw_reflect_ui(ui, &mut offset);
+            let changed = draw_reflect_ui(ui, &mut offset, &empty_ctx());
             let after = ui.next_auto_id();
             let is_wrapped_group = top_level_response_exists_at(ctx, before).is_none();
             (changed, after, is_wrapped_group)
@@ -267,7 +291,7 @@ mod tests {
         let mut angle: bsengine_core::ReflectDegrees = 45.0_f32.into();
         let (changed, widget_count, is_focusable) = with_test_ui(|ctx, ui| {
             let before = ui.next_auto_id();
-            let changed = draw_reflect_ui(ui, &mut angle);
+            let changed = draw_reflect_ui(ui, &mut angle, &empty_ctx());
             let after = ui.next_auto_id();
             let is_focusable = top_level_response_exists_at(ctx, before)
                 .map(|r| r.sense.focusable)
@@ -301,7 +325,7 @@ mod tests {
         let mut color: bsengine_core::ReflectColor = glam::Vec3::new(1.0, 0.5, 0.0).into();
         let (changed, widget_count, is_focusable) = with_test_ui(|ctx, ui| {
             let before = ui.next_auto_id();
-            let changed = draw_reflect_ui(ui, &mut color);
+            let changed = draw_reflect_ui(ui, &mut color, &empty_ctx());
             let after = ui.next_auto_id();
             let is_focusable = top_level_response_exists_at(ctx, before)
                 .map(|r| r.sense.focusable)
@@ -336,7 +360,7 @@ mod tests {
         };
         let expected = s.clone();
         let (changed, widget_count) = with_test_ui(|_ctx, ui| {
-            let changed = draw_reflect_ui(ui, &mut s);
+            let changed = draw_reflect_ui(ui, &mut s, &empty_ctx());
             let after = ui.next_auto_id();
             (changed, after)
         });
@@ -365,7 +389,7 @@ mod tests {
         let mut value: i32 = 7;
         let (changed, widget_count, is_focusable) = with_test_ui(|ctx, ui| {
             let before = ui.next_auto_id();
-            let changed = draw_reflect_ui(ui, &mut value);
+            let changed = draw_reflect_ui(ui, &mut value, &empty_ctx());
             let after = ui.next_auto_id();
             let is_focusable = top_level_response_exists_at(ctx, before)
                 .map(|r| r.sense.focusable)

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -158,7 +158,7 @@ pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &Reflect
             }
             changed
         }
-        _ => draw_leaf_ui(ui, value),
+        _ => draw_leaf_ui(ui, value, ctx),
     }
 }
 
@@ -202,7 +202,67 @@ fn build_default_variant(
     ))
 }
 
-fn draw_leaf_ui(ui: &mut egui::Ui, value: &mut dyn Reflect) -> bool {
+fn draw_leaf_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &ReflectUiCtx) -> bool {
+    // `Entity`-typed fields (e.g. Follow/LookAt/Parent's target) get a
+    // dedicated picker: the current target is shown as "[id] name", a drop
+    // zone accepts the same u64 drag payload Hierarchy rows already emit
+    // (`row_response.dnd_set_drag_payload(info.id)` in hierarchy.rs) for
+    // reparenting, and a searchable ComboBox is offered as a fallback for
+    // when drag-and-drop isn't convenient.
+    if let Some(entity) = value.downcast_mut::<bevy_ecs::prelude::Entity>() {
+        let mut changed = false;
+        let current_label = if *entity == bevy_ecs::prelude::Entity::PLACEHOLDER {
+            "(none)".to_string()
+        } else {
+            ctx.entities
+                .iter()
+                .find(|e| e.id == entity.index() as u64)
+                .map(|e| format!("[{}] {}", e.id, e.name.as_deref().unwrap_or("(unnamed)")))
+                .unwrap_or_else(|| format!("[{}] (not found)", entity.index()))
+        };
+        let (rect, response) = ui.allocate_exact_size(
+            egui::vec2(ui.available_width().min(160.0), 20.0),
+            egui::Sense::hover(),
+        );
+        ui.painter().text(
+            rect.left_center(),
+            egui::Align2::LEFT_CENTER,
+            &current_label,
+            egui::FontId::default(),
+            ui.visuals().text_color(),
+        );
+        if let Some(dropped_id) = response.dnd_release_payload::<u64>() {
+            *entity = bevy_ecs::prelude::Entity::from_raw(*dropped_id as u32);
+            changed = true;
+        }
+        // `ui.next_auto_id()` (NOT `ui.id()`) as the salt -- `ui.id()` is
+        // egui's *stable* id, identical across sibling fields under the
+        // same parent `Ui`, which caused a real ComboBox id-collision bug
+        // fixed earlier in this file's history (see the `combo_salt`
+        // comment in the Enum arm of `draw_reflect_ui` above, for sibling
+        // enum-typed fields). `next_auto_id()` varies correctly per call
+        // site even when siblings share the same stable `.id()`, because
+        // each child `Ui`'s auto-id counter increments per creation.
+        // Captured here, before the ComboBox call below (the only other
+        // widget call in this block), for the same reason.
+        let picker_salt = ui.next_auto_id();
+        egui::ComboBox::from_id_salt(picker_salt)
+            .selected_text("Search…")
+            .show_ui(ui, |ui| {
+                for info in ctx.entities {
+                    let label = format!(
+                        "[{}] {}",
+                        info.id,
+                        info.name.as_deref().unwrap_or("(unnamed)")
+                    );
+                    if ui.selectable_label(false, label).clicked() {
+                        *entity = bevy_ecs::prelude::Entity::from_raw(info.id as u32);
+                        changed = true;
+                    }
+                }
+            });
+        return changed;
+    }
     // Fields of type `glam::Vec2/Vec3/Vec4/Quat` are never `Reflect` themselves (Task 1: Rust's
     // orphan rule blocks that impl from bsengine-core) — reflected components store these as the
     // local `ReflectVec2`/`ReflectVec3`/`ReflectVec4`/`ReflectQuat` wrapper types instead
@@ -1092,5 +1152,246 @@ mod tests {
             "only the first (X) DragValue was interacted with -- Y and Z must stay at 0, got \
              ({ry_deg}, {rz_deg})"
         );
+    }
+
+    #[test]
+    fn entity_leaf_shows_target_name_and_accepts_a_hierarchy_drag_payload() {
+        let entities = vec![
+            bsengine_core::InspectorEntityInfo {
+                id: 1,
+                name: Some("Player".to_string()),
+                ..Default::default()
+            },
+            bsengine_core::InspectorEntityInfo {
+                id: 2,
+                name: Some("Boss".to_string()),
+                ..Default::default()
+            },
+        ];
+        let ctx = ReflectUiCtx {
+            entities: &entities,
+            type_registry: None,
+        };
+        let mut target = bevy_ecs::prelude::Entity::PLACEHOLDER;
+
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        // Frame 1: draw with no target set yet -- establishes the field's
+        // drop-zone rect and confirms the "(none)" placeholder shows.
+        let mut field_rect = egui::Rect::NOTHING;
+        let _ = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    let before = ui.next_auto_id();
+                    draw_reflect_ui(ui, &mut target, &ctx);
+                    field_rect = ui
+                        .ctx()
+                        .read_response(before)
+                        .map(|r| r.rect)
+                        .unwrap_or(egui::Rect::NOTHING);
+                });
+            },
+        );
+
+        // Frame 2: set a drag payload directly -- the same call
+        // `Response::dnd_set_drag_payload` makes internally on
+        // `drag_started()` (egui's `response.rs`), so this is equivalent to
+        // a real drag having started elsewhere (e.g. a Hierarchy row, which
+        // calls `.dnd_set_drag_payload(info.id)` in `hierarchy.rs`) without
+        // needing to simulate the full drag gesture -- then release the
+        // pointer over the field's rect. `Response::dnd_release_payload`
+        // only requires `contains_pointer()` (true once the field's
+        // `Sense::hover()` rect contains the pointer position) and
+        // `pointer.any_released()` (true from a single `PointerButton
+        // {pressed: false}` event, unconditional on any prior `pressed:
+        // true` in this test -- confirmed directly against egui 0.29.1's
+        // `input_state/mod.rs`: every `pressed: false` event unconditionally
+        // pushes a `PointerEvent::Released`).
+        egui::DragAndDrop::set_payload(&egui_ctx, 2u64);
+        let drop_pos = field_rect.center();
+        let _ = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                events: vec![
+                    egui::Event::PointerMoved(drop_pos),
+                    egui::Event::PointerButton {
+                        pos: drop_pos,
+                        button: egui::PointerButton::Primary,
+                        pressed: false,
+                        modifiers: egui::Modifiers::default(),
+                    },
+                ],
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    draw_reflect_ui(ui, &mut target, &ctx);
+                });
+            },
+        );
+
+        assert_eq!(
+            target.index(),
+            2,
+            "dropping the id-2 Hierarchy payload should set the field's target to that raw index"
+        );
+    }
+
+    #[derive(Reflect, Debug, Clone)]
+    struct SampleTwoEntityFields {
+        first: bevy_ecs::prelude::Entity,
+        second: bevy_ecs::prelude::Entity,
+    }
+
+    #[test]
+    fn opening_a_sibling_entity_fields_picker_only_affects_that_field() {
+        // Regression test for the same class of sibling-id-collision bug
+        // fixed in Task 4 (see `combo_salt = ui.next_auto_id()` in
+        // `draw_reflect_ui`'s Enum arm, and its `opening_a_sibling_enum_..`
+        // regression test above) -- but for the Entity picker's own
+        // `picker_salt = ui.next_auto_id()` line in `draw_leaf_ui`. Mirrors
+        // a component with 2+ sibling `Entity`-typed fields (e.g. a future
+        // component with 2 `Entity` fields, or `Follow`+`LookAt` ending up
+        // as siblings under one parent `Ui` in a future refactor) and
+        // drives the *real* `draw_reflect_ui`, through its actual
+        // `ReflectMut::Struct` arm, exactly the call shape that would make
+        // `first` and `second`'s picker ComboBoxes collide on one id if the
+        // salt regressed back to `ui.id()`.
+        //
+        // If `picker_salt` regressed to `ui.id()` (stable, identical across
+        // sibling fields), both fields' ComboBox internals would register
+        // under the same id, so opening one field's popup while a sibling
+        // Entity field is also present would toggle it right back closed
+        // within the same frame (the exact mechanism documented on the
+        // enum regression test above) -- silently no-op'ing the selection
+        // click below. This test opens `first`'s picker and selects the
+        // 2nd entity ("Boss", id 2) while `second` is also present and
+        // untouched; it is red on the pre-fix `ui.id()` salt and green on
+        // the `next_auto_id()` fix already in production code.
+        //
+        // Coordinates below were measured empirically against this exact
+        // scene (2 Entity fields, 2 registered entities, fontless/400x400
+        // headless canvas) the same way the enum sibling test's were: by
+        // instrumenting the real production path with a scratch diagnostic
+        // (not committed) that scanned candidate click points and printed
+        // which one actually flipped `first`/`second`, then hard-coding the
+        // ones that worked.
+        let entities = vec![
+            bsengine_core::InspectorEntityInfo {
+                id: 1,
+                name: Some("Player".to_string()),
+                ..Default::default()
+            },
+            bsengine_core::InspectorEntityInfo {
+                id: 2,
+                name: Some("Boss".to_string()),
+                ..Default::default()
+            },
+        ];
+        let ctx = ReflectUiCtx {
+            entities: &entities,
+            type_registry: None,
+        };
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+        let click_events = |pos: egui::Pos2| {
+            vec![
+                egui::Event::PointerMoved(pos),
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ]
+        };
+
+        // --- Scenario A: interact with `first`'s picker; `second` must stay untouched. ---
+        {
+            let mut value = SampleTwoEntityFields {
+                first: bevy_ecs::prelude::Entity::PLACEHOLDER,
+                second: bevy_ecs::prelude::Entity::PLACEHOLDER,
+            };
+            let egui_ctx = egui::Context::default();
+            egui_ctx.set_fonts(egui::FontDefinitions::empty());
+            let run = |events: Vec<egui::Event>, v: &mut SampleTwoEntityFields| {
+                let _ = egui_ctx.run(
+                    egui::RawInput {
+                        screen_rect: Some(screen_rect),
+                        events,
+                        ..Default::default()
+                    },
+                    |c| {
+                        egui::CentralPanel::default().show(c, |ui| draw_reflect_ui(ui, v, &ctx));
+                    },
+                );
+            };
+            run(vec![], &mut value); // frame 1: establish prior-frame widget rects
+            run(click_events(egui::Pos2::new(180.0, 15.0)), &mut value); // frame 2: open `first`'s combo
+            run(vec![], &mut value); // frame 3: settle (popup's cached size/id sequence stabilizes)
+            run(click_events(egui::Pos2::new(200.0, 60.0)), &mut value); // frame 4: select "Boss" (id 2)
+
+            assert_eq!(
+                value.first,
+                bevy_ecs::prelude::Entity::from_raw(2),
+                "opening and selecting in `first`'s picker should set it to entity id 2 -- if \
+                 this is still PLACEHOLDER, the click had no effect, which is exactly the \
+                 symptom of the sibling-id-collision bug (both fields' picker ComboBoxes \
+                 toggling the same shared popup id back closed within the same frame)"
+            );
+            assert_eq!(
+                value.second,
+                bevy_ecs::prelude::Entity::PLACEHOLDER,
+                "only `first`'s picker was interacted with -- `second` must stay untouched"
+            );
+        }
+
+        // --- Scenario B: interact with `second`'s picker; `first` must stay untouched. ---
+        {
+            let mut value = SampleTwoEntityFields {
+                first: bevy_ecs::prelude::Entity::PLACEHOLDER,
+                second: bevy_ecs::prelude::Entity::PLACEHOLDER,
+            };
+            let egui_ctx = egui::Context::default();
+            egui_ctx.set_fonts(egui::FontDefinitions::empty());
+            let run = |events: Vec<egui::Event>, v: &mut SampleTwoEntityFields| {
+                let _ = egui_ctx.run(
+                    egui::RawInput {
+                        screen_rect: Some(screen_rect),
+                        events,
+                        ..Default::default()
+                    },
+                    |c| {
+                        egui::CentralPanel::default().show(c, |ui| draw_reflect_ui(ui, v, &ctx));
+                    },
+                );
+            };
+            run(vec![], &mut value); // frame 1: establish prior-frame widget rects
+            run(click_events(egui::Pos2::new(180.0, 40.0)), &mut value); // frame 2: open `second`'s combo
+            run(vec![], &mut value); // frame 3: settle
+            run(click_events(egui::Pos2::new(200.0, 85.0)), &mut value); // frame 4: select "Boss" (id 2)
+
+            assert_eq!(
+                value.second,
+                bevy_ecs::prelude::Entity::from_raw(2),
+                "opening and selecting in `second`'s picker should set it to entity id 2"
+            );
+            assert_eq!(
+                value.first,
+                bevy_ecs::prelude::Entity::PLACEHOLDER,
+                "only `second`'s picker was interacted with -- `first` must stay untouched"
+            );
+        }
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -664,15 +664,41 @@ mod tests {
 
         // Simulate a click on the append ("+") button by calling
         // draw_reflect_ui inside a frame where the button's id is pressed.
-        // This mirrors the click-simulation pattern used in
-        // hierarchy.rs's `row_click_registers_despite_unioned_drag_sense_interact`
-        // test: two `Context::run` passes, since egui hit-tests against the
-        // *previous* frame's widget rects.
         let egui_ctx = egui::Context::default();
         egui_ctx.set_fonts(egui::FontDefinitions::empty());
         let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
 
-        let mut button_rect = egui::Rect::NOTHING;
+        // Frame 1: measure where the append row starts via
+        // `next_widget_position()` -- the same technique used by
+        // `enum_variant_combo_switches_to_a_default_instance_of_the_chosen_variant`
+        // above. This deliberately does NOT use
+        // `ui.ctx().read_response(before)`: that only resolves for bare,
+        // unwrapped top-level widgets, and the "+" button lives inside its
+        // own `ui.horizontal` wrapper (see the `ReflectMut::List` arm),
+        // which puts it on an independently-salted *child* `Ui` that never
+        // claims the parent's pre-call id (see `top_level_response_exists_at`'s
+        // doc comment above). With `read_response` that silently collapsed
+        // to `Rect::NOTHING`, whose `center()` is `(NaN, NaN)`.
+        //
+        // That NaN position didn't just harmlessly miss the button --
+        // verified directly against egui 0.29.1's own
+        // `emath::Rect::distance_sq_to_pos` and `egui::hit_test::hit_test`:
+        // a NaN pointer position makes every `if`/`else if` distance
+        // comparison evaluate to `false`, so *every* widget's
+        // distance-to-pointer falls through to `distance_sq_to_pos`'s final
+        // `else { 0.0 }` arm. Every widget therefore ties at distance zero,
+        // and `hit_test`'s own "in a tie, pick last = topmost" rule means a
+        // NaN-position click always resolves to whichever click/drag-sense
+        // widget was drawn *last* in the frame -- not "whatever's under the
+        // (nonexistent) pointer". The old test only ever passed because the
+        // "+" button happened to be both the last and only such widget on
+        // screen. The trailing "decoy" button below is a permanent
+        // regression guard against exactly that: if this test ever
+        // regressed back to the `read_response` technique, the click would
+        // land on "decoy" instead and the assertion below would fail (this
+        // was verified by temporarily reverting to `read_response` with
+        // this same decoy in place).
+        let mut append_top = egui::Pos2::ZERO;
         let _ = egui_ctx.run(
             egui::RawInput {
                 screen_rect: Some(screen_rect),
@@ -680,30 +706,16 @@ mod tests {
             },
             |egui_ctx| {
                 egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    append_top = ui.next_widget_position();
                     draw_reflect_ui(ui, &mut tags, &ctx);
-                });
-            },
-        );
-        // Re-run once, capturing the actual button response this time.
-        let _ = egui_ctx.run(
-            egui::RawInput {
-                screen_rect: Some(screen_rect),
-                ..Default::default()
-            },
-            |egui_ctx| {
-                egui::CentralPanel::default().show(egui_ctx, |ui| {
-                    let before = ui.next_auto_id();
-                    draw_reflect_ui(ui, &mut tags, &ctx);
-                    button_rect = ui
-                        .ctx()
-                        .read_response(before)
-                        .map(|r| r.rect)
-                        .unwrap_or(egui::Rect::NOTHING);
+                    let _ = ui.button("decoy");
                 });
             },
         );
 
-        let pos = button_rect.center();
+        // A click safely inside the "+" `small_button`'s row (top-left of
+        // the append row's own `ui.horizontal`, nudged in from its corner).
+        let pos = egui::Pos2::new(append_top.x + 8.0, append_top.y + 8.0);
         let click_events = vec![
             egui::Event::PointerMoved(pos),
             egui::Event::PointerButton {
@@ -728,6 +740,7 @@ mod tests {
             |egui_ctx| {
                 egui::CentralPanel::default().show(egui_ctx, |ui| {
                     draw_reflect_ui(ui, &mut tags, &ctx);
+                    let _ = ui.button("decoy");
                 });
             },
         );

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -47,7 +47,19 @@ pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &Reflect
         {
             let current_variant = e.variant_name().to_string();
             let mut target_variant: Option<&str> = None;
-            ui.push_id(ui.id().with("enum_variant_combo"), |ui| {
+            // `ui.id()` is egui's *stable* id, which is shared across sibling
+            // children of the same parent `Ui` (e.g. every field in a Struct's
+            // field loop gets a child `Ui` via `new_child`, and unless an
+            // explicit id_salt is given, that always resolves to the same
+            // `.id()`). Deriving the combo's id from it would collide when a
+            // component has 2+ sibling enum fields (e.g. `Tween`'s
+            // target/easing/repeat), making their popups share open/closed
+            // state. `ui.next_auto_id()` is the per-call-site auto-id counter,
+            // which *does* vary between sibling calls, so it's captured here
+            // -- before any other widget call in this block consumes it --
+            // and used as the combo's id salt instead.
+            let combo_salt = ui.next_auto_id();
+            ui.push_id(combo_salt, |ui| {
                 egui::ComboBox::from_id_salt("variant")
                     .selected_text(&current_variant)
                     .show_ui(ui, |ui| {
@@ -768,6 +780,51 @@ mod tests {
             value,
             SampleEnum::Tuple(0.0),
             "selecting 'Tuple' in the variant combo should switch to Tuple with a default f32 field"
+        );
+    }
+
+    #[test]
+    fn sibling_enum_fields_get_distinct_variant_combo_ids() {
+        // Regression test for a bug where the variant ComboBox's id was derived
+        // from `ui.id()` -- egui's *stable* id, which (verified against egui
+        // 0.29.1's `Ui::new_child`) is identical across sibling children of the
+        // same parent `Ui`, since `ui.horizontal(..)` (used by the Struct match
+        // arm's per-field loop) doesn't override the child's id_salt away from
+        // the literal default `"child"`. That meant every sibling enum field's
+        // ComboBox resolved to the exact same egui id -- concretely,
+        // `bsengine_core::Tween`'s three sibling enum fields (`target`,
+        // `easing`, `repeat`), all rendered through this exact code path,
+        // would all share one popup's open/closed state.
+        //
+        // This replicates the *exact* pattern `draw_reflect_ui`'s Enum arm now
+        // uses -- `let combo_salt = ui.next_auto_id(); ui.push_id(combo_salt, ..)`
+        // -- inside two sibling field-child `Ui`s built the same way the Struct
+        // match arm builds them (`ui.horizontal(|ui| { .. })` per field), and
+        // asserts the two resulting ComboBox button ids differ. This directly
+        // exercises the id-uniqueness invariant the fix relies on, without the
+        // sub-pixel popup-click simulation the other test in this file needs
+        // (and which egui's own multi-pass, cache-warming popup layout makes
+        // fragile to aim at two *different* popups in the same frame).
+        let mut combo_ids = Vec::new();
+        with_test_ui(|_ctx, ui| {
+            for _ in 0..2 {
+                ui.horizontal(|ui| {
+                    let combo_salt = ui.next_auto_id();
+                    let outer = ui.push_id(combo_salt, |ui| {
+                        egui::ComboBox::from_id_salt("variant")
+                            .selected_text("Unit")
+                            .show_ui(ui, |_ui| {})
+                    });
+                    combo_ids.push(outer.inner.response.id);
+                });
+            }
+        });
+        assert_eq!(combo_ids.len(), 2);
+        assert_ne!(
+            combo_ids[0], combo_ids[1],
+            "sibling enum fields' variant ComboBoxes must not resolve to the same \
+             egui id -- a shared id means their popup open/closed state (and thus \
+             clicks) collide, as happened for Tween's target/easing/repeat fields"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -783,48 +783,129 @@ mod tests {
         );
     }
 
+    #[derive(Reflect, Debug, PartialEq, Clone, Default)]
+    enum SampleSiblingEnum {
+        #[default]
+        A,
+        B,
+    }
+
+    #[derive(Reflect, Debug, PartialEq, Clone, Default)]
+    struct SampleTwoEnumFields {
+        first: SampleSiblingEnum,
+        second: SampleSiblingEnum,
+    }
+
     #[test]
-    fn sibling_enum_fields_get_distinct_variant_combo_ids() {
-        // Regression test for a bug where the variant ComboBox's id was derived
-        // from `ui.id()` -- egui's *stable* id, which (verified against egui
-        // 0.29.1's `Ui::new_child`) is identical across sibling children of the
-        // same parent `Ui`, since `ui.horizontal(..)` (used by the Struct match
-        // arm's per-field loop) doesn't override the child's id_salt away from
-        // the literal default `"child"`. That meant every sibling enum field's
-        // ComboBox resolved to the exact same egui id -- concretely,
-        // `bsengine_core::Tween`'s three sibling enum fields (`target`,
-        // `easing`, `repeat`), all rendered through this exact code path,
-        // would all share one popup's open/closed state.
+    fn opening_a_sibling_enum_fields_combo_actually_switches_its_variant() {
+        // Regression test for the sibling-id-collision bug fixed alongside this
+        // test (see the `combo_salt = ui.next_auto_id()` comment in
+        // `draw_reflect_ui`'s Enum arm) -- mirrors `bsengine_core::Tween`'s
+        // shape (2+ sibling enum-typed fields on one struct) and drives the
+        // *real* `draw_reflect_ui`, through its actual `ReflectMut::Struct`
+        // arm, which recurses into each field's own `ui.horizontal(..)` --
+        // exactly the call shape that made `first` and `second`'s combos
+        // collide on one id pre-fix.
         //
-        // This replicates the *exact* pattern `draw_reflect_ui`'s Enum arm now
-        // uses -- `let combo_salt = ui.next_auto_id(); ui.push_id(combo_salt, ..)`
-        // -- inside two sibling field-child `Ui`s built the same way the Struct
-        // match arm builds them (`ui.horizontal(|ui| { .. })` per field), and
-        // asserts the two resulting ComboBox button ids differ. This directly
-        // exercises the id-uniqueness invariant the fix relies on, without the
-        // sub-pixel popup-click simulation the other test in this file needs
-        // (and which egui's own multi-pass, cache-warming popup layout makes
-        // fragile to aim at two *different* popups in the same frame).
-        let mut combo_ids = Vec::new();
-        with_test_ui(|_ctx, ui| {
-            for _ in 0..2 {
-                ui.horizontal(|ui| {
-                    let combo_salt = ui.next_auto_id();
-                    let outer = ui.push_id(combo_salt, |ui| {
-                        egui::ComboBox::from_id_salt("variant")
-                            .selected_text("Unit")
-                            .show_ui(ui, |_ui| {})
-                    });
-                    combo_ids.push(outer.inner.response.id);
-                });
-            }
-        });
-        assert_eq!(combo_ids.len(), 2);
-        assert_ne!(
-            combo_ids[0], combo_ids[1],
-            "sibling enum fields' variant ComboBoxes must not resolve to the same \
-             egui id -- a shared id means their popup open/closed state (and thus \
-             clicks) collide, as happened for Tween's target/easing/repeat fields"
+        // Empirically (verified by temporarily reverting *only* the
+        // production `combo_salt` line back to `ui.id().with(..)`, see the
+        // task notes): with the id collision, `first`'s combo becomes
+        // entirely unclickable when `second` is also present. The reason is
+        // structural, not incidental to this test's specific click
+        // coordinates: `draw_reflect_ui`'s Struct arm draws `first` then
+        // `second` in the *same frame*; since both fields' combo buttons
+        // register under the identical id, egui's global per-id "was this
+        // clicked this frame" flag is shared, so *both* fields' ComboBox
+        // internals independently see the click and each call
+        // `toggle_popup` on the (shared) popup id -- once each, i.e. twice
+        // total, which cancels back to closed. So opening a field's combo
+        // silently does nothing whenever a sibling enum field is drawn
+        // alongside it. With the fix, each field's combo has its own id, so
+        // only the clicked field's `toggle_popup` fires and the popup
+        // actually opens.
+        //
+        // This test opens `first`'s combo and selects "B" (the non-default
+        // 2nd variant); it is red on the pre-fix code (the click has no
+        // effect -- `first` stays `A`) and green on the fix.
+        let mut value = SampleTwoEnumFields::default();
+        let registry = bevy_reflect::TypeRegistry::default(); // Unit variants need no ReflectDefault lookups.
+        let ctx = ReflectUiCtx {
+            entities: &[],
+            type_registry: Some(&registry),
+        };
+
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let run_frame = |events: Vec<egui::Event>, value: &mut SampleTwoEnumFields| {
+            let _ = egui_ctx.run(
+                egui::RawInput {
+                    screen_rect: Some(screen_rect),
+                    events,
+                    ..Default::default()
+                },
+                |egui_ctx| {
+                    egui::CentralPanel::default()
+                        .show(egui_ctx, |ui| draw_reflect_ui(ui, value, &ctx));
+                },
+            );
+        };
+        let click_events = |pos: egui::Pos2| {
+            vec![
+                egui::Event::PointerMoved(pos),
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ]
+        };
+
+        // Layout is deterministic (fixed screen size, no fonts, identical
+        // default field values) and was measured empirically: `first`'s row
+        // spans y=[8, 29], `second`'s spans y=[29, 50] directly below it,
+        // with no gap. x=60 lands inside either row's combo regardless of
+        // the (near-zero-width, fontless) preceding field-name label --
+        // verified directly by scanning x in [20..120] and confirming every
+        // candidate opens the popup.
+        //
+        // Frame 1: draw once (closed) to establish prior-frame widget rects.
+        run_frame(vec![], &mut value);
+
+        // Frame 2: click inside `first`'s row to open its combo.
+        run_frame(click_events(egui::Pos2::new(60.0, 15.0)), &mut value);
+
+        // Frame 3 ("settle"): redraw with no input, so the popup's cached
+        // size/id sequence stabilizes before anything clicks into it (same
+        // reason as the single-enum combo test above).
+        run_frame(vec![], &mut value);
+
+        // Frame 4: click the settled popup's 2nd entry ("B", index 1 of
+        // `SampleSiblingEnum`'s 2 variants). Its row starts exactly at
+        // `first`'s row bottom (29) with the same ~21px stride + ~9px
+        // half-height measured for the single-enum combo test.
+        run_frame(click_events(egui::Pos2::new(60.0, 60.0)), &mut value);
+
+        assert_eq!(
+            value.first,
+            SampleSiblingEnum::B,
+            "opening and selecting in `first`'s combo should switch it to B -- if this \
+             is still A, the click had no effect, which is exactly the symptom of the \
+             sibling-id-collision bug (both fields' ComboBoxes toggling the same shared \
+             popup id back closed within the same frame)"
+        );
+        assert_eq!(
+            value.second,
+            SampleSiblingEnum::A,
+            "only `first` was interacted with -- `second` must stay at its default"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -22,15 +22,60 @@ pub struct ReflectUiCtx<'a> {
 /// - `Struct`: iterate fields, label + recurse.
 /// - `TupleStruct`: iterate fields and recurse, with no label wrapper
 ///   (tuple struct fields have no name to show).
-/// - `Enum`: display the current variant's name (read-only — switching
-///   variants generically is out of scope for this pass, see design doc)
-///   and recurse into its fields.
+/// - `Enum`: a combo box listing every variant (from `EnumInfo`); picking a
+///   different one builds a `ReflectDefault`-based `DynamicEnum` for it and
+///   applies it, then recurses into the (possibly new) active variant's
+///   fields.
 /// - `List`: one row per element (recursively-rendered widget + a remove
 ///   button), plus an append row that pushes a `ReflectDefault`-constructed
 ///   item via the type registry.
 /// - Opaque `Value`: glam Vec2/Vec3/Vec4/Quat get dedicated multi-DragValue
 ///   rows; everything else falls through to primitive widgets.
 pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &ReflectUiCtx) -> bool {
+    // Enum variant switching is decided in a read-only pass first: building
+    // the DynamicEnum needs `value.apply(..)`, a *mutable* borrow, but the
+    // combo box itself is drawn while holding `e: &mut dyn Enum` (an
+    // existing mutable borrow of `value` from `value.reflect_mut()`) --
+    // those two mutable borrows can't coexist. Deciding the switch via
+    // `value.reflect_ref()` (immutable) first, entirely separate from the
+    // `reflect_mut()` match below, sidesteps the conflict: by the time
+    // `value.apply(..)` runs, this `if let` block (and its immutable
+    // borrows) has already gone out of scope.
+    let variant_switch =
+        if let (bevy_reflect::ReflectRef::Enum(e), Some(bevy_reflect::TypeInfo::Enum(enum_info))) =
+            (value.reflect_ref(), value.get_represented_type_info())
+        {
+            let current_variant = e.variant_name().to_string();
+            let mut target_variant: Option<&str> = None;
+            ui.push_id(ui.id().with("enum_variant_combo"), |ui| {
+                egui::ComboBox::from_id_salt("variant")
+                    .selected_text(&current_variant)
+                    .show_ui(ui, |ui| {
+                        for name in enum_info.variant_names() {
+                            if ui
+                                .selectable_label(*name == current_variant, *name)
+                                .clicked()
+                                && *name != current_variant
+                            {
+                                target_variant = Some(name);
+                            }
+                        }
+                    });
+            });
+            target_variant.and_then(|name| {
+                ctx.type_registry
+                    .and_then(|registry| build_default_variant(enum_info, name, registry))
+            })
+        } else {
+            None
+        };
+    if let Some(dyn_enum) = variant_switch {
+        value.apply(&dyn_enum);
+        return true;
+    }
+
+    // `l` (below) mutably borrows value for the rest of this match, so this lookup (which
+    // needs &value) has to happen first.
     let list_item_type_id = match value.get_represented_type_info() {
         Some(bevy_reflect::TypeInfo::List(list_info)) => Some(list_info.item_type_id()),
         _ => None,
@@ -103,6 +148,46 @@ pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &Reflect
         }
         _ => draw_leaf_ui(ui, value),
     }
+}
+
+/// Builds a `DynamicEnum` representing `variant_name` with every field set
+/// to its `ReflectDefault`-constructed value, or `None` if `variant_name`
+/// doesn't exist on this enum or any of its fields lack a registered
+/// `ReflectDefault` (a safe no-op switch in that case, rather than a partial
+/// / panicking one).
+fn build_default_variant(
+    enum_info: &bevy_reflect::EnumInfo,
+    variant_name: &str,
+    registry: &bevy_reflect::TypeRegistry,
+) -> Option<bevy_reflect::DynamicEnum> {
+    let variant_info = enum_info.variant(variant_name)?;
+    let dynamic_variant = match variant_info {
+        bevy_reflect::VariantInfo::Unit(_) => bevy_reflect::DynamicVariant::Unit,
+        bevy_reflect::VariantInfo::Tuple(tuple_info) => {
+            let mut t = bevy_reflect::DynamicTuple::default();
+            for field in tuple_info.iter() {
+                let default = registry
+                    .get_type_data::<bevy_reflect::std_traits::ReflectDefault>(field.type_id())?
+                    .default();
+                t.insert_boxed(default);
+            }
+            bevy_reflect::DynamicVariant::Tuple(t)
+        }
+        bevy_reflect::VariantInfo::Struct(struct_info) => {
+            let mut s = bevy_reflect::DynamicStruct::default();
+            for field in struct_info.iter() {
+                let default = registry
+                    .get_type_data::<bevy_reflect::std_traits::ReflectDefault>(field.type_id())?
+                    .default();
+                s.insert_boxed(field.name(), default);
+            }
+            bevy_reflect::DynamicVariant::Struct(s)
+        }
+    };
+    Some(bevy_reflect::DynamicEnum::new(
+        variant_name,
+        dynamic_variant,
+    ))
 }
 
 fn draw_leaf_ui(ui: &mut egui::Ui, value: &mut dyn Reflect) -> bool {
@@ -562,6 +647,127 @@ mod tests {
             tags,
             vec!["".to_string()],
             "clicking append should push one default (empty-string) item"
+        );
+    }
+
+    #[derive(Reflect, Debug, PartialEq, Clone, Default)]
+    enum SampleEnum {
+        #[default]
+        Unit,
+        Tuple(f32),
+        Named {
+            x: f32,
+        },
+    }
+
+    #[test]
+    fn enum_variant_combo_switches_to_a_default_instance_of_the_chosen_variant() {
+        let mut value = SampleEnum::Unit;
+        let mut registry = bevy_reflect::TypeRegistry::default();
+        registry.register::<f32>();
+        let ctx = ReflectUiCtx {
+            entities: &[],
+            type_registry: Some(&registry),
+        };
+
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let run_frame =
+            |egui_ctx: &egui::Context, events: Vec<egui::Event>, value: &mut SampleEnum| {
+                let _ = egui_ctx.run(
+                    egui::RawInput {
+                        screen_rect: Some(screen_rect),
+                        events,
+                        ..Default::default()
+                    },
+                    |egui_ctx| {
+                        egui::CentralPanel::default().show(egui_ctx, |ui| {
+                            draw_reflect_ui(ui, value, &ctx);
+                        });
+                    },
+                );
+            };
+        let click_events = |pos: egui::Pos2| {
+            vec![
+                egui::Event::PointerMoved(pos),
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ]
+        };
+
+        // Frame 1: draw the combo box (closed) to learn where it sits.
+        // `SampleEnum::Unit` has no fields, so the combo box is the *only*
+        // thing drawn -- the cursor position before and after fully brackets
+        // its row (CentralPanel's content Ui doesn't shrink-to-fit its
+        // `min_rect`, it pre-allocates the full available area, so
+        // `ui.min_rect()` can't be used for this; `next_widget_position()`
+        // tracks the actual layout cursor instead).
+        let mut combo_top = egui::Pos2::ZERO;
+        let mut combo_bottom = egui::Pos2::ZERO;
+        let _ = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    combo_top = ui.next_widget_position();
+                    draw_reflect_ui(ui, &mut value, &ctx);
+                    combo_bottom = ui.next_widget_position();
+                });
+            },
+        );
+
+        // Frame 2: click the combo box (safely inside its row) to open the popup.
+        let open_pos = egui::Pos2::new(combo_top.x + 20.0, combo_top.y + 8.0);
+        run_frame(&egui_ctx, click_events(open_pos), &mut value);
+
+        // Frame 3 ("settle"): redraw with no input. The popup's first-ever
+        // frame (frame 2) sizes its `Area`/`ScrollArea` from a placeholder
+        // default (it hasn't measured real content yet), which shifts how
+        // many internal child `Ui`s get created versus every frame after --
+        // and that shift changes the auto-generated `Id`s of the entries
+        // inside it. A click sent in frame 2's immediate next frame gets
+        // hit-tested against frame 2's (pre-settle) ids, but resolved
+        // against the newly-drawn (post-settle) ones, so it never lands.
+        // One extra no-op redraw lets the popup's cached size (and thus its
+        // id sequence) stabilize *before* anything tries to click into it;
+        // every frame from here on reproduces the same ids/positions.
+        run_frame(&egui_ctx, vec![], &mut value);
+
+        // Frame 4: click the settled popup's 2nd entry ("Tuple", index 1 in
+        // `EnumInfo::variant_names()` declaration order: Unit, Tuple, Named).
+        // Its row starts exactly at `combo_bottom.y` (the popup is anchored
+        // to the combo box's bottom-left) and each row after that is a fixed
+        // stride down; both the stride and horizontal center were measured
+        // empirically against this popup (button padding + a bare/unstyled
+        // `FontDefinitions::empty()` row height) and are stable across
+        // frames once settled.
+        let row_stride = 21.0;
+        let row_half_height = 9.0;
+        let tuple_variant_index = 1.0;
+        let tuple_pos = egui::Pos2::new(
+            combo_top.x + 50.0,
+            combo_bottom.y + row_stride * tuple_variant_index + row_half_height,
+        );
+        run_frame(&egui_ctx, click_events(tuple_pos), &mut value);
+
+        assert_eq!(
+            value,
+            SampleEnum::Tuple(0.0),
+            "selecting 'Tuple' in the variant combo should switch to Tuple with a default f32 field"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -40,6 +40,15 @@ pub fn draw_reflect_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &Reflect
             }
             changed
         }
+        bevy_reflect::ReflectMut::TupleStruct(ts) => {
+            let mut changed = false;
+            for i in 0..ts.field_len() {
+                if let Some(field) = ts.field_mut(i) {
+                    changed |= draw_reflect_ui(ui, field, ctx);
+                }
+            }
+            changed
+        }
         bevy_reflect::ReflectMut::Enum(e) => {
             ui.label(format!("({})", e.variant_name()));
             let mut changed = false;
@@ -158,6 +167,9 @@ mod tests {
         offset: bsengine_core::ReflectVec3,
         enabled: bool,
     }
+
+    #[derive(Reflect, Debug, PartialEq, Clone)]
+    struct SampleTupleStruct(f32, bool);
 
     /// Runs `add_contents` against a real (headless) `egui::Ui` inside a single frame and
     /// returns whatever it returns. This mirrors the pattern egui's own crate uses internally
@@ -376,6 +388,31 @@ mod tests {
             widget_count,
             auto_id_after_n_top_level_widgets(3),
             "expected exactly 3 top-level field groups (one ui.horizontal per struct field)"
+        );
+    }
+
+    #[test]
+    fn tuple_struct_recursion_renders_two_field_widgets_not_a_single_fallback_label() {
+        let mut s = SampleTupleStruct(2.0, true);
+        let expected = s.clone();
+        let (changed, widget_count) = with_test_ui(|_ctx, ui| {
+            let changed = draw_reflect_ui(ui, &mut s, &empty_ctx());
+            let after = ui.next_auto_id();
+            (changed, after)
+        });
+        assert!(!changed, "no interaction happened, so nothing changed");
+        assert_eq!(s, expected, "no field should have been touched");
+        // Unlike SampleStruct's fields, a tuple struct's fields have no
+        // `ui.horizontal` label wrapper of their own in this implementation
+        // (there's no field name to show) -- each field is drawn directly by
+        // recursing into draw_reflect_ui, so a bare f32 leaf claims 1
+        // top-level id and the bool leaf claims another: 2 total.
+        assert_eq!(
+            widget_count,
+            auto_id_after_n_top_level_widgets(2),
+            "expected exactly 2 top-level widgets (one f32 DragValue, one bool checkbox) -- \
+             a widget count of 1 would mean this fell through to the single fallback label \
+             instead of iterating the tuple struct's fields"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -260,15 +260,27 @@ fn draw_leaf_ui(ui: &mut egui::Ui, value: &mut dyn Reflect) -> bool {
         return changed;
     }
     if let Some(v) = value.downcast_mut::<bsengine_core::ReflectQuat>() {
-        let mut arr = v.to_array();
+        // Same to_euler/from_euler(EulerRot::XYZ) convention already used by
+        // the hardcoded Transform panel (inspector.rs) and hierarchy.rs --
+        // showing/editing raw quaternion x/y/z/w here would be far less
+        // usable than the degrees a user actually thinks in.
+        let (rx, ry, rz) = v.0.to_euler(glam::EulerRot::XYZ);
+        let mut degrees = [rx.to_degrees(), ry.to_degrees(), rz.to_degrees()];
         let mut changed = false;
         ui.horizontal(|ui| {
-            for a in arr.iter_mut() {
-                changed |= ui.add(egui::DragValue::new(a).speed(0.05)).changed();
+            for d in degrees.iter_mut() {
+                changed |= ui
+                    .add(egui::DragValue::new(d).speed(0.5).suffix("°"))
+                    .changed();
             }
         });
         if changed {
-            v.0 = glam::Quat::from_array(arr);
+            v.0 = glam::Quat::from_euler(
+                glam::EulerRot::XYZ,
+                degrees[0].to_radians(),
+                degrees[1].to_radians(),
+                degrees[2].to_radians(),
+            );
         }
         return changed;
     }
@@ -937,6 +949,148 @@ mod tests {
             !is_focusable,
             "the fallback label must be a plain, non-focusable label — if this becomes \
              focusable, a live interactive widget is being silently drawn for an unhandled type"
+        );
+    }
+
+    #[test]
+    fn reflect_quat_leaf_renders_three_euler_degree_dragvalues_not_four_raw_components() {
+        let mut rot: bsengine_core::ReflectQuat = glam::Quat::IDENTITY.into();
+        let (changed, widget_count) = with_test_ui(|_ctx, ui| {
+            let changed = draw_reflect_ui(ui, &mut rot, &empty_ctx());
+            let after = ui.next_auto_id();
+            (changed, after)
+        });
+        assert!(!changed, "no interaction happened, so nothing changed");
+        assert_eq!(rot.0, glam::Quat::IDENTITY, "value must be untouched");
+        // Previously rendered 4 bare DragValues (x, y, z, w) inside one
+        // ui.horizontal (1 top-level group). Now renders 3 (Euler XYZ
+        // degrees) inside the same kind of group -- still 1 top-level
+        // group either way, so the widget-count signal alone can't
+        // distinguish "3 DragValues" from "4 DragValues". This is why the
+        // keyboard-interaction test below (not this one) is the real
+        // regression guard; this test only proves the leaf still dispatches
+        // to a wrapped group, not the unsupported-type fallback.
+        assert_eq!(
+            widget_count,
+            auto_id_after_n_top_level_widgets(1),
+            "expected exactly one top-level group wrapping the Euler DragValues"
+        );
+    }
+
+    #[test]
+    fn reflect_quat_euler_edit_roundtrips_through_the_quaternion() {
+        // A quaternion built from known Euler XYZ degrees, converted back
+        // to Euler degrees via the exact same to_euler/from_euler(XYZ)
+        // convention draw_leaf_ui must use -- proves the conversion formula
+        // is lossless within float tolerance, independent of any UI code.
+        let original_degrees = [30.0_f32, 45.0, 60.0];
+        let quat = glam::Quat::from_euler(
+            glam::EulerRot::XYZ,
+            original_degrees[0].to_radians(),
+            original_degrees[1].to_radians(),
+            original_degrees[2].to_radians(),
+        );
+        let (rx, ry, rz) = quat.to_euler(glam::EulerRot::XYZ);
+        let degrees_via_conversion = [rx.to_degrees(), ry.to_degrees(), rz.to_degrees()];
+        for (a, b) in original_degrees.iter().zip(degrees_via_conversion.iter()) {
+            assert!(
+                (a - b).abs() < 1e-3,
+                "Euler XYZ round-trip must be lossless within float tolerance: {a} vs {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn reflect_quat_leaf_edits_only_the_dragged_euler_axis_via_keyboard() {
+        // Real regression gate for "3 Euler-degree DragValues, not 4 raw
+        // x/y/z/w components": tabs keyboard focus onto the *first* widget
+        // draw_leaf_ui's ReflectQuat branch creates (order-based, so no
+        // pixel-position guessing is needed -- see egui 0.29.1's
+        // `Memory::interested_in_focus`: "nothing has focus and the user
+        // pressed tab -- give focus to the first widget that wants it"),
+        // then presses ArrowUp 3 times while it's focused. egui's DragValue
+        // reads ArrowUp/Down directly off the keyboard while focused
+        // (`is_kb_editing`, drag_value.rs) and bumps its bound value by
+        // `speed` per press -- no mouse/pixel interaction needed at all.
+        //
+        // On the current (post-Step-2) code the first DragValue drawn is
+        // bound to the X Euler-degree with speed(0.5), so 3 presses must
+        // move it by exactly 1.5 degrees, leaving Y and Z untouched. On the
+        // pre-Step-2 code (4 raw quaternion x/y/z/w components, speed(0.05))
+        // the first DragValue is bound to the raw quaternion x component
+        // instead -- 3 presses would add 0.15 to it directly (no Euler
+        // conversion at all), and `Quat::from_array` doesn't renormalize,
+        // producing an entirely different (and non-unit) quaternion whose
+        // Euler decomposition would not show "X moved by ~1.5°, Y/Z at 0" --
+        // so this test is red on that code, not just tautologically green.
+        let mut rot: bsengine_core::ReflectQuat = glam::Quat::IDENTITY.into();
+
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        // Frame 1: Tab with nothing focused yet. egui grants focus, within
+        // this very same frame, to the first widget that registers interest
+        // in it -- whichever DragValue draw_leaf_ui's loop creates first.
+        let _ = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                events: vec![egui::Event::Key {
+                    key: egui::Key::Tab,
+                    physical_key: None,
+                    pressed: true,
+                    repeat: false,
+                    modifiers: egui::Modifiers::default(),
+                }],
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default()
+                    .show(egui_ctx, |ui| draw_reflect_ui(ui, &mut rot, &empty_ctx()));
+            },
+        );
+
+        // Frame 2: 3x ArrowUp while that first DragValue still holds
+        // keyboard focus. DragValue consumes these directly and bumps its
+        // bound value by `speed` per press.
+        let mut changed = false;
+        let _ = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                events: vec![
+                    egui::Event::Key {
+                        key: egui::Key::ArrowUp,
+                        physical_key: None,
+                        pressed: true,
+                        repeat: false,
+                        modifiers: egui::Modifiers::default(),
+                    };
+                    3
+                ],
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    changed = draw_reflect_ui(ui, &mut rot, &empty_ctx());
+                });
+            },
+        );
+
+        assert!(
+            changed,
+            "3 ArrowUp presses on the focused first DragValue should have registered a change"
+        );
+        let (rx, ry, rz) = rot.0.to_euler(glam::EulerRot::XYZ);
+        let (rx_deg, ry_deg, rz_deg) = (rx.to_degrees(), ry.to_degrees(), rz.to_degrees());
+        assert!(
+            (rx_deg - 1.5).abs() < 1e-2,
+            "expected the X Euler degree to have moved by exactly 3 * speed(0.5) = 1.5 -- got \
+             {rx_deg}"
+        );
+        assert!(
+            ry_deg.abs() < 1e-2 && rz_deg.abs() < 1e-2,
+            "only the first (X) DragValue was interacted with -- Y and Z must stay at 0, got \
+             ({ry_deg}, {rz_deg})"
         );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -210,6 +210,22 @@ fn draw_leaf_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &ReflectUiCtx) 
     // reparenting, and a searchable ComboBox is offered as a fallback for
     // when drag-and-drop isn't convenient.
     if let Some(entity) = value.downcast_mut::<bevy_ecs::prelude::Entity>() {
+        // `ui.next_auto_id()` (NOT `ui.id()`) as the ComboBox salt -- `ui.id()`
+        // is egui's *stable* id, identical across sibling fields under the
+        // same parent `Ui`, which caused a real ComboBox id-collision bug
+        // fixed earlier in this file's history (see the `combo_salt` comment
+        // in the Enum arm of `draw_reflect_ui` above, for sibling enum-typed
+        // fields). `next_auto_id()` varies correctly per call site even when
+        // siblings share the same stable `.id()`, because each child `Ui`'s
+        // auto-id counter increments per creation.
+        //
+        // Captured first, before any other call in this block that would
+        // consume an id -- including `allocate_exact_size` below, which
+        // (via `allocate_response`/`allocate_space`) unconditionally
+        // advances the `Ui`'s auto-id counter regardless of `Sense`, so it
+        // is itself an id-consuming call, not just the `ComboBox` further
+        // down.
+        let picker_salt = ui.next_auto_id();
         let mut changed = false;
         let current_label = if *entity == bevy_ecs::prelude::Entity::PLACEHOLDER {
             "(none)".to_string()
@@ -235,17 +251,6 @@ fn draw_leaf_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &ReflectUiCtx) 
             *entity = bevy_ecs::prelude::Entity::from_raw(*dropped_id as u32);
             changed = true;
         }
-        // `ui.next_auto_id()` (NOT `ui.id()`) as the salt -- `ui.id()` is
-        // egui's *stable* id, identical across sibling fields under the
-        // same parent `Ui`, which caused a real ComboBox id-collision bug
-        // fixed earlier in this file's history (see the `combo_salt`
-        // comment in the Enum arm of `draw_reflect_ui` above, for sibling
-        // enum-typed fields). `next_auto_id()` varies correctly per call
-        // site even when siblings share the same stable `.id()`, because
-        // each child `Ui`'s auto-id counter increments per creation.
-        // Captured here, before the ComboBox call below (the only other
-        // widget call in this block), for the same reason.
-        let picker_salt = ui.next_auto_id();
         egui::ComboBox::from_id_salt(picker_salt)
             .selected_text("Search…")
             .show_ui(ui, |ui| {

--- a/crates/bsengine-scene/Cargo.toml
+++ b/crates/bsengine-scene/Cargo.toml
@@ -10,6 +10,7 @@ bsengine-ecs.workspace = true
 bsengine-gltf.workspace = true
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+bevy_reflect.workspace = true
 glam.workspace = true
 ron.workspace = true
 serde.workspace = true

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -1,4 +1,6 @@
-use bevy_ecs::prelude::{Component, Resource};
+use bevy_ecs::prelude::{Component, ReflectComponent, Resource};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
 use serde::{Deserialize, Serialize};
 
 /// Root of a scene file: the list of entities to spawn plus scene-wide settings.
@@ -12,9 +14,11 @@ pub struct SceneDescriptor {
 }
 
 /// Built-in primitive mesh shapes that the runtime can spawn without an asset file.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Reflect)]
+#[reflect(Default)]
 pub enum Primitive {
     /// Unit cube.
+    #[default]
     Cube,
     /// Unit sphere.
     Sphere,
@@ -25,12 +29,17 @@ pub enum Primitive {
 }
 
 /// Marker component inserted by `ScenePlugin` for entities with `primitive: Some(...)`.
-/// The runtime converts this into a `MeshRenderer` with registered GPU geometry.
-#[derive(Component, Debug, Clone)]
+/// The runtime converts this into a `MeshRenderer` with registered GPU geometry. Reflected
+/// so it appears in the Inspector's generic Reflected Fields list -- its shape is editable
+/// there via the enum-variant-switching UI added earlier in this plan.
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component, Default)]
 pub struct PrimitiveMesh(pub Primitive);
 
-/// Relative path to a JS script file, resolved against the project root by the scripting plugin.
-#[derive(Component, Debug, Clone)]
+/// Relative path to a JS script file, resolved against the project root by the scripting
+/// plugin. Reflected so it appears in the Inspector's generic Reflected Fields list.
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component, Default)]
 pub struct ScriptPath(pub String);
 
 /// Describes a single entity in the scene file.


### PR DESCRIPTION
## Summary

Phase 1 of a two-phase plan (design doc: `docs/superpowers/specs/2026-07-24-inspector-unity-style-reflected-list-design.md`) moving the Inspector panel from a hybrid hardcoded-UI + generic-reflected-fields design toward a fully generic, Unity-style reflected-component-list architecture. This phase is purely additive — existing hardcoded Transform/Tags/Script/Mesh sections keep working unchanged; Phase 2 (separate follow-up) will remove them once this foundation is proven.

**`reflect_ui.rs` generic renderer extensions:**
- `TupleStruct` and `List` (`Vec<T>`) reflect-kind support, with Unity/Unreal-style row add/remove UI for lists
- Generic enum variant switching (a `ComboBox` to pick any variant, constructing a `ReflectDefault`-based instance) — covers `Primitive` (Mesh shape) and `TweenTarget` with one implementation
- `ReflectQuat` now displays/edits as Euler XYZ degrees instead of raw quaternion x/y/z/w, matching the rest of the codebase's convention
- An `Entity`-reference picker: drag-and-drop from Hierarchy rows (reusing the existing `u64` DnD payload) plus a searchable `ComboBox` fallback, matching Unity's own combination for Object reference fields

**Component promotions:**
- `Tags`, `ScriptPath`, `PrimitiveMesh`/`Primitive`, and `Tween` are now real `#[derive(Reflect)]` components with `Default` impls and registry registration, so they show up in the Inspector's Reflected Fields list and the unified Add Component menu — with zero change to their existing attach-side-effect systems (`resolve_primitives`, `load_scripts`)

**Correctness:**
- A generation-fixup pass in `bsengine-editor`'s reflected-component-apply path corrects any `Entity`-typed field's generation before it reaches a live component (the UI layer only ever knows a raw index, no `World` access)
- Found and fixed a real, shipped bug along the way: the enum variant-switch `ComboBox`'s id collided across sibling enum-typed fields (reproducible today with `Tween`'s 3 sibling enum fields), causing their popups to fight over shared open/close state

**Add Component menu unification:** the hardcoded "Point Light"/"Camera" buttons are gone — one filtered combo lists every registered, `ReflectDefault`-constructible type not already attached to the entity.

Every task went through TDD-first implementation, a spec-compliance review, and a code-quality review (all via fresh subagents, per `superpowers:subagent-driven-development`), plus a final whole-branch review and 4 non-blocking follow-up hardening fixes.

## Test plan
- [x] `cargo test -p bsengine-rhi-wgpu` — 89 passed
- [x] `cargo test -p bsengine-editor` — 812 passed
- [x] `cargo test -p bsengine-core` — 178 passed
- [x] `cargo test -p bsengine-scene` — 12 passed
- [x] `cargo test -p bsengine-runtime`, `-p bsengine-scripting` — all pass
- [x] `cargo check --workspace` — clean
- [x] `cargo +nightly fmt --check` across all touched crates — clean, zero warnings
- [ ] Manual verification in the running editor (see the plan's "Finishing checklist" — Tags list editing, Mesh variant switching, Transform Euler display, Follow/LookAt Entity-picker drag-and-drop, unified Add Component menu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)