### PR TITLE
fix: gltf:/CustomShader.path project-relative resolution

### DIFF
--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -291,6 +291,26 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 
 ---
 
+### 18. `gltf:`/`CustomShader.path` 프로젝트 상대 경로 해석 ✅
+
+**목표:** `gltf:` 씬 RON 필드와 `Bsengine.setShader`의 `CustomShader.path`가
+`script:`/`loadScene`/`setSkybox`처럼 프로젝트 디렉터리 기준 상대 경로로
+해석되게 함 (기존에는 프로세스 CWD 기준이라 리포 루트에서만 실행 가능했음)
+
+**완료 조건:**
+- [x] `ProjectDir`/`resolve_project_path`를 `bsengine-core`로 이동 (scripting/
+  scene/gltf/editor가 공유하는 크레이트이므로)
+- [x] `bsengine-scene::spawn_scene_entities`의 `gltf:` 필드, `bsengine-scripting`의
+  `SetCustomShader` 핸들러가 새 helper로 경로 해석
+- [x] 구현 중 발견한 관련 버그 수정: `EditorCommand::LoadScene`(에디터 자체의
+  별도 씬 로딩 경로)가 `entity.gltf`를 아예 처리하지 않아 `load_scene` MCP
+  툴로 불러온 씬은 gltf 엔티티의 메시가 통째로 빠졌음
+- [x] Mini Action Arena 콘텐츠(`main.ron`, `pickup.js`)를 CWD 상대 경로
+  워크어라운드에서 프로젝트 상대 경로로 전환
+- [x] CI 통과
+
+---
+
 ## 완료 이력
 
 | 항목 | 완료일 | PR |
@@ -344,4 +364,5 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 | 14. Fix: 5 content bugs in player.js found the same way — isKeyDown instead of isKeyPressed for held movement, 180°-backwards yaw/forward vector, attack raycast self-hit + wrong height, stale getShield() read after damageShield() (Enemy took 3 hits instead of the documented 2); see `games/mini-arena/GAP_LOG.md` for full detail | 2026-07-29 | [#1735](https://github.com/blas1n/BSEngine/pull/1735) |
 | 15. `Bsengine.moveEntity` relative-move scripting op; mini-arena's player.js/enemy.js migrated to it from manual get-add-set position math | 2026-07-30 | [#1736](https://github.com/blas1n/BSEngine/pull/1736) |
 | 16. `Bsengine.quit()` scripting op sending `AppExit`; winit runner now honors `AppExit` (previously only `WindowEvent::CloseRequested`); mini-arena's pause menu Quit button wired to it | 2026-07-30 | [#1737](https://github.com/blas1n/BSEngine/pull/1737) |
-| 17. `attach_physics_body`/`detach_physics_body` MCP tools; `EntityInfo`/`build_entity_descriptors` extended so physics bodies survive `save_scene` (were always dropped); fixed `EditorCommand::LoadScene`'s own separate scene-loading path, which never spawned `PhysicsBodyDesc` from loaded rigidbody/collider RON at all | 2026-07-30 | branch `feat/physics-body-mcp` (PR #TBD) |
+| 17. `attach_physics_body`/`detach_physics_body` MCP tools; `EntityInfo`/`build_entity_descriptors` extended so physics bodies survive `save_scene` (were always dropped); fixed `EditorCommand::LoadScene`'s own separate scene-loading path, which never spawned `PhysicsBodyDesc` from loaded rigidbody/collider RON at all | 2026-07-30 | [#1738](https://github.com/blas1n/BSEngine/pull/1738) |
+| 18. `gltf:`/`CustomShader.path` project-relative resolution via shared `bsengine_core::ProjectDir`/`resolve_project_path`; fixed `EditorCommand::LoadScene` never spawning `GltfAsset` for gltf entities at all; mini-arena content migrated off its CWD-relative workaround | 2026-07-30 | branch `feat/gltf-shader-project-paths` (PR #TBD) |

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -62,6 +62,8 @@ pub mod nav_mesh_agent;
 pub mod network_id;
 /// Parent-entity reference for building transform hierarchies.
 pub mod parent;
+/// Root directory of the current project, used to resolve project-relative asset paths.
+pub mod project_dir;
 /// `bevy_reflect`-friendly wrapper for RGBA color values.
 pub mod reflect_color;
 /// `bevy_reflect`-friendly wrapper for angles expressed in degrees.
@@ -128,6 +130,7 @@ pub use nav_mesh::NavMesh;
 pub use nav_mesh_agent::{NavAgentState, NavMeshAgent};
 pub use network_id::{NetworkAuthority, NetworkId};
 pub use parent::Parent;
+pub use project_dir::{resolve_project_path, ProjectDir};
 pub use reflect_color::ReflectColor;
 pub use reflect_degrees::ReflectDegrees;
 pub use reflect_glam::{ReflectQuat, ReflectVec2, ReflectVec3, ReflectVec4};

--- a/crates/bsengine-core/src/project_dir.rs
+++ b/crates/bsengine-core/src/project_dir.rs
@@ -1,0 +1,42 @@
+use bevy_ecs::prelude::Resource;
+
+/// Root directory of the current project, used to resolve every
+/// project-relative asset path (`script:`, `gltf:`, custom shader paths, ...).
+#[derive(Resource, Default, Clone)]
+pub struct ProjectDir(pub String);
+
+/// Resolves `path` against `project_dir`, unless `project_dir` is absent or empty.
+pub fn resolve_project_path(project_dir: Option<&ProjectDir>, path: &str) -> String {
+    match project_dir {
+        Some(pd) if !pd.0.is_empty() => format!("{}/{}", pd.0, path),
+        _ => path.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_with_project_dir_joins_with_slash() {
+        let pd = ProjectDir("games/demo".to_string());
+        assert_eq!(
+            resolve_project_path(Some(&pd), "assets/x.glb"),
+            "games/demo/assets/x.glb"
+        );
+    }
+
+    #[test]
+    fn resolve_with_empty_project_dir_returns_path_unchanged() {
+        let pd = ProjectDir(String::new());
+        assert_eq!(
+            resolve_project_path(Some(&pd), "assets/x.glb"),
+            "assets/x.glb"
+        );
+    }
+
+    #[test]
+    fn resolve_with_no_project_dir_returns_path_unchanged() {
+        assert_eq!(resolve_project_path(None, "assets/x.glb"), "assets/x.glb");
+    }
+}

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -103,6 +103,7 @@ fn update_editor_snapshot(
 
 const MAX_UNDO_HISTORY: usize = 100;
 
+#[allow(clippy::too_many_arguments)] // Bevy system params; splitting into a struct is a larger refactor
 fn process_editor_commands(
     queue_res: Res<EditorCommandQueueResource>,
     snapshot_res: Res<EditorSnapshotResource>,

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -108,6 +108,7 @@ fn process_editor_commands(
     snapshot_res: Res<EditorSnapshotResource>,
     history_res: Res<EditorHistoryResource>,
     type_registry_res: Res<bevy_ecs::reflect::AppTypeRegistry>,
+    project_dir: Option<Res<bsengine_core::ProjectDir>>,
     mut inspector: Option<ResMut<InspectorState>>,
     mut params: ParamSet<(
         Query<Entity>,
@@ -142,7 +143,8 @@ fn process_editor_commands(
                 commands.spawn(Name(name));
             }
             EditorCommand::SpawnMeshAsset { name, path } => {
-                commands.spawn((Name(name), bsengine_gltf::GltfAsset::new(path)));
+                let resolved = bsengine_core::resolve_project_path(project_dir.as_deref(), &path);
+                commands.spawn((Name(name), bsengine_gltf::GltfAsset::new(resolved)));
             }
             EditorCommand::Despawn { entity_id } => {
                 let target = params.p0().iter().find(|e| e.index() as u64 == entity_id);
@@ -631,6 +633,11 @@ fn process_editor_commands(
                     }
                     if let Some(prim) = &entity.primitive {
                         eb.insert(PrimitiveMesh(prim.clone()));
+                    }
+                    if let Some(gltf_path) = &entity.gltf {
+                        let resolved =
+                            bsengine_core::resolve_project_path(project_dir.as_deref(), gltf_path);
+                        eb.insert(bsengine_gltf::GltfAsset::new(resolved));
                     }
                     if entity.camera {
                         match entity.camera_fov {
@@ -91898,6 +91905,71 @@ mod tests {
             .expect("expected one entity with Name + GltfAsset");
         assert_eq!(name.0, "Rock");
         assert_eq!(gltf_asset.path, "assets/models/rock.glb");
+    }
+
+    #[test]
+    fn spawn_mesh_asset_command_resolves_path_against_project_dir() {
+        let mut app = new_app();
+        app.insert_resource(bsengine_core::ProjectDir("games/demo".to_string()));
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        {
+            let queue = app.world().resource::<EditorCommandQueueResource>();
+            queue.0.lock().unwrap().push(EditorCommand::SpawnMeshAsset {
+                name: "Rock".to_string(),
+                path: "assets/models/rock.glb".to_string(),
+            });
+        }
+        app.update();
+
+        let mut query = app.world_mut().query::<(&Name, &bsengine_gltf::GltfAsset)>();
+        let (name, gltf_asset) = query
+            .iter(app.world())
+            .next()
+            .expect("expected one entity with Name + GltfAsset");
+        assert_eq!(name.0, "Rock");
+        assert_eq!(gltf_asset.path, "games/demo/assets/models/rock.glb");
+    }
+
+    #[test]
+    fn load_scene_spawns_gltf_asset_for_entity_with_gltf_field() {
+        let path = std::env::temp_dir()
+            .join("bsengine_test_load_scene_gltf.ron")
+            .to_string_lossy()
+            .to_string();
+        std::fs::write(
+            &path,
+            r#"SceneDescriptor(entities: [
+                EntityDescriptor(name: "Player", gltf: Some("models/hero.glb")),
+            ])"#,
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.insert_resource(bsengine_core::ProjectDir("games/demo".to_string()));
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            mcp.0
+                .lock()
+                .unwrap()
+                .execute("load_scene", json!({"path": path}))
+                .expect("load_scene not found");
+        }
+        app.update();
+
+        let mut query = app.world_mut().query::<(&Name, &bsengine_gltf::GltfAsset)>();
+        let (name, gltf_asset) = query
+            .iter(app.world())
+            .find(|(n, _)| n.0 == "Player")
+            .expect("expected Player entity with GltfAsset after load_scene");
+        assert_eq!(name.0, "Player");
+        assert_eq!(gltf_asset.path, "games/demo/models/hero.glb");
     }
 
     /// Verifies the property List-append/enum-variant-switch actually

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -56,6 +56,7 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
     let app_registry = world
         .get_resource::<bevy_ecs::reflect::AppTypeRegistry>()
         .cloned();
+    let project_dir = world.get_resource::<bsengine_core::ProjectDir>().cloned();
 
     for entity in entities {
         let mut builder = world.spawn(Name(entity.name.clone()));
@@ -81,7 +82,10 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
         }
 
         if let Some(path) = &entity.gltf {
-            builder.insert(GltfAsset::new(path.clone()));
+            builder.insert(GltfAsset::new(bsengine_core::resolve_project_path(
+                project_dir.as_ref(),
+                path,
+            )));
         }
 
         if entity.camera {
@@ -432,6 +436,46 @@ mod tests {
         let mut q = app.world_mut().query::<&Name>();
         let names: Vec<String> = q.iter(app.world()).map(|n| n.0.clone()).collect();
         assert!(names.contains(&"Ghost".to_string()));
+    }
+
+    #[test]
+    fn scene_plugin_gltf_path_resolves_against_project_dir() {
+        let ron = r#"SceneDescriptor(entities: [
+            EntityDescriptor(name: "Player", gltf: Some("models/hero.glb")),
+        ])"#;
+        let path = write_temp_scene("test_gltf_project_dir.ron", ron);
+
+        let mut app = new_app();
+        app.insert_resource(bsengine_core::ProjectDir("games/demo".to_string()));
+        app.add_plugins(ScenePlugin::from_file(&path));
+        app.update();
+
+        let mut q = app
+            .world_mut()
+            .query::<(&Name, &bsengine_gltf::GltfAsset)>();
+        let results: Vec<_> = q.iter(app.world()).collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0 .0, "Player");
+        assert_eq!(results[0].1.path, "games/demo/models/hero.glb");
+    }
+
+    #[test]
+    fn scene_plugin_gltf_path_unchanged_without_project_dir() {
+        let ron = r#"SceneDescriptor(entities: [
+            EntityDescriptor(name: "Player", gltf: Some("models/hero.glb")),
+        ])"#;
+        let path = write_temp_scene("test_gltf_no_project_dir.ron", ron);
+
+        let mut app = new_app();
+        app.add_plugins(ScenePlugin::from_file(&path));
+        app.update();
+
+        let mut q = app
+            .world_mut()
+            .query::<(&Name, &bsengine_gltf::GltfAsset)>();
+        let results: Vec<_> = q.iter(app.world()).collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1.path, "models/hero.glb");
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/lib.rs
+++ b/crates/bsengine-scripting/src/lib.rs
@@ -20,8 +20,8 @@ pub mod plugin;
 pub mod runtime;
 /// Script-driven save-game serialization to/from JSON.
 pub mod save;
+pub use bsengine_core::ProjectDir;
 pub use plugin::{
-    load_scripts, ProjectDir, Script, ScriptRuntimeResource, ScriptingPlugin, SoundHandles,
-    KEY_MAPPINGS,
+    load_scripts, Script, ScriptRuntimeResource, ScriptingPlugin, SoundHandles, KEY_MAPPINGS,
 };
 pub use runtime::ScriptRuntime;

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -4,8 +4,9 @@ use bevy_app::{App, AppExit, Plugin, PostStartup, Update};
 use bevy_ecs::prelude::*;
 use bsengine_audio::AudioWorld;
 use bsengine_core::{
-    CursorConfig, CustomShader, EditorPlayState, GlobalTransform, HudTexts, InspectorState,
-    Material, Parent, ScreenSize, SkyboxPath, Transform, UiState, UiWidget, Visible,
+    resolve_project_path, CursorConfig, CustomShader, EditorPlayState, GlobalTransform, HudTexts,
+    InspectorState, Material, Parent, ProjectDir, ScreenSize, SkyboxPath, Transform, UiState,
+    UiWidget, Visible,
 };
 use bsengine_input::{GamepadButton, GamepadSticks, Input, KeyCode, MouseButton, MouseState};
 use bsengine_network::NetworkSession;
@@ -33,10 +34,6 @@ use crate::ops::{
     UI_CLICKED_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
-
-/// Root directory of the current project — used to resolve relative script paths.
-#[derive(Resource, Default)]
-pub struct ProjectDir(pub String);
 
 /// Loaded JS source for a scripted entity.
 #[derive(Component)]
@@ -1448,10 +1445,7 @@ fn run_scripts(world: &mut World) {
                 // already carry. Without this, loadScene only works by
                 // accident when the process's CWD happens to equal
                 // project_dir.
-                let full_path = match world.get_resource::<ProjectDir>() {
-                    Some(pd) if !pd.0.is_empty() => format!("{}/{path}", pd.0),
-                    _ => path,
-                };
+                let full_path = resolve_project_path(world.get_resource::<ProjectDir>(), &path);
                 world.insert_resource(PendingSceneLoad { path: full_path });
             }
             ScriptCommand::SetVisible { name, visible } => {
@@ -1464,15 +1458,7 @@ fn run_scripts(world: &mut World) {
                 }
             }
             ScriptCommand::SetSkybox { path } => {
-                let project_dir = world
-                    .get_resource::<ProjectDir>()
-                    .map(|pd| pd.0.clone())
-                    .unwrap_or_default();
-                let full_path = if project_dir.is_empty() {
-                    path
-                } else {
-                    format!("{}/{}", project_dir, path)
-                };
+                let full_path = resolve_project_path(world.get_resource::<ProjectDir>(), &path);
                 world.insert_resource(SkyboxPath(Some(full_path)));
             }
             ScriptCommand::SetParent { child, parent } => {

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -920,7 +920,8 @@ fn run_scripts(world: &mut World) {
                     q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
                 };
                 if let Some(e) = entity {
-                    world.entity_mut(e).insert(CustomShader { path });
+                    let resolved = resolve_project_path(world.get_resource::<ProjectDir>(), &path);
+                    world.entity_mut(e).insert(CustomShader { path: resolved });
                 }
             }
             ScriptCommand::NetworkStartServer { port } => {
@@ -2905,5 +2906,53 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&script_path);
+    }
+
+    #[test]
+    fn set_shader_resolves_path_against_project_dir() {
+        use bsengine_core::CustomShader;
+
+        // `load_scripts` also resolves `ScriptPath` against `ProjectDir` (see
+        // its doc comment above), so an absolute `ScriptPath` combined with a
+        // non-empty `project_dir` would make script loading itself fail
+        // (project_dir gets prefixed onto an already-absolute path). Using a
+        // real temp directory as `project_dir` with a project-relative
+        // `ScriptPath`, mirroring how a real game's `project_dir` +
+        // `assets/scripts/...` are related, keeps both resolutions valid.
+        let project_dir = std::env::temp_dir().join(format!(
+            "bsengine_test_set_shader_project_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("set_shader.js"),
+            "function onUpdate(name) { Bsengine.setShader(name, \"shaders/glow.wgsl\"); }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(ScriptingPlugin {
+            project_dir: project_dir.to_string_lossy().to_string(),
+        });
+        app.world_mut().spawn((
+            Name("Hero".to_string()),
+            ScriptPath("set_shader.js".to_string()),
+        ));
+
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let mut q = world.query::<(&Name, &CustomShader)>();
+        let (_, shader) = q
+            .iter(world)
+            .find(|(n, _)| n.0 == "Hero")
+            .expect("Hero entity with CustomShader not found");
+        assert_eq!(
+            shader.path,
+            format!("{}/shaders/glow.wgsl", project_dir.to_string_lossy())
+        );
+
+        let _ = std::fs::remove_dir_all(&project_dir);
     }
 }

--- a/games/mini-arena/assets/scenes/main.ron
+++ b/games/mini-arena/assets/scenes/main.ron
@@ -25,10 +25,7 @@ SceneDescriptor(entities: [
     ),
     EntityDescriptor(
         name: "Player",
-        // NOTE: `gltf:` paths resolve relative to the process CWD, not the
-        // project dir (pre-existing, logged gap). Only run via
-        // `cargo run -p bsengine-runtime -- ./games/mini-arena` from the repo root.
-        gltf: Some("games/mini-arena/assets/models/fox.glb"),
+        gltf: Some("assets/models/fox.glb"),
         transform: Some((translation: (0.0, 0.0, 0.0), scale: (0.02, 0.02, 0.02))),
         rigidbody: Some(Kinematic),
         collider: Some((shape: Capsule(half_height: 0.5, radius: 0.35), friction: 0.3)),
@@ -61,7 +58,7 @@ SceneDescriptor(entities: [
     ),
     EntityDescriptor(
         name: "Enemy",
-        gltf: Some("games/mini-arena/assets/models/fox.glb"),
+        gltf: Some("assets/models/fox.glb"),
         transform: Some((translation: (5.0, 0.0, 5.0), scale: (0.02, 0.02, 0.02))),
         rigidbody: Some(Kinematic),
         collider: Some((shape: Capsule(half_height: 0.5, radius: 0.35), friction: 0.3)),

--- a/games/mini-arena/assets/scripts/pickup.js
+++ b/games/mini-arena/assets/scripts/pickup.js
@@ -5,11 +5,7 @@ const BASE_R = 0.2, BASE_G = 0.6, BASE_B = 1.0;
 
 function onUpdate(self) {
     if (!shaderAssigned) {
-        // CWD-relative, same as `gltf:` scene paths -- NOT project-dir-relative
-        // like `script:` paths. Confirmed against ScriptCommand::SetCustomShader
-        // in bsengine-scripting/src/plugin.rs (no ProjectDir join) and the
-        // std::fs::read_to_string call in bsengine-render/src/plugin.rs.
-        Bsengine.setShader(self, "games/mini-arena/assets/shaders/glow.wgsl");
+        Bsengine.setShader(self, "assets/shaders/glow.wgsl");
         shaderAssigned = true;
     }
 


### PR DESCRIPTION
## Summary
- `gltf:` scene-RON paths and `Bsengine.setShader`'s `CustomShader.path` now resolve relative to the project directory, matching `script:`/`loadScene`/`setSkybox` (previously resolved against the process CWD, only working by accident when run from the repo root) — via a new shared `bsengine_core::ProjectDir`/`resolve_project_path`, moved out of `bsengine-scripting` so `bsengine-scene` and `bsengine-editor` can use it too.
- Fixed a bug found during this item's own research: `EditorCommand::LoadScene` (the editor's own separate scene-loading path, distinct from `bsengine_scene::spawn_scene_entities`) never handled `entity.gltf` at all — loading a scene through the editor's `load_scene` MCP tool silently dropped every gltf-based entity's mesh.
- Migrated `games/mini-arena`'s `main.ron`/`pickup.js` off their CWD-relative path workaround onto plain project-relative paths.
- ENGINE_ROADMAP item 18 added; backfilled item 17's PR link (#1738).

## Test plan
- [x] `cargo test -p bsengine-core` / `-p bsengine-scripting` / `-p bsengine-scene` / `-p bsengine-editor` — all pass in isolation
- [x] `cargo build --workspace` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean (only 2 pre-existing, unrelated `derivable_impls` warnings in `bsengine-core`)
- [x] Manual playtest: `cargo run -p bsengine-runtime -- ./games/mini-arena` — fox model and pickup glow shader load correctly with the new project-relative paths
- Note: `cargo test --workspace` hits two known, pre-existing, environment-specific stack overflows (`bsengine-editor::get_entity_includes_mesh_id_when_present` when run concatenated with other crates; `bsengine-runtime::editor_plugin_reload_scene_does_not_corrupt_scripting` in isolation) — both reproduce identically on the pre-branch baseline (`f9b82ded`), confirmed unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)