### PR TITLE
Inspector: simplify component list to match Unity-style headers

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -105,7 +105,11 @@ impl EditorPanel for InspectorPanel {
             }
         }
 
-        if !insp.reflected_components.is_empty() {
+        if insp
+            .reflected_components
+            .iter()
+            .any(|(p, _)| !is_hidden_reflected_type(p))
+        {
             ui.separator();
             let type_registry = ctx.type_registry;
             let reflect_ctx = ReflectUiCtx {
@@ -1390,6 +1394,80 @@ mod tests {
         assert!(
             !rendered_texts.iter().any(|t| t == "Reflected Fields"),
             "the \"Reflected Fields\" banner must be gone entirely, got: {rendered_texts:?}"
+        );
+    }
+
+    #[test]
+    fn an_entity_with_only_hidden_components_renders_identically_to_no_components() {
+        // Found during the final whole-branch review: the section guard
+        // `if !insp.reflected_components.is_empty()` checked the *unfiltered*
+        // vec, but the loop below only iterates the *filtered* (non-hidden)
+        // list. An entity whose only reflected_components entries are
+        // GlobalTransform/Visible (both hidden by is_hidden_reflected_type)
+        // would satisfy the unfiltered emptiness check, draw the leading
+        // ui.separator(), then iterate zero times -- a dangling separator
+        // with nothing below it. Real-world reachability is low
+        // (GlobalTransform is normally paired with a present, non-hidden
+        // Transform), but nothing in the ECS structurally prevents it.
+        //
+        // Fixed by checking emptiness on the filtered set instead. Verified
+        // here by rendering two scenarios -- reflected_components empty vs.
+        // containing only hidden entries -- and asserting their rendered
+        // shape counts are identical, proving the hidden-only case draws
+        // nothing extra (no dangling separator) beyond what the truly-empty
+        // case draws.
+        fn render_shape_count(
+            reflected_components: Vec<(String, Box<dyn bevy_reflect::Reflect>)>,
+        ) -> usize {
+            let mut insp = InspectorState::default();
+            insp.selected_id = Some(1);
+            insp.reflected_components = reflected_components;
+
+            let entities_snapshot: Vec<InspectorEntityInfo> = Vec::new();
+            let mut panel = InspectorPanel;
+
+            let egui_ctx = egui::Context::default();
+            egui_ctx.set_fonts(egui::FontDefinitions::empty());
+            let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+            let full_output = egui_ctx.run(
+                egui::RawInput {
+                    screen_rect: Some(screen_rect),
+                    ..Default::default()
+                },
+                |egui_ctx| {
+                    egui::CentralPanel::default().show(egui_ctx, |ui| {
+                        let mut ctx = EditorPanelContext {
+                            insp: &mut insp,
+                            entities_snapshot: &entities_snapshot,
+                            cursor_pos: (0.0, 0.0),
+                            type_registry: None,
+                        };
+                        panel.ui(ui, &mut ctx);
+                    });
+                },
+            );
+
+            full_output.shapes.len()
+        }
+
+        let empty_count = render_shape_count(vec![]);
+        let hidden_only_count = render_shape_count(vec![
+            (
+                "bsengine_core::global_transform::GlobalTransform".to_string(),
+                Box::new(bsengine_core::GlobalTransform::default())
+                    as Box<dyn bevy_reflect::Reflect>,
+            ),
+            (
+                "bsengine_core::visible::Visible".to_string(),
+                Box::new(bsengine_core::Visible::default()) as Box<dyn bevy_reflect::Reflect>,
+            ),
+        ]);
+
+        assert_eq!(
+            empty_count, hidden_only_count,
+            "an entity with only hidden reflected components must render exactly like an \
+             entity with none -- no dangling separator or empty section left behind"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -1394,7 +1394,7 @@ mod tests {
     }
 
     #[test]
-    fn separator_is_drawn_before_every_component_except_the_first() {
+    fn component_list_handles_multiple_counts_without_panicking() {
         // Visual boundary design (approved via the visual companion,
         // 2026-07-27 brainstorm): no framed box per component, just a thin
         // ui.separator() between each pair -- drawn *before* each component

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -88,7 +88,8 @@ impl EditorPanel for InspectorPanel {
                         if already_attached {
                             continue;
                         }
-                        if ui.selectable_label(false, &type_path).clicked() {
+                        let short_name = short_component_name(&type_path, Some(registry));
+                        if ui.selectable_label(false, &short_name).clicked() {
                             to_attach = Some(type_path);
                         }
                     }
@@ -806,6 +807,122 @@ mod tests {
             "clicking where Camera's row would sit if it weren't filtered out must not \
              queue a second command -- a length of 2 here means the already_attached \
              filter regressed and Camera became clickable again"
+        );
+    }
+
+    #[test]
+    fn add_component_menu_shows_short_names_not_full_type_paths() {
+        // Mirrors add_component_menu_click_only_offers_the_not_yet_attached_type's
+        // setup (Camera already attached, PointLight registered and not
+        // attached) but checks *rendered text* after opening the combo,
+        // rather than the resulting command -- this test would fail if the
+        // dropdown's selectable rows went back to showing the raw type_path.
+        let mut registry = bevy_reflect::TypeRegistry::default();
+        registry.register::<bsengine_core::Camera>();
+        registry.register::<bsengine_core::PointLight>();
+
+        let mut insp = InspectorState::default();
+        insp.selected_id = Some(1);
+        insp.reflected_components = vec![(
+            "bsengine_core::camera::Camera".to_string(),
+            Box::new(bsengine_core::Camera::default()) as Box<dyn bevy_reflect::Reflect>,
+        )];
+
+        let entities_snapshot: Vec<InspectorEntityInfo> = Vec::new();
+        let mut panel = InspectorPanel;
+
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let run_frame = |egui_ctx: &egui::Context,
+                         events: Vec<egui::Event>,
+                         insp: &mut InspectorState,
+                         entities_snapshot: &[InspectorEntityInfo],
+                         panel: &mut InspectorPanel| {
+            egui_ctx.run(
+                egui::RawInput {
+                    screen_rect: Some(screen_rect),
+                    events,
+                    ..Default::default()
+                },
+                |egui_ctx| {
+                    egui::CentralPanel::default().show(egui_ctx, |ui| {
+                        let mut ctx = EditorPanelContext {
+                            insp,
+                            entities_snapshot,
+                            cursor_pos: (0.0, 0.0),
+                            type_registry: Some(&registry),
+                        };
+                        panel.ui(ui, &mut ctx);
+                    });
+                },
+            )
+        };
+        let click_events = |pos: egui::Pos2| {
+            vec![
+                egui::Event::PointerMoved(pos),
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ]
+        };
+
+        // Frame 1: draw once (combo closed). Frame 2: click the combo to
+        // open its popup, at the same empirically-found position the
+        // existing add_component_menu_click_only_offers_the_not_yet_attached_type
+        // test uses for this identical scenario (Camera attached, PointLight
+        // not) -- check that test's own comment for the coordinate's
+        // derivation history and confirm it's still accurate for the
+        // current file before reusing it here (if the coordinate has since
+        // changed in that test, use whatever its CURRENT value is instead
+        // of the one shown here, since that test is the source of truth
+        // for this exact scenario's combo position).
+        run_frame(&egui_ctx, vec![], &mut insp, &entities_snapshot, &mut panel);
+        let combo_pos = egui::Pos2::new(20.0, 88.0);
+        let _ = run_frame(
+            &egui_ctx,
+            click_events(combo_pos),
+            &mut insp,
+            &entities_snapshot,
+            &mut panel,
+        );
+
+        // Frame 3 ("settle"): redraw with no input. Per
+        // add_component_menu_click_only_offers_the_not_yet_attached_type's
+        // own "settle frame" comment (and enum_variant_combo_switches_..._'s
+        // longer explanation in reflect_ui.rs), the popup's first-ever frame
+        // (frame 2, just above) sizes its Area/ScrollArea from a placeholder
+        // default and does not yet paint its selectable rows -- confirmed
+        // empirically here too: capturing frame 2's own FullOutput finds
+        // none of the popup's row text at all, not even the full type_path,
+        // so a bare frame-2 capture can't distinguish "not fixed yet" from
+        // "popup never opened." Capturing the settle frame's output instead
+        // is what actually exercises the rendered row text.
+        let full_output = run_frame(&egui_ctx, vec![], &mut insp, &entities_snapshot, &mut panel);
+
+        let rendered_texts = collect_rendered_texts(&full_output.shapes);
+
+        assert!(
+            rendered_texts.iter().any(|t| t == "PointLight"),
+            "expected the short name \"PointLight\" among rendered texts once the popup is \
+             open, got: {rendered_texts:?}"
+        );
+        assert!(
+            !rendered_texts
+                .iter()
+                .any(|t| t.contains("bsengine_core::light::PointLight")),
+            "the full, namespace-qualified type_path must never be rendered as visible text \
+             in the dropdown, got: {rendered_texts:?}"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -1,5 +1,6 @@
 use crate::panels::reflect_ui::{
-    draw_reflect_ui, is_hidden_reflected_type, validate_after_edit, ReflectUiCtx,
+    draw_reflect_ui, is_hidden_reflected_type, short_component_name, validate_after_edit,
+    ReflectUiCtx,
 };
 use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd};
 
@@ -125,7 +126,10 @@ impl EditorPanel for InspectorPanel {
                     true,
                 )
                 .show_header(ui, |ui| {
-                    ui.colored_label(crate::theme::TEXT, type_path.as_str());
+                    ui.colored_label(
+                        crate::theme::TEXT,
+                        short_component_name(type_path.as_str(), type_registry),
+                    );
                     ui.menu_button(egui_phosphor::regular::DOTS_THREE, |ui| {
                         if ui.button("Remove Component").clicked() {
                             to_remove = Some(type_path.clone());
@@ -177,6 +181,89 @@ mod tests {
             });
         });
         result.expect("add_contents must run exactly once per test frame")
+    }
+
+    /// Recursively collects every literal string egui actually rendered as
+    /// text in one frame's output shapes -- used to assert on rendered
+    /// content directly (e.g. "the header shows 'Transform', never the full
+    /// type_path"), without needing egui's `accesskit` feature (not enabled
+    /// in this workspace). `Shape::Text`'s `galley.text()` gives the exact
+    /// rendered string; `Shape::Vec` nests recursively and must be walked.
+    fn collect_rendered_texts(shapes: &[egui::epaint::ClippedShape]) -> Vec<String> {
+        fn walk(shape: &egui::Shape, out: &mut Vec<String>) {
+            match shape {
+                egui::Shape::Text(text_shape) => out.push(text_shape.galley.text().to_string()),
+                egui::Shape::Vec(nested) => {
+                    for s in nested {
+                        walk(s, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut out = Vec::new();
+        for clipped in shapes {
+            walk(&clipped.shape, &mut out);
+        }
+        out
+    }
+
+    #[test]
+    fn component_header_shows_short_type_name_not_full_path() {
+        // The header used to render `type_path.as_str()` directly (e.g.
+        // "bsengine_core::transform::Transform"). It must now render only
+        // the short name ("Transform"), via short_component_name -- verified
+        // here by walking the actual rendered egui shapes (not just calling
+        // short_component_name directly in isolation), so this would catch
+        // a regression back to raw type_path display.
+        let mut insp = InspectorState::default();
+        insp.selected_id = Some(1);
+        insp.reflected_components = vec![(
+            "bsengine_core::transform::Transform".to_string(),
+            Box::new(bsengine_core::Transform::default()) as Box<dyn bevy_reflect::Reflect>,
+        )];
+
+        let mut registry = bevy_reflect::TypeRegistry::default();
+        registry.register::<bsengine_core::Transform>();
+
+        let entities_snapshot: Vec<InspectorEntityInfo> = Vec::new();
+        let mut panel = InspectorPanel;
+
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let full_output = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    let mut ctx = EditorPanelContext {
+                        insp: &mut insp,
+                        entities_snapshot: &entities_snapshot,
+                        cursor_pos: (0.0, 0.0),
+                        type_registry: Some(&registry),
+                    };
+                    panel.ui(ui, &mut ctx);
+                });
+            },
+        );
+
+        let rendered_texts = collect_rendered_texts(&full_output.shapes);
+
+        assert!(
+            rendered_texts.iter().any(|t| t == "Transform"),
+            "expected the short name \"Transform\" among rendered texts, got: {rendered_texts:?}"
+        );
+        assert!(
+            !rendered_texts
+                .iter()
+                .any(|t| t.contains("bsengine_core::transform::Transform")),
+            "the full, namespace-qualified type_path must never be rendered as visible text, \
+             got: {rendered_texts:?}"
+        );
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/inspector.rs
@@ -6,12 +6,15 @@ use bsengine_core::{EditorPanel, EditorPanelContext, InspectorCmd};
 
 /// The Inspector panel: renders a header (entity name + Visible toggle), a
 /// unified Add Component menu for attaching any registered, reflectable
-/// component not already present, and a generic Reflected Fields list that
+/// component not already present, and a generic component list (no
+/// wrapping section label -- each attached component is its own block,
+/// separated by a thin rule, matching Unity's Inspector convention) that
 /// renders and edits every reflectable component currently attached to the
-/// selected entity via `draw_reflect_ui`. No component type gets bespoke,
-/// hand-built UI here anymore -- Transform, Tags, Script, and Mesh (the
-/// former hardcoded sections) all now render exclusively through the
-/// generic list, same as every other reflected component.
+/// selected entity via `draw_reflect_ui`, showing each one's short type
+/// name rather than its full namespace-qualified path. No component type
+/// gets bespoke, hand-built UI here anymore -- Transform, Tags, Script, and
+/// Mesh (the former hardcoded sections) all now render exclusively through
+/// this generic list, same as every other reflected component.
 pub struct InspectorPanel;
 
 impl EditorPanel for InspectorPanel {
@@ -104,10 +107,6 @@ impl EditorPanel for InspectorPanel {
 
         if !insp.reflected_components.is_empty() {
             ui.separator();
-            ui.horizontal(|ui| {
-                ui.colored_label(crate::theme::ACCENT, egui_phosphor::regular::LIST);
-                ui.colored_label(crate::theme::TEXT, "Reflected Fields");
-            });
             let type_registry = ctx.type_registry;
             let reflect_ctx = ReflectUiCtx {
                 entities: ctx.entities_snapshot,
@@ -115,11 +114,15 @@ impl EditorPanel for InspectorPanel {
             };
             let mut to_apply: Vec<(String, Box<dyn bevy_reflect::Reflect>)> = Vec::new();
             let mut to_remove: Option<String> = None;
-            for (type_path, value) in insp
+            for (i, (type_path, value)) in insp
                 .reflected_components
                 .iter_mut()
                 .filter(|(p, _)| !is_hidden_reflected_type(p))
+                .enumerate()
             {
+                if i > 0 {
+                    ui.separator();
+                }
                 let header_id = ui.make_persistent_id(type_path.as_str());
                 egui::containers::collapsing_header::CollapsingState::load_with_default_open(
                     ui.ctx(),
@@ -1333,5 +1336,111 @@ mod tests {
             (sl.inner_angle_degrees.0 - 60.0).abs() < 1e-6,
             "with no type registry available, the value should be left untouched, not panic"
         );
+    }
+
+    #[test]
+    fn reflected_fields_banner_label_is_never_rendered() {
+        // The "Reflected Fields" section banner (icon + text row that used
+        // to precede the component list) is being removed entirely --
+        // Unity's Inspector has no equivalent wrapping label, each
+        // component is just its own block directly. This is a straight
+        // regression guard: the literal string must never appear in
+        // rendered output again, regardless of how many components exist.
+        let mut insp = InspectorState::default();
+        insp.selected_id = Some(1);
+        insp.reflected_components = vec![
+            (
+                "bsengine_core::transform::Transform".to_string(),
+                Box::new(bsengine_core::Transform::default()) as Box<dyn bevy_reflect::Reflect>,
+            ),
+            (
+                "bsengine_editor::snapshot::Tags".to_string(),
+                Box::new(bsengine_editor::snapshot::Tags(vec!["enemy".to_string()]))
+                    as Box<dyn bevy_reflect::Reflect>,
+            ),
+        ];
+
+        let entities_snapshot: Vec<InspectorEntityInfo> = Vec::new();
+        let mut panel = InspectorPanel;
+
+        let egui_ctx = egui::Context::default();
+        egui_ctx.set_fonts(egui::FontDefinitions::empty());
+        let screen_rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0));
+
+        let full_output = egui_ctx.run(
+            egui::RawInput {
+                screen_rect: Some(screen_rect),
+                ..Default::default()
+            },
+            |egui_ctx| {
+                egui::CentralPanel::default().show(egui_ctx, |ui| {
+                    let mut ctx = EditorPanelContext {
+                        insp: &mut insp,
+                        entities_snapshot: &entities_snapshot,
+                        cursor_pos: (0.0, 0.0),
+                        type_registry: None,
+                    };
+                    panel.ui(ui, &mut ctx);
+                });
+            },
+        );
+
+        let rendered_texts = collect_rendered_texts(&full_output.shapes);
+
+        assert!(
+            !rendered_texts.iter().any(|t| t == "Reflected Fields"),
+            "the \"Reflected Fields\" banner must be gone entirely, got: {rendered_texts:?}"
+        );
+    }
+
+    #[test]
+    fn separator_is_drawn_before_every_component_except_the_first() {
+        // Visual boundary design (approved via the visual companion,
+        // 2026-07-27 brainstorm): no framed box per component, just a thin
+        // ui.separator() between each pair -- drawn *before* each component
+        // except the first, since a separator already precedes the whole
+        // list (ending the Add Component section), which serves as the rule
+        // before the first component. With N components there must be
+        // exactly N-1 *additional* separators drawn by the loop itself.
+        //
+        // egui doesn't expose "shapes drawn by ui.separator()" as a
+        // distinct, directly-queryable shape variant (a separator paints a
+        // Shape::Line/Rect, indistinguishable at this level from any other
+        // thin rect this panel might draw) -- so instead of counting
+        // separator shapes precisely, this test asserts the weaker but
+        // still meaningful invariant that CAN be checked without
+        // over-fitting to egui's internal paint representation: the panel
+        // renders without panicking for 1, 2, and 3 reflected_components
+        // entries (0 separators, 1 separator, 2 separators respectively),
+        // proving the enumerate()-based conditional doesn't panic or
+        // corrupt state at any component count, including the boundary
+        // case of exactly one component (i == 0, no separator drawn at
+        // all).
+        for count in 1..=3 {
+            let mut insp = InspectorState::default();
+            insp.selected_id = Some(1);
+            insp.reflected_components = (0..count)
+                .map(|i| {
+                    (
+                        format!("test_module::Component{i}"),
+                        Box::new(bsengine_core::Transform::default())
+                            as Box<dyn bevy_reflect::Reflect>,
+                    )
+                })
+                .collect();
+
+            let entities_snapshot: Vec<InspectorEntityInfo> = Vec::new();
+            let mut panel = InspectorPanel;
+
+            with_test_ui(|ui| {
+                let mut ctx = EditorPanelContext {
+                    insp: &mut insp,
+                    entities_snapshot: &entities_snapshot,
+                    cursor_pos: (0.0, 0.0),
+                    type_registry: None,
+                };
+                panel.ui(ui, &mut ctx);
+            });
+        }
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/reflect_ui.rs
@@ -32,6 +32,32 @@ pub(crate) fn is_hidden_reflected_type(path: &str) -> bool {
         || path == "bsengine_core::visible::Visible"
 }
 
+/// Returns the short, human-readable name for `type_path` (e.g. `"Transform"`
+/// for `"bsengine_core::transform::Transform"`), used to display a component
+/// in the Inspector without its full namespace. Falls back to the original
+/// `type_path` string when no registry is available, or when the type isn't
+/// registered in it (both are safe, valid states — the display just becomes
+/// less friendly, nothing breaks).
+///
+/// Uses `bevy_reflect`'s own `TypePathTable::short_path()` rather than
+/// manually splitting `type_path` on `"::"`, since that would mis-handle any
+/// type with `::` inside its generic parameters (e.g. `Vec<other::Type>`).
+pub(crate) fn short_component_name(
+    type_path: &str,
+    type_registry: Option<&bevy_reflect::TypeRegistry>,
+) -> String {
+    type_registry
+        .and_then(|registry| registry.get_with_type_path(type_path))
+        .map(|registration| {
+            registration
+                .type_info()
+                .type_path_table()
+                .short_path()
+                .to_string()
+        })
+        .unwrap_or_else(|| type_path.to_string())
+}
+
 /// Looks up the `ReflectValidate` type data for `type_path` (if the
 /// component's `#[derive(Reflect)]` registered one via
 /// `#[reflect(..., Validate)]`) and calls it on `value` in place. A no-op
@@ -411,7 +437,7 @@ fn draw_leaf_ui(ui: &mut egui::Ui, value: &mut dyn Reflect, ctx: &ReflectUiCtx) 
 
 #[cfg(test)]
 mod tests {
-    use super::{draw_reflect_ui, ReflectUiCtx};
+    use super::{draw_reflect_ui, short_component_name, ReflectUiCtx};
     use bevy_reflect::Reflect;
 
     fn empty_ctx() -> ReflectUiCtx<'static> {
@@ -1455,5 +1481,42 @@ mod tests {
                 "only `second`'s picker was interacted with -- `first` must stay untouched"
             );
         }
+    }
+
+    #[test]
+    fn short_component_name_resolves_a_registered_types_short_path() {
+        let mut registry = bevy_reflect::TypeRegistry::default();
+        registry.register::<bsengine_core::Transform>();
+
+        let short = short_component_name("bsengine_core::transform::Transform", Some(&registry));
+
+        assert_eq!(
+            short, "Transform",
+            "a registered type's short_path() must be used instead of the full type_path"
+        );
+    }
+
+    #[test]
+    fn short_component_name_falls_back_to_the_full_path_without_a_registry() {
+        let short = short_component_name("bsengine_core::transform::Transform", None);
+
+        assert_eq!(
+            short, "bsengine_core::transform::Transform",
+            "with no type registry available, the full type_path must be returned unchanged \
+             (existing tests that pass type_registry: None rely on this fallback)"
+        );
+    }
+
+    #[test]
+    fn short_component_name_falls_back_to_the_full_path_when_the_type_isnt_registered() {
+        let registry = bevy_reflect::TypeRegistry::default();
+
+        let short = short_component_name("some_crate::not_registered::Thing", Some(&registry));
+
+        assert_eq!(
+            short, "some_crate::not_registered::Thing",
+            "an unregistered type_path has no TypeRegistration to look up a short name from, \
+             so it must fall back to the original string rather than panicking"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the Inspector Unity-style reflected-component-list work (#1726, #1727). After using it, the component list still didn't read like Unity's Inspector: headers showed the full namespace-qualified type_path, an unnecessary "Reflected Fields" banner label preceded the list, and there wasn't enough visual separation between components. Approved via a full brainstorming session, including a visual-companion mockup comparison where the user picked a lightweight thin-separator boundary (no framed box).

- Added a `short_component_name` helper (`bevy_reflect`'s own `TypePathTable::short_path()`, not manual `::` splitting) to resolve a component's short display name from its full type_path.
- Wired it into both the component header label and the Add Component dropdown — display-only change; the full type_path remains the internal identifier for commands, persistent ids, and the already-attached filter everywhere.
- Removed the "Reflected Fields" banner entirely; the separator that used to precede it now serves as the rule before the first component, and a new per-component separator is drawn before every subsequent one.
- Fixed an edge case found during final review: the section's emptiness guard checked the unfiltered component list, which could leave a dangling separator for an entity whose only reflected components are hidden ones (`GlobalTransform`/`Visible`) — now checks the filtered list instead, with a regression test.

Every commit was independently reviewed for spec compliance and code quality; the whole branch also got a final, holistic review pass.

## Test plan

- [x] `cargo test -p bsengine-rhi-wgpu` — 102/102 passing
- [x] `cargo check --workspace` — clean, no warnings
- [x] `cargo +nightly fmt --check` — clean
- [ ] Manual verification in the running editor (`cargo run -p bsengine-editor-app`): component headers show short names, no "Reflected Fields" banner, thin separators between components, Add Component dropdown shows short names, in both docked and overlay mode

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>