### PR TITLE
feat: point light shadows via linear-distance cube arrays

### DIFF
--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -363,6 +363,24 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 
 ---
 
+### 22. 포인트 라이트 그림자 ✅
+
+**목표:** 기존엔 방향광(directional light) 하나만 그림자를 드리웠는데,
+포인트 라이트(최대 8개, `MAX_POINT_LIGHTS`)도 실제로 그림자를 드리우게 함
+
+**완료 조건:**
+- [x] 선형 거리 큐브 배열(linear-distance cube array) 방식으로 구현 — 각
+  포인트 라이트당 6면(정육면체 각 방향) 렌더 패스, `R32Float` 텍스처
+  배열(최대 48 레이어)에 광원으로부터의 선형 거리 저장
+- [x] 메인 라이팅 셰이더(`MESH_WGSL`)에서 수동 큐브 면 선택 + 저장된 거리와
+  비교하는 방식으로 그림자 적용 (depth-compare 큐브맵 대신 선택 — 면 선택
+  재구성 로직이 훨씬 단순하고 seam 버그 위험이 적음)
+- [x] Mini Action Arena의 `ArenaLight`(포인트 라이트)가 별도 콘텐츠 수정 없이
+  자동으로 그림자를 드리움 (방향광과 동일하게 옵트아웃 토글 없음)
+- [x] CI 통과
+
+---
+
 ## 완료 이력
 
 | 항목 | 완료일 | PR |
@@ -420,4 +438,5 @@ self-hit, (8) player.js: 레이캐스트 origin 높이(+0.9)가 콜라이더 상
 | 18. `gltf:`/`CustomShader.path` project-relative resolution via shared `bsengine_core::ProjectDir`/`resolve_project_path`; fixed `EditorCommand::LoadScene` never spawning `GltfAsset` for gltf entities at all; mini-arena content migrated off its CWD-relative workaround | 2026-07-30 | [#1739](https://github.com/blas1n/BSEngine/pull/1739) |
 | 19. Exposed elapsed time to custom WGSL shaders via `CameraUniform.time` (reusing an existing unused padding field, zero buffer layout change); mini-arena's `glow.wgsl`/`pickup.js` migrated from per-frame JS-driven emissive pulsing to a GPU-computed one | 2026-07-30 | [#1740](https://github.com/blas1n/BSEngine/pull/1740) |
 | 20. Added `UiWidget::ProgressBar` / `Bsengine.ui.setProgressBar`, rendered via `egui::ProgressBar`; mini-arena's `hud.js` migrated from a plain-text HP readout to a real health bar | 2026-07-30 | [#1741](https://github.com/blas1n/BSEngine/pull/1741) |
-| 21. Real pause: `bsengine_core::PauseState` actually gates `PhysicsPlugin`/`NavMeshPlugin`; `Bsengine.pause`/`resume`/`isPaused` scripting API; mini-arena's pause menu now actually stops the Enemy and Player instead of just showing a panel | 2026-07-30 | branch `feat/pause-timescale-system` (PR #TBD) |
+| 21. Real pause: `bsengine_core::PauseState` actually gates `PhysicsPlugin`/`NavMeshPlugin`; `Bsengine.pause`/`resume`/`isPaused` scripting API; mini-arena's pause menu now actually stops the Enemy and Player instead of just showing a panel | 2026-07-30 | [#1742](https://github.com/blas1n/BSEngine/pull/1742) |
+| 22. Point light shadows via linear-distance cube arrays (up to `MAX_POINT_LIGHTS`=8, 6 faces each, `R32Float` texture array), sampled in `MESH_WGSL` via manual cube-face selection; mini-arena's `ArenaLight` now casts a shadow automatically | 2026-07-31 | branch `feat/point-light-shadows` (PR #TBD) |

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -227,6 +227,45 @@ fn vs_shadow(in: VertIn) -> @builtin(position) vec4<f32> {
 }
 "#;
 
+const POINT_SHADOW_WGSL: &str = r#"
+struct ShadowUniform {
+    view_proj: mat4x4<f32>,
+    light_pos: vec3<f32>,
+};
+@group(0) @binding(0) var<uniform> shadow_uniform: ShadowUniform;
+
+struct ModelUniform {
+    model: mat4x4<f32>,
+};
+@group(1) @binding(0) var<uniform> model_data: ModelUniform;
+
+struct VertIn {
+    @location(0) pos: vec3<f32>,
+    @location(1) col: vec3<f32>,
+    @location(2) normal: vec3<f32>,
+    @location(3) uv: vec2<f32>,
+}
+struct VertOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) world_pos: vec3<f32>,
+}
+
+@vertex
+fn vs_point_shadow(in: VertIn) -> VertOut {
+    var out: VertOut;
+    let world = model_data.model * vec4<f32>(in.pos, 1.0);
+    out.clip_pos = shadow_uniform.view_proj * world;
+    out.world_pos = world.xyz;
+    return out;
+}
+
+@fragment
+fn fs_point_shadow(in: VertOut) -> @location(0) vec4<f32> {
+    let dist = length(in.world_pos - shadow_uniform.light_pos);
+    return vec4<f32>(dist, 0.0, 0.0, 1.0);
+}
+"#;
+
 const SKYBOX_WGSL: &str = r#"
 const PI: f32 = 3.14159265358979323846;
 struct SkyUniform {
@@ -278,6 +317,14 @@ const LIGHT_UNIFORM_SIZE: u64 = 960;
 // Vertex stride: position(12) + color(12) + normal(12) + uv(8) = 44 bytes
 const VERTEX_STRIDE: u64 = 44;
 const SHADOW_MAP_SIZE: u32 = 2048;
+/// Deliberately much smaller than `SHADOW_MAP_SIZE` — at this size, 48 layers
+/// (`MAX_POINT_LIGHTS` * 6 faces) of `R32Float` is ~48 MiB; at 2048 it would be
+/// ~768 MiB, unreasonable for a secondary shadow feature.
+const POINT_SHADOW_MAP_SIZE: u32 = 512;
+/// Per-face dynamic-offset stride for `point_shadow_uniform_buffer`, mirroring
+/// `MODEL_STRIDE`'s 256-byte convention (`PointShadowUniformData` is 80 bytes;
+/// 256 satisfies wgpu's minimum uniform buffer offset alignment on every backend).
+const POINT_SHADOW_STRIDE: u64 = 256;
 
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
@@ -326,6 +373,14 @@ struct ModelUniformData {
     _pad2: f32,
     base_color: [f32; 3],
     _pad3: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct PointShadowUniformData {
+    view_proj: [[f32; 4]; 4],
+    light_pos: [f32; 3],
+    _pad: f32,
 }
 
 /// A single point light entry for the GPU buffer.
@@ -556,6 +611,13 @@ pub struct WgpuSurface {
     _shadow_map_texture: wgpu::Texture,
     shadow_map_view: wgpu::TextureView,
     _shadow_comparison_sampler: wgpu::Sampler,
+    point_shadow_pipeline: wgpu::RenderPipeline,
+    _point_shadow_color_texture: wgpu::Texture,
+    _point_shadow_depth_texture: wgpu::Texture,
+    point_shadow_depth_view: wgpu::TextureView,
+    _point_shadow_sampler: wgpu::Sampler,
+    point_shadow_uniform_buffer: wgpu::Buffer,
+    point_shadow_bind_group: wgpu::BindGroup,
     egui_ctx: egui::Context,
     egui_renderer: egui_wgpu::Renderer,
     skybox: Option<SkyboxState>,
@@ -727,6 +789,22 @@ impl WgpuSurface {
                     },
                     count: None,
                 },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 4,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2Array,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
             ],
         });
 
@@ -761,6 +839,96 @@ impl WgpuSurface {
             ..Default::default()
         });
 
+        // --- point light shadow maps (linear-distance cube arrays) ---
+        let point_shadow_color_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("point shadow color array"),
+            size: wgpu::Extent3d {
+                width: POINT_SHADOW_MAP_SIZE,
+                height: POINT_SHADOW_MAP_SIZE,
+                depth_or_array_layers: (MAX_POINT_LIGHTS * 6) as u32,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R32Float,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let point_shadow_color_full_view =
+            point_shadow_color_texture.create_view(&wgpu::TextureViewDescriptor {
+                label: Some("point shadow color array view (full)"),
+                dimension: Some(wgpu::TextureViewDimension::D2Array),
+                ..Default::default()
+            });
+
+        let point_shadow_depth_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("point shadow depth"),
+            size: wgpu::Extent3d {
+                width: POINT_SHADOW_MAP_SIZE,
+                height: POINT_SHADOW_MAP_SIZE,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let point_shadow_depth_view =
+            point_shadow_depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // R32Float is not natively filterable without the FLOAT32_FILTERABLE
+        // device feature (not requested — required_features is empty()), so
+        // this must be a non-filtering sampler with Nearest filter modes,
+        // matching the directional shadow's own shadow_comparison_sampler
+        // (also Nearest) for consistency.
+        let point_shadow_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("point shadow sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        let point_shadow_uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("point shadow uniform"),
+            size: POINT_SHADOW_STRIDE * (MAX_POINT_LIGHTS * 6) as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let point_shadow_uniform_bgl =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("point shadow uniform bgl"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: wgpu::BufferSize::new(
+                            std::mem::size_of::<PointShadowUniformData>() as u64,
+                        ),
+                    },
+                    count: None,
+                }],
+            });
+        let point_shadow_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("point shadow uniform bg"),
+            layout: &point_shadow_uniform_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &point_shadow_uniform_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(
+                        std::mem::size_of::<PointShadowUniformData>() as u64
+                    ),
+                }),
+            }],
+        });
+
         let light_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("light bg"),
             layout: &light_bgl,
@@ -776,6 +944,14 @@ impl WgpuSurface {
                 wgpu::BindGroupEntry {
                     binding: 2,
                     resource: wgpu::BindingResource::TextureView(&shadow_map_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::Sampler(&point_shadow_sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: wgpu::BindingResource::TextureView(&point_shadow_color_full_view),
                 },
             ],
         });
@@ -848,6 +1024,54 @@ impl WgpuSurface {
             multiview: None,
             cache: None,
         });
+
+        let point_shadow_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("point shadow shader"),
+            source: wgpu::ShaderSource::Wgsl(POINT_SHADOW_WGSL.into()),
+        });
+        let point_shadow_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("point shadow pipeline layout"),
+                bind_group_layouts: &[&point_shadow_uniform_bgl, &model_bgl],
+                push_constant_ranges: &[],
+            });
+        let point_shadow_pipeline =
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("point shadow pipeline"),
+                layout: Some(&point_shadow_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &point_shadow_shader,
+                    entry_point: "vs_point_shadow",
+                    buffers: std::slice::from_ref(&vertex_buffer_layout),
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &point_shadow_shader,
+                    entry_point: "fs_point_shadow",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::R32Float,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    cull_mode: Some(wgpu::Face::Back),
+                    front_face: wgpu::FrontFace::Ccw,
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: DEPTH_FORMAT,
+                    depth_write_enabled: true,
+                    depth_compare: wgpu::CompareFunction::Less,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
 
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("mesh shader"),
@@ -931,6 +1155,13 @@ impl WgpuSurface {
             _shadow_map_texture: shadow_map_texture,
             shadow_map_view,
             _shadow_comparison_sampler: shadow_comparison_sampler,
+            point_shadow_pipeline,
+            _point_shadow_color_texture: point_shadow_color_texture,
+            _point_shadow_depth_texture: point_shadow_depth_texture,
+            point_shadow_depth_view,
+            _point_shadow_sampler: point_shadow_sampler,
+            point_shadow_uniform_buffer,
+            point_shadow_bind_group,
             egui_ctx,
             egui_renderer,
             skybox: None,
@@ -2357,5 +2588,11 @@ mod tests {
     fn shadow_shader_compiles() {
         let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
         let _module = WgpuSurface::compile_shader(&rhi.device, SHADOW_WGSL);
+    }
+
+    #[test]
+    fn point_shadow_shader_compiles() {
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
+        let _module = WgpuSurface::compile_shader(&rhi.device, POINT_SHADOW_WGSL);
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1694,6 +1694,89 @@ impl WgpuSurface {
             }
         }
 
+        // --- point light shadow passes (linear-distance cube arrays) ---
+        {
+            let active_lights: Vec<_> = light.point_lights.iter().take(MAX_POINT_LIGHTS).collect();
+            for (light_idx, pl) in active_lights.iter().enumerate() {
+                let view_projs = point_light_face_view_projs(pl.position, pl.range);
+                for (face, vp) in view_projs.iter().enumerate() {
+                    let slot = light_idx * 6 + face;
+                    let data = PointShadowUniformData {
+                        view_proj: vp.to_cols_array_2d(),
+                        light_pos: pl.position.to_array(),
+                        _pad: 0.0,
+                    };
+                    self.queue.write_buffer(
+                        &self.point_shadow_uniform_buffer,
+                        slot as u64 * POINT_SHADOW_STRIDE,
+                        bytemuck::cast_slice(&[data]),
+                    );
+                }
+            }
+            for (light_idx, _pl) in active_lights.iter().enumerate() {
+                for face in 0..6usize {
+                    let slot = light_idx * 6 + face;
+                    let layer_view =
+                        self._point_shadow_color_texture.create_view(&wgpu::TextureViewDescriptor {
+                            label: Some("point shadow layer view"),
+                            dimension: Some(wgpu::TextureViewDimension::D2),
+                            base_array_layer: slot as u32,
+                            array_layer_count: Some(1),
+                            ..Default::default()
+                        });
+                    let mut point_shadow_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("point shadow pass"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &layer_view,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color {
+                                    r: 1.0e6,
+                                    g: 0.0,
+                                    b: 0.0,
+                                    a: 1.0,
+                                }),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                            view: &self.point_shadow_depth_view,
+                            depth_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(1.0),
+                                store: wgpu::StoreOp::Store,
+                            }),
+                            stencil_ops: None,
+                        }),
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+                    point_shadow_pass.set_pipeline(&self.point_shadow_pipeline);
+                    let uniform_offset = (slot as u64 * POINT_SHADOW_STRIDE) as u32;
+                    point_shadow_pass.set_bind_group(
+                        0,
+                        &self.point_shadow_bind_group,
+                        &[uniform_offset],
+                    );
+                    for (i, (mesh_id, _, _, _, _)) in draw_calls.iter().enumerate() {
+                        if i >= MAX_OBJECTS {
+                            break;
+                        }
+                        let Some(mesh) = registry.get(*mesh_id) else {
+                            continue;
+                        };
+                        let offset = (i as u64 * MODEL_STRIDE) as u32;
+                        point_shadow_pass.set_bind_group(1, &self.model_bind_group, &[offset]);
+                        point_shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                        point_shadow_pass.set_index_buffer(
+                            mesh.index_buffer.slice(..),
+                            wgpu::IndexFormat::Uint32,
+                        );
+                        point_shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
+                    }
+                }
+            }
+        }
+
         // --- main pass (into HDR buffer) ---
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -973,9 +973,9 @@ impl WgpuSurface {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: true,
-                        min_binding_size: wgpu::BufferSize::new(
-                            std::mem::size_of::<PointShadowUniformData>() as u64,
-                        ),
+                        min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<
+                            PointShadowUniformData,
+                        >() as u64),
                     },
                     count: None,
                 }],
@@ -1782,40 +1782,44 @@ impl WgpuSurface {
             for (light_idx, _pl) in active_lights.iter().enumerate() {
                 for face in 0..6usize {
                     let slot = light_idx * 6 + face;
-                    let layer_view =
-                        self._point_shadow_color_texture.create_view(&wgpu::TextureViewDescriptor {
+                    let layer_view = self._point_shadow_color_texture.create_view(
+                        &wgpu::TextureViewDescriptor {
                             label: Some("point shadow layer view"),
                             dimension: Some(wgpu::TextureViewDimension::D2),
                             base_array_layer: slot as u32,
                             array_layer_count: Some(1),
                             ..Default::default()
+                        },
+                    );
+                    let mut point_shadow_pass =
+                        encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: Some("point shadow pass"),
+                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                view: &layer_view,
+                                resolve_target: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                                        r: 1.0e6,
+                                        g: 0.0,
+                                        b: 0.0,
+                                        a: 1.0,
+                                    }),
+                                    store: wgpu::StoreOp::Store,
+                                },
+                            })],
+                            depth_stencil_attachment: Some(
+                                wgpu::RenderPassDepthStencilAttachment {
+                                    view: &self.point_shadow_depth_view,
+                                    depth_ops: Some(wgpu::Operations {
+                                        load: wgpu::LoadOp::Clear(1.0),
+                                        store: wgpu::StoreOp::Store,
+                                    }),
+                                    stencil_ops: None,
+                                },
+                            ),
+                            timestamp_writes: None,
+                            occlusion_query_set: None,
                         });
-                    let mut point_shadow_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                        label: Some("point shadow pass"),
-                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                            view: &layer_view,
-                            resolve_target: None,
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(wgpu::Color {
-                                    r: 1.0e6,
-                                    g: 0.0,
-                                    b: 0.0,
-                                    a: 1.0,
-                                }),
-                                store: wgpu::StoreOp::Store,
-                            },
-                        })],
-                        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                            view: &self.point_shadow_depth_view,
-                            depth_ops: Some(wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(1.0),
-                                store: wgpu::StoreOp::Store,
-                            }),
-                            stencil_ops: None,
-                        }),
-                        timestamp_writes: None,
-                        occlusion_query_set: None,
-                    });
                     point_shadow_pass.set_pipeline(&self.point_shadow_pipeline);
                     let uniform_offset = (slot as u64 * POINT_SHADOW_STRIDE) as u32;
                     point_shadow_pass.set_bind_group(

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2651,6 +2651,68 @@ mod tests {
     }
 
     #[test]
+    fn point_shadow_wgsl_face_selection_matches_view_proj_ndc() {
+        // Independently reimplements point_shadow_factor's manual cube-face
+        // selection + UV math from MESH_WGSL in Rust, and checks it agrees
+        // with the ACTUAL NDC the corresponding point_light_face_view_projs
+        // matrix produces for the same point -- that matrix is what actually
+        // gets rendered into each shadow face, so agreement here is what
+        // proves the shader samples the correct texel. Deliberately uses
+        // off-axis points (not purely along one axis) so a U/V swap or sign
+        // error would be caught -- a point exactly on-axis projects to NDC
+        // (0,0) either way and can't distinguish those bugs (see the
+        // "projects_near_center" test above, which only checks that case).
+        fn wgsl_face_uv(to_frag: Vec3) -> (usize, f32, f32) {
+            let ax = to_frag.x.abs();
+            let ay = to_frag.y.abs();
+            let az = to_frag.z.abs();
+            let (face, u, v, ma) = if ax >= ay && ax >= az {
+                if to_frag.x > 0.0 {
+                    (0, -to_frag.z, -to_frag.y, ax)
+                } else {
+                    (1, to_frag.z, -to_frag.y, ax)
+                }
+            } else if ay >= ax && ay >= az {
+                if to_frag.y > 0.0 {
+                    (2, to_frag.x, to_frag.z, ay)
+                } else {
+                    (3, to_frag.x, -to_frag.z, ay)
+                }
+            } else if to_frag.z > 0.0 {
+                (4, to_frag.x, -to_frag.y, az)
+            } else {
+                (5, -to_frag.x, -to_frag.y, az)
+            };
+            (face, u / ma, v / ma)
+        }
+
+        let light_pos = Vec3::ZERO;
+        let vps = point_light_face_view_projs(light_pos, 10.0);
+        let cases: [(Vec3, usize); 6] = [
+            (Vec3::new(3.0, 0.5, -1.0), 0),
+            (Vec3::new(-3.0, 0.5, -1.0), 1),
+            (Vec3::new(0.5, 3.0, -1.0), 2),
+            (Vec3::new(0.5, -3.0, -1.0), 3),
+            (Vec3::new(0.5, -1.0, 3.0), 4),
+            (Vec3::new(0.5, -1.0, -3.0), 5),
+        ];
+        for (to_frag, expected_face) in cases {
+            let (face, u, v) = wgsl_face_uv(to_frag);
+            assert_eq!(
+                face, expected_face,
+                "face selection mismatch for {to_frag:?}"
+            );
+            let world = light_pos + to_frag;
+            let clip = vps[face] * world.extend(1.0);
+            let ndc = clip.truncate() / clip.w;
+            assert!(
+                (ndc.x - u).abs() < 1e-4 && (ndc.y - v).abs() < 1e-4,
+                "face {face}: WGSL-equivalent uv=({u},{v}) does not match actual NDC {ndc:?} for {to_frag:?}"
+            );
+        }
+    }
+
+    #[test]
     fn mesh_shader_compiles() {
         let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
         let _module = WgpuSurface::compile_shader(&rhi.device, MESH_WGSL);

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -70,6 +70,7 @@ struct LightUniform {
 @group(3) @binding(1) var s_diffuse: sampler;
 @group(2) @binding(1) var shadow_sampler: sampler_comparison;
 @group(2) @binding(2) var shadow_map: texture_depth_2d;
+@group(2) @binding(4) var point_shadow_map: texture_2d_array<f32>;
 
 struct VertIn {
     @location(0) pos: vec3<f32>,
@@ -110,6 +111,70 @@ fn shadow_factor(lsp: vec4<f32>) -> f32 {
         return 1.0;
     }
     return textureSampleCompare(shadow_map, shadow_sampler, uv, depth - 0.003);
+}
+// Linear-distance cube shadow lookup: `to_frag` is the direction from the
+// light to the fragment (world-space, unnormalized). Selects the cube face
+// whose axis has the largest magnitude, derives that face's UV analytically
+// (matching point_light_face_view_projs's Rust-side look_at_rh/perspective
+// construction exactly -- verified by hand against glam's look_at_rh
+// convention), then compares against the stored linear distance for that
+// face/light layer instead of using a depth-compare sampler (R32Float isn't
+// natively filterable without an unrequested device feature, so this reads
+// a raw texel via textureLoad rather than textureSample).
+fn point_shadow_factor(light_index: u32, to_frag: vec3<f32>) -> f32 {
+    let ax = abs(to_frag.x);
+    let ay = abs(to_frag.y);
+    let az = abs(to_frag.z);
+    var face: u32;
+    var u: f32;
+    var v: f32;
+    var ma: f32;
+    if (ax >= ay && ax >= az) {
+        ma = ax;
+        if (to_frag.x > 0.0) {
+            face = 0u;
+            u = -to_frag.z;
+            v = -to_frag.y;
+        } else {
+            face = 1u;
+            u = to_frag.z;
+            v = -to_frag.y;
+        }
+    } else if (ay >= ax && ay >= az) {
+        ma = ay;
+        if (to_frag.y > 0.0) {
+            face = 2u;
+            u = to_frag.x;
+            v = to_frag.z;
+        } else {
+            face = 3u;
+            u = to_frag.x;
+            v = -to_frag.z;
+        }
+    } else {
+        ma = az;
+        if (to_frag.z > 0.0) {
+            face = 4u;
+            u = to_frag.x;
+            v = -to_frag.y;
+        } else {
+            face = 5u;
+            u = -to_frag.x;
+            v = -to_frag.y;
+        }
+    }
+    let ndc = vec2<f32>(u, v) / max(ma, 0.0001);
+    let uv = ndc * vec2<f32>(0.5, -0.5) + vec2<f32>(0.5, 0.5);
+    // Must match POINT_SHADOW_MAP_SIZE in bsengine-rhi-wgpu/src/surface.rs.
+    let size = 512.0;
+    let px = vec2<i32>(clamp(uv, vec2<f32>(0.0), vec2<f32>(0.999999)) * size);
+    let layer = i32(light_index * 6u + face);
+    let stored = textureLoad(point_shadow_map, px, layer, 0).r;
+    let dist = length(to_frag);
+    if (dist - 0.1 > stored) {
+        return 0.0;
+    }
+    return 1.0;
 }
 fn distribution_ggx(n_dot_h: f32, roughness: f32) -> f32 {
     let a = roughness * roughness;
@@ -169,7 +234,8 @@ fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
             let f = fresnel_schlick(h_dot_v, f0);
             let kd = (vec3<f32>(1.0, 1.0, 1.0) - f) * (1.0 - metallic);
             let specular = (ndf * g * f) / (4.0 * n_dot_v * n_dot_l + 0.0001);
-            lo += (kd * albedo / PI + specular) * pl.color * (pl.intensity * t * t) * n_dot_l;
+            let pt_lit = point_shadow_factor(i, -to_light);
+            lo += (kd * albedo / PI + specular) * pl.color * (pl.intensity * t * t) * n_dot_l * pt_lit;
         }
     }
     for (var j: u32 = 0u; j < light.num_spot_lights; j++) {

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -514,6 +514,24 @@ fn map_keycode_to_egui(code: bsengine_input::KeyCode) -> Option<egui::Key> {
     })
 }
 
+/// Computes the 6 face view-projection matrices for a point light's cube shadow
+/// map, one per axis-aligned direction, using the standard cubemap face
+/// orientation convention (+Y/-Y up-vectors on the X/Z faces to avoid a
+/// degenerate look-at when looking straight up/down).
+fn point_light_face_view_projs(position: Vec3, range: f32) -> [Mat4; 6] {
+    let far = range.max(0.5);
+    let proj = Mat4::perspective_rh(std::f32::consts::FRAC_PI_2, 1.0, 0.05, far);
+    let dirs: [(Vec3, Vec3); 6] = [
+        (Vec3::X, Vec3::NEG_Y),
+        (Vec3::NEG_X, Vec3::NEG_Y),
+        (Vec3::Y, Vec3::Z),
+        (Vec3::NEG_Y, Vec3::NEG_Z),
+        (Vec3::Z, Vec3::NEG_Y),
+        (Vec3::NEG_Z, Vec3::NEG_Y),
+    ];
+    dirs.map(|(dir, up)| proj * Mat4::look_at_rh(position, position + dir, up))
+}
+
 /// Owns the wgpu swapchain, all GPU pipelines/buffers for the main scene and
 /// shadow passes, the egui renderer, and per-frame render state for one window.
 pub struct WgpuSurface {
@@ -2213,6 +2231,40 @@ pub struct WgpuSurfaceResource(pub WgpuSurface);
 mod tests {
     use super::*;
     use crate::rhi::WgpuRHI;
+
+    #[test]
+    fn point_light_face_view_projs_all_invertible() {
+        let vps = point_light_face_view_projs(Vec3::new(1.0, 2.0, 3.0), 10.0);
+        for (i, vp) in vps.iter().enumerate() {
+            assert!(
+                vp.determinant().abs() > 1e-6,
+                "face {i} view-proj should be invertible"
+            );
+        }
+    }
+
+    #[test]
+    fn point_light_face_view_projs_point_along_face_direction_projects_near_center() {
+        let light_pos = Vec3::ZERO;
+        let vps = point_light_face_view_projs(light_pos, 10.0);
+        let dirs = [
+            Vec3::X,
+            Vec3::NEG_X,
+            Vec3::Y,
+            Vec3::NEG_Y,
+            Vec3::Z,
+            Vec3::NEG_Z,
+        ];
+        for (vp, dir) in vps.iter().zip(dirs.iter()) {
+            let world = light_pos + *dir * 5.0;
+            let clip = *vp * world.extend(1.0);
+            let ndc = clip.truncate() / clip.w;
+            assert!(
+                ndc.x.abs() < 1e-4 && ndc.y.abs() < 1e-4,
+                "point along face direction {dir:?} should project near NDC (0,0), got {ndc:?}"
+            );
+        }
+    }
 
     #[test]
     fn mesh_shader_compiles() {


### PR DESCRIPTION
## Summary
- All active point lights (up to `MAX_POINT_LIGHTS = 8`) now cast real shadows, closing the last of 8 non-blocking gaps from `games/mini-arena/GAP_LOG.md` — previously only the single directional light cast a shadow.
- Technique: **linear-distance cube arrays**, not depth-compare cubemaps. Each point light gets 6 shadow render passes (48 total when 8 lights are active), rendering `length(world_pos - light_pos)` into a `R32Float` texture array layer. The main lighting shader (`MESH_WGSL`) does manual cube-face selection (largest-magnitude-axis test) and a plain distance comparison via `textureLoad` — avoids the more error-prone per-face NDC reconstruction a real depth-compare cubemap would need.
- `POINT_SHADOW_MAP_SIZE = 512` (deliberately much smaller than the directional shadow's 2048) keeps VRAM to ~48 MiB for all 48 layers.
- `R32Float` isn't natively filterable without an unrequested device feature — discovered via an actual wgpu validation panic during implementation, fixed by declaring the texture non-filterable and sampling with `textureLoad` instead of `textureSample`.
- **Correctness verification for the hand-derived cube-face math** (the highest-risk part of this change): added `point_shadow_wgsl_face_selection_matches_view_proj_ndc`, which reimplements the WGSL face-selection/UV logic in Rust and checks it against the *actual* NDC output of the matrices used to render each face, using off-axis test points for all 6 faces (an on-axis-only check can't catch a U/V swap or sign error, since those still project to NDC center) — this passes, giving strong confidence the shader samples the correct shadow texel.
- mini-arena's `ArenaLight` (existing point light) automatically starts casting a shadow — no content changes needed, matching the directional light's own always-on precedent (no per-light opt-out).
- ENGINE_ROADMAP item 22 added (the last item in this 8-gap series); backfilled item 21's PR link (#1742).

## Test plan
- [x] `cargo test -p bsengine-rhi-wgpu` — all pass (116, including the new face-view-proj tests and the independent numerical cross-check)
- [x] `cargo build --workspace` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean (only 2 pre-existing, unrelated `derivable_impls` warnings in `bsengine-core`)
- [x] Three separate `cargo run` smoke tests (8s/10s/20s) against `./games/mini-arena` — no wgpu validation panics across many frames of real rendering with the new bind group layout, 48 shadow passes, and shader sampling all active
- [x] Replayed the existing recorded mini-arena E2E playthrough — exits 0, confirming no gameplay regression (this doesn't exercise the GPU rendering path, since headless test mode has no window/surface)
- **Honest limitation**: none of this constitutes actual pixel/visual confirmation that the shadow renders in the geometrically correct position/shape — this crate has no test infrastructure that inspects rendered output, and I cannot view the window myself. The numerical cross-check test is the strongest evidence of correctness available without a human looking at the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)