### PR TITLE
fix(build): set RUST_MIN_STACK in .cargo/config.toml so local tests match CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,3 +9,17 @@ target-dir = "C:\\BSEngine-target"
 # wgpu Vulkan layer enumeration exceeds Windows' default 1MB main-thread stack
 # in debug builds. 64MB gives ample headroom for both debug and release.
 rustflags = ["-C", "link-args=/STACK:67108864"]
+
+[env]
+# The /STACK: link arg above only sizes the *main* thread. libtest runs every
+# #[test] on a spawned thread instead, and Rust passes its own default stack
+# size (2 MiB) to CreateThread rather than inheriting the PE header's value —
+# so tests never saw that 64MB. 2 MiB isn't enough for V8 (deno_core, reached
+# via any scripting test) or bsengine-editor's reflection-heavy suite, which
+# made `cargo test --workspace` die with STATUS_STACK_OVERFLOW locally while
+# CI stayed green: CI already sets this exact variable inline in
+# .github/workflows/ci.yml, so only local runs were affected. Setting it here
+# makes local match CI. Deliberately the same 8 MiB value CI uses, not more —
+# the point is parity, so a passing local run means a passing CI run. Not
+# `force = true`, so CI's explicit env var (and any manual override) still wins.
+RUST_MIN_STACK = "8388608"


### PR DESCRIPTION
## Summary

`cargo test --workspace` has been dying locally with `STATUS_STACK_OVERFLOW` — in `bsengine-editor`'s test binary, and in `bsengine-runtime`'s `editor_plugin_reload_scene_does_not_corrupt_scripting` — while CI stayed green. It reproduces on pristine `master`, so it kept getting filed as an unexplained pre-existing bug (twice: once on 2026-07-28 during #1719, again on 2026-07-31 during item 23).

**Root cause:** the `/STACK:67108864` link arg already in `.cargo/config.toml` only sizes the **main** thread. libtest runs every `#[test]` on a **spawned** thread, and Rust passes its own default (2 MiB) to `CreateThread` rather than inheriting the PE header's value — so tests never saw that 64MB. 2 MiB isn't enough for V8 (deno_core, reached via any scripting test) or `bsengine-editor`'s reflection-heavy suite.

**Why CI was unaffected:** `.github/workflows/ci.yml` already sets `RUST_MIN_STACK: 8388608` inline on both test steps. This was never a bug in any crate's code — purely a local-vs-CI configuration gap. (Older plan docs from 2026-07-13 worked around it by manually prefixing *every* test command with `RUST_MIN_STACK=8388608`.)

**Fix:** set the same 8 MiB value in `.cargo/config.toml`'s `[env]`, so a local run matches CI by default. Deliberately the same value CI uses rather than something larger — the point is parity, so "passes locally" means "passes in CI". Not `force = true`, so CI's explicit env var still wins.

CI's separate `--exclude bsengine-editor` step is **left alone on purpose**: 8 MiB proved sufficient for the concatenated run locally, but that step exists for a CI-specific reason (V8 reserving large VA regions blocking editor test-thread stack growth), which a local pass can't disprove.

## Evidence

Experiments that isolated the cause:

| | result |
|---|---|
| baseline `cargo test -p bsengine-runtime editor_plugin_reload_scene_does_not_corrupt_scripting` | overflow, 100% reproducible |
| same + `RUST_MIN_STACK=64MB` | passes |
| same + `--test-threads=1` (no env var) | still overflows → confirms spawned-thread stack, not main |
| `cargo test --workspace` + `RUST_MIN_STACK=64MB` | 0 overflows, exit 0 |
| `cargo test --workspace` + `RUST_MIN_STACK=8MB` (CI's value, incl. `bsengine-editor`) | 0 overflows, exit 0 |

## Test plan

- [x] With **no env var set**, on this commit: `cargo test -p bsengine-runtime editor_plugin_reload_scene_does_not_corrupt_scripting` → `1 passed` (was a 100%-reproducible overflow immediately before)
- [x] With **no env var set**: `cargo test --workspace --no-fail-fast` → exit 0, zero overflows, zero failures (previously died in `bsengine-editor`)
- [x] Config-only change; no crate source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)