### PR TITLE
feat: add Bsengine.ui.setProgressBar (health-bar UI widget)

### DIFF
--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -329,6 +329,22 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 
 ---
 
+### 20. 프로그레스 바 / 체력 바 UI 위젯 ✅
+
+**목표:** `Bsengine.ui.*`에 `setLabel`/`setButton`/`setPanel`/`setTextInput`와
+동급인 프로그레스/체력 바 위젯 추가 (기존엔 텍스트로만 흉내 낼 수 있었음)
+
+**완료 조건:**
+- [x] `UiWidget::ProgressBar` 추가, `Bsengine.ui.setProgressBar(id, x, y,
+  width, height, fraction)` 스크립팅 API로 노출 — 기존 5개 위젯과 동일한
+  파이프라인(ScriptCommand → op → JS 바인딩 → 핸들러 → egui 렌더)
+- [x] `egui::ProgressBar`로 렌더링
+- [x] Mini Action Arena의 `hud.js`가 실제로 전환 — 체력 표시가 평문 텍스트
+  대신 진짜 바 위젯 사용
+- [x] CI 통과
+
+---
+
 ## 완료 이력
 
 | 항목 | 완료일 | PR |
@@ -384,4 +400,5 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 | 16. `Bsengine.quit()` scripting op sending `AppExit`; winit runner now honors `AppExit` (previously only `WindowEvent::CloseRequested`); mini-arena's pause menu Quit button wired to it | 2026-07-30 | [#1737](https://github.com/blas1n/BSEngine/pull/1737) |
 | 17. `attach_physics_body`/`detach_physics_body` MCP tools; `EntityInfo`/`build_entity_descriptors` extended so physics bodies survive `save_scene` (were always dropped); fixed `EditorCommand::LoadScene`'s own separate scene-loading path, which never spawned `PhysicsBodyDesc` from loaded rigidbody/collider RON at all | 2026-07-30 | [#1738](https://github.com/blas1n/BSEngine/pull/1738) |
 | 18. `gltf:`/`CustomShader.path` project-relative resolution via shared `bsengine_core::ProjectDir`/`resolve_project_path`; fixed `EditorCommand::LoadScene` never spawning `GltfAsset` for gltf entities at all; mini-arena content migrated off its CWD-relative workaround | 2026-07-30 | [#1739](https://github.com/blas1n/BSEngine/pull/1739) |
-| 19. Exposed elapsed time to custom WGSL shaders via `CameraUniform.time` (reusing an existing unused padding field, zero buffer layout change); mini-arena's `glow.wgsl`/`pickup.js` migrated from per-frame JS-driven emissive pulsing to a GPU-computed one | 2026-07-30 | branch `feat/custom-shader-time-uniform` (PR #TBD) |
+| 19. Exposed elapsed time to custom WGSL shaders via `CameraUniform.time` (reusing an existing unused padding field, zero buffer layout change); mini-arena's `glow.wgsl`/`pickup.js` migrated from per-frame JS-driven emissive pulsing to a GPU-computed one | 2026-07-30 | [#1740](https://github.com/blas1n/BSEngine/pull/1740) |
+| 20. Added `UiWidget::ProgressBar` / `Bsengine.ui.setProgressBar`, rendered via `egui::ProgressBar`; mini-arena's `hud.js` migrated from a plain-text HP readout to a real health bar | 2026-07-30 | branch `feat/health-bar-ui-widget` (PR #TBD) |

--- a/crates/bsengine-core/src/ui_state.rs
+++ b/crates/bsengine-core/src/ui_state.rs
@@ -76,6 +76,21 @@ pub enum UiWidget {
         /// Image height, in pixels.
         height: f32,
     },
+    /// A horizontal fill bar, e.g. for health/progress display.
+    ProgressBar {
+        /// Unique widget identifier.
+        id: String,
+        /// X position, in screen-space pixels.
+        x: f32,
+        /// Y position, in screen-space pixels.
+        y: f32,
+        /// Bar width, in pixels.
+        width: f32,
+        /// Bar height, in pixels.
+        height: f32,
+        /// Fill fraction, expected in 0.0..=1.0 (egui clamps out-of-range values).
+        fraction: f32,
+    },
 }
 
 impl UiWidget {
@@ -86,7 +101,8 @@ impl UiWidget {
             | Self::Button { id, .. }
             | Self::Panel { id, .. }
             | Self::TextInput { id, .. }
-            | Self::Image { id, .. } => id,
+            | Self::Image { id, .. }
+            | Self::ProgressBar { id, .. } => id,
         }
     }
 }
@@ -131,6 +147,38 @@ impl UiState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn set_widget_inserts_progress_bar() {
+        let mut state = UiState::default();
+        state.set_widget(UiWidget::ProgressBar {
+            id: "hp".into(),
+            x: 10.0,
+            y: 10.0,
+            width: 200.0,
+            height: 20.0,
+            fraction: 0.75,
+        });
+        assert_eq!(state.widgets.len(), 1);
+        if let UiWidget::ProgressBar { fraction, .. } = &state.widgets[0] {
+            assert_eq!(*fraction, 0.75);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn progress_bar_id_returns_its_id() {
+        let widget = UiWidget::ProgressBar {
+            id: "hp".into(),
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 10.0,
+            fraction: 0.5,
+        };
+        assert_eq!(widget.id(), "hp");
+    }
 
     #[test]
     fn set_widget_inserts_new() {

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1726,6 +1726,23 @@ impl WgpuSurface {
                                     );
                                 });
                         }
+                        UiWidget::ProgressBar {
+                            id,
+                            x,
+                            y,
+                            width,
+                            height,
+                            fraction,
+                        } => {
+                            egui::Area::new(egui::Id::new(id.as_str()))
+                                .fixed_pos(egui::pos2(*x, *y))
+                                .show(ctx, |ui| {
+                                    ui.add_sized(
+                                        egui::vec2(*width, *height),
+                                        egui::ProgressBar::new(*fraction),
+                                    );
+                                });
+                        }
                     }
                 }
 

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -948,6 +948,21 @@ pub enum ScriptCommand {
         /// Widget width, in pixels.
         width: f32,
     },
+    /// Create or update a UI progress/health bar.
+    SetUiProgressBar {
+        /// Identifier of the sound or UI widget to target.
+        id: String,
+        /// New absolute X position.
+        x: f32,
+        /// New absolute Y position.
+        y: f32,
+        /// Widget width, in pixels.
+        width: f32,
+        /// Widget height, in pixels.
+        height: f32,
+        /// Fill fraction, expected in 0.0..=1.0.
+        fraction: f32,
+    },
     /// Remove a UI widget by id.
     RemoveUiWidget {
         /// Identifier of the sound or UI widget to target.
@@ -5490,6 +5505,28 @@ pub fn bsengine_ui_set_text_input(
     });
 }
 
+/// Queue creating or updating a UI progress/health bar.
+#[op2(fast)]
+pub fn bsengine_ui_set_progress_bar(
+    #[string] id: String,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    fraction: f32,
+) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::SetUiProgressBar {
+            id,
+            x,
+            y,
+            width,
+            height,
+            fraction,
+        })
+    });
+}
+
 /// Queue removing a UI widget by id.
 #[op2(fast)]
 pub fn bsengine_ui_remove_widget(#[string] id: String) {
@@ -5905,6 +5942,7 @@ deno_core::extension!(
         bsengine_ui_set_button,
         bsengine_ui_set_panel,
         bsengine_ui_set_text_input,
+        bsengine_ui_set_progress_bar,
         bsengine_ui_remove_widget,
         bsengine_ui_clear,
         bsengine_ui_is_clicked,
@@ -6381,13 +6419,14 @@ var Bsengine = {
     // UI widgets — immediate-mode overlay (egui-backed)
     // Each call sets or replaces the widget with the given id.
     ui: {
-        setLabel:    (id, text, x, y, fontSize)       => Deno.core.ops.bsengine_ui_set_label(id, String(text), x, y, fontSize ?? 20),
-        setButton:   (id, label, x, y, width, height) => Deno.core.ops.bsengine_ui_set_button(id, label, x, y, width, height),
-        setPanel:    (id, title, x, y, width, height) => Deno.core.ops.bsengine_ui_set_panel(id, title ?? '', x, y, width, height),
-        setTextInput:(id, hint, x, y, width)          => Deno.core.ops.bsengine_ui_set_text_input(id, hint ?? '', x, y, width),
-        remove:      (id)                             => Deno.core.ops.bsengine_ui_remove_widget(id),
-        clear:       ()                               => Deno.core.ops.bsengine_ui_clear(),
-        isClicked:   (id)                             => Deno.core.ops.bsengine_ui_is_clicked(id),
+        setLabel:       (id, text, x, y, fontSize)          => Deno.core.ops.bsengine_ui_set_label(id, String(text), x, y, fontSize ?? 20),
+        setButton:      (id, label, x, y, width, height)    => Deno.core.ops.bsengine_ui_set_button(id, label, x, y, width, height),
+        setPanel:       (id, title, x, y, width, height)    => Deno.core.ops.bsengine_ui_set_panel(id, title ?? '', x, y, width, height),
+        setTextInput:   (id, hint, x, y, width)             => Deno.core.ops.bsengine_ui_set_text_input(id, hint ?? '', x, y, width),
+        setProgressBar: (id, x, y, width, height, fraction) => Deno.core.ops.bsengine_ui_set_progress_bar(id, x, y, width, height, fraction),
+        remove:         (id)                                => Deno.core.ops.bsengine_ui_remove_widget(id),
+        clear:          ()                                  => Deno.core.ops.bsengine_ui_clear(),
+        isClicked:      (id)                                => Deno.core.ops.bsengine_ui_is_clicked(id),
     },
 
     // NavMesh pathfinding — call navmesh.init() first to build the grid
@@ -10655,6 +10694,28 @@ JSON.stringify(received)
             "3"
         );
         super::NETWORK_STATE_SNAPSHOT.with(|s| *s.borrow_mut() = (false, false, 0, 0));
+    }
+
+    #[test]
+    fn test_ui_set_progress_bar_queues_command() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.exec_source(
+            r#"Bsengine.ui.setProgressBar("hp", 10, 20, 200, 24, 0.75);"#,
+            "<test>",
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetUiProgressBar { id, x, y, width, height, fraction }
+                    if id == "hp" && *x == 10.0 && *y == 20.0 && *width == 200.0
+                    && *height == 24.0 && *fraction == 0.75
+            )));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -1427,6 +1427,25 @@ fn run_scripts(world: &mut World) {
                     });
                 }
             }
+            ScriptCommand::SetUiProgressBar {
+                id,
+                x,
+                y,
+                width,
+                height,
+                fraction,
+            } => {
+                if let Some(mut ui) = world.get_resource_mut::<UiState>() {
+                    ui.set_widget(UiWidget::ProgressBar {
+                        id,
+                        x,
+                        y,
+                        width,
+                        height,
+                        fraction,
+                    });
+                }
+            }
             ScriptCommand::RemoveUiWidget { id } => {
                 if let Some(mut ui) = world.get_resource_mut::<UiState>() {
                     ui.remove_widget(&id);

--- a/games/mini-arena/assets/scripts/hud.js
+++ b/games/mini-arena/assets/scripts/hud.js
@@ -11,7 +11,8 @@ Bsengine.onMessage("Hud", "scoreLoaded", (data) => {
 function onUpdate(self) {
     const hp = Math.round(Bsengine.getShield("Player"));
     const maxHp = Math.round(Bsengine.getMaxShield("Player"));
-    Bsengine.setHudText("health", `HP: ${hp}/${maxHp}`);
+    Bsengine.ui.setProgressBar("healthbar", 10, 10, 200, 24, hp / maxHp);
+    Bsengine.ui.setLabel("healthbar_label", `HP: ${hp}/${maxHp}`, 16, 13, 16);
     Bsengine.setHudText("score", `Score: ${score}`);
     Bsengine.setSaveField("Player", "score", String(score));
 }


### PR DESCRIPTION
## Summary
- Added `UiWidget::ProgressBar`, exposed as `Bsengine.ui.setProgressBar(id, x, y, width, height, fraction)`, following the exact same pipeline the other four `Bsengine.ui.*` widgets (`setLabel`/`setButton`/`setPanel`/`setTextInput`) already use — `UiWidget` variant → `ScriptCommand` variant → `#[op2(fast)]` op → JS binding → `run_scripts` handler → egui render branch (`egui::ProgressBar`).
- `games/mini-arena`'s `hud.js` migrated from a plain-text `HP: X/Y` HUD readout to a real health bar + overlaid label, closing the gap where "a health bar has to be faked with plain text."
- ENGINE_ROADMAP item 20 added; backfilled item 19's PR link (#1740).

## Test plan
- [x] `cargo test -p bsengine-core -p bsengine-scripting -p bsengine-rhi-wgpu` — all pass (183/285/112)
- [x] `cargo build --workspace` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean (only 2 pre-existing, unrelated `derivable_impls` warnings in `bsengine-core`)
- [x] Manual playtest: `cargo run -p bsengine-runtime -- ./games/mini-arena` — health bar renders correctly, no egui/panic errors
- Note: same known, pre-existing, environment-specific stack overflows as prior PRs (#1739, #1740) in `bsengine-editor`/`bsengine-runtime`'s own test suites when run concatenated — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)