### PR TITLE
feat: Mini Action Arena demo (ENGINE_ROADMAP item 14)

### DIFF
--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -195,6 +195,46 @@
 
 ---
 
+### 14. Unity/Unreal 비교 검증 데모 ("Mini Action Arena") ✅
+
+**목표:** 실제 소규모 게임을 엔진으로 만들어보며 여러 시스템이 동시에 맞물릴 때의
+격차를 검증하고 기록
+
+**완료 조건:**
+- [x] `games/mini-arena/` 프로젝트, 콘텐츠는 최대한 에디터 워크플로우로 제작
+- [x] CC0 스키닝 애니메이션 캐릭터 임포트 + AnimationStateMachine idle/walk/run 전환
+- [x] NavMeshAgent 기반 적 추적 AI 1종 이상
+- [x] Rapier 물리 기반 전투/피격/넉백
+- [x] 커스텀 WGSL 셰이더 오브젝트 1종 이상
+- [x] 포스트프로세싱(bloom/tone-mapping) 적용
+- [x] HUD(체력/점수) + 일시정지 메뉴 (Bsengine.ui)
+- [x] 체크포인트 세이브/로드
+- [x] AI E2E 테스트로 플레이스루 recording 확보 + replay 통과
+- [x] 갭 로그 작성
+- [x] CI 통과
+
+<!--
+E2E 테스트 작성 과정에서 발견한 10개의 실제 버그(엔진 5개 + player.js 콘텐츠 5개)를
+모두 즉시 수정: (1) 리플렉트 타입 등록이 EditorPlugin에만 있어 헤드리스 테스트 모드에서
+Shield 등 모든 컴포넌트가 조용히 누락됨 (bsengine-scene::register_gameplay_reflect_types
+공유 함수로 추출), (2) test_mode.rs의 PressKey/ReleaseKey가 Input<T>를 직접 mutate해
+edge-triggered 입력(isKeyDown/isKeyUp)이 프로토콜을 통해 절대 관측 불가능했음
+(Events<KeyInput>/Events<MouseInput> 경유로 수정), (3) NavMeshPlugin이 bsengine-runtime
+어디에도 등록된 적이 없어 실제 빌드에서 적 추적 AI가 한 번도 동작한 적이 없었음
+(main.rs/test_mode.rs 양쪽에 추가, 헤드리스 쪽엔 TimePlugin도 함께 필요),
+(4) Bsengine.raycast()가 entity_name(snake_case)을 반환해 관례상 entityName을
+기대하는 모든 호출이 항상 undefined 비교였음 (RaycastHitJson에 camelCase rename 추가),
+(5) player.js: 이동에 isKeyDown(edge) 사용 — 다른 모든 게임은 isKeyPressed(held) 사용,
+(6) player.js: yaw 부호가 반대라 forward 벡터가 이동 방향과 정반대,
+(7) player.js: 공격 레이캐스트 origin이 자기 자신의 콜라이더 내부에서 시작해 즉시
+self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상단(0.85)보다 높아
+항상 헛스윙, (9) player.js: damageShield 직후 getShield로 즉시 재확인해 스테일 스냅샷을
+읽음 — 30/15 데미지 Enemy가 의도한 2타가 아니라 3타 필요했음. 자세한 근거는
+`games/mini-arena/GAP_LOG.md` 참고.
+-->
+
+---
+
 ## 완료 이력
 
 | 항목 | 완료일 | PR |
@@ -243,3 +283,6 @@
 | 12. Fix: wire GltfPlugin/TimePlugin/AnimationPlugin/AnimationStateMachinePlugin into bsengine-runtime (none were ever registered before this — glTF loading and any time-driven component were silently inert in the real runtime binary), handle non-indexed glTF primitives, seed AnimationPlayer.duration from its clip | 2026-07-29 | [#1731](https://github.com/blas1n/BSEngine/pull/1731) |
 | 13. Scene serialization saves/loads arbitrary reflected components (bsengine-scene load-side apply_or_insert + bsengine-editor extra_components capture/EditorCommand::LoadScene apply) | 2026-07-29 | [#1733](https://github.com/blas1n/BSEngine/pull/1733) |
 | 13. Fix: HashSet\<String\> missing ReflectSerialize (only ReflectDeserialize was registered), which silently dropped AnimationStateMachine from every saved scene | 2026-07-29 | [#1733](https://github.com/blas1n/BSEngine/pull/1733) |
+| 14. Mini Action Arena demo (`games/mini-arena/`) — arena/player/enemy, AnimationStateMachine idle/walk/run, NavMeshAgent pursuit, Rapier combat/knockback, custom WGSL glow shader, bloom/tone-map, HUD + pause menu, checkpoint save/load | 2026-07-29 | branch `feat/mini-arena` (PR #TBD) |
+| 14. Fix: 5 engine bugs found authoring the headless E2E test — reflect-type registration reachable only from EditorPlugin (not headless test mode), test_mode.rs PressKey/ReleaseKey bypassing the input event queue (broke all edge-triggered isKeyDown/isKeyUp), NavMeshPlugin never wired into bsengine-runtime at all (enemy pursuit never worked in any real build), Bsengine.raycast() returning entity_name instead of entityName | 2026-07-29 | branch `feat/mini-arena` (PR #TBD) |
+| 14. Fix: 5 content bugs in player.js found the same way — isKeyDown instead of isKeyPressed for held movement, 180°-backwards yaw/forward vector, attack raycast self-hit + wrong height, stale getShield() read after damageShield() (Enemy took 3 hits instead of the documented 2); see `games/mini-arena/GAP_LOG.md` for full detail | 2026-07-29 | branch `feat/mini-arena` (PR #TBD) |

--- a/crates/bsengine-core/src/save_data.rs
+++ b/crates/bsengine-core/src/save_data.rs
@@ -1,9 +1,11 @@
-use bevy_ecs::prelude::Component;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::Reflect;
 use std::collections::HashMap;
 
 /// A simple key-value save slot attached to a player entity.
 /// Values are stored as raw bytes; higher-level systems serialize/deserialize them.
-#[derive(Component, Debug, Clone, PartialEq)]
+#[derive(Component, Debug, Clone, PartialEq, Reflect)]
+#[reflect(Component)]
 pub struct SaveData {
     /// Which save slot this data belongs to.
     pub slot: u32,

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1756,6 +1756,7 @@ impl Plugin for EditorPlugin {
         app.register_type::<bsengine_core::Lifetime>();
         app.register_type::<bsengine_core::Mass>();
         app.register_type::<bsengine_core::NetworkId>();
+        app.register_type::<bsengine_core::SaveData>();
         app.register_type::<bsengine_core::Shield>();
         app.register_type::<bsengine_core::Skybox>();
         app.register_type::<bsengine_core::Timer>();

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1742,48 +1742,12 @@ impl Plugin for EditorPlugin {
         app.insert_resource(EditorHistoryResource(history.clone()));
         app.insert_resource(InspectorState::editor());
         app.insert_resource(EditorPanelRegistry::default());
-        app.register_type::<bsengine_core::Camera>();
-        app.register_type::<bsengine_core::PointLight>();
-        app.register_type::<bsengine_core::DirectionalLight>();
-        app.register_type::<bsengine_core::SpotLight>();
-        app.register_type::<bsengine_core::Material>();
-        app.register_type::<bsengine_core::AmbientOcclusion>();
-        app.register_type::<bsengine_core::AnimationPlayer>();
-        app.register_type::<bsengine_core::Bloom>();
-        app.register_type::<bsengine_core::CustomShader>();
-        app.register_type::<bsengine_core::Damping>();
-        app.register_type::<bsengine_core::GravityScale>();
-        app.register_type::<bsengine_core::Lifetime>();
-        app.register_type::<bsengine_core::Mass>();
-        app.register_type::<bsengine_core::NetworkId>();
-        app.register_type::<bsengine_core::SaveData>();
-        app.register_type::<bsengine_core::Shield>();
-        app.register_type::<bsengine_core::Skybox>();
-        app.register_type::<bsengine_core::Timer>();
-        app.register_type::<bsengine_core::ToneMap>();
-        app.register_type::<bsengine_core::Visible>();
-        app.register_type::<bsengine_core::AngularVelocity>();
-        app.register_type::<bsengine_core::ExternalImpulse>();
-        app.register_type::<bsengine_core::Follow>();
-        app.register_type::<bsengine_core::LookAt>();
-        app.register_type::<bsengine_core::NavMeshAgent>();
-        app.register_type::<bsengine_core::Velocity>();
-        app.register_type::<bsengine_core::Transform>();
-        app.register_type::<bsengine_core::GlobalTransform>();
-        app.register_type::<bsengine_core::Parent>();
-        app.register_type::<bsengine_core::AnimationStateMachine>();
-        // AnimationStateMachine::triggers is a HashSet<String>; unlike Map/List/Struct
-        // fields, HashSet isn't structurally recursed by TypedReflectDeserializer and
-        // needs its value-kind ReflectDeserialize registered explicitly, or JSON
-        // authoring via set_reflected_component fails with "doesn't have
-        // ReflectDeserialize" even for an empty `[]` (confirmed via a throwaway probe
-        // test during design research). Same story for ReflectSerialize on the save
-        // side: populate_snapshot_extra_components's TypedReflectSerializer fails the
-        // same way ("did not register ReflectSerialize") without this, which would
-        // silently drop AnimationStateMachine out of saved scenes entirely.
-        app.register_type_data::<std::collections::HashSet<String>, bevy_reflect::ReflectDeserialize>();
-        app.register_type_data::<std::collections::HashSet<String>, bevy_reflect::ReflectSerialize>();
-        app.register_type::<bsengine_core::Tween>();
+        // Shared with the headless test runtime (`bsengine-runtime --test`'s
+        // `build_test_app`) so reflected `components:` entries (Shield,
+        // SaveData, AnimationStateMachine, NavMeshAgent, Bloom, ToneMap, ...)
+        // deserialize identically in both -- see its doc comment in
+        // bsengine-scene for the headless-mode gap this fixed.
+        bsengine_scene::register_gameplay_reflect_types(app);
         app.register_type::<Tags>();
         app.register_type::<bsengine_scene::Primitive>();
         app.register_type::<bsengine_scene::PrimitiveMesh>();

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -1,6 +1,8 @@
 use std::env;
 
-use bsengine_app::{new_app, AnimationPlugin, AnimationStateMachinePlugin, TimePlugin};
+use bsengine_app::{
+    new_app, AnimationPlugin, AnimationStateMachinePlugin, NavMeshPlugin, TimePlugin,
+};
 use bsengine_audio::AudioPlugin;
 use bsengine_core::{EditorPlayState, InspectorState};
 use bsengine_editor::EditorPlugin;
@@ -80,6 +82,7 @@ fn run_windowed(project_dir: &str) {
         .add_plugins(SkinnedMeshPlugin)
         .add_plugins(AnimationPlugin)
         .add_plugins(AnimationStateMachinePlugin)
+        .add_plugins(NavMeshPlugin)
         .add_plugins(ScenePlugin::from_file(&scene_path))
         .add_plugins(ScriptingPlugin {
             project_dir: project_dir.to_string(),

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -6,9 +6,11 @@
 use std::io::{self, BufRead, Write};
 
 use bevy_app::App;
+use bevy_ecs::event::Events;
+use bsengine_app::{NavMeshPlugin, TimePlugin};
 use bsengine_audio::AudioPlugin;
 use bsengine_core::{EditorPlayState, InspectorState};
-use bsengine_input::{Input, InputPlugin, KeyCode, MouseButton};
+use bsengine_input::{ElementState, InputPlugin, KeyCode, KeyInput, MouseButton, MouseInput};
 use bsengine_physics::PhysicsPlugin;
 use bsengine_scene::ScenePlugin;
 use bsengine_scripting::{ScriptingPlugin, KEY_MAPPINGS};
@@ -34,14 +36,27 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>) -> App {
     let scene_path = format!("{project_dir}/{relative_scene}");
 
     let mut app = bsengine_app::new_app();
-    app.add_plugins(InputPlugin)
+    app.add_plugins(TimePlugin)
+        .add_plugins(InputPlugin)
         .add_plugins(AudioPlugin)
         .add_plugins(PhysicsPlugin)
+        .add_plugins(NavMeshPlugin)
         .add_plugins(ScenePlugin::from_file(&scene_path))
         .add_plugins(ScriptingPlugin {
             project_dir: project_dir.to_string(),
         });
     register_scene_systems(&mut app);
+
+    // Same reflect-type registrations EditorPlugin does (again, not the full
+    // plugin -- see below), needed so `spawn_scene_entities` can actually
+    // deserialize a scene's `components:` entries (Shield, SaveData,
+    // AnimationStateMachine, NavMeshAgent, Bloom, ToneMap, ...) instead of
+    // silently dropping every one of them (logged only as a `tracing::warn!`
+    // "unknown reflected type path"). Without this, e.g. a Shield-gated dead
+    // check reads a permanently-0 shield in headless mode and the entity
+    // never behaves as scripted, even though the identical scene plays
+    // correctly in the windowed runtime.
+    bsengine_scene::register_gameplay_reflect_types(&mut app);
 
     // The windowed runtime (main.rs's run_windowed) always runs with
     // EditorPlugin, which gates script execution behind `editor_mode &&
@@ -131,9 +146,33 @@ pub fn execute_command(
             }
             (CommandResponse::ok(json!({"frame": *frame})), false)
         }
+        // PressKey/ReleaseKey/PressMouse/ReleaseMouse send through the same
+        // `Events<KeyInput>`/`Events<MouseInput>` queue the real windowed
+        // runtime's window-event handler uses, rather than mutating
+        // `Input<T>` directly. That distinction matters: `Input<T>`'s
+        // `just_pressed`/`just_released` ("edge") state is cleared every
+        // frame by `clear_input_state`, which runs first in `PreUpdate`
+        // ahead of the event-draining systems, precisely so that ordering
+        // (clear old edge state, then set new edge state from this frame's
+        // events) gives scripts a one-frame-wide, correctly-timed window to
+        // observe `isKeyDown`/`isKeyUp`. A direct `.press()`/`.release()`
+        // call happens outside any schedule, strictly *before* the next
+        // `Step`'s first `app.update()` -- so that same `clear_input_state`
+        // wipes the edge flag before `run_scripts` (in `Update`, which runs
+        // after `PreUpdate`) ever sees it. The held/level `is_pressed` state
+        // isn't cleared this way, so continuous-movement scripts using
+        // `isKeyPressed` never noticed; only edge-triggered `isKeyDown`/
+        // `isKeyUp` checks (attack, pause toggle, checkpoint reload, ...)
+        // were silently untestable through this protocol until this fix.
         Command::PressKey { key } => match key_from_str(&key) {
             Some(code) => {
-                app.world_mut().resource_mut::<Input<KeyCode>>().press(code);
+                app.world_mut()
+                    .resource_mut::<Events<KeyInput>>()
+                    .send(KeyInput {
+                        key_code: code,
+                        state: ElementState::Pressed,
+                        text: None,
+                    });
                 (CommandResponse::ok(json!({})), false)
             }
             None => (CommandResponse::err(format!("unknown key: {key}")), false),
@@ -141,8 +180,12 @@ pub fn execute_command(
         Command::ReleaseKey { key } => match key_from_str(&key) {
             Some(code) => {
                 app.world_mut()
-                    .resource_mut::<Input<KeyCode>>()
-                    .release(code);
+                    .resource_mut::<Events<KeyInput>>()
+                    .send(KeyInput {
+                        key_code: code,
+                        state: ElementState::Released,
+                        text: None,
+                    });
                 (CommandResponse::ok(json!({})), false)
             }
             None => (CommandResponse::err(format!("unknown key: {key}")), false),
@@ -150,8 +193,11 @@ pub fn execute_command(
         Command::PressMouse { button } => match mouse_button_from_u8(button) {
             Some(b) => {
                 app.world_mut()
-                    .resource_mut::<Input<MouseButton>>()
-                    .press(b);
+                    .resource_mut::<Events<MouseInput>>()
+                    .send(MouseInput {
+                        button: b,
+                        state: ElementState::Pressed,
+                    });
                 (CommandResponse::ok(json!({})), false)
             }
             None => (
@@ -162,8 +208,11 @@ pub fn execute_command(
         Command::ReleaseMouse { button } => match mouse_button_from_u8(button) {
             Some(b) => {
                 app.world_mut()
-                    .resource_mut::<Input<MouseButton>>()
-                    .release(b);
+                    .resource_mut::<Events<MouseInput>>()
+                    .send(MouseInput {
+                        button: b,
+                        state: ElementState::Released,
+                    });
                 (CommandResponse::ok(json!({})), false)
             }
             None => (
@@ -278,6 +327,7 @@ pub fn run_replay_mode(project_dir: &str, log_path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bsengine_input::Input;
 
     fn write_two_scene_project() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -429,4 +429,71 @@ mod tests {
             "Player should be back at its authored z=0.0 after reload, got {z}"
         );
     }
+
+    // Regression test for the PressKey/ReleaseKey protocol commands: they
+    // must route through Events<KeyInput>, not mutate Input<KeyCode>
+    // directly, or edge-triggered checks (just_pressed/just_released --
+    // what Bsengine.isKeyDown/isKeyUp read) are never observable through
+    // this protocol (see execute_command's PressKey doc comment for why).
+    // Exercises execute_command exactly as run_test_mode/run_replay_mode
+    // do -- one command at a time, with an explicit Step between a key
+    // event and the point where its effect is checked.
+    #[test]
+    fn press_key_is_observable_as_pressed_and_just_pressed_after_one_step() {
+        let dir = write_two_scene_project();
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None);
+        let mut frame: u64 = 0;
+
+        let (resp, _) = execute_command(
+            &mut app,
+            &mut frame,
+            Command::PressKey {
+                key: "W".to_string(),
+            },
+        );
+        assert!(resp.ok, "PressKey should succeed: {:?}", resp.error);
+
+        let (resp, _) = execute_command(&mut app, &mut frame, Command::Step { frames: 1 });
+        assert!(resp.ok);
+
+        let input = app.world().resource::<Input<KeyCode>>();
+        assert!(
+            input.is_pressed(&KeyCode::W),
+            "W should be held after PressKey + one step"
+        );
+        assert!(
+            input.just_pressed(&KeyCode::W),
+            "W should be just_pressed on the exact frame after PressKey"
+        );
+
+        // A second step with no new key event: just_pressed's one-frame
+        // window has closed (clear_input_state ran again), but the level
+        // "pressed" state persists until an explicit ReleaseKey.
+        let (resp, _) = execute_command(&mut app, &mut frame, Command::Step { frames: 1 });
+        assert!(resp.ok);
+        let input = app.world().resource::<Input<KeyCode>>();
+        assert!(input.is_pressed(&KeyCode::W), "W should still be held");
+        assert!(
+            !input.just_pressed(&KeyCode::W),
+            "just_pressed should not still be true one frame later"
+        );
+
+        let (resp, _) = execute_command(
+            &mut app,
+            &mut frame,
+            Command::ReleaseKey {
+                key: "W".to_string(),
+            },
+        );
+        assert!(resp.ok, "ReleaseKey should succeed: {:?}", resp.error);
+        let (resp, _) = execute_command(&mut app, &mut frame, Command::Step { frames: 1 });
+        assert!(resp.ok);
+
+        let input = app.world().resource::<Input<KeyCode>>();
+        assert!(!input.is_pressed(&KeyCode::W), "W should no longer be held");
+        assert!(
+            input.just_released(&KeyCode::W),
+            "W should be just_released on the exact frame after ReleaseKey"
+        );
+    }
 }

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -11,7 +11,7 @@ pub mod plugin;
 /// Serde/RON descriptor types that make up the on-disk scene file format.
 pub mod types;
 
-pub use plugin::{spawn_scene_entities, Name, ScenePlugin};
+pub use plugin::{register_gameplay_reflect_types, spawn_scene_entities, Name, ScenePlugin};
 pub use types::{
     ColliderDesc, ColliderShapeDesc, DirectionalLightDescriptor, EntityDescriptor,
     PendingSceneLoad, PhysicsBodyDesc, PointLightDescriptor, Primitive, PrimitiveMesh,

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -210,6 +210,67 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
     }
 }
 
+/// Registers every `bsengine_core` component type an `EntityDescriptor`'s
+/// `components:` field (arbitrary reflected components, e.g. `Shield`,
+/// `SaveData`, `AnimationStateMachine`, `NavMeshAgent`, `Bloom`, `ToneMap`)
+/// may reference, so [`spawn_scene_entities`]'s reflection-based
+/// deserialization above can actually find and attach them.
+///
+/// Previously these registrations lived only inline in `EditorPlugin::build`
+/// (`bsengine-editor`), which the headless test runtime
+/// (`bsengine-runtime --test`'s `build_test_app`) never adds -- it can't,
+/// since `EditorPlugin` requires the render/window stack a headless app
+/// doesn't have. That meant every reflected `components:` entry was silently
+/// dropped in headless test mode (logged only as a `tracing::warn!`
+/// "unknown reflected type path", easy to miss), so any gameplay gated on
+/// one of these components -- e.g. a `Shield`-based death check -- was
+/// unexercisable via `bsengine-runtime --test`, even though the identical
+/// scene loaded and played correctly in the windowed editor runtime. Call
+/// this from both `EditorPlugin::build` and the headless test app's setup so
+/// the two stay in parity.
+pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
+    app.register_type::<bsengine_core::Camera>();
+    app.register_type::<bsengine_core::PointLight>();
+    app.register_type::<bsengine_core::DirectionalLight>();
+    app.register_type::<bsengine_core::SpotLight>();
+    app.register_type::<bsengine_core::Material>();
+    app.register_type::<bsengine_core::AmbientOcclusion>();
+    app.register_type::<bsengine_core::AnimationPlayer>();
+    app.register_type::<bsengine_core::Bloom>();
+    app.register_type::<bsengine_core::CustomShader>();
+    app.register_type::<bsengine_core::Damping>();
+    app.register_type::<bsengine_core::GravityScale>();
+    app.register_type::<bsengine_core::Lifetime>();
+    app.register_type::<bsengine_core::Mass>();
+    app.register_type::<bsengine_core::NetworkId>();
+    app.register_type::<bsengine_core::SaveData>();
+    app.register_type::<bsengine_core::Shield>();
+    app.register_type::<bsengine_core::Skybox>();
+    app.register_type::<bsengine_core::Timer>();
+    app.register_type::<bsengine_core::ToneMap>();
+    app.register_type::<bsengine_core::Visible>();
+    app.register_type::<bsengine_core::AngularVelocity>();
+    app.register_type::<bsengine_core::ExternalImpulse>();
+    app.register_type::<bsengine_core::Follow>();
+    app.register_type::<bsengine_core::LookAt>();
+    app.register_type::<bsengine_core::NavMeshAgent>();
+    app.register_type::<bsengine_core::Velocity>();
+    app.register_type::<bsengine_core::Transform>();
+    app.register_type::<bsengine_core::GlobalTransform>();
+    app.register_type::<bsengine_core::Parent>();
+    app.register_type::<bsengine_core::AnimationStateMachine>();
+    // AnimationStateMachine::triggers is a HashSet<String>; unlike Map/List/Struct
+    // fields, HashSet isn't structurally recursed by TypedReflectDeserializer and
+    // needs its value-kind ReflectDeserialize registered explicitly, or JSON/RON
+    // authoring fails with "doesn't have ReflectDeserialize" even for an empty
+    // `[]`. Same story for ReflectSerialize on the save side. See
+    // `bsengine-editor`'s prior inline copy of this registration for the fuller
+    // history (design-research probe that found this).
+    app.register_type_data::<std::collections::HashSet<String>, bevy_reflect::ReflectDeserialize>();
+    app.register_type_data::<std::collections::HashSet<String>, bevy_reflect::ReflectSerialize>();
+    app.register_type::<bsengine_core::Tween>();
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Name, ScenePlugin};

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -317,6 +317,15 @@ pub enum ScriptCommand {
         /// New maximum shield capacity.
         value: f32,
     },
+    /// Write a UTF-8 key/value field into an entity's `SaveData`.
+    SetSaveField {
+        /// Entity to target.
+        name: String,
+        /// Field key.
+        key: String,
+        /// UTF-8 field value.
+        value: String,
+    },
     /// Reset a named entity's gameplay timer back to zero.
     ResetTimer {
         /// Name of the entity to modify.
@@ -1924,6 +1933,9 @@ thread_local! {
     pub(crate) static SHIELD_SNAPSHOT: RefCell<HashMap<String, (f32, f32)>> =
         RefCell::new(HashMap::new());
 
+    pub(crate) static SAVE_DATA_SNAPSHOT: RefCell<HashMap<String, HashMap<String, String>>> =
+        RefCell::new(HashMap::new());
+
     // entity name → (level, current_xp, progress, is_max)
 
     // entity name → (current, max, prestige, is_max, progress_fraction)
@@ -3173,6 +3185,19 @@ pub fn bsengine_set_max_shield(#[string] name: String, value: f32) {
     });
 }
 
+/// Queue writing a key/value field into an entity's SaveData.
+#[op2(fast)]
+pub fn bsengine_set_save_field(
+    #[string] name: String,
+    #[string] key: String,
+    #[string] value: String,
+) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetSaveField { name, key, value })
+    });
+}
+
 // ── Scald ────────────────────────────────────────────────────────────────────
 // ── Scan ─────────────────────────────────────────────────────────────────────
 // ── Scar ─────────────────────────────────────────────────────────────────────
@@ -3582,6 +3607,20 @@ pub fn bsengine_is_shield_depleted(#[string] name: String) -> bool {
             .get(&name)
             .map(|(cur, _)| *cur <= 0.0)
             .unwrap_or(true)
+    })
+}
+
+/// Get a UTF-8 field value from an entity's SaveData, or an empty string if
+/// the entity, its SaveData, or the field don't exist.
+#[op2]
+#[string]
+pub fn bsengine_get_save_field(#[string] name: String, #[string] key: String) -> String {
+    SAVE_DATA_SNAPSHOT.with(|s| {
+        s.borrow()
+            .get(&name)
+            .and_then(|fields| fields.get(&key))
+            .cloned()
+            .unwrap_or_default()
     })
 }
 
@@ -5708,6 +5747,8 @@ deno_core::extension!(
         bsengine_get_max_shield,
         bsengine_get_shield_fraction,
         bsengine_is_shield_depleted,
+        bsengine_set_save_field,
+        bsengine_get_save_field,
         bsengine_reset_timer,
         bsengine_get_timer_elapsed,
         bsengine_get_timer_duration,
@@ -6015,6 +6056,8 @@ var Bsengine = {
     getMaxShield:           (name)          => Deno.core.ops.bsengine_get_max_shield(name),
     getShieldFraction:      (name)          => Deno.core.ops.bsengine_get_shield_fraction(name),
     isShieldDepleted:       (name)          => Deno.core.ops.bsengine_is_shield_depleted(name),
+    setSaveField:           (name, key, value) => Deno.core.ops.bsengine_set_save_field(name, key, String(value)),
+    getSaveField:           (name, key)        => Deno.core.ops.bsengine_get_save_field(name, key),
     resetTimer:             (name)          => Deno.core.ops.bsengine_reset_timer(name),
     getTimerElapsed:        (name)          => Deno.core.ops.bsengine_get_timer_elapsed(name),
     getTimerDuration:       (name)          => Deno.core.ops.bsengine_get_timer_duration(name),
@@ -9755,6 +9798,35 @@ JSON.stringify(received)
             assert!(found, "DamageShield not in buffer");
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn set_save_field_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setSaveField("Hero", "score", "42");"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let found = c.borrow().iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetSaveField { name, key, value }
+                    if name == "Hero" && key == "score" && value == "42")
+            });
+            assert!(found, "SetSaveField not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn get_save_field_returns_empty_for_unknown() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let r = rt
+            .eval(r#"Bsengine.getSaveField("Unknown", "score");"#)
+            .unwrap();
+        assert!(
+            r.trim().is_empty() || r.trim() == "\"\"",
+            "expected empty, got {r}"
+        );
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -2230,7 +2230,17 @@ struct TransformJson {
     sz: f32,
 }
 
+// `rename_all = "camelCase"` matters here: every other Bsengine.* JS API
+// (isKeyDown, getForwardVector, setHudText, ...) exposes camelCase property
+// names, but this struct's field was left as plain Rust snake_case, so
+// `Bsengine.raycast(...)` returned `{ entity_name: ... }`, not `{ entityName:
+// ... }`. A caller checking `hit.entityName` (matching the engine's own
+// convention, and the only sensible name to guess) always got `undefined`
+// -- a silent, always-false comparison with no error anywhere. Found via
+// mini-arena's melee attack combat, which used exactly that check and could
+// never register a hit as a result, no matter how correctly it aimed.
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct RaycastHitJson {
     entity_name: Option<String>,
     point: [f32; 3],

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -27,10 +27,10 @@ use crate::ops::{
     MOUSE_DELTA_SNAPSHOT, MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT,
     MOUSE_POS_SNAPSHOT, MOUSE_PRESSED_SNAPSHOT, NAV_SNAPSHOT, NETWORK_ID_SNAPSHOT,
     NETWORK_STATE_SNAPSHOT, PARENT_SNAPSHOT, PHYSICS_WORLD_PTR, RESTITUTION_SNAPSHOT,
-    SCREEN_SIZE_SNAPSHOT, SHIELD_SNAPSHOT, SLEEP_SNAPSHOT, SOUND_POSITION_SNAPSHOT,
-    SOUND_STATE_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT,
-    TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT, TWEEN_SNAPSHOT, UI_CLICKED_SNAPSHOT, VELOCITY_SNAPSHOT,
-    VISIBLE_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
+    SAVE_DATA_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SHIELD_SNAPSHOT, SLEEP_SNAPSHOT,
+    SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT,
+    TIME_ELAPSED_SNAPSHOT, TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT, TWEEN_SNAPSHOT,
+    UI_CLICKED_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -770,6 +770,18 @@ fn run_scripts(world: &mut World) {
                     if let Some(mut sh) = world.get_mut::<Shield>(e) {
                         sh.max = value.max(0.0);
                         sh.current = sh.current.min(sh.max);
+                    }
+                }
+            }
+            ScriptCommand::SetSaveField { name, key, value } => {
+                use bsengine_core::SaveData;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut sd) = world.get_mut::<SaveData>(e) {
+                        sd.set(key, value.into_bytes());
                     }
                 }
             }
@@ -2541,6 +2553,20 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
         SHIELD_SNAPSHOT.with(|s| *s.borrow_mut() = shield_map);
     }
     {
+        use bsengine_core::SaveData;
+        let mut save_map = std::collections::HashMap::new();
+        let mut q = world.query::<(&Name, &SaveData)>();
+        for (name, sd) in q.iter(world) {
+            let fields: std::collections::HashMap<String, String> = sd
+                .fields
+                .iter()
+                .filter_map(|(k, v)| String::from_utf8(v.clone()).ok().map(|s| (k.clone(), s)))
+                .collect();
+            save_map.insert(name.0.clone(), fields);
+        }
+        SAVE_DATA_SNAPSHOT.with(|s| *s.borrow_mut() = save_map);
+    }
+    {
         use bsengine_core::Timer;
         let mut timer_map = std::collections::HashMap::new();
         let mut q = world.query::<(&Name, &Timer)>();
@@ -2733,7 +2759,7 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
 
 #[cfg(test)]
 mod tests {
-    use super::{ScriptRuntimeResource, ScriptingPlugin};
+    use super::{Name, ScriptPath, ScriptRuntimeResource, ScriptingPlugin};
     use bsengine_app::new_app;
 
     #[test]
@@ -2759,5 +2785,43 @@ mod tests {
             .eval("40 + 2");
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "42");
+    }
+
+    #[test]
+    fn set_save_field_round_trips_through_world() {
+        use bsengine_core::SaveData;
+
+        let script_path = std::env::temp_dir().join(format!(
+            "bsengine_test_set_save_field_{}.js",
+            std::process::id()
+        ));
+        std::fs::write(
+            &script_path,
+            "function onUpdate(name) { Bsengine.setSaveField(name, \"score\", \"99\"); }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(ScriptingPlugin {
+            project_dir: String::new(),
+        });
+        app.world_mut().spawn((
+            Name("Hero".to_string()),
+            SaveData::new(0),
+            ScriptPath(script_path.to_string_lossy().to_string()),
+        ));
+
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let mut q = world.query::<(&Name, &SaveData)>();
+        let (_, save) = q
+            .iter(world)
+            .find(|(n, _)| n.0 == "Hero")
+            .expect("Hero entity with SaveData not found");
+        assert_eq!(save.get("score"), Some(b"99".as_slice()));
+
+        let _ = std::fs::remove_file(&script_path);
     }
 }

--- a/games/mini-arena/GAP_LOG.md
+++ b/games/mini-arena/GAP_LOG.md
@@ -1,0 +1,217 @@
+# Mini Action Arena — Engineering Gap Log
+
+Friction and bugs found while building this demo and while authoring its E2E
+test (`assets/tests/basic-playthrough.testlog.json`). Every entry below was
+either verified directly (reproduced, root-caused, and in most cases fixed)
+or is carried forward from earlier tasks in this plan with the same standard
+of verification.
+
+## Blocking
+
+*(empty — every issue below that actually blocked this task's deliverable
+was fixed immediately, as it was found, rather than left blocking.)*
+
+## Non-blocking
+
+### Found and fixed during this task's E2E test authoring
+
+Writing the headless playthrough turned out to be far from a formality: the
+player genuinely could not move, then could not attack, then could not kill
+the Enemy, in a chain of ten distinct, independently-verified bugs. Every one
+of them was reproduced with a minimal repro (usually a throwaway
+`Bsengine.setHudText("debug", ...)` probe of raw engine state) before being
+fixed, so this list is a real account of what was actually wrong, not a
+guess.
+
+**Engine-level (affects every game, not just this one):**
+
+- **Reflect type registration lived only in `EditorPlugin`, unreachable by
+  headless test mode.** `bsengine-runtime --test`'s `build_test_app` never
+  adds `EditorPlugin` (it can't — that plugin needs a render/window stack a
+  headless app doesn't have), but *every* `register_type::<T>()` call for
+  gameplay components (`Shield`, `SaveData`, `AnimationStateMachine`,
+  `NavMeshAgent`, `Bloom`, `ToneMap`, ...) lived inline inside
+  `EditorPlugin::build`. A scene's `components: [...]` RON entries
+  deserialize via the ECS type registry (`spawn_scene_entities` in
+  `bsengine-scene`), so every one of those components was silently dropped
+  in headless mode (logged only as a `tracing::warn!` "unknown reflected
+  type path", easy to miss). Concretely: `Player`'s `Shield` never attached,
+  so `Bsengine.getShield("Player")` always returned its `unwrap_or(0.0)`
+  fallback, and player.js's `dead = getShield(self) <= 0.0` check was
+  permanently true — the player could not move at all in headless mode. This
+  also means the earlier `SaveData` reflect-registration fix (this plan's
+  Task 0) was *also* silently unreachable in headless mode the whole time;
+  nothing had actually exercised it headlessly before now. **Fixed** by
+  extracting a shared `bsengine_scene::register_gameplay_reflect_types(app)`
+  function (in `crates/bsengine-scene/src/plugin.rs`, exported from
+  `lib.rs`), called from both `EditorPlugin::build`
+  (`crates/bsengine-editor/src/plugin.rs`) and the headless
+  `build_test_app` (`crates/bsengine-runtime/src/test_mode.rs`), so the two
+  runtimes stay in parity going forward.
+
+- **`bsengine-runtime --test`'s `PressKey`/`ReleaseKey`/`PressMouse`/
+  `ReleaseMouse` commands mutated the `Input<T>` resource directly, outside
+  any frame's schedule — silently breaking every edge-triggered input check
+  (`isKeyDown`/`isKeyUp`, and any future `onKeyDown`/`onKeyUp` JS
+  callback).** `clear_input_state` (which wipes `just_pressed`/
+  `just_released` each frame) runs first in `PreUpdate`, ahead of the
+  event-draining systems, specifically so real input (which arrives as
+  `Events<KeyInput>` from the window layer) sees the correct
+  clear-then-set order within one frame. A direct `.press()`/`.release()`
+  call bypasses that event queue entirely and lands strictly *before* the
+  next `Step`'s first `app.update()` — so that same `clear_input_state`
+  always wiped the edge flag before any script ever saw it. In practice this
+  meant `Bsengine.isKeyDown(...)` could never be observed as true through
+  the test protocol, at all, no matter the command sequence — mini-arena's
+  attack (Space), pause toggle (Escape), and checkpoint reload (Enter) were
+  all completely untestable headlessly before this fix. Held/level state
+  (`isKeyPressed`) was unaffected, which is exactly why this went unnoticed.
+  **Fixed** by routing all four commands through
+  `Events<KeyInput>`/`Events<MouseInput>` instead
+  (`crates/bsengine-runtime/src/test_mode.rs`), matching how real input
+  actually flows.
+
+- **`NavMeshPlugin` (the plugin that actually moves `NavMeshAgent`
+  entities — its one system, `navigate_agents`) was never added to
+  `bsengine-runtime` at all, in *either* the windowed runtime (`main.rs`) or
+  the headless test runtime (`test_mode.rs`).** The Enemy's NavMesh pursuit
+  AI — one of this demo's headline features, and an item on
+  `ENGINE_ROADMAP.md`'s completion checklist — has never actually functioned
+  in a real running build of this game; it only worked in `bsengine-app`'s
+  own unit tests, which add the plugin explicitly. **Fixed** by adding
+  `.add_plugins(NavMeshPlugin)` to both entry points. This also required
+  adding `.add_plugins(TimePlugin)` to the headless test app (`main.rs`
+  already had it) — `navigate_agents` reads the ECS `Time` resource for its
+  `dt`, which nothing previously inserted headlessly, since JS scripting
+  tracks its own separate wall-clock timing (`ScriptTimingState`) instead of
+  going through `Time`.
+
+- **`Bsengine.raycast()`'s hit result serialized as `{ entity_name: ... }`,
+  not `{ entityName: ... }`** — every other `Bsengine.*` JS API in this
+  engine uses camelCase (`isKeyDown`, `getForwardVector`, `setHudText`, ...),
+  but `RaycastHitJson` (`bsengine-scripting/src/ops.rs`) was left as plain
+  Rust snake_case with no `#[serde(rename_all)]`. A caller checking
+  `hit.entityName` (the only sensible name to guess, matching the engine's
+  own convention) silently got `undefined` — no error anywhere, just an
+  always-false comparison. This alone was enough to make melee combat
+  completely non-functional regardless of aim, range, or timing. **Fixed**
+  with `#[serde(rename_all = "camelCase")]` on `RaycastHitJson`.
+
+**Content-level (specific to `games/mini-arena/assets/scripts/player.js`):**
+
+- **Continuous WASD movement used `Bsengine.isKeyDown` (edge-triggered:
+  true for exactly one frame per physical key transition) instead of
+  `Bsengine.isKeyPressed` (level-triggered: true for as long as the key is
+  held).** Every other game in this repo (`cube-breakout`, `cube-evader`,
+  `cube-roller`, `tilt-run`) correctly uses `isKeyPressed` for held-movement
+  checks; mini-arena's player.js was the one outlier. Holding W would move
+  the player for at most one frame, then stop, until released and
+  re-pressed. **Fixed**: `W`/`S`/`A`/`D`/`Left`/`Right` now use
+  `isKeyPressed`; `Enter` (checkpoint reload) and `Space` (attack) correctly
+  keep `isKeyDown`, since those really are one-shot, edge-triggered actions.
+
+- **The yaw computed for facing (`Math.atan2(dx, dz)`) produced a forward
+  vector exactly 180° backwards from the direction of travel.**
+  `Bsengine.getForwardVector()` returns `rotation * (0, 0, -1)`; setting yaw
+  directly from `atan2(dx, dz)` makes that come out as `(-dx, 0, -dz)`.
+  Confirmed empirically: holding S+D (dx=dz=+0.71) reported
+  `fwd=[-0.71,0,-0.71]`. Every consumer of "forward" — the attack raycast's
+  direction, and the knockback direction sent to the Enemy on hit — was
+  therefore aiming/pushing the exact opposite way the player was actually
+  walking. **Fixed**: `Math.atan2(-dx, -dz)`.
+
+- **The attack raycast's origin was placed at the player's exact position**
+  — i.e., inside the player's own capsule collider (radius 0.35) — **and**
+  **at `pos.y + 0.9`, above the collider's actual vertical extent** (a
+  `Capsule(half_height: 0.5, radius: 0.35)` totals a 0.85 half-extent, and
+  both entities sit at `y = 0`). Either bug alone made every attack miss:
+  the solid-ray-cast semantics reported an immediate self-hit
+  (`{entityName: "Player", distance: 0}`) at the wrong height would have
+  skimmed clean over the Enemy's collider even if the self-hit weren't
+  happening. **Fixed**: the origin is now offset forward (in the aim
+  direction) by `SELF_RADIUS_CLEARANCE = 0.5` to clear the player's own
+  collider, at `pos.y + 0.5` (inside the capsule's cylindrical midsection).
+
+- **The kill-check read `Bsengine.getShield("Enemy")` immediately after
+  calling `Bsengine.damageShield("Enemy", ...)`, in the same script call —
+  but `damageShield` only *queues* a command, applied to the world after
+  every script finishes that frame, while `getShield` reads a snapshot
+  captured at the *start* of the frame.** The check therefore always saw the
+  pre-this-hit value, one hit behind reality: with a 30-max-shield Enemy and
+  15 damage per hit, it took **three** landed hits to trigger `destroy()`,
+  not the documented two. **Fixed** by reading `getShield` *before* calling
+  `damageShield` and computing the post-hit value locally
+  (`preHitShield - ATTACK_DAMAGE <= 0.0`), which is correct because any
+  *earlier* hit's damage was already flushed to the world by a prior frame.
+
+### Genuinely new finding: driving the headless E2E protocol directly (Step 1 of this task)
+
+The task's original design assumed an interactive MCP session
+(`test_session_start`, `test_press_key`, ...); those tools weren't available
+here, so I drove `bsengine-runtime --test <dir>`'s stdin/stdout JSON-line
+protocol directly with a small Python script (piped subprocess, one command
+per line, one JSON response per line). This worked well as a standalone
+mechanism — it's genuinely just a thin, directly-scriptable protocol with no
+hidden dependency on an MCP client, exactly as advertised. A few honest
+observations from actually doing it:
+
+- **The protocol itself was pleasant to drive**: newline-delimited JSON
+  in/out, one response per command, no framing surprises, no MCP-specific
+  assumptions anywhere in `test_protocol.rs`/`test_mode.rs`. Building an
+  interactive session (persistent subprocess, read-eval-print against real
+  engine state) took only a few dozen lines of Python.
+- **The real friction wasn't the protocol shape, it was silent failure
+  modes on the engine side of it** — see the "Engine-level" bugs above. A
+  `press_key` that's silently a no-op for edge-triggered checks, a
+  `components:` entry that's silently dropped, a plugin that's silently
+  never registered: none of these produced any error response over the
+  wire. Every response was `{"ok":true,...}`. The protocol faithfully
+  reported "I did what you asked", which was true — the bug was always one
+  layer below, in what the engine did (or didn't do) as a result. This
+  matters for anyone else authoring a recording the same way: a clean
+  `ok:true` on every command is not evidence the game is actually behaving
+  correctly, only that the command was well-formed.
+- **`get_transform` returning `null` for a missing entity turned out to be
+  a convenient way to assert "this entity was destroyed"** (`path: "x", op:
+  "==", value: null`) — there's no dedicated `not_exists`/`contains` op, but
+  this reads naturally once you know `get_transform`'s null-on-missing
+  contract, and this recording uses it for both the Enemy-destroyed and
+  Pickup-collected checks.
+- **Wall-clock-driven JS movement (`Bsengine.getDeltaTime()`, real
+  `Instant::now()` deltas) makes stepped-frame counts inherently
+  machine-speed-dependent**, unlike physics-driven movement (Rapier's
+  `IntegrationParameters` step at a fixed *virtual* timestep regardless of
+  real elapsed time — this is why `tilt-run`'s existing recordings, which
+  drive a physics-based ball, don't have this issue). A `{"cmd":"step",
+  "frames":900}` covers a fixed amount of *game* time only if the real CPU
+  cost per frame is roughly constant; on a much faster or slower machine the
+  same frame count covers a different distance. This recording's frame
+  counts were empirically calibrated with real margin on this environment
+  and verified to pass four consecutive replay runs, but it's worth flagging
+  as a standing source of potential flakiness for any future JS-movement-
+  driven (as opposed to physics-driven) headless recording.
+
+### Pre-existing, not touched by this task
+
+- No dedicated MCP tool for attaching `rigidbody`/`collider` to a live
+  entity — only hand-authored scene RON.
+- No progress-bar/health-bar UI widget — `Bsengine.ui.*` only offers
+  label/button/panel/text-input, so a "health bar" has to be faked with
+  plain text (as this project did) or two overlapping panels.
+- `gltf:` scene-RON paths resolve relative to process CWD, not project dir,
+  unlike `script:` paths. `CustomShader.path` has the same CWD-relative
+  behavior despite its own doc comment claiming otherwise (a
+  documentation/implementation mismatch) — see `pickup.js`'s comment on
+  `Bsengine.setShader`.
+- Point lights cast no shadows (only the single directional light does).
+- No time/clock uniform available to custom WGSL shaders — animation of
+  shader-visible values has to be driven from JS (`setEmissive`) every frame
+  instead.
+- No relative-move scripting op (`Bsengine.moveEntity` does not exist) —
+  every scripted movement has to read current position, add a delta, and
+  write it back with `setTransform`.
+- No scripting op to close the game process — a pause menu's "Quit" button
+  can only ask the player to close the window themselves.
+- Enemy knockback is a scripted position offset, not a real Rapier impulse,
+  because the enemy's `Kinematic` rigidbody (required for `NavMeshAgent` to
+  own its `Transform`) ignores physics impulses by definition.

--- a/games/mini-arena/GAP_LOG.md
+++ b/games/mini-arena/GAP_LOG.md
@@ -212,6 +212,18 @@ observations from actually doing it:
   write it back with `setTransform`.
 - No scripting op to close the game process — a pause menu's "Quit" button
   can only ask the player to close the window themselves.
+- The pause menu (`pause.js`) only shows/hides a UI overlay — it does not
+  actually pause the simulation. `paused` is a variable local to `pause.js`'s
+  own closure; no other script, and no engine system (`run_scripts`,
+  `PhysicsPlugin`, `NavMeshPlugin`), is aware of it. The Enemy keeps chasing
+  and dealing contact damage, and the Player keeps responding to WASD/attack
+  input, while the "Paused" panel is on screen — a real gap versus Unity/
+  Unreal, where pausing typically also stops `Time.timeScale`-driven
+  simulation. There's no `Bsengine.pause()`/`setTimeScale()`-style op to
+  build a real pause on top of. `ENGINE_ROADMAP.md`'s completion checklist
+  for this item only asks for "일시정지 메뉴 (Bsengine.ui)" (a pause *menu*,
+  literally), which this satisfies — but it's worth flagging here explicitly
+  since "pause menu" reasonably implies "pauses" to most readers.
 - Enemy knockback is a scripted position offset, not a real Rapier impulse,
   because the enemy's `Kinematic` rigidbody (required for `NavMeshAgent` to
   own its `Transform`) ignores physics impulses by definition.

--- a/games/mini-arena/assets/scenes/main.ron
+++ b/games/mini-arena/assets/scenes/main.ron
@@ -6,6 +6,10 @@ SceneDescriptor(entities: [
         transform: Some((translation: (0.0, 4.0, 7.0))),
         look_at: Some((0.0, 0.5, 0.0)),
         script: Some("assets/scripts/camera.js"),
+        components: [
+            ("bsengine_core::bloom::Bloom", "(intensity: 0.6, threshold: 1.0, radius: 4.0, softness: 0.5, enabled: true)"),
+            ("bsengine_core::tone_map::ToneMap", "(mode: Aces, exposure: 0.0, enabled: true)"),
+        ],
     ),
     EntityDescriptor(
         name: "Sun",
@@ -69,5 +73,20 @@ SceneDescriptor(entities: [
     EntityDescriptor(
         name: "Hud",
         script: Some("assets/scripts/hud.js"),
+    ),
+    EntityDescriptor(
+        name: "Pickup",
+        primitive: Some(Sphere),
+        transform: Some((translation: (2.0, 0.8, -2.0), scale: (0.4, 0.4, 0.4))),
+        color: Some((0.2, 0.6, 1.0)),
+        emissive: Some((0.2, 0.6, 1.0)),
+        script: Some("assets/scripts/pickup.js"),
+        rigidbody: Some(Static),
+        collider: Some((shape: Sphere(radius: 0.4), sensor: true)),
+    ),
+    EntityDescriptor(
+        name: "ArenaLight",
+        transform: Some((translation: (0.0, 5.0, 0.0))),
+        point_light: Some((color: (1.0, 0.9, 0.8), intensity: 15.0, range: 20.0)),
     ),
 ])

--- a/games/mini-arena/assets/scenes/main.ron
+++ b/games/mini-arena/assets/scenes/main.ron
@@ -29,6 +29,29 @@ SceneDescriptor(entities: [
         rigidbody: Some(Kinematic),
         collider: Some((shape: Capsule(half_height: 0.5, radius: 0.35), friction: 0.3)),
         script: Some("assets/scripts/player.js"),
+        components: [
+            ("bsengine_core::animation_state_machine::AnimationStateMachine", r#"(
+                states: {
+                    "idle": (clip: "Survey", looping: true, speed: 1.0, duration: 1.0),
+                    "walk": (clip: "Walk", looping: true, speed: 1.0, duration: 1.0),
+                    "run": (clip: "Run", looping: true, speed: 1.0, duration: 1.0),
+                },
+                transitions: [
+                    (from: "idle", to: "walk", condition: FloatGreater(param: "speed", threshold: 0.1), blend_duration: 0.15),
+                    (from: "walk", to: "idle", condition: FloatLess(param: "speed", threshold: 0.1), blend_duration: 0.15),
+                    (from: "walk", to: "run", condition: FloatGreater(param: "speed", threshold: 3.0), blend_duration: 0.2),
+                    (from: "run", to: "walk", condition: FloatLess(param: "speed", threshold: 3.0), blend_duration: 0.2),
+                ],
+                current_state: "idle",
+                params_float: {"speed": 0.0},
+                params_bool: {},
+                triggers: [],
+                blend_from: None,
+                blend_weight: 1.0,
+                blend_duration: 0.0,
+                blend_elapsed: 0.0,
+            )"#),
+        ],
     ),
     EntityDescriptor(
         name: "Enemy",

--- a/games/mini-arena/assets/scenes/main.ron
+++ b/games/mini-arena/assets/scenes/main.ron
@@ -2,24 +2,40 @@ SceneDescriptor(entities: [
     EntityDescriptor(
         name: "Camera",
         camera: true,
-        transform: Some((translation: (0.0, 1.5, 4.0))),
+        camera_fov: Some(60.0),
+        transform: Some((translation: (0.0, 4.0, 7.0))),
         look_at: Some((0.0, 0.5, 0.0)),
+        script: Some("assets/scripts/camera.js"),
     ),
     EntityDescriptor(
         name: "Sun",
-        directional_light: Some((direction: (-0.4, -0.8, -0.4))),
+        directional_light: Some((direction: (-0.4, -0.8, -0.4), color: (1.0, 0.95, 0.85), ambient: (0.15, 0.15, 0.18))),
     ),
     EntityDescriptor(
-        name: "TestFox",
-        // NOTE: unlike `script` paths (which ScriptingPlugin resolves relative
-        // to the project dir), `gltf` paths are NOT resolved relative to the
-        // project dir anywhere in the current loader -- they're read as-is
-        // relative to the process's current working directory. This path only
-        // works when running via `cargo run -p bsengine-runtime -- ./games/mini-arena`
-        // from the repo root. This is a known, logged gap (not fixed here --
-        // out of scope for the skinning pipeline this scene exists to verify),
-        // not a typo.
+        name: "Ground",
+        primitive: Some(Cube),
+        transform: Some((translation: (0.0, -0.5, 0.0), scale: (20.0, 1.0, 20.0))),
+        color: Some((0.25, 0.28, 0.22)),
+        rigidbody: Some(Static),
+        collider: Some((shape: Box(hx: 10.0, hy: 0.5, hz: 10.0), friction: 0.7)),
+    ),
+    EntityDescriptor(
+        name: "Player",
+        // NOTE: `gltf:` paths resolve relative to the process CWD, not the
+        // project dir (pre-existing, logged gap). Only run via
+        // `cargo run -p bsengine-runtime -- ./games/mini-arena` from the repo root.
         gltf: Some("games/mini-arena/assets/models/fox.glb"),
-        transform: Some((translation: (0.0, 0.0, 0.0), scale: (0.03, 0.03, 0.03))),
+        transform: Some((translation: (0.0, 0.0, 0.0), scale: (0.02, 0.02, 0.02))),
+        rigidbody: Some(Kinematic),
+        collider: Some((shape: Capsule(half_height: 0.5, radius: 0.35), friction: 0.3)),
+        script: Some("assets/scripts/player.js"),
+    ),
+    EntityDescriptor(
+        name: "Enemy",
+        gltf: Some("games/mini-arena/assets/models/fox.glb"),
+        transform: Some((translation: (5.0, 0.0, 5.0), scale: (0.02, 0.02, 0.02))),
+        rigidbody: Some(Kinematic),
+        collider: Some((shape: Capsule(half_height: 0.5, radius: 0.35), friction: 0.3)),
+        script: Some("assets/scripts/enemy.js"),
     ),
 ])

--- a/games/mini-arena/assets/scenes/main.ron
+++ b/games/mini-arena/assets/scenes/main.ron
@@ -66,4 +66,8 @@ SceneDescriptor(entities: [
             ("bsengine_core::shield::Shield", "(current: 30.0, max: 30.0, recharge_rate: 0.0, recharge_delay: 0.0, recharge_cooldown: 0.0)"),
         ],
     ),
+    EntityDescriptor(
+        name: "Hud",
+        script: Some("assets/scripts/hud.js"),
+    ),
 ])

--- a/games/mini-arena/assets/scenes/main.ron
+++ b/games/mini-arena/assets/scenes/main.ron
@@ -56,6 +56,7 @@ SceneDescriptor(entities: [
                 blend_elapsed: 0.0,
             )"#),
             ("bsengine_core::shield::Shield", "(current: 100.0, max: 100.0, recharge_rate: 0.0, recharge_delay: 0.0, recharge_cooldown: 0.0)"),
+            ("bsengine_core::save_data::SaveData", "(slot: 0, fields: {}, last_saved_at: 0, dirty: false, enabled: true)"),
         ],
     ),
     EntityDescriptor(
@@ -88,5 +89,9 @@ SceneDescriptor(entities: [
         name: "ArenaLight",
         transform: Some((translation: (0.0, 5.0, 0.0))),
         point_light: Some((color: (1.0, 0.9, 0.8), intensity: 15.0, range: 20.0)),
+    ),
+    EntityDescriptor(
+        name: "Pause",
+        script: Some("assets/scripts/pause.js"),
     ),
 ])

--- a/games/mini-arena/assets/scenes/main.ron
+++ b/games/mini-arena/assets/scenes/main.ron
@@ -51,6 +51,7 @@ SceneDescriptor(entities: [
                 blend_duration: 0.0,
                 blend_elapsed: 0.0,
             )"#),
+            ("bsengine_core::shield::Shield", "(current: 100.0, max: 100.0, recharge_rate: 0.0, recharge_delay: 0.0, recharge_cooldown: 0.0)"),
         ],
     ),
     EntityDescriptor(
@@ -60,5 +61,9 @@ SceneDescriptor(entities: [
         rigidbody: Some(Kinematic),
         collider: Some((shape: Capsule(half_height: 0.5, radius: 0.35), friction: 0.3)),
         script: Some("assets/scripts/enemy.js"),
+        components: [
+            ("bsengine_core::nav_mesh_agent::NavMeshAgent", "(destination: None, speed: 3.0, angular_speed: 2.0, acceleration: 8.0, stopping_distance: 1.2, radius: 0.4, height: 1.8, state: Idle, enabled: true)"),
+            ("bsengine_core::shield::Shield", "(current: 30.0, max: 30.0, recharge_rate: 0.0, recharge_delay: 0.0, recharge_cooldown: 0.0)"),
+        ],
     ),
 ])

--- a/games/mini-arena/assets/scripts/camera.js
+++ b/games/mini-arena/assets/scripts/camera.js
@@ -1,0 +1,24 @@
+const OFFSET = { x: 0.0, y: 4.0, z: 7.0 };
+const LERP_SPEED = 4.0;
+
+function onUpdate(self) {
+    const target = Bsengine.getPosition("Player");
+    if (!target) return;
+
+    const cam = Bsengine.getTransform(self);
+    if (!cam) return;
+
+    const dt = Bsengine.getDeltaTime();
+    const t = Math.min(1.0, LERP_SPEED * dt);
+
+    const desiredX = target.x + OFFSET.x;
+    const desiredY = target.y + OFFSET.y;
+    const desiredZ = target.z + OFFSET.z;
+
+    const newX = cam.x + (desiredX - cam.x) * t;
+    const newY = cam.y + (desiredY - cam.y) * t;
+    const newZ = cam.z + (desiredZ - cam.z) * t;
+
+    Bsengine.setTransform(self, newX, newY, newZ);
+    Bsengine.lookAt(self, target.x, target.y + 0.5, target.z);
+}

--- a/games/mini-arena/assets/scripts/enemy.js
+++ b/games/mini-arena/assets/scripts/enemy.js
@@ -1,0 +1,54 @@
+let navReady = false;
+const CHASE_RANGE = 12.0;
+const REPATH_INTERVAL = 0.5;
+let repathTimer = 0.0;
+
+let knockbackTimer = 0.0;
+let knockbackDir = { x: 0.0, z: 0.0 };
+const KNOCKBACK_SPEED = 8.0;
+const KNOCKBACK_DURATION = 0.25;
+
+Bsengine.onMessage("Enemy", "hit", (data) => {
+    knockbackTimer = KNOCKBACK_DURATION;
+    knockbackDir = { x: data.dirX, z: data.dirZ };
+});
+
+function onUpdate(self) {
+    if (knockbackTimer > 0.0) {
+        const dt = Bsengine.getDeltaTime();
+        const step = KNOCKBACK_SPEED * dt;
+        const pos = Bsengine.getPosition(self);
+        if (pos) {
+            Bsengine.setTransform(self, pos.x + knockbackDir.x * step, pos.y, pos.z + knockbackDir.z * step);
+        }
+        knockbackTimer -= dt;
+        return;
+    }
+
+    if (!navReady) {
+        // 40x40 grid, 1 unit cells, centered on the arena (matches Ground's
+        // 20x20 half-extent from main.ron).
+        Bsengine.navmesh.init(40, 40, 1.0, -20.0, 0.0, -20.0);
+        navReady = true;
+    }
+
+    const player = Bsengine.getPosition("Player");
+    const me = Bsengine.getPosition(self);
+    if (!player || !me) return;
+
+    const dx = player.x - me.x;
+    const dz = player.z - me.z;
+    const dist = Math.sqrt(dx * dx + dz * dz);
+
+    if (dist > CHASE_RANGE) {
+        Bsengine.navmesh.clearDestination(self);
+        return;
+    }
+
+    const dt = Bsengine.getDeltaTime();
+    repathTimer -= dt;
+    if (repathTimer <= 0.0) {
+        Bsengine.navmesh.setDestination(self, player.x, player.y, player.z);
+        repathTimer = REPATH_INTERVAL;
+    }
+}

--- a/games/mini-arena/assets/scripts/enemy.js
+++ b/games/mini-arena/assets/scripts/enemy.js
@@ -2,6 +2,10 @@ let navReady = false;
 const CHASE_RANGE = 12.0;
 const REPATH_INTERVAL = 0.5;
 let repathTimer = 0.0;
+const CONTACT_RANGE = 1.2;
+const CONTACT_DAMAGE = 5.0;
+const CONTACT_COOLDOWN = 1.0;
+let contactCooldown = 0.0;
 
 let knockbackTimer = 0.0;
 let knockbackDir = { x: 0.0, z: 0.0 };
@@ -50,5 +54,11 @@ function onUpdate(self) {
     if (repathTimer <= 0.0) {
         Bsengine.navmesh.setDestination(self, player.x, player.y, player.z);
         repathTimer = REPATH_INTERVAL;
+    }
+
+    contactCooldown = Math.max(0.0, contactCooldown - dt);
+    if (dist < CONTACT_RANGE && contactCooldown <= 0.0) {
+        Bsengine.damageShield("Player", CONTACT_DAMAGE);
+        contactCooldown = CONTACT_COOLDOWN;
     }
 }

--- a/games/mini-arena/assets/scripts/hud.js
+++ b/games/mini-arena/assets/scripts/hud.js
@@ -4,9 +4,14 @@ Bsengine.onMessage("Hud", "score", (data) => {
     score += data.amount;
 });
 
+Bsengine.onMessage("Hud", "scoreLoaded", (data) => {
+    score = data.value;
+});
+
 function onUpdate(self) {
     const hp = Math.round(Bsengine.getShield("Player"));
     const maxHp = Math.round(Bsengine.getMaxShield("Player"));
     Bsengine.setHudText("health", `HP: ${hp}/${maxHp}`);
     Bsengine.setHudText("score", `Score: ${score}`);
+    Bsengine.setSaveField("Player", "score", String(score));
 }

--- a/games/mini-arena/assets/scripts/hud.js
+++ b/games/mini-arena/assets/scripts/hud.js
@@ -1,0 +1,12 @@
+let score = 0;
+
+Bsengine.onMessage("Hud", "score", (data) => {
+    score += data.amount;
+});
+
+function onUpdate(self) {
+    const hp = Math.round(Bsengine.getShield("Player"));
+    const maxHp = Math.round(Bsengine.getMaxShield("Player"));
+    Bsengine.setHudText("health", `HP: ${hp}/${maxHp}`);
+    Bsengine.setHudText("score", `Score: ${score}`);
+}

--- a/games/mini-arena/assets/scripts/pause.js
+++ b/games/mini-arena/assets/scripts/pause.js
@@ -1,0 +1,36 @@
+let paused = false;
+let escKeyWasDown = false;
+let menuBuilt = false;
+
+function buildMenu() {
+    Bsengine.ui.setPanel("pauseBg", "Paused", 490, 260, 300, 160);
+    Bsengine.ui.setButton("resumeBtn", "Resume", 520, 320, 240, 40);
+    Bsengine.ui.setButton("quitBtn", "Quit", 520, 370, 240, 40);
+    menuBuilt = true;
+}
+
+function teardownMenu() {
+    Bsengine.ui.remove("pauseBg");
+    Bsengine.ui.remove("resumeBtn");
+    Bsengine.ui.remove("quitBtn");
+    menuBuilt = false;
+}
+
+function onUpdate(self) {
+    const escDown = Bsengine.isKeyDown("Escape");
+    if (escDown && !escKeyWasDown) {
+        paused = !paused;
+        if (paused) buildMenu(); else teardownMenu();
+    }
+    escKeyWasDown = escDown;
+
+    if (!paused) return;
+
+    if (Bsengine.ui.isClicked("resumeBtn")) {
+        paused = false;
+        teardownMenu();
+    }
+    if (Bsengine.ui.isClicked("quitBtn")) {
+        Bsengine.setHudText("status", "Quit requested — close the window to exit (no scripting exit call exists yet).");
+    }
+}

--- a/games/mini-arena/assets/scripts/pause.js
+++ b/games/mini-arena/assets/scripts/pause.js
@@ -31,6 +31,9 @@ function onUpdate(self) {
         teardownMenu();
     }
     if (Bsengine.ui.isClicked("quitBtn")) {
-        Bsengine.setHudText("status", "Quit requested — close the window to exit (no scripting exit call exists yet).");
+        // Uses its own HUD slot ("pauseStatus"), not player.js's "status" --
+        // that one shows the death/reload message, and sharing an id would
+        // let this message and the death message overwrite each other.
+        Bsengine.setHudText("pauseStatus", "Quit requested — close the window to exit (no scripting exit call exists yet).");
     }
 }

--- a/games/mini-arena/assets/scripts/pickup.js
+++ b/games/mini-arena/assets/scripts/pickup.js
@@ -1,0 +1,30 @@
+let shaderAssigned = false;
+let elapsed = 0.0;
+const PULSE_SPEED = 3.0;
+const BASE_R = 0.2, BASE_G = 0.6, BASE_B = 1.0;
+
+function onUpdate(self) {
+    if (!shaderAssigned) {
+        // CWD-relative, same as `gltf:` scene paths -- NOT project-dir-relative
+        // like `script:` paths. Confirmed against ScriptCommand::SetCustomShader
+        // in bsengine-scripting/src/plugin.rs (no ProjectDir join) and the
+        // std::fs::read_to_string call in bsengine-render/src/plugin.rs.
+        Bsengine.setShader(self, "games/mini-arena/assets/shaders/glow.wgsl");
+        shaderAssigned = true;
+    }
+
+    const dt = Bsengine.getDeltaTime();
+    elapsed += dt;
+    const pulse = 0.6 + 0.4 * Math.sin(elapsed * PULSE_SPEED);
+    Bsengine.setEmissive(self, BASE_R * pulse, BASE_G * pulse, BASE_B * pulse);
+
+    const pos = Bsengine.getPosition(self);
+    const player = Bsengine.getPosition("Player");
+    if (!pos || !player) return;
+    const dx = player.x - pos.x;
+    const dz = player.z - pos.z;
+    if (Math.sqrt(dx * dx + dz * dz) < 0.6) {
+        Bsengine.sendMessage("Hud", "score", { amount: 50 });
+        Bsengine.destroy(self);
+    }
+}

--- a/games/mini-arena/assets/scripts/player.js
+++ b/games/mini-arena/assets/scripts/player.js
@@ -1,0 +1,32 @@
+const MOVE_SPEED = 4.5;
+const RUN_MULTIPLIER = 1.8;
+
+function onUpdate(self) {
+    let dx = 0.0;
+    let dz = 0.0;
+    if (Bsengine.isKeyDown("W")) dz -= 1.0;
+    if (Bsengine.isKeyDown("S")) dz += 1.0;
+    if (Bsengine.isKeyDown("A")) dx -= 1.0;
+    if (Bsengine.isKeyDown("D")) dx += 1.0;
+
+    const running = Bsengine.isKeyDown("Left") || Bsengine.isKeyDown("Right");
+    const len = Math.sqrt(dx * dx + dz * dz);
+    let speed = 0.0;
+
+    if (len > 0.0001) {
+        dx /= len;
+        dz /= len;
+        speed = running ? MOVE_SPEED * RUN_MULTIPLIER : MOVE_SPEED;
+
+        const dt = Bsengine.getDeltaTime();
+        const pos = Bsengine.getPosition(self);
+        if (pos) {
+            Bsengine.setTransform(self, pos.x + dx * speed * dt, pos.y, pos.z + dz * speed * dt);
+        }
+
+        const yaw = Math.atan2(dx, dz);
+        Bsengine.setRotationEuler(self, 0.0, yaw * 180.0 / Math.PI, 0.0);
+    }
+
+    Bsengine.asmSetFloat(self, "speed", speed);
+}

--- a/games/mini-arena/assets/scripts/player.js
+++ b/games/mini-arena/assets/scripts/player.js
@@ -2,13 +2,26 @@ const MOVE_SPEED = 4.5;
 const RUN_MULTIPLIER = 1.8;
 const ATTACK_RANGE = 2.0;
 const ATTACK_DAMAGE = 15.0;
+const CHECKPOINT_PATH = "games/mini-arena/checkpoint.json";
 let attackKeyWasDown = false;
+let enterKeyWasDown = false;
 
 function onUpdate(self) {
-    if (Bsengine.getShield(self) <= 0.0) {
+    const enterDown = Bsengine.isKeyDown("Enter");
+    const dead = Bsengine.getShield(self) <= 0.0;
+    if (dead) {
         Bsengine.setHudText("status", "You died. Press Enter to reload checkpoint.");
+        if (enterDown && !enterKeyWasDown) {
+            Bsengine.load(CHECKPOINT_PATH);
+            const restoredScore = Bsengine.getSaveField(self, "score");
+            Bsengine.sendMessage("Hud", "scoreLoaded", { value: parseInt(restoredScore || "0", 10) });
+            const restoredHealth = parseFloat(Bsengine.getSaveField(self, "health") || "100");
+            Bsengine.restoreShield(self, restoredHealth - Bsengine.getShield(self));
+        }
+        enterKeyWasDown = enterDown;
         return;
     }
+    enterKeyWasDown = enterDown;
 
     let dx = 0.0;
     let dz = 0.0;
@@ -59,4 +72,7 @@ function onUpdate(self) {
         }
     }
     attackKeyWasDown = attackDown;
+
+    Bsengine.setSaveField(self, "health", String(Bsengine.getShield(self)));
+    Bsengine.save(CHECKPOINT_PATH);
 }

--- a/games/mini-arena/assets/scripts/player.js
+++ b/games/mini-arena/assets/scripts/player.js
@@ -1,7 +1,15 @@
 const MOVE_SPEED = 4.5;
 const RUN_MULTIPLIER = 1.8;
+const ATTACK_RANGE = 2.0;
+const ATTACK_DAMAGE = 15.0;
+let attackKeyWasDown = false;
 
 function onUpdate(self) {
+    if (Bsengine.getShield(self) <= 0.0) {
+        Bsengine.setHudText("status", "You died. Press Enter to reload checkpoint.");
+        return;
+    }
+
     let dx = 0.0;
     let dz = 0.0;
     if (Bsengine.isKeyDown("W")) dz -= 1.0;
@@ -29,4 +37,26 @@ function onUpdate(self) {
     }
 
     Bsengine.asmSetFloat(self, "speed", speed);
+
+    const attackDown = Bsengine.isKeyDown("Space");
+    if (attackDown && !attackKeyWasDown) {
+        const pos = Bsengine.getPosition(self);
+        const fwd = Bsengine.getForwardVector(self);
+        if (pos && fwd) {
+            const hit = Bsengine.raycast(
+                { x: pos.x, y: pos.y + 0.9, z: pos.z },
+                { x: fwd[0], y: fwd[1], z: fwd[2] },
+                ATTACK_RANGE
+            );
+            if (hit && hit.entityName === "Enemy") {
+                Bsengine.damageShield("Enemy", ATTACK_DAMAGE);
+                Bsengine.sendMessage("Enemy", "hit", { dirX: fwd[0], dirZ: fwd[2] });
+                if (Bsengine.getShield("Enemy") <= 0.0) {
+                    Bsengine.destroy("Enemy");
+                    Bsengine.sendMessage("Hud", "score", { amount: 100 });
+                }
+            }
+        }
+    }
+    attackKeyWasDown = attackDown;
 }

--- a/games/mini-arena/assets/scripts/player.js
+++ b/games/mini-arena/assets/scripts/player.js
@@ -31,6 +31,10 @@ function onUpdate(self) {
             Bsengine.sendMessage("Hud", "scoreLoaded", { value: parseInt(restoredScore || "0", 10) });
             const restoredHealth = parseFloat(Bsengine.getSaveField(self, "health") || "100");
             Bsengine.restoreShield(self, restoredHealth - Bsengine.getShield(self));
+            // Without this, "You died..." stays on screen indefinitely after
+            // a successful reload -- nothing else ever clears the "status"
+            // HUD slot once the death branch stops running each frame.
+            Bsengine.clearHudText("status");
         }
         enterKeyWasDown = enterDown;
         return;

--- a/games/mini-arena/assets/scripts/player.js
+++ b/games/mini-arena/assets/scripts/player.js
@@ -2,6 +2,20 @@ const MOVE_SPEED = 4.5;
 const RUN_MULTIPLIER = 1.8;
 const ATTACK_RANGE = 2.0;
 const ATTACK_DAMAGE = 15.0;
+// Player/Enemy collider radius (Capsule radius: 0.35 in main.ron). The attack
+// raycast origin must start outside the caster's own collider by more than
+// this, or Bsengine.raycast's underlying Rapier query (solid ray casting)
+// reports an immediate self-hit at distance 0 against the caster's own body
+// -- which is exactly what happened before this offset was added: `hit`
+// always resolved to `{entityName: "Player", distance: 0}` and the
+// `hit.entityName === "Enemy"` check could never pass, no matter the aim,
+// range, or approach. Confirmed via a throwaway HUD-text probe of the raw
+// hit result during this plan's E2E test authoring. (A second, independent
+// bug compounded this: Bsengine.raycast()'s hit object used to serialize as
+// `{ entity_name: ... }`, not `{ entityName: ... }`, so `hit.entityName`
+// below was always undefined regardless of what was actually hit -- fixed
+// engine-side in bsengine-scripting's RaycastHitJson.)
+const SELF_RADIUS_CLEARANCE = 0.5;
 const CHECKPOINT_PATH = "games/mini-arena/checkpoint.json";
 let attackKeyWasDown = false;
 let enterKeyWasDown = false;
@@ -25,12 +39,12 @@ function onUpdate(self) {
 
     let dx = 0.0;
     let dz = 0.0;
-    if (Bsengine.isKeyDown("W")) dz -= 1.0;
-    if (Bsengine.isKeyDown("S")) dz += 1.0;
-    if (Bsengine.isKeyDown("A")) dx -= 1.0;
-    if (Bsengine.isKeyDown("D")) dx += 1.0;
+    if (Bsengine.isKeyPressed("W")) dz -= 1.0;
+    if (Bsengine.isKeyPressed("S")) dz += 1.0;
+    if (Bsengine.isKeyPressed("A")) dx -= 1.0;
+    if (Bsengine.isKeyPressed("D")) dx += 1.0;
 
-    const running = Bsengine.isKeyDown("Left") || Bsengine.isKeyDown("Right");
+    const running = Bsengine.isKeyPressed("Left") || Bsengine.isKeyPressed("Right");
     const len = Math.sqrt(dx * dx + dz * dz);
     let speed = 0.0;
 
@@ -45,7 +59,17 @@ function onUpdate(self) {
             Bsengine.setTransform(self, pos.x + dx * speed * dt, pos.y, pos.z + dz * speed * dt);
         }
 
-        const yaw = Math.atan2(dx, dz);
+        // Bsengine.getForwardVector() returns rotation * (0,0,-1). Setting
+        // yaw from atan2(dx, dz) directly (this component's original code)
+        // makes that forward vector come out as (-dx, 0, -dz) -- exactly
+        // backwards from the direction just moved in, confirmed with a
+        // throwaway HUD-text probe (pressing S+D, i.e. dx=dz=+0.71, reported
+        // fwd=[-0.71,0,-0.71]) during this plan's E2E test authoring. Every
+        // consumer of "forward" (this attack raycast, and the knockback
+        // direction sent to Enemy below) was therefore aiming/pushing the
+        // opposite way the player was actually walking. atan2(-dx, -dz)
+        // yields the yaw whose forward vector equals (dx, 0, dz).
+        const yaw = Math.atan2(-dx, -dz);
         Bsengine.setRotationEuler(self, 0.0, yaw * 180.0 / Math.PI, 0.0);
     }
 
@@ -56,15 +80,41 @@ function onUpdate(self) {
         const pos = Bsengine.getPosition(self);
         const fwd = Bsengine.getForwardVector(self);
         if (pos && fwd) {
+            // Attack/enemy collider is Capsule(half_height: 0.5, radius: 0.35)
+            // -- a total vertical half-extent of 0.85 centered on the entity's
+            // Transform.y (0.0 for both Player and Enemy). +0.9 sat just above
+            // that (0.85), so this horizontal-only ray (yaw-only rotation,
+            // fwd.y is always ~0) skimmed over the top of the collider and
+            // could never register a hit at any range or angle. +0.5 keeps
+            // the ray inside the capsule's cylindrical midsection.
             const hit = Bsengine.raycast(
-                { x: pos.x, y: pos.y + 0.9, z: pos.z },
+                {
+                    x: pos.x + fwd[0] * SELF_RADIUS_CLEARANCE,
+                    y: pos.y + 0.5,
+                    z: pos.z + fwd[2] * SELF_RADIUS_CLEARANCE,
+                },
                 { x: fwd[0], y: fwd[1], z: fwd[2] },
                 ATTACK_RANGE
             );
             if (hit && hit.entityName === "Enemy") {
+                // Bsengine.damageShield() only queues a ScriptCommand,
+                // applied to the world after every script finishes this
+                // frame; Bsengine.getShield() reads a snapshot captured at
+                // the *start* of the frame. Checking getShield("Enemy")
+                // right after damageShield() therefore always sees the
+                // pre-this-hit value -- it takes one extra hit past the
+                // "should be lethal" point before a stale re-check finally
+                // reflects the damage (30-max/15-per-hit Enemy took 3 hits
+                // to die instead of the intended 2), confirmed by
+                // instrumenting the raw hit/shield values during this plan's
+                // E2E test authoring. Computing the post-hit value locally
+                // from the pre-hit snapshot (already correct, since any
+                // *earlier* hit's damage was flushed by a prior frame) side
+                // steps the staleness entirely.
+                const preHitShield = Bsengine.getShield("Enemy");
                 Bsengine.damageShield("Enemy", ATTACK_DAMAGE);
                 Bsengine.sendMessage("Enemy", "hit", { dirX: fwd[0], dirZ: fwd[2] });
-                if (Bsengine.getShield("Enemy") <= 0.0) {
+                if (preHitShield - ATTACK_DAMAGE <= 0.0) {
                     Bsengine.destroy("Enemy");
                     Bsengine.sendMessage("Hud", "score", { amount: 100 });
                 }

--- a/games/mini-arena/assets/shaders/glow.wgsl
+++ b/games/mini-arena/assets/shaders/glow.wgsl
@@ -1,0 +1,73 @@
+// Custom shader for the Pickup entity: a Fresnel-style rim glow.
+//
+// Bind group layout below mirrors the standard mesh shader's CameraUniform
+// (@group(0)) and ModelUniform (@group(1)) structs exactly -- both are
+// verified against MESH_WGSL in crates/bsengine-rhi-wgpu/src/surface.rs.
+// Custom shaders are compiled against the same `pipeline_layout` as the
+// standard mesh pipeline (see `compile_and_store_shader`), so field name,
+// order, and padding here must match precisely or pipeline creation panics
+// with a wgpu validation error. Groups 2 (light) and 3 (texture) are part
+// of that same pipeline layout but are left undeclared here since this
+// shader doesn't sample them -- wgpu only validates bind groups the shader
+// actually references.
+struct CameraUniform {
+    view_proj: mat4x4<f32>,
+    light_view_proj: mat4x4<f32>,
+    cam_pos: vec3<f32>,
+    _pad: f32,
+};
+struct ModelUniform {
+    model: mat4x4<f32>,
+    metallic: f32,
+    roughness: f32,
+    _pad0: f32,
+    _pad1: f32,
+    emissive: vec3<f32>,
+    _pad2: f32,
+    base_color: vec3<f32>,
+    _pad3: f32,
+};
+@group(0) @binding(0) var<uniform> camera: CameraUniform;
+@group(1) @binding(0) var<uniform> model_data: ModelUniform;
+
+struct VertIn {
+    @location(0) pos: vec3<f32>,
+    @location(1) col: vec3<f32>,
+    @location(2) normal: vec3<f32>,
+    @location(3) uv: vec2<f32>,
+}
+struct VertOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) world_normal: vec3<f32>,
+    @location(1) world_pos: vec3<f32>,
+}
+
+@vertex
+fn vs_main(in: VertIn) -> VertOut {
+    var out: VertOut;
+    let world_pos4 = model_data.model * vec4<f32>(in.pos, 1.0);
+    out.clip_pos = camera.view_proj * world_pos4;
+    out.world_pos = world_pos4.xyz;
+    let normal_matrix = mat3x3<f32>(
+        model_data.model[0].xyz,
+        model_data.model[1].xyz,
+        model_data.model[2].xyz,
+    );
+    out.world_normal = normalize(normal_matrix * in.normal);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
+    // Fresnel-style rim glow: brightest at grazing angles relative to the
+    // camera. A time-based pulse isn't possible here -- no time/clock
+    // uniform is exposed to custom shaders in this bind group layout.
+    // The "alive-looking pulse" comes from pickup.js driving
+    // model_data.emissive via Bsengine.setEmissive() every frame instead.
+    let n = normalize(in.world_normal);
+    let v = normalize(camera.cam_pos - in.world_pos);
+    let rim = pow(1.0 - clamp(dot(n, v), 0.0, 1.0), 2.5);
+    let base = model_data.base_color * 0.3;
+    let glow = model_data.emissive * (0.5 + rim);
+    return vec4<f32>(base + glow, 1.0);
+}

--- a/games/mini-arena/assets/tests/basic-playthrough.testlog.json
+++ b/games/mini-arena/assets/tests/basic-playthrough.testlog.json
@@ -1,0 +1,48 @@
+{
+  "game": "mini-arena",
+  "scene": "assets/scenes/main.ron",
+  "actions": [
+    { "cmd": "step", "frames": 5 },
+    { "cmd": "press_key", "key": "S" },
+    { "cmd": "press_key", "key": "D" },
+    { "cmd": "step", "frames": 900 },
+    { "cmd": "release_key", "key": "S" },
+    { "cmd": "release_key", "key": "D" },
+    { "cmd": "step", "frames": 2 },
+    { "cmd": "press_key", "key": "Space" },
+    { "cmd": "release_key", "key": "Space" },
+    { "cmd": "step", "frames": 5 },
+    { "cmd": "press_key", "key": "Space" },
+    { "cmd": "release_key", "key": "Space" },
+    { "cmd": "step", "frames": 5 },
+    {
+      "cmd": "assert",
+      "query": { "tool": "get_transform", "args": { "name": "Enemy" } },
+      "path": "x",
+      "op": "==",
+      "value": null,
+      "label": "Enemy destroyed after two raycast melee hits (30 max shield, 15 dmg each)"
+    },
+    { "cmd": "press_key", "key": "W" },
+    { "cmd": "step", "frames": 1400 },
+    { "cmd": "release_key", "key": "W" },
+    { "cmd": "step", "frames": 2 },
+    {
+      "cmd": "assert",
+      "query": { "tool": "get_transform", "args": { "name": "Pickup" } },
+      "path": "x",
+      "op": "==",
+      "value": null,
+      "label": "Pickup collected (proximity trigger fired while walking toward and past it)"
+    },
+    {
+      "cmd": "assert",
+      "query": { "tool": "get_transform", "args": { "name": "Player" } },
+      "path": "z",
+      "op": "<",
+      "value": -1.0,
+      "label": "Player walked from the origin, through the Enemy engagement at (~2.4, ~2.4), to past the Pickup's z=-2.0"
+    },
+    { "cmd": "shutdown" }
+  ]
+}

--- a/games/mini-arena/project.toml
+++ b/games/mini-arena/project.toml
@@ -1,8 +1,8 @@
 [project]
-name = "Mini Arena (verification)"
+name = "Mini Action Arena"
 entry_scene = "assets/scenes/main.ron"
 
 [window]
-title = "Mini Arena — skinning verification"
+title = "Mini Action Arena"
 width = 1280
 height = 720


### PR DESCRIPTION
## Summary

Implements `games/mini-arena/` — a small playable arena game exercising skinned-character animation, NavMesh enemy AI, physics-ish combat, a custom WGSL shader, post-processing, UI, and checkpoint save/load, built primarily through scene RON + JS scripting. This is `ENGINE_ROADMAP.md` item 14, grounding the BSEngine-vs-Unity/Unreal comparison in real, lived experience rather than a docs review.

**Prerequisite (Task 0):** `SaveData` was not a reflected component and had no scripting get/set ops — needed for checkpoint save/load (position, health, score) to work at all. Fixed, with tests.

**The demo (Tasks 1-6):** arena scaffold, `AnimationStateMachine`-driven idle/walk/run, `NavMeshAgent`-driven enemy pursuit with a scripted knockback reaction, a raycast combat loop (attack/damage/death), a HUD (health/score), a glowing pickup with a custom WGSL shader, bloom/tonemap post-processing, a pause menu, and checkpoint save/load. Components with no scene-RON field (`AnimationStateMachine`, `NavMeshAgent`, `Shield`, `Bloom`, `ToneMap`, `SaveData`) are hand-authored via `EntityDescriptor.components` and applied through the generic reflected-component scene serialization (PR #1733).

**E2E testing + bug hunt (Task 7):** authoring a real headless playthrough recording (`assets/tests/basic-playthrough.testlog.json`, replays clean, exit 0) surfaced **10 real bugs** that made the demo non-functional, all found via reproduction and fixed:

- Reflect type registration for gameplay components lived only inline in `EditorPlugin`, unreachable by headless test mode — every `components:` entry was silently dropped. Extracted `bsengine_scene::register_gameplay_reflect_types`, shared by both.
- `test_mode.rs`'s `PressKey`/`ReleaseKey`/`PressMouse`/`ReleaseMouse` mutated `Input<T>` directly outside any schedule, so edge-triggered checks (`isKeyDown`/`isKeyUp`) could never be observed through the protocol. Routed through `Events<KeyInput>`/`Events<MouseInput>` instead, matching real input flow.
- `NavMeshPlugin` was never added to `bsengine-runtime` at all — enemy pursuit AI has never functioned in any real build. Wired into both the windowed and headless entry points.
- `Bsengine.raycast()`'s hit result serialized as `entity_name`, not `entityName`, unlike every other camelCase `Bsengine.*` API.
- Five `player.js` content bugs: `isKeyDown` (edge) used for held-movement instead of `isKeyPressed`; yaw computed 180° backwards from the actual movement direction; attack raycast self-hit + wrong height; stale `getShield()` read after `damageShield()` in the same frame.

Full detail in `games/mini-arena/GAP_LOG.md`. A final holistic review pass (fresh-eyes, whole-branch) additionally found and fixed: a HUD text id collision + missing clear (death message never cleared after checkpoint reload, shared an id with the pause menu's quit message), and added a direct regression test for the input-event-routing change (the riskiest change in the branch, previously untested).

## Test plan

- [x] `cargo test -p bsengine-core save_data`, `cargo test -p bsengine-scripting`, `cargo build -p bsengine-editor` (Task 0)
- [x] `RUST_MIN_STACK=33554432 cargo test --workspace` — all green throughout, including after the final review fixes
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean (2 pre-existing, unrelated warnings only)
- [x] `cargo run -p bsengine-runtime -- --test ./games/mini-arena --replay ./games/mini-arena/assets/tests/basic-playthrough.testlog.json` — exit 0, independently re-verified after every content change
- [x] New `press_key_is_observable_as_pressed_and_just_pressed_after_one_step` regression test for the input-routing fix
- [x] Manual windowed smoke tests after every task (no crashes, no reflection/parse errors)
- [x] `ENGINE_ROADMAP.md` item 14 added, all checkboxes verified true