### PR TITLE
feat: Bsengine.moveEntity relative-move scripting op

### DIFF
--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -235,6 +235,20 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 
 ---
 
+### 15. `Bsengine.moveEntity` 상대 이동 스크립팅 op ✅
+
+**목표:** 스크립트에서 엔티티를 상대적으로 이동시킬 때마다 위치를 읽고 델타를 더해
+다시 쓰는 반복 패턴을 없애기 (Mini Action Arena 갭 로그에서 발견)
+
+**완료 조건:**
+- [x] `Bsengine.moveEntity(name, dx, dy, dz)` op 추가 — 월드 스페이스 델타를
+  `Transform.translation`에 직접 적용, 대상 없으면 조용히 no-op
+- [x] `games/mini-arena`의 `player.js`/`enemy.js`를 새 op로 교체
+- [x] E2E replay(`basic-playthrough.testlog.json`) 통과 확인
+- [x] CI 통과
+
+---
+
 ## 완료 이력
 
 | 항목 | 완료일 | PR |
@@ -283,6 +297,7 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 | 12. Fix: wire GltfPlugin/TimePlugin/AnimationPlugin/AnimationStateMachinePlugin into bsengine-runtime (none were ever registered before this — glTF loading and any time-driven component were silently inert in the real runtime binary), handle non-indexed glTF primitives, seed AnimationPlayer.duration from its clip | 2026-07-29 | [#1731](https://github.com/blas1n/BSEngine/pull/1731) |
 | 13. Scene serialization saves/loads arbitrary reflected components (bsengine-scene load-side apply_or_insert + bsengine-editor extra_components capture/EditorCommand::LoadScene apply) | 2026-07-29 | [#1733](https://github.com/blas1n/BSEngine/pull/1733) |
 | 13. Fix: HashSet\<String\> missing ReflectSerialize (only ReflectDeserialize was registered), which silently dropped AnimationStateMachine from every saved scene | 2026-07-29 | [#1733](https://github.com/blas1n/BSEngine/pull/1733) |
-| 14. Mini Action Arena demo (`games/mini-arena/`) — arena/player/enemy, AnimationStateMachine idle/walk/run, NavMeshAgent pursuit, Rapier combat/knockback, custom WGSL glow shader, bloom/tone-map, HUD + pause menu, checkpoint save/load | 2026-07-29 | branch `feat/mini-arena` (PR #TBD) |
-| 14. Fix: 5 engine bugs found authoring the headless E2E test — reflect-type registration reachable only from EditorPlugin (not headless test mode), test_mode.rs PressKey/ReleaseKey bypassing the input event queue (broke all edge-triggered isKeyDown/isKeyUp), NavMeshPlugin never wired into bsengine-runtime at all (enemy pursuit never worked in any real build), Bsengine.raycast() returning entity_name instead of entityName | 2026-07-29 | branch `feat/mini-arena` (PR #TBD) |
-| 14. Fix: 5 content bugs in player.js found the same way — isKeyDown instead of isKeyPressed for held movement, 180°-backwards yaw/forward vector, attack raycast self-hit + wrong height, stale getShield() read after damageShield() (Enemy took 3 hits instead of the documented 2); see `games/mini-arena/GAP_LOG.md` for full detail | 2026-07-29 | branch `feat/mini-arena` (PR #TBD) |
+| 14. Mini Action Arena demo (`games/mini-arena/`) — arena/player/enemy, AnimationStateMachine idle/walk/run, NavMeshAgent pursuit, Rapier combat/knockback, custom WGSL glow shader, bloom/tone-map, HUD + pause menu, checkpoint save/load | 2026-07-29 | [#1735](https://github.com/blas1n/BSEngine/pull/1735) |
+| 14. Fix: 5 engine bugs found authoring the headless E2E test — reflect-type registration reachable only from EditorPlugin (not headless test mode), test_mode.rs PressKey/ReleaseKey bypassing the input event queue (broke all edge-triggered isKeyDown/isKeyUp), NavMeshPlugin never wired into bsengine-runtime at all (enemy pursuit never worked in any real build), Bsengine.raycast() returning entity_name instead of entityName | 2026-07-29 | [#1735](https://github.com/blas1n/BSEngine/pull/1735) |
+| 14. Fix: 5 content bugs in player.js found the same way — isKeyDown instead of isKeyPressed for held movement, 180°-backwards yaw/forward vector, attack raycast self-hit + wrong height, stale getShield() read after damageShield() (Enemy took 3 hits instead of the documented 2); see `games/mini-arena/GAP_LOG.md` for full detail | 2026-07-29 | [#1735](https://github.com/blas1n/BSEngine/pull/1735) |
+| 15. `Bsengine.moveEntity` relative-move scripting op; mini-arena's player.js/enemy.js migrated to it from manual get-add-set position math | 2026-07-30 | branch `feat/move-entity-op` (PR #TBD) |

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -317,6 +317,17 @@ pub enum ScriptCommand {
         /// New maximum shield capacity.
         value: f32,
     },
+    /// Move a named entity by a world-space delta.
+    MoveEntity {
+        /// Entity to move.
+        name: String,
+        /// Delta along X.
+        dx: f32,
+        /// Delta along Y.
+        dy: f32,
+        /// Delta along Z.
+        dz: f32,
+    },
     /// Write a UTF-8 key/value field into an entity's `SaveData`.
     SetSaveField {
         /// Entity to target.
@@ -3177,6 +3188,15 @@ pub fn bsengine_damage_shield(#[string] name: String, amount: f32) {
     });
 }
 
+/// Queue moving a named entity by a world-space delta.
+#[op2(fast)]
+pub fn bsengine_move_entity(#[string] name: String, dx: f32, dy: f32, dz: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::MoveEntity { name, dx, dy, dz })
+    });
+}
+
 /// Queue restoring some of an entity's shield value.
 #[op2(fast)]
 pub fn bsengine_restore_shield(#[string] name: String, amount: f32) {
@@ -5751,6 +5771,7 @@ deno_core::extension!(
         bsengine_set_lifetime,
         bsengine_get_lifetime,
         bsengine_damage_shield,
+        bsengine_move_entity,
         bsengine_restore_shield,
         bsengine_set_max_shield,
         bsengine_get_shield,
@@ -6060,6 +6081,7 @@ var Bsengine = {
     setLifetime:            (name, seconds) => Deno.core.ops.bsengine_set_lifetime(name, seconds),
     getLifetime:            (name)          => Deno.core.ops.bsengine_get_lifetime(name),
     damageShield:           (name, amount)  => Deno.core.ops.bsengine_damage_shield(name, amount),
+    moveEntity:             (name, dx, dy, dz) => Deno.core.ops.bsengine_move_entity(name, dx, dy, dz),
     restoreShield:          (name, amount)  => Deno.core.ops.bsengine_restore_shield(name, amount),
     setMaxShield:           (name, value)   => Deno.core.ops.bsengine_set_max_shield(name, value),
     getShield:              (name)          => Deno.core.ops.bsengine_get_shield(name),
@@ -9782,6 +9804,22 @@ JSON.stringify(received)
                     if name == "Bullet" && (*seconds - 3.0).abs() < 1e-5)
             });
             assert!(found, "SetLifetime not in buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn move_entity_enqueues_command() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.moveEntity("Hero", 1.0, 2.0, 3.0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let found = c.borrow().iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::MoveEntity { name, dx, dy, dz }
+                    if name == "Hero" && (*dx - 1.0).abs() < 1e-6 && (*dy - 2.0).abs() < 1e-6 && (*dz - 3.0).abs() < 1e-6)
+            });
+            assert!(found, "MoveEntity not in buffer");
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -773,6 +773,19 @@ fn run_scripts(world: &mut World) {
                     }
                 }
             }
+            ScriptCommand::MoveEntity { name, dx, dy, dz } => {
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut t) = world.get_mut::<Transform>(e) {
+                        t.translation.x += dx;
+                        t.translation.y += dy;
+                        t.translation.z += dz;
+                    }
+                }
+            }
             ScriptCommand::SetSaveField { name, key, value } => {
                 use bsengine_core::SaveData;
                 let entity = {
@@ -2759,7 +2772,7 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
 
 #[cfg(test)]
 mod tests {
-    use super::{Name, ScriptPath, ScriptRuntimeResource, ScriptingPlugin};
+    use super::{Name, ScriptPath, ScriptRuntimeResource, ScriptingPlugin, Transform, Vec3};
     use bsengine_app::new_app;
 
     #[test]
@@ -2821,6 +2834,56 @@ mod tests {
             .find(|(n, _)| n.0 == "Hero")
             .expect("Hero entity with SaveData not found");
         assert_eq!(save.get("score"), Some(b"99".as_slice()));
+
+        let _ = std::fs::remove_file(&script_path);
+    }
+
+    #[test]
+    fn move_entity_moves_transform_by_delta() {
+        let script_path = std::env::temp_dir().join(format!(
+            "bsengine_test_move_entity_{}.js",
+            std::process::id()
+        ));
+        std::fs::write(
+            &script_path,
+            "function onUpdate(name) { Bsengine.moveEntity(name, 1.0, 0.0, 2.0); }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(ScriptingPlugin {
+            project_dir: String::new(),
+        });
+        app.world_mut().spawn((
+            Name("Hero".to_string()),
+            Transform::from_translation(Vec3::new(5.0, 0.0, 5.0)),
+            ScriptPath(script_path.to_string_lossy().to_string()),
+        ));
+
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let mut q = world.query::<(&Name, &Transform)>();
+        let (_, t) = q
+            .iter(world)
+            .find(|(n, _)| n.0 == "Hero")
+            .expect("Hero entity with Transform not found");
+        // `load_scripts` runs at `PostStartup`, which executes during the *first*
+        // `app.update()` call, immediately before that same call's `Update` schedule
+        // (which runs `run_scripts`/`onUpdate`). So two `app.update()` calls invoke
+        // `onUpdate` twice total (once during update #1, once during update #2), and
+        // the (1.0, 0.0, 2.0) delta from `moveEntity` is applied twice: (2.0, 0.0, 4.0).
+        assert!(
+            (t.translation.x - 7.0).abs() < 1e-4,
+            "x: {}",
+            t.translation.x
+        );
+        assert!(
+            (t.translation.z - 9.0).abs() < 1e-4,
+            "z: {}",
+            t.translation.z
+        );
 
         let _ = std::fs::remove_file(&script_path);
     }

--- a/games/mini-arena/assets/scripts/enemy.js
+++ b/games/mini-arena/assets/scripts/enemy.js
@@ -21,10 +21,7 @@ function onUpdate(self) {
     if (knockbackTimer > 0.0) {
         const dt = Bsengine.getDeltaTime();
         const step = KNOCKBACK_SPEED * dt;
-        const pos = Bsengine.getPosition(self);
-        if (pos) {
-            Bsengine.setTransform(self, pos.x + knockbackDir.x * step, pos.y, pos.z + knockbackDir.z * step);
-        }
+        Bsengine.moveEntity(self, knockbackDir.x * step, 0.0, knockbackDir.z * step);
         knockbackTimer -= dt;
         return;
     }

--- a/games/mini-arena/assets/scripts/player.js
+++ b/games/mini-arena/assets/scripts/player.js
@@ -58,10 +58,7 @@ function onUpdate(self) {
         speed = running ? MOVE_SPEED * RUN_MULTIPLIER : MOVE_SPEED;
 
         const dt = Bsengine.getDeltaTime();
-        const pos = Bsengine.getPosition(self);
-        if (pos) {
-            Bsengine.setTransform(self, pos.x + dx * speed * dt, pos.y, pos.z + dz * speed * dt);
-        }
+        Bsengine.moveEntity(self, dx * speed * dt, 0.0, dz * speed * dt);
 
         // Bsengine.getForwardVector() returns rotation * (0,0,-1). Setting
         // yaw from atan2(dx, dz) directly (this component's original code)


### PR DESCRIPTION
## Summary

Adds `Bsengine.moveEntity(name, dx, dy, dz)` — a relative-move scripting op that adds a world-space delta directly to `Transform.translation`. Closes `ENGINE_ROADMAP.md` item 15, from `games/mini-arena/GAP_LOG.md`'s "No relative-move scripting op" entry: every script needing relative movement previously had to `getPosition` + add delta + `setTransform` manually.

Mirrors the existing `ScriptCommand`/`#[op2]`/`BOOTSTRAP_JS` pattern used by every other named-entity mutation op (`ScriptCommand::MoveEntity`, `bsengine_move_entity`, JS binding, application arm in `run_scripts`). `games/mini-arena`'s `player.js` (movement) and `enemy.js` (knockback) are migrated to use it.

## Test plan

- [x] New unit test (`move_entity_enqueues_command`) and integration test (`move_entity_moves_transform_by_delta`) in `bsengine-scripting`
- [x] `cargo test -p bsengine-scripting` — 281 passed
- [x] `RUST_MIN_STACK=33554432 cargo test --workspace` — all green
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean (2 pre-existing, unrelated warnings only)
- [x] `cargo run -p bsengine-runtime -- --test ./games/mini-arena --replay ./games/mini-arena/assets/tests/basic-playthrough.testlog.json` — exit 0, confirms the migrated player.js/enemy.js are behaviorally identical to the manual math they replaced