### PR TITLE
feat: attach_physics_body/detach_physics_body MCP tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ dependencies = [
  "bsengine-gltf",
  "bsengine-input",
  "bsengine-mcp",
+ "bsengine-physics",
  "bsengine-render",
  "bsengine-scene",
  "glam 0.29.3",

--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -269,6 +269,28 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 
 ---
 
+### 17. 물리 바디(rigidbody/collider) 부착 MCP 툴 ✅
+
+**목표:** 살아있는 엔티티에 물리 바디를 AI/MCP가 직접 부착할 수 있게 (지금까지는
+수동 작성 씬 RON에서만 가능했음). 설계 중 발견한 관련 갭도 함께 수정: 에디터의
+`save_scene`이 로드된 씬의 rigidbody/collider도 항상 조용히 버리고 있었음
+(Mini Action Arena 갭 로그에서 발견)
+
+**완료 조건:**
+- [x] `attach_physics_body`/`detach_physics_body` MCP 툴 추가 — 기존
+  `resolve_physics_bodies` 시스템이 `PhysicsBodyDesc` 삽입을 감지해 실제 Rapier
+  컴포넌트로 변환하므로 물리 로직 중복 없음
+- [x] `EntityInfo`/`update_editor_snapshot`/`build_entity_descriptors` 확장 —
+  물리 바디가 `save_scene` 이후에도 살아남도록 (부착 경로 무관하게)
+- [x] 구현 중 발견한 관련 로드측 버그 수정: `EditorCommand::LoadScene`(
+  `bsengine_scene::spawn_scene_entities`와 별개인, 에디터 자체의 두 번째 씬
+  로딩 경로)가 로드된 rigidbody/collider로부터 `PhysicsBodyDesc`를 스폰한 적이
+  없어서, 저장은 되어도 다시 로드하면 사라졌음
+- [x] 부착/해제/저장-재로드 왕복 테스트 추가
+- [x] CI 통과
+
+---
+
 ## 완료 이력
 
 | 항목 | 완료일 | PR |
@@ -321,4 +343,5 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 | 14. Fix: 5 engine bugs found authoring the headless E2E test — reflect-type registration reachable only from EditorPlugin (not headless test mode), test_mode.rs PressKey/ReleaseKey bypassing the input event queue (broke all edge-triggered isKeyDown/isKeyUp), NavMeshPlugin never wired into bsengine-runtime at all (enemy pursuit never worked in any real build), Bsengine.raycast() returning entity_name instead of entityName | 2026-07-29 | [#1735](https://github.com/blas1n/BSEngine/pull/1735) |
 | 14. Fix: 5 content bugs in player.js found the same way — isKeyDown instead of isKeyPressed for held movement, 180°-backwards yaw/forward vector, attack raycast self-hit + wrong height, stale getShield() read after damageShield() (Enemy took 3 hits instead of the documented 2); see `games/mini-arena/GAP_LOG.md` for full detail | 2026-07-29 | [#1735](https://github.com/blas1n/BSEngine/pull/1735) |
 | 15. `Bsengine.moveEntity` relative-move scripting op; mini-arena's player.js/enemy.js migrated to it from manual get-add-set position math | 2026-07-30 | [#1736](https://github.com/blas1n/BSEngine/pull/1736) |
-| 16. `Bsengine.quit()` scripting op sending `AppExit`; winit runner now honors `AppExit` (previously only `WindowEvent::CloseRequested`); mini-arena's pause menu Quit button wired to it | 2026-07-30 | branch `feat/quit-op` (PR #TBD) |
+| 16. `Bsengine.quit()` scripting op sending `AppExit`; winit runner now honors `AppExit` (previously only `WindowEvent::CloseRequested`); mini-arena's pause menu Quit button wired to it | 2026-07-30 | [#1737](https://github.com/blas1n/BSEngine/pull/1737) |
+| 17. `attach_physics_body`/`detach_physics_body` MCP tools; `EntityInfo`/`build_entity_descriptors` extended so physics bodies survive `save_scene` (were always dropped); fixed `EditorCommand::LoadScene`'s own separate scene-loading path, which never spawned `PhysicsBodyDesc` from loaded rigidbody/collider RON at all | 2026-07-30 | branch `feat/physics-body-mcp` (PR #TBD) |

--- a/crates/bsengine-editor/Cargo.toml
+++ b/crates/bsengine-editor/Cargo.toml
@@ -7,21 +7,22 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-bsengine-ecs    = { workspace = true }
-bsengine-input  = { workspace = true }
-bsengine-mcp    = { workspace = true }
-bsengine-scene  = { workspace = true }
-bsengine-core   = { workspace = true }
-bsengine-render = { workspace = true }
-bsengine-gltf   = { workspace = true }
-bevy_app        = { workspace = true }
-bevy_ecs        = { workspace = true }
-bevy_reflect    = { workspace = true }
-serde_json      = { workspace = true }
-glam            = { workspace = true }
-ron             = { workspace = true }
-serde           = { workspace = true }
-tracing         = { workspace = true }
+bsengine-ecs     = { workspace = true }
+bsengine-input   = { workspace = true }
+bsengine-mcp     = { workspace = true }
+bsengine-scene   = { workspace = true }
+bsengine-physics = { workspace = true }
+bsengine-core    = { workspace = true }
+bsengine-render  = { workspace = true }
+bsengine-gltf    = { workspace = true }
+bevy_app         = { workspace = true }
+bevy_ecs         = { workspace = true }
+bevy_reflect     = { workspace = true }
+serde_json       = { workspace = true }
+glam             = { workspace = true }
+ron              = { workspace = true }
+serde            = { workspace = true }
+tracing          = { workspace = true }
 
 [dev-dependencies]
 bsengine-app = { workspace = true }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -38,6 +38,7 @@ fn update_editor_snapshot(
         (
             Option<&PrimitiveMesh>,
             Option<&bsengine_scene::ScriptPath>,
+            Option<&bsengine_scene::PhysicsBodyDesc>,
         ),
     )>,
 ) {
@@ -46,7 +47,7 @@ fn update_editor_snapshot(
     snapshot.entities = query
         .iter()
         .map(
-            |(e, name, transform, mesh, pt, dir, spot, cam, parent, tags, vis, mat, (prim, script))| {
+            |(e, name, transform, mesh, pt, dir, spot, cam, parent, tags, vis, mat, (prim, script, physics_body))| {
                 let light_type = if pt.is_some() {
                     Some("point".to_string())
                 } else if dir.is_some() {
@@ -93,6 +94,7 @@ fn update_editor_snapshot(
                     visible: vis.map(|v| v.is_visible).unwrap_or(true),
                     selected: selection.contains(&(e.index() as u64)),
                     extra_components: Vec::new(),
+                    physics_body: physics_body.cloned(),
                 }
             },
         )
@@ -698,6 +700,12 @@ fn process_editor_commands(
                             ..Default::default()
                         });
                     }
+                    if let (Some(rb), Some(col)) = (&entity.rigidbody, &entity.collider) {
+                        eb.insert(bsengine_scene::PhysicsBodyDesc {
+                            rigidbody: rb.clone(),
+                            collider: col.clone(),
+                        });
+                    }
                     for (type_path, value_ron) in &entity.components {
                         let registry = type_registry_res.read();
                         let Some(registration) = registry.get_with_type_path(type_path) else {
@@ -1007,8 +1015,8 @@ fn spawn_entity_from_info(world: &mut World, info: &EntityInfo) -> Entity {
 
 /// Builds RON-serializable `EntityDescriptor`s from tracked snapshot entities.
 /// Only named entities are included (unnamed entities aren't addressable in
-/// scene files). GLTF paths and physics rigidbody/collider are not tracked by
-/// `EntityInfo` and are intentionally left `None` here.
+/// scene files). GLTF paths are not tracked by `EntityInfo` and are
+/// intentionally left `None` here.
 fn build_entity_descriptors(entities: &[EntityInfo]) -> Vec<EntityDescriptor> {
     entities
         .iter()
@@ -1080,8 +1088,8 @@ fn build_entity_descriptors(entities: &[EntityInfo]) -> Vec<EntityDescriptor> {
                     emissive: e.material_emissive,
                     color: e.material_base_color,
                     look_at: None,
-                    rigidbody: None,
-                    collider: None,
+                    rigidbody: e.physics_body.as_ref().map(|p| p.rigidbody.clone()),
+                    collider: e.physics_body.as_ref().map(|p| p.collider.clone()),
                 }
             })
         })
@@ -91238,6 +91246,81 @@ mod tests {
             assert_eq!(results[0].0 .0, "Enemy");
             assert!((results[0].1.speed - 3.5).abs() < 1e-4);
             assert!(results[0].1.enabled);
+        }
+    }
+
+    #[test]
+    fn mcp_save_load_scene_round_trip_preserves_physics_body_attached_via_mcp() {
+        let path = std::env::temp_dir()
+            .join("bsengine_test_roundtrip_physics_body.ron")
+            .to_string_lossy()
+            .to_string();
+
+        {
+            let mut app = new_app();
+            app.add_plugins(McpPlugin);
+            app.add_plugins(EditorPlugin);
+            let eid = app
+                .world_mut()
+                .spawn((
+                    Name("Crate".to_string()),
+                    Transform::from_translation(Vec3::new(2.0, 0.0, 0.0)),
+                ))
+                .id();
+            app.update();
+
+            {
+                let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+                let out = mcp
+                    .0
+                    .lock()
+                    .unwrap()
+                    .execute(
+                        "attach_physics_body",
+                        json!({
+                            "entity_id": eid.index() as u64,
+                            "rigidbody": "Static",
+                            "collider_shape": "Box",
+                            "hx": 1.0, "hy": 1.0, "hz": 1.0,
+                        }),
+                    )
+                    .expect("attach_physics_body not found");
+                assert!(out.is_ok(), "{:?}", out.error);
+            }
+            app.update();
+            app.update();
+
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let r = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute("save_scene", json!({"path": path}))
+                .unwrap();
+            assert!(r.is_ok(), "{:?}", r.error);
+        }
+
+        {
+            let mut app = new_app();
+            app.add_plugins(McpPlugin);
+            app.add_plugins(EditorPlugin);
+            {
+                let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+                mcp.0
+                    .lock()
+                    .unwrap()
+                    .execute("load_scene", json!({"path": path}))
+                    .expect("load_scene not found");
+            }
+            app.update();
+
+            let mut q = app
+                .world_mut()
+                .query::<(&Name, &bsengine_scene::PhysicsBodyDesc)>();
+            let results: Vec<_> = q.iter(app.world()).collect();
+            assert_eq!(results.len(), 1, "PhysicsBodyDesc missing after load");
+            assert_eq!(results[0].0 .0, "Crate");
+            assert_eq!(results[0].1.rigidbody, bsengine_scene::RigidBodyDesc::Static);
         }
     }
 

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -170,6 +170,29 @@ fn process_editor_commands(
                     commands.entity(entity).remove::<MeshRenderer>();
                 }
             }
+            EditorCommand::AttachPhysicsBody {
+                entity_id,
+                rigidbody,
+                collider,
+            } => {
+                let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
+                if let Some(entity) = target {
+                    commands
+                        .entity(entity)
+                        .insert(bsengine_scene::PhysicsBodyDesc { rigidbody, collider });
+                }
+            }
+            EditorCommand::DetachPhysicsBody { entity_id } => {
+                let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
+                if let Some(entity) = target {
+                    commands
+                        .entity(entity)
+                        .remove::<bsengine_scene::PhysicsBodyDesc>()
+                        .remove::<bsengine_physics::RigidBody>()
+                        .remove::<bsengine_physics::Collider>()
+                        .remove::<bsengine_physics::PhysicsInput>();
+                }
+            }
             EditorCommand::SpawnPointLight {
                 color,
                 intensity,
@@ -2047,6 +2070,101 @@ impl Plugin for EditorPlugin {
                         .lock()
                         .unwrap()
                         .push(EditorCommand::DetachMeshRenderer { entity_id });
+                    McpToolOutput::success(json!({"status": "queued", "entity_id": entity_id}))
+                }),
+            });
+
+            // attach_physics_body
+            let queue_phys_attach = cmd_queue.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "attach_physics_body".to_string(),
+                description: "Attach a physics body (rigidbody + collider) to an entity by ID (applied next frame)".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "entity_id":     { "type": "number", "description": "Entity ID" },
+                        "rigidbody":     { "type": "string", "enum": ["Dynamic", "Static", "Kinematic"] },
+                        "collider_shape":{ "type": "string", "enum": ["Box", "Sphere", "Capsule"] },
+                        "hx":            { "type": "number", "description": "Box half-extent X" },
+                        "hy":            { "type": "number", "description": "Box half-extent Y" },
+                        "hz":            { "type": "number", "description": "Box half-extent Z" },
+                        "radius":        { "type": "number", "description": "Sphere/Capsule radius" },
+                        "half_height":   { "type": "number", "description": "Capsule half-height" },
+                        "restitution":   { "type": "number", "description": "Bounciness, 0-1 (default 0.0)" },
+                        "friction":      { "type": "number", "description": "Surface friction (default 0.5)" },
+                        "sensor":        { "type": "boolean", "description": "Overlap-only, no physical collision (default false)" }
+                    },
+                    "required": ["entity_id", "rigidbody", "collider_shape"]
+                })),
+                handler: Box::new(move |input| {
+                    let entity_id = match input["entity_id"].as_u64() {
+                        Some(v) => v,
+                        None => return McpToolOutput::error("missing numeric 'entity_id' field"),
+                    };
+                    let rigidbody = match input["rigidbody"].as_str() {
+                        Some("Dynamic") => bsengine_scene::RigidBodyDesc::Dynamic,
+                        Some("Static") => bsengine_scene::RigidBodyDesc::Static,
+                        Some("Kinematic") => bsengine_scene::RigidBodyDesc::Kinematic,
+                        _ => return McpToolOutput::error(
+                            "'rigidbody' must be one of \"Dynamic\", \"Static\", \"Kinematic\"",
+                        ),
+                    };
+                    let shape = match input["collider_shape"].as_str() {
+                        Some("Box") => {
+                            let hx = input["hx"].as_f64().unwrap_or(0.5) as f32;
+                            let hy = input["hy"].as_f64().unwrap_or(0.5) as f32;
+                            let hz = input["hz"].as_f64().unwrap_or(0.5) as f32;
+                            bsengine_scene::ColliderShapeDesc::Box { hx, hy, hz }
+                        }
+                        Some("Sphere") => {
+                            let radius = input["radius"].as_f64().unwrap_or(0.5) as f32;
+                            bsengine_scene::ColliderShapeDesc::Sphere { radius }
+                        }
+                        Some("Capsule") => {
+                            let half_height = input["half_height"].as_f64().unwrap_or(0.5) as f32;
+                            let radius = input["radius"].as_f64().unwrap_or(0.3) as f32;
+                            bsengine_scene::ColliderShapeDesc::Capsule { half_height, radius }
+                        }
+                        _ => return McpToolOutput::error(
+                            "'collider_shape' must be one of \"Box\", \"Sphere\", \"Capsule\"",
+                        ),
+                    };
+                    let collider = bsengine_scene::ColliderDesc {
+                        shape,
+                        restitution: input["restitution"].as_f64().unwrap_or(0.0) as f32,
+                        friction: input["friction"].as_f64().unwrap_or(0.5) as f32,
+                        sensor: input["sensor"].as_bool().unwrap_or(false),
+                    };
+                    queue_phys_attach.lock().unwrap().push(EditorCommand::AttachPhysicsBody {
+                        entity_id,
+                        rigidbody,
+                        collider,
+                    });
+                    McpToolOutput::success(json!({"status": "queued", "entity_id": entity_id}))
+                }),
+            });
+
+            // detach_physics_body
+            let queue_phys_detach = cmd_queue.clone();
+            mcp.0.lock().unwrap().register(McpTool {
+                name: "detach_physics_body".to_string(),
+                description: "Remove an entity's physics body by ID (applied next frame)".to_string(),
+                input_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "entity_id": { "type": "number", "description": "Entity ID" }
+                    },
+                    "required": ["entity_id"]
+                })),
+                handler: Box::new(move |input| {
+                    let entity_id = match input["entity_id"].as_u64() {
+                        Some(v) => v,
+                        None => return McpToolOutput::error("missing numeric 'entity_id' field"),
+                    };
+                    queue_phys_detach
+                        .lock()
+                        .unwrap()
+                        .push(EditorCommand::DetachPhysicsBody { entity_id });
                     McpToolOutput::success(json!({"status": "queued", "entity_id": entity_id}))
                 }),
             });
@@ -30475,6 +30593,53 @@ mod tests {
             .iter(app.world())
             .any(|(n, m)| n.0 == "Cube" && m.mesh_id == 42);
         assert!(found, "MeshRenderer not attached");
+    }
+
+    #[test]
+    fn mcp_attach_physics_body_adds_physics_body_desc() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app
+            .world_mut()
+            .spawn((
+                Name("Box".to_string()),
+                Transform::from_translation(Vec3::ZERO),
+            ))
+            .id();
+        app.update();
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let result = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "attach_physics_body",
+                    json!({
+                        "entity_id": eid.index() as u64,
+                        "rigidbody": "Dynamic",
+                        "collider_shape": "Sphere",
+                        "radius": 0.75,
+                    }),
+                )
+                .expect("attach_physics_body not found");
+            assert!(result.is_ok(), "{:?}", result.error);
+        }
+        app.update();
+
+        let desc = app
+            .world()
+            .get::<bsengine_scene::PhysicsBodyDesc>(eid)
+            .expect("PhysicsBodyDesc should be attached");
+        assert_eq!(desc.rigidbody, bsengine_scene::RigidBodyDesc::Dynamic);
+        match &desc.collider.shape {
+            bsengine_scene::ColliderShapeDesc::Sphere { radius } => {
+                assert!((radius - 0.75).abs() < 1e-5);
+            }
+            other => panic!("expected Sphere shape, got {other:?}"),
+        }
     }
 
     #[test]
@@ -90876,6 +91041,42 @@ mod tests {
             q.iter(app.world()).next().is_none(),
             "MeshRenderer still present after detach"
         );
+    }
+
+    #[test]
+    fn mcp_detach_physics_body_removes_physics_body_desc() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        let eid = app
+            .world_mut()
+            .spawn((
+                Name("Box".to_string()),
+                Transform::from_translation(Vec3::ZERO),
+                bsengine_scene::PhysicsBodyDesc {
+                    rigidbody: bsengine_scene::RigidBodyDesc::Static,
+                    collider: bsengine_scene::ColliderDesc {
+                        shape: bsengine_scene::ColliderShapeDesc::Box { hx: 1.0, hy: 1.0, hz: 1.0 },
+                        restitution: 0.0,
+                        friction: 0.5,
+                        sensor: false,
+                    },
+                },
+            ))
+            .id();
+        app.update();
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("detach_physics_body", json!({"entity_id": eid.index() as u64}))
+                .expect("detach_physics_body not found");
+        }
+        app.update();
+
+        assert!(app.world().get::<bsengine_scene::PhysicsBodyDesc>(eid).is_none());
     }
 
     #[test]

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -137,6 +137,20 @@ pub enum EditorCommand {
         /// Entity to detach the renderer from.
         entity_id: u64,
     },
+    /// Attach a physics body (rigidbody + collider) to an entity.
+    AttachPhysicsBody {
+        /// Entity to attach the body to.
+        entity_id: u64,
+        /// Physics simulation type.
+        rigidbody: bsengine_scene::RigidBodyDesc,
+        /// Collision shape and material.
+        collider: bsengine_scene::ColliderDesc,
+    },
+    /// Remove an entity's physics body, if any.
+    DetachPhysicsBody {
+        /// Entity to detach the body from.
+        entity_id: u64,
+    },
     /// Spawn a new point light entity.
     SpawnPointLight {
         /// Light color.

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -78,6 +78,8 @@ pub struct EntityInfo {
     /// components with no dedicated field (e.g. `NavMeshAgent`, `Shield`)
     /// still persist.
     pub extra_components: Vec<(String, String)>,
+    /// Physics body (rigidbody + collider), if the entity has one.
+    pub physics_body: Option<bsengine_scene::PhysicsBodyDesc>,
 }
 
 /// Full flattened capture of every tracked entity in the world, taken once


### PR DESCRIPTION
## Summary

Adds `attach_physics_body`/`detach_physics_body` MCP tools so a rigidbody+collider can be attached to a live entity without hand-authoring scene RON. Closes `ENGINE_ROADMAP.md` item 17, from `games/mini-arena/GAP_LOG.md`'s "No dedicated MCP tool for attaching rigidbody/collider" entry.

Two related gaps found and fixed while implementing this:
1. **Save-side data loss**: `bsengine-editor`'s `EntityInfo`/`build_entity_descriptors` never captured `PhysicsBodyDesc` at all — `save_scene` always emitted `rigidbody: None, collider: None`, silently dropping any entity's physics body (whether attached via the new tools, or already present from a loaded scene) the moment it was re-saved through the editor.
2. **Load-side data loss** (found while testing the save-side fix): `EditorCommand::LoadScene` — the editor's own separate, hand-duplicated scene-loading path (distinct from `bsengine_scene::spawn_scene_entities`) — never spawned `PhysicsBodyDesc` from a loaded entity's `rigidbody`/`collider` RON fields at all. So even after the save-side fix, physics bodies would serialize correctly but vanish again on the next load.

No new physics logic was needed anywhere: `bsengine-runtime`'s existing `resolve_physics_bodies` system already turns an inserted `PhysicsBodyDesc` into real Rapier `RigidBody`/`Collider`/`PhysicsInput` components.

## Test plan

- [x] New unit tests: `mcp_attach_physics_body_adds_physics_body_desc`, `mcp_detach_physics_body_removes_physics_body_desc`
- [x] New save/load round-trip test: `mcp_save_load_scene_round_trip_preserves_physics_body_attached_via_mcp`
- [x] `cargo test -p bsengine-editor` — 823 passed
- [x] `cargo build --workspace`, `RUST_MIN_STACK=33554432 cargo test --workspace` — all green
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean (2 pre-existing, unrelated warnings only)