### PR TITLE
feat: expose elapsed time to custom WGSL shaders (CameraUniform.time)

### DIFF
--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -311,6 +311,24 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 
 ---
 
+### 19. 커스텀 셰이더 시간(time) 유니폼 ✅
+
+**목표:** 커스텀 WGSL 셰이더가 `Bsengine.setEmissive()` 같은 매 프레임 JS
+왕복 없이 자체적으로 시간 기반 애니메이션(pulse 등)을 계산할 수 있게
+
+**완료 조건:**
+- [x] `CameraUniformData`의 기존 미사용 패딩 필드(`_pad`)를 `time`으로 재활용 —
+  버퍼 크기/정렬 변경 없음
+- [x] `bsengine_core::Time`(이미 매 프레임 tick)을 `bsengine-render`의
+  `render_frame` 시스템 → `bsengine-rhi-wgpu`의 `WgpuSurface::render_frame`
+  → GPU 유니폼 버퍼까지 연결
+- [x] Mini Action Arena의 `glow.wgsl`/`pickup.js`를 실제로 전환 — 셰이더가
+  `camera.time`으로 직접 pulse 계산, `pickup.js`의 매 프레임
+  `Bsengine.setEmissive()` 폴링 제거
+- [x] CI 통과
+
+---
+
 ## 완료 이력
 
 | 항목 | 완료일 | PR |
@@ -365,4 +383,5 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 | 15. `Bsengine.moveEntity` relative-move scripting op; mini-arena's player.js/enemy.js migrated to it from manual get-add-set position math | 2026-07-30 | [#1736](https://github.com/blas1n/BSEngine/pull/1736) |
 | 16. `Bsengine.quit()` scripting op sending `AppExit`; winit runner now honors `AppExit` (previously only `WindowEvent::CloseRequested`); mini-arena's pause menu Quit button wired to it | 2026-07-30 | [#1737](https://github.com/blas1n/BSEngine/pull/1737) |
 | 17. `attach_physics_body`/`detach_physics_body` MCP tools; `EntityInfo`/`build_entity_descriptors` extended so physics bodies survive `save_scene` (were always dropped); fixed `EditorCommand::LoadScene`'s own separate scene-loading path, which never spawned `PhysicsBodyDesc` from loaded rigidbody/collider RON at all | 2026-07-30 | [#1738](https://github.com/blas1n/BSEngine/pull/1738) |
-| 18. `gltf:`/`CustomShader.path` project-relative resolution via shared `bsengine_core::ProjectDir`/`resolve_project_path`; fixed `EditorCommand::LoadScene` never spawning `GltfAsset` for gltf entities at all; mini-arena content migrated off its CWD-relative workaround | 2026-07-30 | branch `feat/gltf-shader-project-paths` (PR #TBD) |
+| 18. `gltf:`/`CustomShader.path` project-relative resolution via shared `bsengine_core::ProjectDir`/`resolve_project_path`; fixed `EditorCommand::LoadScene` never spawning `GltfAsset` for gltf entities at all; mini-arena content migrated off its CWD-relative workaround | 2026-07-30 | [#1739](https://github.com/blas1n/BSEngine/pull/1739) |
+| 19. Exposed elapsed time to custom WGSL shaders via `CameraUniform.time` (reusing an existing unused padding field, zero buffer layout change); mini-arena's `glow.wgsl`/`pickup.js` migrated from per-frame JS-driven emissive pulsing to a GPU-computed one | 2026-07-30 | branch `feat/custom-shader-time-uniform` (PR #TBD) |

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -3,7 +3,7 @@ use bevy_ecs::prelude::{Entity, EventReader, IntoSystemConfigs, ParamSet, Query,
 use bsengine_core::{
     AmbientOcclusion, Bloom, Camera, CustomShader, DirectionalLight, EditorPanelRegistry,
     EditorPlayState, GlobalTransform, HudTexts, InspectorState, Material, Parent, PointLight,
-    SkyboxPath, SpotLight, ToneMap, Transform, UiState, Visible,
+    SkyboxPath, SpotLight, Time, ToneMap, Transform, UiState, Visible,
 };
 use bsengine_ecs::Res;
 use bsengine_input::{Input, KeyCode, KeyInput, MouseButton, MouseState};
@@ -102,6 +102,7 @@ fn propagate_children(
 #[allow(clippy::too_many_arguments)] // Bevy system params; splitting into a struct is a larger refactor
 fn render_frame(
     surface: Option<ResMut<WgpuSurfaceResource>>,
+    time: Option<Res<Time>>,
     registry: Option<Res<GpuMeshRegistry>>,
     tex_registry: Option<Res<GpuTextureRegistry>>,
     hud_texts: Option<Res<HudTexts>>,
@@ -354,6 +355,7 @@ fn render_frame(
         alt_held,
         editor_panels.as_deref(),
         type_registry.as_deref(),
+        time.as_deref().map(|t| t.elapsed_seconds).unwrap_or(0.0),
     ) {
         Ok(clicked) => {
             if let Some(ref mut state) = ui_state {

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -14,7 +14,7 @@ struct CameraUniform {
     view_proj: mat4x4<f32>,
     light_view_proj: mat4x4<f32>,
     cam_pos: vec3<f32>,
-    _pad: f32,
+    time: f32,
 };
 struct ModelUniform {
     model: mat4x4<f32>,
@@ -285,7 +285,10 @@ struct CameraUniformData {
     view_proj: [[f32; 4]; 4],
     light_view_proj: [[f32; 4]; 4],
     cam_pos: [f32; 3],
-    _pad: f32,
+    /// Seconds elapsed since app startup — was an unused padding field
+    /// (`cam_pos: vec3<f32>` needs 16-byte alignment; this fills the
+    /// remaining 4 bytes), now exposed to shaders as `camera.time`.
+    time: f32,
 }
 
 /// Material parameters uploaded per draw call.
@@ -1254,12 +1257,13 @@ impl WgpuSurface {
         alt_held: bool,
         editor_panels: Option<&bsengine_core::EditorPanelRegistry>,
         type_registry: Option<&bevy_ecs::reflect::AppTypeRegistry>,
+        elapsed_seconds: f32,
     ) -> Result<std::collections::HashSet<String>, String> {
         let camera_data = CameraUniformData {
             view_proj: view_proj.to_cols_array_2d(),
             light_view_proj: light_view_proj.to_cols_array_2d(),
             cam_pos: cam_pos.to_array(),
-            _pad: 0.0,
+            time: elapsed_seconds,
         };
         self.queue
             .write_buffer(&self.camera_buffer, 0, bytemuck::cast_slice(&[camera_data]));
@@ -2197,6 +2201,28 @@ mod tests {
     fn mesh_shader_compiles() {
         let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
         let _module = WgpuSurface::compile_shader(&rhi.device, MESH_WGSL);
+    }
+
+    #[test]
+    fn camera_uniform_data_time_field_at_correct_byte_offset() {
+        let data = CameraUniformData {
+            view_proj: [[0.0; 4]; 4],
+            light_view_proj: [[0.0; 4]; 4],
+            cam_pos: [1.0, 2.0, 3.0],
+            time: 42.5,
+        };
+        assert_eq!(
+            std::mem::size_of::<CameraUniformData>(),
+            CAMERA_UNIFORM_SIZE as usize
+        );
+        let bytes = bytemuck::bytes_of(&data);
+        // view_proj(64) + light_view_proj(64) + cam_pos(12) = 140, time starts at 140... but
+        // cam_pos:vec3<f32> requires 16-byte alignment in the uniform buffer layout this struct
+        // mirrors, so time actually lands at offset 140 within this Rust repr(C) struct (no
+        // padding is inserted by Rust here since f32 has 4-byte alignment) -- what matters for
+        // the GPU is CAMERA_UNIFORM_SIZE staying 144 and this field being the last 4 bytes.
+        let time_bytes = &bytes[140..144];
+        assert_eq!(f32::from_ne_bytes(time_bytes.try_into().unwrap()), 42.5);
     }
 
     #[test]

--- a/games/mini-arena/assets/scripts/pickup.js
+++ b/games/mini-arena/assets/scripts/pickup.js
@@ -1,18 +1,10 @@
 let shaderAssigned = false;
-let elapsed = 0.0;
-const PULSE_SPEED = 3.0;
-const BASE_R = 0.2, BASE_G = 0.6, BASE_B = 1.0;
 
 function onUpdate(self) {
     if (!shaderAssigned) {
         Bsengine.setShader(self, "assets/shaders/glow.wgsl");
         shaderAssigned = true;
     }
-
-    const dt = Bsengine.getDeltaTime();
-    elapsed += dt;
-    const pulse = 0.6 + 0.4 * Math.sin(elapsed * PULSE_SPEED);
-    Bsengine.setEmissive(self, BASE_R * pulse, BASE_G * pulse, BASE_B * pulse);
 
     const pos = Bsengine.getPosition(self);
     const player = Bsengine.getPosition("Player");

--- a/games/mini-arena/assets/shaders/glow.wgsl
+++ b/games/mini-arena/assets/shaders/glow.wgsl
@@ -1,4 +1,5 @@
-// Custom shader for the Pickup entity: a Fresnel-style rim glow.
+// Custom shader for the Pickup entity: a Fresnel-style rim glow that pulses
+// over time, driven entirely by the GPU via camera.time.
 //
 // Bind group layout below mirrors the standard mesh shader's CameraUniform
 // (@group(0)) and ModelUniform (@group(1)) structs exactly -- both are
@@ -14,7 +15,7 @@ struct CameraUniform {
     view_proj: mat4x4<f32>,
     light_view_proj: mat4x4<f32>,
     cam_pos: vec3<f32>,
-    _pad: f32,
+    time: f32,
 };
 struct ModelUniform {
     model: mat4x4<f32>,
@@ -60,14 +61,14 @@ fn vs_main(in: VertIn) -> VertOut {
 @fragment
 fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
     // Fresnel-style rim glow: brightest at grazing angles relative to the
-    // camera. A time-based pulse isn't possible here -- no time/clock
-    // uniform is exposed to custom shaders in this bind group layout.
-    // The "alive-looking pulse" comes from pickup.js driving
-    // model_data.emissive via Bsengine.setEmissive() every frame instead.
+    // camera, pulsing over time via camera.time (matches pickup.js's old
+    // PULSE_SPEED=3.0 / 0.6+0.4*sin(...) formula, now computed on the GPU
+    // instead of being pushed from JS every frame).
     let n = normalize(in.world_normal);
     let v = normalize(camera.cam_pos - in.world_pos);
     let rim = pow(1.0 - clamp(dot(n, v), 0.0, 1.0), 2.5);
+    let pulse = 0.6 + 0.4 * sin(camera.time * 3.0);
     let base = model_data.base_color * 0.3;
-    let glow = model_data.emissive * (0.5 + rim);
+    let glow = model_data.emissive * pulse * (0.5 + rim);
     return vec4<f32>(base + glow, 1.0);
 }


### PR DESCRIPTION
## Summary
- Custom WGSL shaders (via the `CustomShader` component / `Bsengine.setShader()`) can now read elapsed time directly through the `CameraUniform` bind group they already use — closing the gap where shader animation had to be driven from JS every frame instead.
- Implemented by reusing `CameraUniformData`'s existing unused padding field (`_pad: f32`, previously always `0.0`, present purely to keep `cam_pos: vec3<f32>` 16-byte aligned) as `time: f32`, threaded from `bsengine_core::Time` (already ticked every frame) through `bsengine-render`'s `render_frame` system and `bsengine-rhi-wgpu`'s `WgpuSurface::render_frame`. Zero buffer layout/size change — existing shaders that don't reference the field are unaffected.
- `games/mini-arena`'s `glow.wgsl`/`pickup.js` migrated to actually use it: the pickup's rim-glow pulse is now computed on the GPU via `camera.time`, and `pickup.js`'s per-frame `Bsengine.setEmissive()` polling is gone entirely.
- ENGINE_ROADMAP item 19 added; backfilled item 18's PR link (#1739).

## Test plan
- [x] `cargo test -p bsengine-rhi-wgpu -p bsengine-render -p bsengine-core` — all pass (new byte-layout test + existing WGSL-compile regression tests)
- [x] `cargo build --workspace` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean (only 2 pre-existing, unrelated `derivable_impls` warnings in `bsengine-core`)
- [x] Manual playtest: `cargo run -p bsengine-runtime -- ./games/mini-arena` — pickup glow still pulses correctly, no pipeline/shader validation errors
- Note: same two known, pre-existing, environment-specific stack overflows as PR #1739 (`bsengine-editor` tests when run concatenated with other crates; `bsengine-runtime::editor_plugin_reload_scene_does_not_corrupt_scripting` in isolation) — both verified unrelated to this change (confirmed on the pre-branch baseline previously).

🤖 Generated with [Claude Code](https://claude.com/claude-code)