### PR TITLE
feat(asset): load glTF, shaders, skybox and audio asynchronously (item 24 Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -471,7 +471,32 @@ libtest는 모든 `#[test]`를 spawn된 스레드에서 실행하고, Rust는 �
   이미 부하에 따라 실패하던 `games/mini-arena` 녹화도 이걸로 복구했다(동시 4회 부하에서
   옛 녹화 4/4 실패 → 새 녹화 4/4 통과). MCP `test_wait_until`로도 노출해 신규 녹화가
   고정 프레임으로 되돌아가지 않게 함
-- [ ] **(Phase 2)** glTF/셰이더/텍스처/오디오 호출부를 `LoadMode::Async`로 전환
+- [x] **(Phase 2)** glTF/셰이더/텍스처/오디오 호출부를 `LoadMode::Async`로 전환 — 4개
+  소비자 모두 "요청은 한 번, 핸들을 보관, 보관한 핸들을 폴링" 형태로 통일. 각각
+  `PendingGltf`(엔티티별 컴포넌트) / `PendingShaders`(경로 키 맵) / `PendingSkybox`(단일
+  슬롯) / `PendingSounds`(큐)로, 자료구조만 소비자 수에 맞게 다르다.
+
+  **핵심 함정 — 실패한 에셋을 다시 요청하면 실패가 지워진다.** `AssetServer::load`는
+  `HandleLoadingMode::Request`를 쓰는데, `bevy_asset-0.14.2`(`server/info.rs:212-221`)는
+  이미 `Failed` 상태인 에셋에 이게 호출되면 **상태를 `Loading`으로 되돌리고 로드를 다시
+  띄운다**. 그리고 `LoadState::Failed`는 `PreUpdate`에서 설정되는데 소비자 시스템은
+  `Update`/`PostUpdate`에서 돈다. 그래서 "매 프레임 경로로 재요청한 뒤 `load_state`로
+  실패를 확인" 하는 자연스러워 보이는 형태는 **실패 분기에 영원히 도달하지 못하고,
+  프레임당 파일시스템 태스크를 하나씩 흘린다.** 실측: 없는 셰이더 경로 하나에 대해
+  200프레임 동안 재요청 방식은 `Path not found` 200회, 현재 방식은 1회.
+
+  부수적으로, 실패 분기가 헤드리스 테스트에서 도달 가능하려면 GPU 리소스
+  검사(`GpuMeshRegistry`/`WgpuSurfaceResource`)를 요청·폴링·실패감지 **아래로** 내려야
+  했다. 진짜 서피스는 진짜 winit 윈도우를 요구하므로, 위에 두면 이 워크스페이스가 쓸 수
+  있는 어떤 테스트로도 give-up 경로를 검증할 수 없다.
+
+  **동반 회귀 수정:** `playSound`가 비동기가 되면서 id가 `SoundHandles`에 몇 프레임 늦게
+  도착한다. 그 사이 도착한 `stopSound`는 아무것도 못 찾고 no-op이 되고, 이후 로드가
+  끝나면 **정지를 요청한 사운드가 재생되는** 반전이 생긴다. `StopSound`가 대기 큐도
+  함께 비우도록 고쳤다. 나머지 6개(`pauseSound`/`resumeSound`/`setSoundVolume`/
+  `setSoundPanning`/`setSoundPlaybackRate`/`seekSound`)는 대기 중인 항목에 닿지 않는 채로
+  두었다 — 항목마다 지연 파라미터 일체를 보관해야 하는 별도 설계인데다, 재생 중이 아닌
+  id에 대해 조용히 무시되는 건 원래부터의 동작이라 반전이 아니기 때문이다.
 - [ ] **(Phase 3)** `bevy_asset`의 `file_watcher` 피처 활성화 — 텍스처/glTF/WGSL/오디오
   변경 시 실행 중인 게임/에디터에 자동 반영. 단, `AssetPlugin.file_path`가 `""`라 에셋
   루트가 리포 전체(`target/` 포함)가 되므로, `<ProjectDir>/assets`로 스코프를 좁힌 워처가

--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -474,7 +474,14 @@ libtest는 모든 `#[test]`를 spawn된 스레드에서 실행하고, Rust는 �
 - [x] **(Phase 2)** glTF/셰이더/텍스처/오디오 호출부를 `LoadMode::Async`로 전환 — 4개
   소비자 모두 "요청은 한 번, 핸들을 보관, 보관한 핸들을 폴링" 형태로 통일. 각각
   `PendingGltf`(엔티티별 컴포넌트) / `PendingShaders`(경로 키 맵) / `PendingSkybox`(단일
-  슬롯) / `PendingSounds`(큐)로, 자료구조만 소비자 수에 맞게 다르다.
+  슬롯) / `SoundLoads`(경로 키 맵) + `PendingSounds`(재생별 큐)로, 자료구조만 소비자
+  수에 맞게 다르다 — 엔티티당 glTF 하나, 셰이더 하나에 엔티티 여럿, 스카이박스는 정확히
+  하나, 사운드는 같은 경로로 동시에 여러 번.
+
+  실패 후 재시도 정책은 소비자마다 다르고, 이건 의도된 것이다: glTF는 마커 컴포넌트를
+  지워 두 번 다시 시도하지 않고, 셰이더/오디오는 `GaveUp`을 영구 보관해 같은 경로를 다시
+  요청하지 않으며, 스카이박스만 `SkyboxPath`가 다른 값으로 바뀌었다 돌아오면 재요청한다
+  (사용자가 경로를 되돌린 건 명시적 재시도 의사로 본다).
 
   **핵심 함정 — 실패한 에셋을 다시 요청하면 실패가 지워진다.** `AssetServer::load`는
   `HandleLoadingMode::Request`를 쓰는데, `bevy_asset-0.14.2`(`server/info.rs:212-221`)는
@@ -490,13 +497,25 @@ libtest는 모든 `#[test]`를 spawn된 스레드에서 실행하고, Rust는 �
   했다. 진짜 서피스는 진짜 winit 윈도우를 요구하므로, 위에 두면 이 워크스페이스가 쓸 수
   있는 어떤 테스트로도 give-up 경로를 검증할 수 없다.
 
-  **동반 회귀 수정:** `playSound`가 비동기가 되면서 id가 `SoundHandles`에 몇 프레임 늦게
-  도착한다. 그 사이 도착한 `stopSound`는 아무것도 못 찾고 no-op이 되고, 이후 로드가
-  끝나면 **정지를 요청한 사운드가 재생되는** 반전이 생긴다. `StopSound`가 대기 큐도
-  함께 비우도록 고쳤다. 나머지 6개(`pauseSound`/`resumeSound`/`setSoundVolume`/
-  `setSoundPanning`/`setSoundPlaybackRate`/`seekSound`)는 대기 중인 항목에 닿지 않는 채로
-  두었다 — 항목마다 지연 파라미터 일체를 보관해야 하는 별도 설계인데다, 재생 중이 아닌
-  id에 대해 조용히 무시되는 건 원래부터의 동작이라 반전이 아니기 때문이다.
+  **동반 회귀 수정 — 비동기가 만든 "억제 명령이 반전되는" 버그.** `playSound`가
+  비동기가 되면서 id가 `SoundHandles`에 몇 프레임 늦게 도착한다. 그 사이 도착한
+  `stopSound`/`pauseSound`는 아무것도 못 찾고 no-op이 되고, 이후 로드가 끝나면 **정지·일시정지를
+  요청한 사운드가 재생되는** 반전이 생긴다. 둘 다 대기 큐에 닿도록 고쳤다(`StopSound`는
+  항목을 제거, `PauseSound`는 항목에 `paused` 플래그를 세워 재생 직후 `pause()` 호출).
+  나머지 4개(`setSoundVolume`/`setSoundPanning`/`setSoundPlaybackRate`/`seekSound`)는
+  대기 중인 항목에 닿지 않는 채로 두었다 — 이들은 사운드를 **억제**하는 게 아니라
+  **조율**하므로, 놓쳐도 "원치 않은 소리가 나는" 게 아니라 "소리가 조금 다르게 나는" 것에
+  그치고, 재생 중이 아닌 id에 조용히 무시되는 건 원래부터의 동작이기 때문이다.
+
+  같은 이유로 `getSoundState`가 대기 중인 사운드에 `""`를 돌려주던 것도 `"loading"`으로
+  바꿨다 — `""`는 "한 번도 재생된 적 없는 id"와 구분되지 않아서, 상태를 폴링하는 스크립트가
+  사운드가 시작되기도 전에 "끝났다" 분기를 타게 만들었다.
+
+  **후속으로 남긴 것(둘 다 현재 도달 불가이거나 경로 수로 제한됨):** glTF만 로드 중
+  `GltfAsset.path`가 바뀌는 걸 감지하지 않는다(스카이박스는 감지하고 테스트도 있다) —
+  현재 이 필드를 제자리에서 바꾸는 코드가 없어 도달 불가. 그리고 로드 중인 엔티티에
+  `MeshRenderer`가 붙거나 마지막 참조 엔티티가 despawn되면 pending 항목이 고아로 남아
+  핸들을 계속 붙잡는다 — 서로 다른 경로 수만큼으로 제한되므로 무한 증가는 아니다.
 - [ ] **(Phase 3)** `bevy_asset`의 `file_watcher` 피처 활성화 — 텍스처/glTF/WGSL/오디오
   변경 시 실행 중인 게임/에디터에 자동 반영. 단, `AssetPlugin.file_path`가 `""`라 에셋
   루트가 리포 전체(`target/` 포함)가 되므로, `<ProjectDir>/assets`로 스코프를 좁힌 워처가

--- a/crates/bsengine-asset/src/load_mode.rs
+++ b/crates/bsengine-asset/src/load_mode.rs
@@ -6,16 +6,33 @@ use bevy_asset::{Asset, AssetServer, Assets, Handle};
 /// not a hint):
 ///
 /// `Sync` calls the loader function directly and inserts the result
-/// immediately (blocking, zero-latency — matches every asset load in this
-/// engine as of item 23). `Async` calls `bevy_asset`'s own
+/// immediately (blocking, zero-latency). `Async` calls `bevy_asset`'s own
 /// `AssetServer::load`, which requires a registered `AssetLoader` for `T` —
-/// multi-frame latency, but automatically tracked by the file watcher item
-/// 24 will enable. Every item-23 consumer passes `Sync` (see `load()`'s
-/// call sites in `bsengine-gltf`/`bsengine-render`/`bsengine-scripting`);
-/// `Async` is exercised only by each asset type's own
-/// `*_loads_async_and_becomes_available` test, proving the path is real and
-/// ready for a future consumer to flip a single call-site argument to use,
-/// without needing to re-plumb anything.
+/// multi-frame latency, but automatically tracked by the file watcher.
+///
+/// Consumers are migrating to `Async` (`bsengine-gltf` already has); the rest
+/// still pass `Sync`.
+///
+/// # Polling an `Async` load correctly
+///
+/// `Async` returns a `Handle` unconditionally, so a missing or malformed file
+/// is indistinguishable from a slow one at the call site. A consumer must
+/// therefore:
+///
+/// 1. **Request once and retain the handle**, rather than re-requesting each
+///    frame while polling. Re-calling `AssetServer::load` for a path whose
+///    state is `Failed` resets it to `Loading` and restarts the load
+///    (`bevy_asset` 0.14.2, `server/info.rs:216-221`). Because `Failed` is set
+///    in `PreUpdate` and consumers poll in `Update`, a re-requesting loop
+///    erases the failure before it can observe it — retrying forever and
+///    spawning a fresh filesystem task every frame. Retaining the handle also
+///    keeps it strong, which nothing else does between frames.
+/// 2. **Treat "absent from `Assets<T>`" as inconclusive** and ask
+///    `asset_server.load_state(&handle)`; on `LoadState::Failed(e)`, warn and
+///    stop. Otherwise a bad path fails silently and permanently, which is
+///    worse than `Sync`'s warn-once-and-give-up.
+///
+/// See `bsengine_gltf::plugin`'s `PendingGltf` for a worked example.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoadMode {
     /// Load and insert synchronously, right now, on the calling thread.

--- a/crates/bsengine-asset/src/load_mode.rs
+++ b/crates/bsengine-asset/src/load_mode.rs
@@ -10,8 +10,12 @@ use bevy_asset::{Asset, AssetServer, Assets, Handle};
 /// `AssetServer::load`, which requires a registered `AssetLoader` for `T` —
 /// multi-frame latency, but automatically tracked by the file watcher.
 ///
-/// Consumers are migrating to `Async` (`bsengine-gltf` already has); the rest
-/// still pass `Sync`.
+/// Nothing in the engine passes `Sync` any more. All four consumers (glTF,
+/// custom shaders, skybox, audio) load asynchronously, and the only `Sync`
+/// call sites left in the workspace are this module's own unit tests. The
+/// variant is kept, working and supported, because blocking-vs-streaming is
+/// the caller's choice to make: a game that wants to stall on a small asset
+/// behind a loading screen should not have to reimplement it.
 ///
 /// # Polling an `Async` load correctly
 ///
@@ -32,7 +36,40 @@ use bevy_asset::{Asset, AssetServer, Assets, Handle};
 ///    stop. Otherwise a bad path fails silently and permanently, which is
 ///    worse than `Sync`'s warn-once-and-give-up.
 ///
-/// See `bsengine_gltf::plugin`'s `PendingGltf` for a worked example.
+/// The resulting shape — request once, retain the handle, poll the retained
+/// handle — is what every consumer in this engine implements:
+///
+/// ```ignore
+/// // First frame for this path: request, and keep what `load` returns
+/// // somewhere that outlives the frame (a component, or a resource keyed
+/// // by path).
+/// let handle = bsengine_asset::load(
+///     LoadMode::Async, &asset_server, &mut assets, path, sync_loader,
+/// )?;
+/// pending.insert(path.to_owned(), Pending::Loading(handle));
+///
+/// // Every later frame: poll the handle that was stored. Never call
+/// // `load` (or `AssetServer::load`) for this path again.
+/// match assets.get(&handle) {
+///     Some(asset) => { /* use it, and drop the pending entry */ }
+///     None => {
+///         if let LoadState::Failed(e) = asset_server.load_state(&handle) {
+///             warn!("{path}: {e}");
+///             // Record "gave up", so the next frame does not re-request
+///             // it and reset the failure back to `Loading`.
+///             pending.insert(path.to_owned(), Pending::GaveUp);
+///         }
+///     }
+/// }
+/// ```
+///
+/// The live implementations are `bsengine_gltf::GltfPlugin` (a per-entity
+/// pending component), `bsengine_render::RenderPlugin` (a path-keyed map for
+/// custom shaders, a single slot for the skybox) and `bsengine_scripting`'s
+/// sound loading. Their pending state is private to each system on purpose:
+/// `CustomShader.path`, `SkyboxPath` and friends stay plain `String`s, so
+/// scene RON, the scripting API and the MCP tools are unaffected by how a
+/// load is tracked.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoadMode {
     /// Load and insert synchronously, right now, on the calling thread.

--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -5,6 +5,9 @@
 //! skeletal animation data. `GltfPlugin` wires loading into the app;
 //! `GltfAsset` is the resulting ECS-facing handle.
 #![warn(missing_docs)]
+// Bevy `Query` types with several optional components and a filter are
+// unavoidably verbose; matches bsengine-render/-rhi-wgpu/-editor/-scripting.
+#![allow(clippy::type_complexity)]
 
 /// Animation clip/channel/interpolation types for skeletal animation data.
 pub mod animation;

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -35,49 +35,75 @@ impl Plugin for GltfPlugin {
     }
 }
 
+/// The in-flight load for a [`GltfAsset`], held so the request is made once
+/// rather than re-issued every frame.
+///
+/// Re-calling `AssetServer::load` for a path whose load has *failed* resets it
+/// to `Loading` and starts the load again (`bevy_asset` 0.14.2,
+/// `server/info.rs:216-221`). `LoadState::Failed` is set in `PreUpdate` while
+/// this system runs in `Update`, so a polling loop that re-requests erases the
+/// failure before it can observe it — retrying a missing file forever and
+/// spawning a fresh filesystem task every frame. Holding the handle also keeps
+/// it strong; nothing else does between frames.
+///
+/// Internal to this system — `GltfAsset.path` stays a plain `String`, so scene
+/// RON, the scripting API and the MCP tools are unaffected.
+#[derive(Component)]
+struct PendingGltf(bevy_asset::Handle<LoadedGltf>);
+
 fn load_gltf_assets(
     mut commands: Commands,
-    query: Query<(Entity, &GltfAsset, Option<&Transform>), Without<MeshRenderer>>,
-    mesh_registry: Option<ResMut<GpuMeshRegistry>>,
-    tex_registry: Option<ResMut<GpuTextureRegistry>>,
+    query: Query<
+        (Entity, &GltfAsset, Option<&PendingGltf>, Option<&Transform>),
+        Without<MeshRenderer>,
+    >,
+    mut mesh_registry: Option<ResMut<GpuMeshRegistry>>,
+    mut tex_registry: Option<ResMut<GpuTextureRegistry>>,
     mut gltf_assets: ResMut<bevy_asset::Assets<LoadedGltf>>,
-    asset_server: bevy_ecs::prelude::Res<bevy_asset::AssetServer>,
+    asset_server: Res<bevy_asset::AssetServer>,
 ) {
-    let Some(mut mesh_reg) = mesh_registry else {
-        return;
-    };
-    let mut tex_reg = tex_registry;
-
-    for (entity, asset, existing_transform) in query.iter() {
-        // Async: the handle comes back immediately, the data does not.
-        // `AssetServer::load` dedups by path, so re-requesting each frame is
-        // cheap and yields the same handle.
-        let handle = match bsengine_asset::load(
-            bsengine_asset::LoadMode::Async,
-            &asset_server,
-            &mut gltf_assets,
-            &asset.path,
-            GltfLoader::load_full,
-        ) {
-            Ok(handle) => handle,
-            Err(e) => {
-                warn!("Failed to request GLTF: {e}");
-                commands.entity(entity).remove::<GltfAsset>();
-                continue;
-            }
-        };
-        let Some(loaded) = gltf_assets.get(&handle) else {
-            // Not resolved yet. A failed load never resolves, so ask whether
-            // it failed -- otherwise a missing file retries silently forever,
-            // where the old blocking path warned once and gave up.
-            if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(&handle) {
-                warn!("Failed to load GLTF {}: {e}", asset.path);
-                commands.entity(entity).remove::<GltfAsset>();
+    for (entity, asset, pending, existing_transform) in query.iter() {
+        // Request exactly once, then retain the handle. See `PendingGltf`.
+        let Some(pending) = pending else {
+            match bsengine_asset::load(
+                bsengine_asset::LoadMode::Async,
+                &asset_server,
+                &mut gltf_assets,
+                &asset.path,
+                GltfLoader::load_full,
+            ) {
+                Ok(handle) => {
+                    commands.entity(entity).insert(PendingGltf(handle));
+                }
+                Err(e) => {
+                    // Unreachable: `LoadMode::Async` is infallible. This arm
+                    // exists only because the shared `load()` signature
+                    // returns `Result` for the benefit of `Sync` callers.
+                    warn!("Failed to request GLTF: {e}");
+                    commands.entity(entity).remove::<GltfAsset>();
+                }
             }
             continue;
         };
 
-        let tex_ids: Vec<Option<u64>> = if let Some(ref mut tr) = tex_reg {
+        let Some(loaded) = gltf_assets.get(&pending.0) else {
+            // Not resolved yet. A failed load never resolves, so ask whether
+            // it failed -- otherwise a missing file retries silently forever,
+            // where the old blocking path warned once and gave up.
+            if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(&pending.0) {
+                warn!("Failed to load GLTF {}: {e}", asset.path);
+                commands.entity(entity).remove::<(GltfAsset, PendingGltf)>();
+            }
+            continue;
+        };
+
+        // The data is here, but turning it into meshes needs the GPU. Without
+        // a registry (no window yet), keep both markers and retry next frame
+        // — the load itself is already done, so this costs nothing.
+        let Some(mesh_reg) = mesh_registry.as_mut() else {
+            continue;
+        };
+        let tex_ids: Vec<Option<u64>> = if let Some(tr) = tex_registry.as_mut() {
             loaded
                 .images
                 .iter()
@@ -131,7 +157,7 @@ fn load_gltf_assets(
                         AnimationPlayer::new(first_clip_name).with_duration(duration),
                     ));
                 }
-                e.remove::<GltfAsset>();
+                e.remove::<(GltfAsset, PendingGltf)>();
                 if existing_transform.is_none() {
                     e.insert((Transform::default(), GlobalTransform::default()));
                 }
@@ -143,7 +169,7 @@ fn load_gltf_assets(
         }
 
         if first {
-            commands.entity(entity).remove::<GltfAsset>();
+            commands.entity(entity).remove::<(GltfAsset, PendingGltf)>();
             warn!("GLTF {} has no meshes", asset.path);
         }
     }
@@ -307,6 +333,41 @@ mod tests {
                 .get(&handle)
                 .is_none(),
             "a failed load must never resolve into Assets<LoadedGltf>"
+        );
+    }
+
+    // Drives the real system, which is the only way to catch the failure
+    // mode the test above cannot see: re-calling `AssetServer::load` for a
+    // path whose state is already `Failed` resets it to `Loading` and
+    // restarts the load (bevy_asset 0.14.2, server/info.rs:216-221). Since
+    // `LoadState::Failed` is set in PreUpdate and this system runs in Update,
+    // a loop that re-requests every frame erases the failure before it can
+    // ever observe it -- retrying a missing file forever and spawning a fresh
+    // filesystem task each frame, which is strictly worse than the blocking
+    // path that warned once and stopped.
+    #[test]
+    fn missing_gltf_is_given_up_on_instead_of_retried_forever() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(GltfPlugin);
+        let e = app
+            .world_mut()
+            .spawn(GltfAsset::new("definitely/not/a/real/file.glb"))
+            .id();
+
+        let mut gave_up = false;
+        for _ in 0..200 {
+            app.update();
+            if app.world().get::<GltfAsset>(e).is_none() {
+                gave_up = true;
+                break;
+            }
+        }
+        assert!(
+            gave_up,
+            "a GltfAsset with an unloadable path must be given up on, not \
+             retried on every frame forever"
         );
     }
 }

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -49,103 +49,102 @@ fn load_gltf_assets(
     let mut tex_reg = tex_registry;
 
     for (entity, asset, existing_transform) in query.iter() {
-        let load_result = bsengine_asset::load(
-            bsengine_asset::LoadMode::Sync,
+        // Async: the handle comes back immediately, the data does not.
+        // `AssetServer::load` dedups by path, so re-requesting each frame is
+        // cheap and yields the same handle.
+        let handle = match bsengine_asset::load(
+            bsengine_asset::LoadMode::Async,
             &asset_server,
             &mut gltf_assets,
             &asset.path,
             GltfLoader::load_full,
-        );
-        match load_result.and_then(|handle| {
-            gltf_assets
-                .get(&handle)
-                .ok_or_else(|| "just-inserted asset missing from Assets<LoadedGltf>".to_string())
-        }) {
-            Ok(loaded) => {
-                let tex_ids: Vec<Option<u64>> = if let Some(ref mut tr) = tex_reg {
-                    loaded
-                        .images
-                        .iter()
-                        .map(|img| Some(tr.load_from_rgba(img.width, img.height, &img.rgba)))
-                        .collect()
-                } else {
-                    vec![None; loaded.images.len()]
-                };
-
-                let mut first = true;
-                for (mesh_data, tex_idx) in loaded.meshes.iter().zip(loaded.mesh_tex_indices.iter())
-                {
-                    let mesh_id = mesh_reg.register(&mesh_data.vertices, &mesh_data.indices);
-                    let texture_id = tex_idx.and_then(|i| tex_ids.get(i).copied().flatten());
-                    let mat = Material {
-                        texture_id,
-                        ..Default::default()
-                    };
-
-                    if first {
-                        let mut e = commands.entity(entity);
-                        e.insert((MeshRenderer { mesh_id }, mat));
-                        if let Some(skin_verts) =
-                            mesh_data.skin.clone().filter(|_| !loaded.skins.is_empty())
-                        {
-                            let skin_data = loaded.skins[0].clone();
-                            let clip_library =
-                                AnimationClipLibrary::from_clips(loaded.animations.clone());
-                            let first_clip_name = clip_library
-                                .clips
-                                .keys()
-                                .next()
-                                .cloned()
-                                .unwrap_or_default();
-                            // AnimationPlayer::new defaults duration to 0.0, and
-                            // AnimationPlayer::tick is a no-op whenever duration <= 0.0
-                            // -- without this, the player's `time` would never
-                            // advance and the clip would appear frozen forever.
-                            let duration = clip_library
-                                .clips
-                                .get(&first_clip_name)
-                                .map(|c| c.duration)
-                                .unwrap_or(0.0);
-                            e.insert((
-                                SkinnedMesh {
-                                    mesh_id,
-                                    rest_vertices: mesh_data.vertices.clone(),
-                                    skin: skin_verts,
-                                    skin_data,
-                                    nodes: loaded.nodes.clone(),
-                                },
-                                clip_library,
-                                AnimationPlayer::new(first_clip_name).with_duration(duration),
-                            ));
-                        }
-                        e.remove::<GltfAsset>();
-                        if existing_transform.is_none() {
-                            e.insert((Transform::default(), GlobalTransform::default()));
-                        }
-                        first = false;
-                    } else {
-                        let t = existing_transform.cloned().unwrap_or_default();
-                        commands.spawn((
-                            MeshRenderer { mesh_id },
-                            mat,
-                            t,
-                            GlobalTransform::default(),
-                        ));
-                    }
-                }
-
-                if first {
-                    commands.entity(entity).remove::<GltfAsset>();
-                    warn!("GLTF {} has no meshes", asset.path);
-                }
-            }
+        ) {
+            Ok(handle) => handle,
             Err(e) => {
-                // `e` already contains the path (formatted by
-                // `bsengine_asset::load`'s Sync branch as "{path}: {error}"),
-                // so it isn't repeated here.
-                warn!("Failed to load GLTF: {e}");
+                warn!("Failed to request GLTF: {e}");
+                commands.entity(entity).remove::<GltfAsset>();
+                continue;
+            }
+        };
+        let Some(loaded) = gltf_assets.get(&handle) else {
+            // Not resolved yet. A failed load never resolves, so ask whether
+            // it failed -- otherwise a missing file retries silently forever,
+            // where the old blocking path warned once and gave up.
+            if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(&handle) {
+                warn!("Failed to load GLTF {}: {e}", asset.path);
                 commands.entity(entity).remove::<GltfAsset>();
             }
+            continue;
+        };
+
+        let tex_ids: Vec<Option<u64>> = if let Some(ref mut tr) = tex_reg {
+            loaded
+                .images
+                .iter()
+                .map(|img| Some(tr.load_from_rgba(img.width, img.height, &img.rgba)))
+                .collect()
+        } else {
+            vec![None; loaded.images.len()]
+        };
+
+        let mut first = true;
+        for (mesh_data, tex_idx) in loaded.meshes.iter().zip(loaded.mesh_tex_indices.iter()) {
+            let mesh_id = mesh_reg.register(&mesh_data.vertices, &mesh_data.indices);
+            let texture_id = tex_idx.and_then(|i| tex_ids.get(i).copied().flatten());
+            let mat = Material {
+                texture_id,
+                ..Default::default()
+            };
+
+            if first {
+                let mut e = commands.entity(entity);
+                e.insert((MeshRenderer { mesh_id }, mat));
+                if let Some(skin_verts) =
+                    mesh_data.skin.clone().filter(|_| !loaded.skins.is_empty())
+                {
+                    let skin_data = loaded.skins[0].clone();
+                    let clip_library = AnimationClipLibrary::from_clips(loaded.animations.clone());
+                    let first_clip_name = clip_library
+                        .clips
+                        .keys()
+                        .next()
+                        .cloned()
+                        .unwrap_or_default();
+                    // AnimationPlayer::new defaults duration to 0.0, and
+                    // AnimationPlayer::tick is a no-op whenever duration <= 0.0
+                    // -- without this, the player's `time` would never
+                    // advance and the clip would appear frozen forever.
+                    let duration = clip_library
+                        .clips
+                        .get(&first_clip_name)
+                        .map(|c| c.duration)
+                        .unwrap_or(0.0);
+                    e.insert((
+                        SkinnedMesh {
+                            mesh_id,
+                            rest_vertices: mesh_data.vertices.clone(),
+                            skin: skin_verts,
+                            skin_data,
+                            nodes: loaded.nodes.clone(),
+                        },
+                        clip_library,
+                        AnimationPlayer::new(first_clip_name).with_duration(duration),
+                    ));
+                }
+                e.remove::<GltfAsset>();
+                if existing_transform.is_none() {
+                    e.insert((Transform::default(), GlobalTransform::default()));
+                }
+                first = false;
+            } else {
+                let t = existing_transform.cloned().unwrap_or_default();
+                commands.spawn((MeshRenderer { mesh_id }, mat, t, GlobalTransform::default()));
+            }
+        }
+
+        if first {
+            commands.entity(entity).remove::<GltfAsset>();
+            warn!("GLTF {} has no meshes", asset.path);
         }
     }
 }
@@ -250,6 +249,64 @@ mod tests {
         assert!(
             loaded,
             "glTF asset did not finish loading within 200 frames"
+        );
+    }
+
+    // The hazard that makes LoadMode::Async different from Sync: `load`
+    // hands back a Handle unconditionally, so a missing file is
+    // indistinguishable from a slow one at the call site. `load_gltf_assets`
+    // therefore has to ask the AssetServer whether the load *failed*, or a
+    // bad path would retry silently forever. This pins down that the failure
+    // really does surface as `LoadState::Failed`, and pins the exact
+    // accessor form the system uses.
+    //
+    // It exercises the dispatcher directly rather than through
+    // `load_gltf_assets`, because that system early-returns without a
+    // `GpuMeshRegistry`, which needs a real window (see
+    // `with_rhi_plugin_but_no_window_gltf_asset_stays`).
+    #[test]
+    fn async_load_of_a_missing_path_reaches_load_state_failed() {
+        use bevy_asset::{AssetServer, Assets, LoadState};
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(GltfPlugin);
+
+        let handle = {
+            let server = app.world().resource::<AssetServer>().clone();
+            let mut assets = app.world_mut().resource_mut::<Assets<LoadedGltf>>();
+            bsengine_asset::load(
+                bsengine_asset::LoadMode::Async,
+                &server,
+                &mut assets,
+                "definitely/not/a/real/file.glb",
+                GltfLoader::load_full,
+            )
+            .expect("Async load always returns a handle, even for a bad path")
+        };
+
+        let mut failed = false;
+        for _ in 0..200 {
+            app.update();
+            let server = app.world().resource::<AssetServer>();
+            if matches!(server.load_state(&handle), LoadState::Failed(_)) {
+                failed = true;
+                break;
+            }
+        }
+        assert!(
+            failed,
+            "a missing path must surface as LoadState::Failed, otherwise the \
+             not-ready branch would retry it forever"
+        );
+        // The asset must never appear in Assets<T>, which is exactly why the
+        // `gltf_assets.get(&handle)` miss cannot be treated as "still loading".
+        assert!(
+            app.world()
+                .resource::<Assets<LoadedGltf>>()
+                .get(&handle)
+                .is_none(),
+            "a failed load must never resolve into Assets<LoadedGltf>"
         );
     }
 }

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -99,8 +99,29 @@ fn propagate_children(
     }
 }
 
+/// What `compile_pending_shaders` knows about one shader path.
+#[derive(Debug)]
+pub enum PendingShader {
+    /// Requested; waiting for `Assets<ShaderSource>` to have it.
+    Loading(bevy_asset::Handle<crate::shader_asset::ShaderSource>),
+    /// The load failed. Kept so the warning fires once rather than per frame,
+    /// and so the path is never re-requested -- re-requesting a failed path
+    /// resets it to `Loading` and starts the load over, which is why a
+    /// re-requesting poll loop can never see the failure.
+    GaveUp,
+}
+
+/// Shader loads in flight, keyed by path.
+///
+/// Keyed by path rather than entity because several entities may name the
+/// same shader, and because `CustomShader.path` stays a plain `String` -- the
+/// boundary item 23 established, so scene RON, the scripting API and the MCP
+/// tools are unaffected.
+#[derive(bevy_ecs::prelude::Resource, Default)]
+pub struct PendingShaders(pub std::collections::HashMap<String, PendingShader>);
+
 /// Lazy-compiles any `CustomShader` not yet cached in the surface, reading
-/// its WGSL source through `bsengine_asset::load` (`LoadMode::Sync`) and
+/// its WGSL source through `bsengine_asset::load` (`LoadMode::Async`) and
 /// handing the text to `compile_and_store_shader`. Split out of
 /// `render_frame` (rather than folded in as two more top-level params)
 /// because that function is already at Bevy 0.14's 16-top-level-param
@@ -118,33 +139,66 @@ fn propagate_children(
 /// just sits compiled-and-unused in the surface's cache) and arguably an
 /// improvement (a shader is ready the instant `MeshRenderer`/`Transform`
 /// are added later, rather than one frame behind).
+///
+/// The missing `WgpuSurfaceResource` case is *not* an early return: only the
+/// final `compile_and_store_shader` step needs the GPU, so requesting,
+/// polling and failure detection run regardless. A real surface needs a real
+/// winit window (see `compile_pending_shaders_runs_before_render_frame`), so
+/// an early return would make the give-up path unreachable in every test
+/// this workspace can write.
 fn compile_pending_shaders(
-    surface: Option<ResMut<WgpuSurfaceResource>>,
+    mut surface: Option<ResMut<WgpuSurfaceResource>>,
     custom_shaders: Query<&CustomShader>,
     mut shader_assets: bevy_ecs::prelude::ResMut<
         bevy_asset::Assets<crate::shader_asset::ShaderSource>,
     >,
     asset_server: bevy_ecs::prelude::Res<bevy_asset::AssetServer>,
+    mut pending: ResMut<PendingShaders>,
 ) {
-    let Some(mut surface) = surface else {
-        return;
-    };
     for cs in custom_shaders.iter() {
-        if !surface.0.has_custom_shader(&cs.path) {
-            match bsengine_asset::load(
-                bsengine_asset::LoadMode::Sync,
+        if surface
+            .as_ref()
+            .is_some_and(|s| s.0.has_custom_shader(&cs.path))
+        {
+            continue;
+        }
+        match pending.0.get(&cs.path) {
+            // Requested already -- poll the handle we kept. Never re-request.
+            Some(PendingShader::Loading(handle)) => {
+                if let Some(src) = shader_assets.get(handle) {
+                    // The source is here; only the compile needs the GPU.
+                    // Without a surface, stay `Loading` and retry next frame
+                    // — the load itself is done, so this costs nothing.
+                    if let Some(surface) = surface.as_mut() {
+                        surface.0.compile_and_store_shader(&cs.path, &src.0);
+                        pending.0.remove(&cs.path);
+                    }
+                } else if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(handle) {
+                    tracing::warn!("[custom_shader] cannot read '{}': {e}", cs.path);
+                    pending.0.insert(cs.path.clone(), PendingShader::GaveUp);
+                }
+            }
+            Some(PendingShader::GaveUp) => {}
+            None => match bsengine_asset::load(
+                bsengine_asset::LoadMode::Async,
                 &asset_server,
                 &mut shader_assets,
                 &cs.path,
                 crate::shader_asset::load_shader_source,
             ) {
                 Ok(handle) => {
-                    if let Some(src) = shader_assets.get(&handle) {
-                        surface.0.compile_and_store_shader(&cs.path, &src.0);
-                    }
+                    pending
+                        .0
+                        .insert(cs.path.clone(), PendingShader::Loading(handle));
                 }
-                Err(e) => tracing::warn!("[custom_shader] cannot read '{}': {e}", cs.path),
-            }
+                Err(e) => {
+                    // Unreachable: `LoadMode::Async` is infallible. Present
+                    // only because the shared `load()` signature returns
+                    // `Result` for `Sync` callers.
+                    tracing::warn!("[custom_shader] cannot request '{}': {e}", cs.path);
+                    pending.0.insert(cs.path.clone(), PendingShader::GaveUp);
+                }
+            },
         }
     }
 }
@@ -422,6 +476,7 @@ impl Plugin for RenderPlugin {
         app.init_asset::<crate::shader_asset::ShaderSource>()
             .register_asset_loader(crate::shader_asset::ShaderSourceLoader)
             .init_resource::<UiState>()
+            .init_resource::<PendingShaders>()
             .add_event::<WindowResized>()
             .add_event::<KeyInput>()
             .add_systems(Update, update_camera_aspect)
@@ -440,7 +495,7 @@ impl Plugin for RenderPlugin {
 
 #[cfg(test)]
 mod tests {
-    use super::RenderPlugin;
+    use super::{PendingShader, PendingShaders, RenderPlugin};
     use crate::components::MeshRenderer;
     use bsengine_app::new_app;
     use bsengine_core::{Camera, Material, PointLight, Transform};
@@ -506,6 +561,35 @@ mod tests {
             "compile_pending_shaders (index {compile_idx}) must run before render_frame \
              (index {render_idx}) so shaders compiled this frame are available to it; \
              actual PostUpdate order: {names:?}"
+        );
+    }
+
+    // A shader path that cannot load must be given up on. Re-requesting a
+    // failed path every frame resets it to Loading and respawns the load, so
+    // the failure is never observable and the warning never fires -- the
+    // blocking path this replaced warned once and stopped.
+    #[test]
+    fn missing_shader_is_given_up_on_instead_of_retried_forever() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+        app.world_mut().spawn(bsengine_core::CustomShader {
+            path: "definitely/not/a/real/shader.wgsl".to_string(),
+        });
+
+        for _ in 0..200 {
+            app.update();
+        }
+
+        let pending = app
+            .world()
+            .resource::<PendingShaders>()
+            .0
+            .get("definitely/not/a/real/shader.wgsl");
+        assert!(
+            matches!(pending, Some(PendingShader::GaveUp)),
+            "an unloadable shader path must end up given up on, got {pending:?}"
         );
     }
 

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -730,6 +730,87 @@ mod tests {
         );
     }
 
+    // Changing `SkyboxPath` mid-load must abandon the in-flight request and
+    // start the new one, or the old texture lands on screen a frame after the
+    // user asked for a different sky. Two frames is the whole story: the first
+    // reaches the request arm (empty slot -> `Loading`, returns immediately),
+    // the second reaches the abandon-and-re-request branch.
+    //
+    // The handle is asserted on, not just the retained path string: the
+    // give-up arm writes the *wanted* path next to the *old* handle, so an
+    // implementation that kept polling the abandoned load can still end up
+    // with "second/sky.png" in the slot. Only the handle says which load is
+    // actually in flight.
+    #[test]
+    fn skybox_path_change_mid_load_requests_the_new_path_instead() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+        app.insert_resource(bsengine_core::SkyboxPath(Some("first/sky.png".to_string())));
+
+        app.update();
+        let pending = &app.world().resource::<PendingSkybox>().0;
+        assert!(
+            matches!(pending, Some((p, PendingSkyboxState::Loading(_))) if p == "first/sky.png"),
+            "precondition: one frame must leave the first path in flight, got {pending:?}"
+        );
+
+        app.world_mut()
+            .resource_mut::<bsengine_core::SkyboxPath>()
+            .0 = Some("second/sky.png".to_string());
+        app.update();
+
+        let pending = &app.world().resource::<PendingSkybox>().0;
+        let Some((path, PendingSkyboxState::Loading(handle))) = pending else {
+            panic!("a changed SkyboxPath must leave a load for the new path in flight, got {pending:?}");
+        };
+        assert_eq!(
+            path, "second/sky.png",
+            "the retained path must be the newly wanted one"
+        );
+        assert_eq!(
+            handle.path().map(ToString::to_string).as_deref(),
+            Some("second/sky.png"),
+            "the retained handle must be the one requested for the new path -- keeping the \
+             old path's handle means the abandoned load is still being polled and its \
+             texture can still be uploaded"
+        );
+    }
+
+    // Setting `SkyboxPath.0` to `None` mid-load must drop the in-flight
+    // request with it. Left in place, the load completes a frame or two later
+    // and uploads a sky the user has already switched off. Observable without
+    // a surface: with no `WgpuSurfaceResource` the dedupe check above can't
+    // match, so control reaches the skybox-off arm, which clears `pending`
+    // whether or not there is a surface to clear.
+    #[test]
+    fn turning_the_skybox_off_mid_load_drops_the_in_flight_request() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+        app.insert_resource(bsengine_core::SkyboxPath(Some("some/sky.png".to_string())));
+
+        app.update();
+        let pending = &app.world().resource::<PendingSkybox>().0;
+        assert!(
+            matches!(pending, Some((_, PendingSkyboxState::Loading(_)))),
+            "precondition: one frame must leave a load in flight, got {pending:?}"
+        );
+
+        app.world_mut()
+            .resource_mut::<bsengine_core::SkyboxPath>()
+            .0 = None;
+        app.update();
+
+        let pending = &app.world().resource::<PendingSkybox>().0;
+        assert!(
+            pending.is_none(),
+            "turning the skybox off must drop the in-flight request, got {pending:?}"
+        );
+    }
+
     #[test]
     fn render_plugin_runs_with_rhi_headless() {
         let mut app = new_app();

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -203,6 +203,122 @@ fn compile_pending_shaders(
     }
 }
 
+/// Whether the skybox named by [`PendingSkybox`] is still loading or was
+/// given up on.
+#[derive(Debug)]
+pub enum PendingSkyboxState {
+    /// Requested; waiting for `Assets<TextureAsset>` to have it.
+    Loading(bevy_asset::Handle<bsengine_asset::TextureAsset>),
+    /// The load failed. Kept so the warning fires once and the path is never
+    /// re-requested -- re-requesting a failed path restarts it, which is why a
+    /// re-requesting poll loop can never see the failure.
+    GaveUp,
+}
+
+/// The skybox load in flight, if any.
+///
+/// One slot rather than a map: there is only ever one skybox. The path is kept
+/// alongside the state so a `SkyboxPath` change mid-load abandons the old
+/// request instead of uploading a texture nobody asked for any more.
+#[derive(bevy_ecs::prelude::Resource, Default)]
+pub struct PendingSkybox(pub Option<(String, PendingSkyboxState)>);
+
+/// Keeps the surface's skybox in sync with `SkyboxPath`, reading the image
+/// through `Assets<TextureAsset>` and uploading it with
+/// `set_skybox_from_rgba`.
+///
+/// Item 23 split `set_skybox` into decode and upload halves; this is the
+/// consumer that split was for. It gets its own system rather than staying in
+/// `render_frame` because that function is already at Bevy 0.14's
+/// 16-top-level-param ceiling (see the comment on its `render_queries` param),
+/// and because waiting across frames is not a render pass's job.
+///
+/// The missing `WgpuSurfaceResource` case is *not* an early return: only the
+/// upload needs the GPU, so requesting, polling and failure detection run
+/// regardless. A real surface needs a real winit window (see
+/// `compile_pending_shaders_runs_before_render_frame`), so an early return
+/// would make the give-up path unreachable in every test this workspace can
+/// write.
+fn upload_pending_skybox(
+    mut surface: Option<ResMut<WgpuSurfaceResource>>,
+    skybox_path: Option<Res<SkyboxPath>>,
+    texture_assets: bevy_ecs::prelude::Res<bevy_asset::Assets<bsengine_asset::TextureAsset>>,
+    asset_server: bevy_ecs::prelude::Res<bevy_asset::AssetServer>,
+    mut pending: ResMut<PendingSkybox>,
+) {
+    let Some(skybox_path) = skybox_path else {
+        return;
+    };
+    let wanted = skybox_path.0.as_deref();
+
+    // Already showing exactly what's asked for. Any request still in flight is
+    // for a path nobody wants any more, so let it go.
+    if surface
+        .as_ref()
+        .is_some_and(|s| s.0.loaded_skybox_path() == wanted)
+    {
+        if pending.0.is_some() {
+            pending.0 = None;
+        }
+        return;
+    }
+
+    let Some(wanted) = wanted else {
+        // The skybox was turned off; drop the in-flight request with it.
+        if let Some(surface) = surface.as_mut() {
+            surface.0.clear_skybox();
+        }
+        if pending.0.is_some() {
+            pending.0 = None;
+        }
+        return;
+    };
+
+    // `SkyboxPath` changed mid-load: abandon the old request rather than
+    // upload a texture nobody asked for any more.
+    if pending.0.as_ref().is_some_and(|(p, _)| p != wanted) {
+        pending.0 = None;
+    }
+
+    // Cloned out so the poll below can write back to `pending` (a `Handle` is
+    // refcounted, so this is a cheap bump, not a copy of the image).
+    let in_flight = match &pending.0 {
+        Some((_, PendingSkyboxState::GaveUp)) => return,
+        Some((_, PendingSkyboxState::Loading(handle))) => Some(handle.clone()),
+        None => None,
+    };
+
+    let Some(handle) = in_flight else {
+        // Requested exactly once, then polled -- never re-requested. Called
+        // directly rather than through `bsengine_asset::load` because that
+        // dispatcher takes a `sync_loader` closure for its `LoadMode::Sync`
+        // arm and there is no synchronous texture loader in this codebase:
+        // item 23 only ever wrote `TextureAssetLoader`, for the async path.
+        let handle = asset_server.load::<bsengine_asset::TextureAsset>(wanted.to_string());
+        pending.0 = Some((wanted.to_string(), PendingSkyboxState::Loading(handle)));
+        return;
+    };
+
+    if let Some(tex) = texture_assets.get(&handle) {
+        // The pixels are here; only the upload needs the GPU. Without a
+        // surface, stay `Loading` and retry next frame — the load itself is
+        // done, so this costs nothing.
+        if let Some(surface) = surface.as_mut() {
+            surface
+                .0
+                .set_skybox_from_rgba(tex.width, tex.height, &tex.data);
+            // `set_skybox_from_rgba` doesn't record the path (item 23 left
+            // that bookkeeping in `set_skybox`), so do it here — the dedupe
+            // check above is what stops this re-uploading every frame.
+            surface.0.set_loaded_skybox_path(wanted);
+            pending.0 = None;
+        }
+    } else if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(&handle) {
+        tracing::warn!("skybox: cannot read '{wanted}': {e}");
+        pending.0 = Some((wanted.to_string(), PendingSkyboxState::GaveUp));
+    }
+}
+
 #[allow(clippy::too_many_arguments)] // Bevy system params; splitting into a struct is a larger refactor
 fn render_frame(
     surface: Option<ResMut<WgpuSurfaceResource>>,
@@ -210,7 +326,6 @@ fn render_frame(
     registry: Option<Res<GpuMeshRegistry>>,
     tex_registry: Option<Res<GpuTextureRegistry>>,
     hud_texts: Option<Res<HudTexts>>,
-    skybox_path: Option<Res<SkyboxPath>>,
     mut ui_state: Option<ResMut<UiState>>,
     mut inspector: Option<ResMut<InspectorState>>,
     mouse_state: Option<Res<MouseState>>,
@@ -277,22 +392,6 @@ fn render_frame(
         .as_deref()
         .map(|k| k.is_pressed(&KeyCode::AltLeft) || k.is_pressed(&KeyCode::AltRight))
         .unwrap_or(false);
-
-    // Load or reload skybox when SkyboxPath changes
-    if let Some(sp) = &skybox_path {
-        let current = sp.0.as_deref();
-        let loaded = surface.0.loaded_skybox_path();
-        if current != loaded {
-            match current {
-                Some(p) => {
-                    if let Err(e) = surface.0.set_skybox(p) {
-                        tracing::warn!("skybox: {e}");
-                    }
-                }
-                None => surface.0.clear_skybox(),
-            }
-        }
-    }
 
     let (mut view_proj, mut cam_pos, mut cam_proj, bloom, tone_map, ambient_occlusion) =
         render_queries
@@ -477,6 +576,7 @@ impl Plugin for RenderPlugin {
             .register_asset_loader(crate::shader_asset::ShaderSourceLoader)
             .init_resource::<UiState>()
             .init_resource::<PendingShaders>()
+            .init_resource::<PendingSkybox>()
             .add_event::<WindowResized>()
             .add_event::<KeyInput>()
             .add_systems(Update, update_camera_aspect)
@@ -486,6 +586,7 @@ impl Plugin for RenderPlugin {
                     propagate_roots,
                     propagate_children,
                     compile_pending_shaders,
+                    upload_pending_skybox,
                     render_frame,
                 )
                     .chain(),
@@ -495,7 +596,7 @@ impl Plugin for RenderPlugin {
 
 #[cfg(test)]
 mod tests {
-    use super::{PendingShader, PendingShaders, RenderPlugin};
+    use super::{PendingShader, PendingShaders, PendingSkybox, PendingSkyboxState, RenderPlugin};
     use crate::components::MeshRenderer;
     use bsengine_app::new_app;
     use bsengine_core::{Camera, Material, PointLight, Transform};
@@ -551,6 +652,10 @@ mod tests {
             .unwrap_or_else(|| {
                 panic!("compile_pending_shaders not found in PostUpdate: {names:?}")
             });
+        let skybox_idx = names
+            .iter()
+            .position(|n| n.contains("upload_pending_skybox"))
+            .unwrap_or_else(|| panic!("upload_pending_skybox not found in PostUpdate: {names:?}"));
         let render_idx = names
             .iter()
             .position(|n| n.contains("render_frame"))
@@ -561,6 +666,12 @@ mod tests {
             "compile_pending_shaders (index {compile_idx}) must run before render_frame \
              (index {render_idx}) so shaders compiled this frame are available to it; \
              actual PostUpdate order: {names:?}"
+        );
+        assert!(
+            skybox_idx < render_idx,
+            "upload_pending_skybox (index {skybox_idx}) must run before render_frame \
+             (index {render_idx}) so a skybox uploaded this frame is available to its \
+             has_skybox check; actual PostUpdate order: {names:?}"
         );
     }
 
@@ -590,6 +701,32 @@ mod tests {
         assert!(
             matches!(pending, Some(PendingShader::GaveUp)),
             "an unloadable shader path must end up given up on, got {pending:?}"
+        );
+    }
+
+    // The skybox equivalent of the shader test above, and for the same
+    // reason: `upload_pending_skybox` requests the texture once and polls the
+    // handle it kept. Re-requesting the path each frame would reset the failed
+    // load to `Loading` and restart it, so the give-up state would never be
+    // reached and this would spin forever.
+    #[test]
+    fn missing_skybox_is_given_up_on_instead_of_retried_forever() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+        app.insert_resource(bsengine_core::SkyboxPath(Some(
+            "definitely/not/a/real/sky.png".to_string(),
+        )));
+
+        for _ in 0..200 {
+            app.update();
+        }
+
+        let pending = &app.world().resource::<PendingSkybox>().0;
+        assert!(
+            matches!(pending, Some((_, PendingSkyboxState::GaveUp))),
+            "an unloadable skybox path must end up given up on, got {pending:?}"
         );
     }
 

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -100,8 +100,12 @@ fn propagate_children(
 }
 
 /// What `compile_pending_shaders` knows about one shader path.
+///
+/// Internal to this system, like `bsengine_gltf`'s `PendingGltf`:
+/// `CustomShader.path` stays a plain `String`, so scene RON, the scripting
+/// API and the MCP tools are unaffected by how a load is tracked.
 #[derive(Debug)]
-pub enum PendingShader {
+enum PendingShader {
     /// Requested; waiting for `Assets<ShaderSource>` to have it.
     Loading(bevy_asset::Handle<crate::shader_asset::ShaderSource>),
     /// The load failed. Kept so the warning fires once rather than per frame,
@@ -118,7 +122,7 @@ pub enum PendingShader {
 /// boundary item 23 established, so scene RON, the scripting API and the MCP
 /// tools are unaffected.
 #[derive(bevy_ecs::prelude::Resource, Default)]
-pub struct PendingShaders(pub std::collections::HashMap<String, PendingShader>);
+struct PendingShaders(std::collections::HashMap<String, PendingShader>);
 
 /// Lazy-compiles any `CustomShader` not yet cached in the surface, reading
 /// its WGSL source through `bsengine_asset::load` (`LoadMode::Async`) and
@@ -206,7 +210,7 @@ fn compile_pending_shaders(
 /// Whether the skybox named by [`PendingSkybox`] is still loading or was
 /// given up on.
 #[derive(Debug)]
-pub enum PendingSkyboxState {
+enum PendingSkyboxState {
     /// Requested; waiting for `Assets<TextureAsset>` to have it.
     Loading(bevy_asset::Handle<bsengine_asset::TextureAsset>),
     /// The load failed. Kept so the warning fires once and the path is never
@@ -220,15 +224,22 @@ pub enum PendingSkyboxState {
 /// One slot rather than a map: there is only ever one skybox. The path is kept
 /// alongside the state so a `SkyboxPath` change mid-load abandons the old
 /// request instead of uploading a texture nobody asked for any more.
+///
+/// Internal to this system, like `bsengine_gltf`'s `PendingGltf`: `SkyboxPath`
+/// stays a plain `String`, so scene RON, the scripting API and the MCP tools
+/// are unaffected by how a load is tracked.
 #[derive(bevy_ecs::prelude::Resource, Default)]
-pub struct PendingSkybox(pub Option<(String, PendingSkyboxState)>);
+struct PendingSkybox(Option<(String, PendingSkyboxState)>);
 
 /// Keeps the surface's skybox in sync with `SkyboxPath`, reading the image
 /// through `Assets<TextureAsset>` and uploading it with
 /// `set_skybox_from_rgba`.
 ///
-/// Item 23 split `set_skybox` into decode and upload halves; this is the
-/// consumer that split was for. It gets its own system rather than staying in
+/// Item 23 split the surface's old blocking `set_skybox` (path in, `image::open`,
+/// upload) into decode and upload halves; this is the consumer that split was
+/// for, and the blocking half has since been deleted outright — nothing in the
+/// engine may stall a frame on a file read any more. It gets its own system
+/// rather than staying in
 /// `render_frame` because that function is already at Bevy 0.14's
 /// 16-top-level-param ceiling (see the comment on its `render_queries` param),
 /// and because waiting across frames is not a render pass's job.
@@ -307,9 +318,10 @@ fn upload_pending_skybox(
             surface
                 .0
                 .set_skybox_from_rgba(tex.width, tex.height, &tex.data);
-            // `set_skybox_from_rgba` doesn't record the path (item 23 left
-            // that bookkeeping in `set_skybox`), so do it here — the dedupe
-            // check above is what stops this re-uploading every frame.
+            // `set_skybox_from_rgba` doesn't record the path (that bookkeeping
+            // lived in the now-deleted blocking `set_skybox`), so do it here —
+            // the dedupe check above is what stops this re-uploading every
+            // frame.
             surface.0.set_loaded_skybox_path(wanted);
             pending.0 = None;
         }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1547,6 +1547,13 @@ impl WgpuSurface {
         self.loaded_skybox_path.as_deref()
     }
 
+    /// Records which path the currently-uploaded skybox came from, for callers
+    /// that upload via [`WgpuSurface::set_skybox_from_rgba`] and do their own
+    /// file loading.
+    pub fn set_loaded_skybox_path(&mut self, path: &str) {
+        self.loaded_skybox_path = Some(path.to_string());
+    }
+
     /// Renders one full frame: shadow map, main scene pass, post-processing,
     /// skybox, and the game/editor UI overlay, then presents the swapchain.
     /// Returns the ids of any `UiWidget::Button`s clicked this frame.

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1518,19 +1518,6 @@ impl WgpuSurface {
         });
     }
 
-    /// Loads a skybox texture from a file path (`image::open`, unchanged
-    /// from before this refactor) and uploads it via
-    /// [`set_skybox_from_rgba`].
-    pub fn set_skybox(&mut self, path: &str) -> Result<(), String> {
-        let img = image::open(path)
-            .map_err(|e| format!("skybox image load failed '{path}': {e}"))?
-            .to_rgba8();
-        let (w, h) = img.dimensions();
-        self.set_skybox_from_rgba(w, h, &img);
-        self.loaded_skybox_path = Some(path.to_string());
-        Ok(())
-    }
-
     /// Unloads the current skybox, if any, reverting to no skybox rendering.
     pub fn clear_skybox(&mut self) {
         self.skybox = None;

--- a/crates/bsengine-scripting/Cargo.toml
+++ b/crates/bsengine-scripting/Cargo.toml
@@ -25,3 +25,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 bsengine-app.workspace = true
+# Only to capture `tracing` output in tests: the audio give-up path's whole
+# point is that the warning reaches the developer, so a test that asserts on
+# state alone would not cover it.
+tracing-subscriber.workspace = true

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -5399,7 +5399,11 @@ pub fn bsengine_seek_sound(id: u32, position: f64) {
     });
 }
 
-/// Get a sound's playback state (e.g. playing/paused/stopped), encoded as an integer.
+/// Get a sound's playback state: `"loading"` while the sound is still being
+/// read from disk, then one of kira's own states (`"playing"`, `"pausing"`,
+/// `"paused"`, `"waiting_to_resume"`, `"resuming"`, `"stopping"`,
+/// `"stopped"`). `""` for an id that was never played, or one whose sound
+/// failed to load.
 #[op2]
 #[string]
 pub fn bsengine_get_sound_state(id: u32) -> String {

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -56,6 +56,14 @@ pub struct SoundHandles(pub HashMap<u32, kira::sound::static_sound::StaticSoundH
 /// `playSound` is fire-and-forget from the script's side, so the request has
 /// to outlive the frame it was made on. Volume and looping are captured here
 /// at request time so the queued play behaves as asked.
+///
+/// Only `stopSound` reaches entries here; `pauseSound`, `resumeSound`,
+/// `setSoundVolume`, `setSoundPanning`, `setSoundPlaybackRate` and `seekSound`
+/// still act on playing sounds only and silently no-op on a queued one. That
+/// is deliberate: they would need a full deferred-parameter set stored per
+/// entry, and a no-op is what they have always done for an id that is not
+/// playing, whereas an ignored stop actively produces the sound it was meant
+/// to prevent.
 #[derive(bevy_ecs::prelude::Resource, Default)]
 pub struct PendingSounds(
     pub  Vec<(
@@ -1394,6 +1402,14 @@ fn run_scripts(world: &mut World) {
                         use kira::Tween;
                         handle.stop(Tween::default());
                     }
+                }
+                // The queue is consulted too because a stop can arrive before
+                // the async load resolves, while the id is still only in
+                // `PendingSounds` and not yet in `SoundHandles`. Without this
+                // the stop would find nothing, and the sound would start once
+                // the load finished — the opposite of what was asked.
+                if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
+                    pending.0.retain(|(pending_id, ..)| *pending_id != id);
                 }
             }
             ScriptCommand::PauseSound { id } => {
@@ -2940,7 +2956,8 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
 #[cfg(test)]
 mod tests {
     use super::{
-        Name, PendingSounds, ScriptPath, ScriptRuntimeResource, ScriptingPlugin, Transform, Vec3,
+        HudTexts, Name, PendingSounds, ScriptPath, ScriptRuntimeResource, ScriptingPlugin,
+        Transform, Vec3,
     };
     use bsengine_app::new_app;
 
@@ -3066,6 +3083,82 @@ mod tests {
         assert!(
             app.world().resource::<PendingSounds>().0.is_empty(),
             "a sound that can never load must be dropped from the queue, not retried forever"
+        );
+
+        let _ = std::fs::remove_file(&script_path);
+    }
+
+    // A stop that arrives before the async load resolves must still stop the
+    // sound. `playSound` only reaches `SoundHandles` once the decode finishes,
+    // so a `SoundHandles`-only stop finds nothing, does nothing, and the sound
+    // then starts anyway — the opposite of what the script asked for. Both
+    // plays and the stop happen in a single `onUpdate`, so all three commands
+    // are applied in one `run_scripts` pass before any load can resolve; the
+    // queue state below is therefore fixed, not a race. The ids are reported
+    // back through `setHudText` because the op assigns them, not the test.
+    // The second, un-stopped sound pins the other direction: a fix that
+    // cleared the whole queue would drop it too. There is no audio device here
+    // (`AudioWorld` no-ops), so the queue is the only observable.
+    #[test]
+    fn stop_sound_drops_a_still_loading_sound_from_the_queue() {
+        let script_path = std::env::temp_dir().join(format!(
+            "bsengine_test_stop_pending_sound_{}.js",
+            std::process::id()
+        ));
+        std::fs::write(
+            &script_path,
+            "var played = false;\n\
+             function onUpdate(name) {\n\
+               if (played) { return; }\n\
+               played = true;\n\
+               var stopped = Bsengine.playSound(\"definitely/not/a/real/stopped.wav\", {});\n\
+               var kept = Bsengine.playSound(\"definitely/not/a/real/kept.wav\", {});\n\
+               Bsengine.stopSound(stopped);\n\
+               Bsengine.setHudText(\"stopped\", String(stopped));\n\
+               Bsengine.setHudText(\"kept\", String(kept));\n\
+             }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: String::new(),
+        });
+        app.world_mut().spawn((
+            Name("Speaker".to_string()),
+            ScriptPath(script_path.to_string_lossy().to_string()),
+        ));
+
+        app.update();
+
+        let read_id = |key: &str| -> u32 {
+            app.world()
+                .resource::<HudTexts>()
+                .0
+                .get(key)
+                .unwrap_or_else(|| panic!("script did not report the {key} sound's id"))
+                .parse()
+                .expect("reported id is not a number")
+        };
+        let stopped = read_id("stopped");
+        let kept = read_id("kept");
+        assert_ne!(stopped, kept, "each play must get its own id");
+
+        let queued: Vec<u32> = app
+            .world()
+            .resource::<PendingSounds>()
+            .0
+            .iter()
+            .map(|(id, ..)| *id)
+            .collect();
+        assert!(
+            !queued.contains(&stopped),
+            "stopSound must cancel a queued play, or the sound starts after being stopped; queue held {queued:?}"
+        );
+        assert!(
+            queued.contains(&kept),
+            "stopSound must drop only the id it was given, not the whole queue; queue held {queued:?}"
         );
 
         let _ = std::fs::remove_file(&script_path);

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -51,28 +51,75 @@ pub struct ScriptRuntimeResource(pub ScriptRuntime);
 #[derive(Resource, Default)]
 pub struct SoundHandles(pub HashMap<u32, kira::sound::static_sound::StaticSoundHandle>);
 
-/// Plays requested before their sound finished loading.
+/// What the audio consumer knows about one sound path.
+#[derive(Debug)]
+enum SoundLoad {
+    /// Requested; waiting for `Assets<AudioSourceAsset>` to have it.
+    Loading(bevy_asset::Handle<bsengine_audio::AudioSourceAsset>),
+    /// Decoded and resident. See [`SoundLoads`] for why the handle is kept
+    /// rather than dropped once the play that asked for it has started.
+    Ready(bevy_asset::Handle<bsengine_audio::AudioSourceAsset>),
+    /// The load failed. Kept so the path is never re-requested --
+    /// re-requesting a failed path resets it to `Loading` and starts the load
+    /// over (`bevy_asset` 0.14.2, `server/info.rs:212-221`), which is why a
+    /// re-requesting poll loop can never see the failure.
+    GaveUp,
+}
+
+/// Every sound path `playSound` has ever asked for, keyed by resolved path.
+///
+/// Gives audio the request-once/retain-the-handle/poll-the-retained-handle
+/// shape the glTF, shader and skybox consumers already have (see
+/// `bsengine_render::plugin`'s `PendingShaders` for the closest analogue).
+/// Keyed by path rather than by play id because a path is what gets loaded,
+/// while several concurrent plays -- each with its own id, volume and loop
+/// flag -- can be waiting on the same one.
+///
+/// A `Ready` path keeps its handle, not just an in-flight one, and that is a
+/// deliberate trade rather than an oversight: `Assets::<A>::track_assets`
+/// frees an asset the frame after its last strong handle drops, so releasing
+/// it here would make *every* repeat play a fresh disk read and decode,
+/// several frames late -- not just the first. The cost is that each distinct
+/// sound path a game plays stays resident for the process lifetime. For a
+/// game engine that is the right way round: SFX are small, and latency on a
+/// repeated trigger is the thing players actually notice. Unity and Unreal
+/// both keep loaded clips resident by default for the same reason.
+#[derive(bevy_ecs::prelude::Resource, Default)]
+struct SoundLoads(HashMap<String, SoundLoad>);
+
+/// One `playSound` waiting for its sound to finish decoding.
 ///
 /// `playSound` is fire-and-forget from the script's side, so the request has
-/// to outlive the frame it was made on. Volume and looping are captured here
-/// at request time so the queued play behaves as asked.
+/// to outlive the frame it was made on; everything needed to start the play
+/// later is captured here at request time.
+#[derive(Debug)]
+struct PendingSound {
+    /// Script-assigned id — what `stopSound`/`pauseSound` name this play by.
+    id: u32,
+    /// Resolved path this play is waiting on; the key into [`SoundLoads`].
+    path: String,
+    /// Linear volume captured at request time.
+    volume: f32,
+    /// Whether the play loops.
+    loop_: bool,
+    /// A `pauseSound` arrived before the sound started, so there was no kira
+    /// handle to pause; pause it the instant it does start.
+    paused: bool,
+}
+
+/// Plays requested before their sound finished loading.
 ///
-/// Only `stopSound` reaches entries here; `pauseSound`, `resumeSound`,
+/// Only `stopSound`, `pauseSound` and `resumeSound` reach entries here;
 /// `setSoundVolume`, `setSoundPanning`, `setSoundPlaybackRate` and `seekSound`
 /// still act on playing sounds only and silently no-op on a queued one. That
-/// is deliberate: they would need a full deferred-parameter set stored per
-/// entry, and a no-op is what they have always done for an id that is not
-/// playing, whereas an ignored stop actively produces the sound it was meant
-/// to prevent.
+/// is deliberate, and the line is what the command does when it is lost: those
+/// four *tune* a sound, so an ignored one yields a wrong-sounding sound, which
+/// is also what they have always done for an id that is not playing. A stop or
+/// a pause instead *suppresses* a sound, so an ignored one actively produces
+/// the sound it was meant to prevent — `playSound(); pauseSound(id)` in one
+/// `onUpdate` would otherwise be audible.
 #[derive(bevy_ecs::prelude::Resource, Default)]
-pub struct PendingSounds(
-    pub  Vec<(
-        u32,
-        bevy_asset::Handle<bsengine_audio::AudioSourceAsset>,
-        f32,
-        bool,
-    )>,
-);
+struct PendingSounds(Vec<PendingSound>);
 
 /// Where `Bsengine.getTime()` / `getDeltaTime()` get their numbers.
 ///
@@ -169,6 +216,7 @@ impl Plugin for ScriptingPlugin {
         app.insert_resource(HudTexts::default());
         app.insert_resource(SoundHandles::default());
         app.init_resource::<PendingSounds>();
+        app.init_resource::<SoundLoads>();
         app.insert_non_send_resource(ScriptRuntimeResource(ScriptRuntime::new_with_ops()));
         // Wall clock by default. `bsengine-runtime --test` overwrites this
         // with `ScriptTimingState::fixed` so replays are reproducible.
@@ -1366,34 +1414,84 @@ fn run_scripts(world: &mut World) {
                 } else {
                     format!("{}/{}", project_dir, path)
                 };
-                let asset_server = world.get_resource::<bevy_asset::AssetServer>().cloned();
-                let requested = match asset_server {
-                    Some(asset_server) => world
-                        .get_resource_mut::<bevy_asset::Assets<bsengine_audio::AudioSourceAsset>>()
-                        .map(|mut assets| {
-                            bsengine_asset::load(
-                                bsengine_asset::LoadMode::Async,
-                                &asset_server,
-                                &mut assets,
-                                &full_path,
-                                bsengine_audio::load_audio_source,
-                            )
-                        }),
-                    None => None,
-                };
-                match requested {
-                    // Queued rather than played: the sound may not be decoded
-                    // yet, and `playSound` is fire-and-forget from the script's
-                    // side, so the request has to outlive this frame.
-                    Some(Ok(handle)) => {
-                        if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
-                            pending.0.push((id, handle, volume, loop_));
+                // What `SoundLoads` already knows decides everything below, so
+                // it is consulted *before* anything is requested. Re-calling
+                // `load()` for a path whose load has since failed resets it to
+                // `Loading` and respawns the filesystem task; because `Failed`
+                // is set in `PreUpdate` and this runs in `Update`, a script
+                // calling `playSound` on a missing path every frame would
+                // queue one entry and spawn one task per frame and never once
+                // observe the failure. Re-calling it for a path that already
+                // resolved would instead throw away the decode `SoundLoads`
+                // exists to keep, making every repeat play a fresh disk read.
+                let known = world
+                    .get_resource::<SoundLoads>()
+                    .and_then(|loads| loads.0.get(&full_path));
+                if matches!(known, Some(SoundLoad::GaveUp)) {
+                    // Dropped now rather than queued: this play can never
+                    // start, and a queue entry that can never resolve is
+                    // exactly the unbounded growth this map prevents.
+                    tracing::warn!("[audio] not playing {full_path}: its load already failed");
+                    continue;
+                }
+                let already_requested = known.is_some();
+
+                if !already_requested {
+                    let asset_server = world.get_resource::<bevy_asset::AssetServer>().cloned();
+                    let requested = match asset_server {
+                        Some(asset_server) => world
+                            .get_resource_mut::<bevy_asset::Assets<bsengine_audio::AudioSourceAsset>>()
+                            .map(|mut assets| {
+                                bsengine_asset::load(
+                                    bsengine_asset::LoadMode::Async,
+                                    &asset_server,
+                                    &mut assets,
+                                    &full_path,
+                                    bsengine_audio::load_audio_source,
+                                )
+                            }),
+                        None => None,
+                    };
+                    let load = match requested {
+                        Some(Ok(handle)) => SoundLoad::Loading(handle),
+                        Some(Err(e)) => {
+                            // Unreachable: `LoadMode::Async` is infallible.
+                            // Present only because the shared `load()`
+                            // signature returns `Result` for `Sync` callers.
+                            tracing::warn!("[audio] failed to request {full_path}: {e}");
+                            SoundLoad::GaveUp
                         }
+                        None => {
+                            tracing::warn!(
+                                "[audio] Assets<AudioSourceAsset> resource missing (AssetPlugin not registered?)"
+                            );
+                            SoundLoad::GaveUp
+                        }
+                    };
+                    let gave_up = matches!(load, SoundLoad::GaveUp);
+                    if let Some(mut loads) = world.get_resource_mut::<SoundLoads>() {
+                        loads.0.insert(full_path.clone(), load);
                     }
-                    Some(Err(e)) => tracing::warn!("[audio] failed to request {full_path}: {e}"),
-                    None => tracing::warn!(
-                        "[audio] Assets<AudioSourceAsset> resource missing (AssetPlugin not registered?)"
-                    ),
+                    if gave_up {
+                        continue;
+                    }
+                }
+
+                // Queued rather than played outright: the sound may not be
+                // decoded yet, and `playSound` is fire-and-forget from the
+                // script's side, so the request has to outlive this frame.
+                // `start_pending_sounds` is chained immediately after
+                // `run_scripts`, so a play on a path that already resolved
+                // still starts on this very frame — the queue costs it
+                // nothing.
+                if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
+                    pending.0.push(PendingSound {
+                        id,
+                        path: full_path,
+                        volume,
+                        loop_,
+                        paused: false,
+                    });
                 }
             }
             ScriptCommand::StopSound { id } => {
@@ -1409,7 +1507,7 @@ fn run_scripts(world: &mut World) {
                 // the stop would find nothing, and the sound would start once
                 // the load finished — the opposite of what was asked.
                 if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
-                    pending.0.retain(|(pending_id, ..)| *pending_id != id);
+                    pending.0.retain(|entry| entry.id != id);
                 }
             }
             ScriptCommand::PauseSound { id } => {
@@ -1419,12 +1517,32 @@ fn run_scripts(world: &mut World) {
                         handle.pause(Tween::default());
                     }
                 }
+                // The queue is consulted for the same reason `stopSound`
+                // consults it: a pause can arrive before the async load
+                // resolves, while the id is still only in `PendingSounds` and
+                // not yet in `SoundHandles`. Without this the pause would find
+                // nothing, and the sound would start audibly once the load
+                // finished — the opposite of what was asked. Recorded rather
+                // than acted on because there is nothing to act on yet;
+                // `start_pending_sounds` pauses the sound the moment it starts.
+                if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
+                    for entry in pending.0.iter_mut().filter(|entry| entry.id == id) {
+                        entry.paused = true;
+                    }
+                }
             }
             ScriptCommand::ResumeSound { id } => {
                 if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
                     if let Some(handle) = handles.0.get_mut(&id) {
                         use kira::Tween;
                         handle.resume(Tween::default());
+                    }
+                }
+                // Clears a pause recorded above, so `playSound(); pauseSound();
+                // resumeSound()` in one `onUpdate` still plays.
+                if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
+                    for entry in pending.0.iter_mut().filter(|entry| entry.id == id) {
+                        entry.paused = false;
                     }
                 }
             }
@@ -2174,53 +2292,104 @@ fn run_scripts(world: &mut World) {
 /// Starts any queued play whose sound has finished decoding.
 ///
 /// Split from the `PlaySound` command handler because an async load is not
-/// ready on the frame it is asked for. Entries stay queued until their handle
-/// resolves; one whose load failed is dropped with a warning, since it will
-/// never resolve and would otherwise sit in the queue forever.
+/// ready on the frame it is asked for. Entries stay queued until the handle
+/// [`SoundLoads`] holds for their path resolves; every entry on a path whose
+/// load failed is dropped, and the path is marked [`SoundLoad::GaveUp`] so
+/// later plays on it are refused at the command handler instead of piling up
+/// here.
+///
+/// Chained immediately after `run_scripts` (see [`ScriptingPlugin::build`]),
+/// so a play queued this frame on a path that already resolved starts this
+/// frame rather than the next one.
 fn start_pending_sounds(world: &mut World) {
-    let Some(pending) = world.get_resource::<PendingSounds>() else {
-        return;
+    // Taken rather than cloned: `PendingSound` is not `Clone`, and nothing
+    // else can push while this exclusive system runs. Every entry is either
+    // started, dropped, or put back below.
+    let entries = match world.get_resource_mut::<PendingSounds>() {
+        Some(mut pending) if !pending.0.is_empty() => std::mem::take(&mut pending.0),
+        _ => return,
     };
-    if pending.0.is_empty() {
-        return;
-    }
 
-    // Decide each entry's fate first, so the borrow of PendingSounds ends
-    // before AudioWorld/SoundHandles are borrowed mutably below.
-    let entries = pending.0.clone();
+    // Decide each entry's fate first, so the borrows of PendingSounds,
+    // SoundLoads and Assets end before AudioWorld/SoundHandles are borrowed
+    // mutably below.
     let mut still_pending = Vec::new();
     let mut ready = Vec::new();
-    let mut failed = Vec::new();
+    let mut resolved_paths = HashSet::new();
+    // Keyed by path so N plays queued on one bad path warn once, not N times.
+    let mut failed: HashMap<String, String> = HashMap::new();
     {
         let assets = world.resource::<bevy_asset::Assets<bsengine_audio::AudioSourceAsset>>();
         let asset_server = world.resource::<bevy_asset::AssetServer>();
-        for (id, handle, volume, loop_) in entries {
-            match assets.get(&handle) {
-                Some(src) => ready.push((id, src.0.clone(), volume, loop_)),
-                None => match asset_server.load_state(&handle) {
-                    bevy_asset::LoadState::Failed(e) => failed.push(format!("{e}")),
-                    _ => still_pending.push((id, handle, volume, loop_)),
+        let loads = world.resource::<SoundLoads>();
+        for entry in entries {
+            // The handle is read from `SoundLoads`, never re-requested here:
+            // `AssetServer::load` on a path already in `Failed` restarts it,
+            // which would make the failure below unobservable.
+            let handle = match loads.0.get(&entry.path) {
+                Some(SoundLoad::Loading(handle) | SoundLoad::Ready(handle)) => handle,
+                // Unreachable: `PlaySound` records the path before queueing,
+                // and refuses to queue at all once it is `GaveUp`.
+                Some(SoundLoad::GaveUp) | None => continue,
+            };
+            match assets.get(handle) {
+                Some(src) => {
+                    resolved_paths.insert(entry.path.clone());
+                    ready.push((entry, src.0.clone()));
+                }
+                None => match asset_server.load_state(handle) {
+                    bevy_asset::LoadState::Failed(e) => {
+                        failed.insert(entry.path.clone(), format!("{e}"));
+                    }
+                    _ => still_pending.push(entry),
                 },
             }
         }
     }
 
-    for e in failed {
-        tracing::warn!("[audio] failed to load queued sound: {e}");
+    for (path, e) in &failed {
+        tracing::warn!("[audio] failed to load queued sound {path}: {e}");
+    }
+    if let Some(mut loads) = world.get_resource_mut::<SoundLoads>() {
+        // `Loading` -> `Ready`: the handle stays held so the decoded sound
+        // stays resident and a repeat play starts instantly (see `SoundLoads`).
+        for path in resolved_paths {
+            if let Some(slot) = loads.0.get_mut(&path) {
+                if let SoundLoad::Loading(handle) = slot {
+                    *slot = SoundLoad::Ready(handle.clone());
+                }
+            }
+        }
+        // `Loading` -> `GaveUp`: the path is never requested again, so the
+        // failure stays observable and later plays on it are refused outright.
+        for path in failed.into_keys() {
+            loads.0.insert(path, SoundLoad::GaveUp);
+        }
     }
     if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
+        still_pending.append(&mut pending.0);
         pending.0 = still_pending;
     }
 
-    for (id, data, volume, loop_) in ready {
+    for (entry, data) in ready {
         use kira::Decibels;
-        let volume_db = 20.0_f32 * volume.max(1e-10_f32).log10();
+        let volume_db = 20.0_f32 * entry.volume.max(1e-10_f32).log10();
         let data = data.volume(Decibels(volume_db));
-        let data = if loop_ { data.loop_region(..) } else { data };
+        let data = if entry.loop_ {
+            data.loop_region(..)
+        } else {
+            data
+        };
         if let Some(mut audio) = world.get_resource_mut::<AudioWorld>() {
-            if let Some(handle) = audio.play(data) {
+            if let Some(mut handle) = audio.play(data) {
+                // A `pauseSound` that arrived while this play was still queued
+                // had no kira handle to act on; apply it now, before the sound
+                // is audible for a frame it was asked not to be.
+                if entry.paused {
+                    handle.pause(kira::Tween::default());
+                }
                 if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
-                    handles.0.insert(id, handle);
+                    handles.0.insert(entry.id, handle);
                 }
             }
         }
@@ -2689,22 +2858,36 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
     GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_just_pressed);
     GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT.with(|s| *s.borrow_mut() = gpad_just_released);
     GAMEPAD_STICKS_SNAPSHOT.with(|s| *s.borrow_mut() = gamepad_sticks);
-    if let Some(handles) = world.get_resource::<SoundHandles>() {
+    {
         use kira::sound::PlaybackState;
         let mut states = std::collections::HashMap::new();
         let mut positions = std::collections::HashMap::new();
-        for (id, handle) in &handles.0 {
-            let state = match handle.state() {
-                PlaybackState::Playing => "playing",
-                PlaybackState::Pausing => "pausing",
-                PlaybackState::Paused => "paused",
-                PlaybackState::WaitingToResume => "waiting_to_resume",
-                PlaybackState::Resuming => "resuming",
-                PlaybackState::Stopping => "stopping",
-                PlaybackState::Stopped => "stopped",
-            };
-            states.insert(*id, state.to_string());
-            positions.insert(*id, handle.position());
+        // Queued plays first, so a real kira handle always wins if an id
+        // somehow appears in both. Without this a sound that has been asked
+        // for but not yet decoded reports "" — indistinguishable from one
+        // that already finished, which is how a script polling
+        // `getSoundState` fires its "sound over" branch several frames early.
+        // No position is written: `getSoundPosition` falls back to 0.0, which
+        // is honest for a sound that has not started.
+        if let Some(pending) = world.get_resource::<PendingSounds>() {
+            for entry in &pending.0 {
+                states.insert(entry.id, "loading".to_string());
+            }
+        }
+        if let Some(handles) = world.get_resource::<SoundHandles>() {
+            for (id, handle) in &handles.0 {
+                let state = match handle.state() {
+                    PlaybackState::Playing => "playing",
+                    PlaybackState::Pausing => "pausing",
+                    PlaybackState::Paused => "paused",
+                    PlaybackState::WaitingToResume => "waiting_to_resume",
+                    PlaybackState::Resuming => "resuming",
+                    PlaybackState::Stopping => "stopping",
+                    PlaybackState::Stopped => "stopped",
+                };
+                states.insert(*id, state.to_string());
+                positions.insert(*id, handle.position());
+            }
         }
         SOUND_STATE_SNAPSHOT.with(|s| *s.borrow_mut() = states);
         SOUND_POSITION_SNAPSHOT.with(|s| *s.borrow_mut() = positions);
@@ -2957,9 +3140,76 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
 mod tests {
     use super::{
         HudTexts, Name, PendingSounds, ScriptPath, ScriptRuntimeResource, ScriptingPlugin,
-        Transform, Vec3,
+        SoundLoad, SoundLoads, Transform, Vec3,
     };
     use bsengine_app::new_app;
+
+    /// Collects everything `tracing` emits on this thread into a string, so a
+    /// test can assert a warning actually reached the developer rather than
+    /// only that the state behind it changed. Thread-local
+    /// (`tracing::subscriber::with_default`), so parallel tests can't see each
+    /// other's output.
+    #[derive(Clone, Default)]
+    struct LogSink(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl LogSink {
+        fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+        }
+    }
+
+    impl std::io::Write for LogSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl tracing_subscriber::fmt::MakeWriter<'_> for LogSink {
+        type Writer = Self;
+        fn make_writer(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// Runs `body` with every `tracing` event on this thread captured.
+    fn capture_logs<T>(body: impl FnOnce() -> T) -> (T, String) {
+        let sink = LogSink::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(sink.clone())
+            .with_ansi(false)
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+        let out = tracing::subscriber::with_default(subscriber, body);
+        let logs = sink.contents();
+        (out, logs)
+    }
+
+    /// The smallest valid FLAC file this workspace knows how to make: mono,
+    /// 16-bit, 8kHz, four 192-sample `CONSTANT` (silence) frames — 86 bytes.
+    ///
+    /// No audio file of any kind is checked into this repo, and only
+    /// `.mp3`/`.flac` decode at all with this workspace's `kira` feature set
+    /// (its `symphonia` deps bundle those two codecs; the WAV/OGG *container*
+    /// readers are present without the PCM/Vorbis *codecs*, so even a real
+    /// `.wav` would fail). These bytes are the exact output of
+    /// `bsengine_audio::audio_source::tests::minimal_flac_silence()`, which is
+    /// the generator of record and documents the encoding field by field;
+    /// it is `#[cfg(test)]`-private to that crate, hence the copy of its
+    /// result rather than a call. Nothing here asserts the bytes are correct
+    /// in isolation — every test using them fails loudly if they stop
+    /// decoding, since the sound then never resolves.
+    const MINIMAL_FLAC_SILENCE: &[u8] = &[
+        0x66, 0x4c, 0x61, 0x43, 0x80, 0x00, 0x00, 0x22, 0x00, 0xc0, 0x00, 0xc0, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x01, 0xf4, 0x00, 0xf0, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xf8, 0x10,
+        0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x11, 0x11, 0xff, 0xf8, 0x10, 0x00, 0x01, 0x2f, 0x00,
+        0x00, 0x00, 0x7d, 0x69, 0xff, 0xf8, 0x10, 0x00, 0x02, 0x26, 0x00, 0x00, 0x00, 0xc9, 0xe1,
+        0xff, 0xf8, 0x10, 0x00, 0x03, 0x21, 0x00, 0x00, 0x00, 0xa5, 0x99,
+    ];
 
     #[test]
     fn scripting_plugin_registers_runtime() {
@@ -3027,30 +3277,33 @@ mod tests {
         let _ = std::fs::remove_file(&script_path);
     }
 
-    // `playSound` requests the sound once and keeps the handle in
-    // `PendingSounds`, polling it every frame. Re-requesting the path instead
-    // would reset the failed load back to `Loading` and restart it
-    // (`bevy_asset` 0.14.2, `server/info.rs:216-221`), so the failure could
-    // never be observed and the entry would sit in the queue forever. Driven
-    // through a real script so the actual `PlaySound` command handler runs,
-    // not an imitation of it. There is no audio device here (`AudioWorld`
-    // no-ops), so the queue is what gets asserted on, never audible output.
+    // `playSound` requests each path exactly once and polls the handle
+    // `SoundLoads` keeps for it. Re-requesting the path instead would reset
+    // the failed load back to `Loading` and restart it (`bevy_asset` 0.14.2,
+    // `server/info.rs:212-221`), so the failure could never be observed and
+    // an entry would join the queue every frame forever.
+    //
+    // The script plays *every frame*, deliberately: that is the case the
+    // path-keyed map exists for, and the case an earlier version of this test
+    // avoided (it played once, because a re-requesting handler would have
+    // refilled the queue and masked the drop — which is precisely the hole
+    // being closed here). Playing once is the easy half and is still covered:
+    // the first frame's assertion below is the once-only case.
+    //
+    // Driven through a real script so the actual `PlaySound` command handler
+    // runs, not an imitation of it. There is no audio device here
+    // (`AudioWorld` no-ops), so the queue, the map and the log are what get
+    // asserted on, never audible output.
     #[test]
-    fn unloadable_pending_sound_is_dropped_from_the_queue() {
+    fn sound_played_every_frame_on_a_missing_path_is_given_up_on() {
         let script_path = std::env::temp_dir().join(format!(
             "bsengine_test_pending_sound_{}.js",
             std::process::id()
         ));
-        // Played once, not every frame: a script that re-requests a failed
-        // path each frame would refill the queue and mask the drop.
         std::fs::write(
             &script_path,
-            "var played = false;\n\
-             function onUpdate(name) {\n\
-               if (!played) {\n\
-                 played = true;\n\
-                 Bsengine.playSound(\"definitely/not/a/real/sound.wav\", { volume: 0.5 });\n\
-               }\n\
+            "function onUpdate(name) {\n\
+               Bsengine.playSound(\"definitely/not/a/real/sound.wav\", { volume: 0.5 });\n\
              }",
         )
         .unwrap();
@@ -3065,24 +3318,305 @@ mod tests {
             ScriptPath(script_path.to_string_lossy().to_string()),
         ));
 
-        // One frame: `PostStartup` loads the script and `Update` runs
-        // `onUpdate`, which reaches the real `PlaySound` handler. The load
-        // cannot have failed yet — `LoadState::Failed` is set in `PreUpdate` —
-        // so the request must be queued rather than resolved or dropped.
+        // The queue is measured after every frame, not just at the end: the
+        // defect being fixed grew it by one entry per frame, which a
+        // start-and-end comparison alone would miss once the queue drains.
+        let (peak_queued, logs) = capture_logs(|| {
+            // One frame: `PostStartup` loads the script and `Update` runs
+            // `onUpdate`, which reaches the real `PlaySound` handler. The load
+            // cannot have failed yet — `LoadState::Failed` is set in
+            // `PreUpdate` — so the request must be queued rather than resolved
+            // or dropped.
+            app.update();
+            assert_eq!(
+                app.world().resource::<PendingSounds>().0.len(),
+                1,
+                "playSound must queue the request instead of blocking on the decode"
+            );
+
+            let mut peak = 1;
+            for _ in 0..200 {
+                app.update();
+                peak = peak.max(app.world().resource::<PendingSounds>().0.len());
+            }
+            peak
+        });
+
+        // A per-frame `playSound` can only queue entries until the load is
+        // seen to fail, which takes a handful of frames at most. Without the
+        // path-keyed map it queued one per frame for all 201 frames.
+        assert!(
+            peak_queued <= 16,
+            "a script playing a missing path every frame must not grow the queue \
+             without bound; the queue peaked at {peak_queued} entries over 201 frames"
+        );
+        assert!(
+            app.world().resource::<PendingSounds>().0.is_empty(),
+            "a sound that can never load must be dropped from the queue, not retried forever"
+        );
+        assert!(
+            matches!(
+                app.world()
+                    .resource::<SoundLoads>()
+                    .0
+                    .get("definitely/not/a/real/sound.wav"),
+                Some(SoundLoad::GaveUp)
+            ),
+            "the failed path must be remembered as given-up on, or the next \
+             playSound restarts the load and the failure is never observed"
+        );
+        assert!(
+            logs.contains("[audio] failed to load queued sound"),
+            "the developer must be told the sound could not be loaded; captured logs were:\n{logs}"
+        );
+
+        let _ = std::fs::remove_file(&script_path);
+    }
+
+    // Repeat plays of a path that already loaded must not go back to disk.
+    // `SoundLoads` is the only holder of a `Handle<AudioSourceAsset>` in the
+    // workspace, so if it released the handle once a play resolved,
+    // `Assets::<A>::track_assets` would free the decoded sound and *every*
+    // repeat play — not just the first — would be a fresh read and decode,
+    // several frames late.
+    //
+    // The script waits for the first play to leave the queue and then idles
+    // several frames before playing again, so a released asset would really
+    // have been freed by the time the repeat is asked for. Since
+    // `start_pending_sounds` is chained immediately after `run_scripts`, the
+    // repeat must be gone from the queue by the time that same `app.update()`
+    // returns — that is what "starts on the requesting frame" means with no
+    // audio device to listen to.
+    #[test]
+    fn a_repeat_play_reuses_the_resident_sound_and_starts_the_same_frame() {
+        use bevy_asset::Assets;
+        use bsengine_audio::AudioSourceAsset;
+
+        let dir =
+            std::env::temp_dir().join(format!("bsengine_test_repeat_play_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sound_path = dir.join("blip.flac");
+        std::fs::write(&sound_path, MINIMAL_FLAC_SILENCE).unwrap();
+        // Backslashes would be escapes inside the JS string literal below;
+        // Windows accepts forward slashes just as happily.
+        let sound_path_js = sound_path.to_string_lossy().replace('\\', "/");
+
+        let script_path = dir.join("repeat.js");
+        std::fs::write(
+            &script_path,
+            format!(
+                "var first = -1;\n\
+                 var second = -1;\n\
+                 var idle = 0;\n\
+                 function onUpdate(name) {{\n\
+                   if (first < 0) {{\n\
+                     first = Bsengine.playSound(\"{sound_path_js}\", {{}});\n\
+                     return;\n\
+                   }}\n\
+                   if (second >= 0) {{ return; }}\n\
+                   if (Bsengine.getSoundState(first) === \"loading\") {{ return; }}\n\
+                   if (idle < 5) {{ idle += 1; return; }}\n\
+                   second = Bsengine.playSound(\"{sound_path_js}\", {{}});\n\
+                   Bsengine.setHudText(\"second\", String(second));\n\
+                 }}"
+            ),
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: String::new(),
+        });
+        app.world_mut().spawn((
+            Name("Speaker".to_string()),
+            ScriptPath(script_path.to_string_lossy().to_string()),
+        ));
+
+        let mut frames = 0;
+        while !app.world().resource::<HudTexts>().0.contains_key("second") {
+            app.update();
+            frames += 1;
+            assert!(
+                frames < 300,
+                "the first play never resolved, so the repeat was never requested \
+                 (is MINIMAL_FLAC_SILENCE still decodable?)"
+            );
+        }
+
+        // `app.update()` has already run `start_pending_sounds` for the frame
+        // that asked for the repeat, so an empty queue here means the repeat
+        // started on its requesting frame rather than waiting for a reload.
+        assert!(
+            app.world().resource::<PendingSounds>().0.is_empty(),
+            "a repeat play of an already-loaded sound must start on the frame it \
+             is requested, not wait for the file to be read again"
+        );
+
+        let loads = app.world().resource::<SoundLoads>();
+        assert_eq!(
+            loads.0.len(),
+            1,
+            "both plays name the same path, so it must be requested once"
+        );
+        // Keyed by exactly the string the script passed, which is what
+        // `PlaySound` resolves and `AssetServer` was handed.
+        let handle = match loads.0.get(&sound_path_js) {
+            Some(SoundLoad::Ready(handle)) => handle.clone(),
+            other => panic!("the resolved path must be retained as Ready, got {other:?}"),
+        };
+        assert!(
+            app.world()
+                .resource::<Assets<AudioSourceAsset>>()
+                .get(&handle)
+                .is_some(),
+            "the decoded sound must stay resident between plays, or every repeat \
+             is a fresh disk read several frames late"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A sound that has been asked for but has not started yet must report
+    // `"loading"`, not `""`. `""` is what `getSoundState` returns for an id
+    // that was never played at all, so a script polling for "has my sound
+    // finished?" cannot tell the two apart and fires its finished branch
+    // several frames early — before the sound has made a sound.
+    //
+    // The timing is fixed rather than raced: frame 1 queues the play (the
+    // load cannot have failed yet, `LoadState::Failed` is set in `PreUpdate`),
+    // and frame 2 reads the snapshot `run_scripts` builds before it runs
+    // `onUpdate`, while the entry is still queued.
+    #[test]
+    fn a_queued_sound_reports_loading_not_nothing() {
+        let script_path = std::env::temp_dir().join(format!(
+            "bsengine_test_queued_sound_state_{}.js",
+            std::process::id()
+        ));
+        std::fs::write(
+            &script_path,
+            "var id = -1;\n\
+             function onUpdate(name) {\n\
+               if (id < 0) {\n\
+                 id = Bsengine.playSound(\"definitely/not/a/real/queued.wav\", {});\n\
+                 return;\n\
+               }\n\
+               Bsengine.setHudText(\"state\", Bsengine.getSoundState(id));\n\
+               Bsengine.setHudText(\"position\", String(Bsengine.getSoundPosition(id)));\n\
+             }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: String::new(),
+        });
+        app.world_mut().spawn((
+            Name("Speaker".to_string()),
+            ScriptPath(script_path.to_string_lossy().to_string()),
+        ));
+
         app.update();
         assert_eq!(
             app.world().resource::<PendingSounds>().0.len(),
             1,
-            "playSound must queue the request instead of blocking on the decode"
+            "the play must still be queued for the state read below to mean anything"
         );
+        app.update();
 
-        for _ in 0..200 {
-            app.update();
-        }
+        let hud = &app.world().resource::<HudTexts>().0;
+        assert_eq!(
+            hud.get("state").map(String::as_str),
+            Some("loading"),
+            "a queued sound must be distinguishable from one that never played"
+        );
+        // Deliberately still 0.0: a sound that has not started has no honest
+        // position to report.
+        assert_eq!(hud.get("position").map(String::as_str), Some("0"));
+
+        let _ = std::fs::remove_file(&script_path);
+    }
+
+    // `playSound(); pauseSound(id)` in one `onUpdate` used to yield an
+    // audible sound: the play was still queued, so the pause found no kira
+    // handle, did nothing, and the sound started anyway — the same inversion
+    // `stopSound` had, one notch weaker only because it is recoverable.
+    // All three plays and both control commands happen in a single
+    // `onUpdate`, so every command is applied in one `run_scripts` pass
+    // before any load can resolve; the queue state below is fixed, not a
+    // race. The un-paused play pins the other direction (a fix that paused
+    // the whole queue would catch it too) and the paused-then-resumed one
+    // pins `resumeSound` clearing the flag again. There is no audio device
+    // here (`AudioWorld` no-ops), so the queue is the only observable.
+    #[test]
+    fn pause_sound_pauses_a_still_loading_sound() {
+        let script_path = std::env::temp_dir().join(format!(
+            "bsengine_test_pause_pending_sound_{}.js",
+            std::process::id()
+        ));
+        std::fs::write(
+            &script_path,
+            "var played = false;\n\
+             function onUpdate(name) {\n\
+               if (played) { return; }\n\
+               played = true;\n\
+               var paused = Bsengine.playSound(\"definitely/not/a/real/paused.wav\", {});\n\
+               var resumed = Bsengine.playSound(\"definitely/not/a/real/resumed.wav\", {});\n\
+               var untouched = Bsengine.playSound(\"definitely/not/a/real/untouched.wav\", {});\n\
+               Bsengine.pauseSound(paused);\n\
+               Bsengine.pauseSound(resumed);\n\
+               Bsengine.resumeSound(resumed);\n\
+               Bsengine.setHudText(\"paused\", String(paused));\n\
+               Bsengine.setHudText(\"resumed\", String(resumed));\n\
+               Bsengine.setHudText(\"untouched\", String(untouched));\n\
+             }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: String::new(),
+        });
+        app.world_mut().spawn((
+            Name("Speaker".to_string()),
+            ScriptPath(script_path.to_string_lossy().to_string()),
+        ));
+
+        app.update();
+
+        let read_id = |key: &str| -> u32 {
+            app.world()
+                .resource::<HudTexts>()
+                .0
+                .get(key)
+                .unwrap_or_else(|| panic!("script did not report the {key} sound's id"))
+                .parse()
+                .expect("reported id is not a number")
+        };
+        let queued_paused = |id: u32| -> bool {
+            app.world()
+                .resource::<PendingSounds>()
+                .0
+                .iter()
+                .find(|entry| entry.id == id)
+                .unwrap_or_else(|| panic!("sound {id} is not queued"))
+                .paused
+        };
 
         assert!(
-            app.world().resource::<PendingSounds>().0.is_empty(),
-            "a sound that can never load must be dropped from the queue, not retried forever"
+            queued_paused(read_id("paused")),
+            "pauseSound must reach a play that is still loading, or the sound \
+             becomes audible after being paused"
+        );
+        assert!(
+            !queued_paused(read_id("resumed")),
+            "resumeSound must clear a pause recorded on a queued play"
+        );
+        assert!(
+            !queued_paused(read_id("untouched")),
+            "pauseSound must reach only the id it was given, not the whole queue"
         );
 
         let _ = std::fs::remove_file(&script_path);
@@ -3150,7 +3684,7 @@ mod tests {
             .resource::<PendingSounds>()
             .0
             .iter()
-            .map(|(id, ..)| *id)
+            .map(|entry| entry.id)
             .collect();
         assert!(
             !queued.contains(&stopped),

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -51,6 +51,21 @@ pub struct ScriptRuntimeResource(pub ScriptRuntime);
 #[derive(Resource, Default)]
 pub struct SoundHandles(pub HashMap<u32, kira::sound::static_sound::StaticSoundHandle>);
 
+/// Plays requested before their sound finished loading.
+///
+/// `playSound` is fire-and-forget from the script's side, so the request has
+/// to outlive the frame it was made on. Volume and looping are captured here
+/// at request time so the queued play behaves as asked.
+#[derive(bevy_ecs::prelude::Resource, Default)]
+pub struct PendingSounds(
+    pub  Vec<(
+        u32,
+        bevy_asset::Handle<bsengine_audio::AudioSourceAsset>,
+        f32,
+        bool,
+    )>,
+);
+
 /// Where `Bsengine.getTime()` / `getDeltaTime()` get their numbers.
 ///
 /// Rapier always steps a fixed 1/60s of simulation per frame, no matter how
@@ -145,6 +160,7 @@ impl Plugin for ScriptingPlugin {
         app.insert_resource(ProjectDir(self.project_dir.clone()));
         app.insert_resource(HudTexts::default());
         app.insert_resource(SoundHandles::default());
+        app.init_resource::<PendingSounds>();
         app.insert_non_send_resource(ScriptRuntimeResource(ScriptRuntime::new_with_ops()));
         // Wall clock by default. `bsengine-runtime --test` overwrites this
         // with `ScriptTimingState::fixed` so replays are reproducible.
@@ -152,7 +168,10 @@ impl Plugin for ScriptingPlugin {
         // Register CollisionEvent so EventReader works even without PhysicsPlugin
         app.add_event::<CollisionEvent>();
         app.add_systems(PostStartup, load_scripts);
-        app.add_systems(Update, (capture_collision_events, run_scripts).chain());
+        app.add_systems(
+            Update,
+            (capture_collision_events, run_scripts, start_pending_sounds).chain(),
+        );
     }
 }
 
@@ -1339,45 +1358,31 @@ fn run_scripts(world: &mut World) {
                 } else {
                     format!("{}/{}", project_dir, path)
                 };
-                let loaded = world
-                    .get_resource::<bevy_asset::AssetServer>()
-                    .cloned()
-                    .and_then(|asset_server| {
-                        world
-                            .get_resource_mut::<bevy_asset::Assets<bsengine_audio::AudioSourceAsset>>()
-                            .map(|mut assets| {
-                                bsengine_asset::load(
-                                    bsengine_asset::LoadMode::Sync,
-                                    &asset_server,
-                                    &mut assets,
-                                    &full_path,
-                                    bsengine_audio::load_audio_source,
-                                )
-                            })
-                    });
-                match loaded {
+                let asset_server = world.get_resource::<bevy_asset::AssetServer>().cloned();
+                let requested = match asset_server {
+                    Some(asset_server) => world
+                        .get_resource_mut::<bevy_asset::Assets<bsengine_audio::AudioSourceAsset>>()
+                        .map(|mut assets| {
+                            bsengine_asset::load(
+                                bsengine_asset::LoadMode::Async,
+                                &asset_server,
+                                &mut assets,
+                                &full_path,
+                                bsengine_audio::load_audio_source,
+                            )
+                        }),
+                    None => None,
+                };
+                match requested {
+                    // Queued rather than played: the sound may not be decoded
+                    // yet, and `playSound` is fire-and-forget from the script's
+                    // side, so the request has to outlive this frame.
                     Some(Ok(handle)) => {
-                        let data = world
-                            .resource::<bevy_asset::Assets<bsengine_audio::AudioSourceAsset>>()
-                            .get(&handle)
-                            .map(|src| src.0.clone());
-                        if let Some(data) = data {
-                            use kira::Decibels;
-                            let volume_db = 20.0_f32 * volume.max(1e-10_f32).log10();
-                            let data = data.volume(Decibels(volume_db));
-                            let data = if loop_ { data.loop_region(..) } else { data };
-                            if let Some(mut audio) = world.get_resource_mut::<AudioWorld>() {
-                                if let Some(handle) = audio.play(data) {
-                                    if let Some(mut handles) =
-                                        world.get_resource_mut::<SoundHandles>()
-                                    {
-                                        handles.0.insert(id, handle);
-                                    }
-                                }
-                            }
+                        if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
+                            pending.0.push((id, handle, volume, loop_));
                         }
                     }
-                    Some(Err(e)) => tracing::warn!("[audio] failed to load {full_path}: {e}"),
+                    Some(Err(e)) => tracing::warn!("[audio] failed to request {full_path}: {e}"),
                     None => tracing::warn!(
                         "[audio] Assets<AudioSourceAsset> resource missing (AssetPlugin not registered?)"
                     ),
@@ -2150,6 +2155,62 @@ fn run_scripts(world: &mut World) {
     }
 }
 
+/// Starts any queued play whose sound has finished decoding.
+///
+/// Split from the `PlaySound` command handler because an async load is not
+/// ready on the frame it is asked for. Entries stay queued until their handle
+/// resolves; one whose load failed is dropped with a warning, since it will
+/// never resolve and would otherwise sit in the queue forever.
+fn start_pending_sounds(world: &mut World) {
+    let Some(pending) = world.get_resource::<PendingSounds>() else {
+        return;
+    };
+    if pending.0.is_empty() {
+        return;
+    }
+
+    // Decide each entry's fate first, so the borrow of PendingSounds ends
+    // before AudioWorld/SoundHandles are borrowed mutably below.
+    let entries = pending.0.clone();
+    let mut still_pending = Vec::new();
+    let mut ready = Vec::new();
+    let mut failed = Vec::new();
+    {
+        let assets = world.resource::<bevy_asset::Assets<bsengine_audio::AudioSourceAsset>>();
+        let asset_server = world.resource::<bevy_asset::AssetServer>();
+        for (id, handle, volume, loop_) in entries {
+            match assets.get(&handle) {
+                Some(src) => ready.push((id, src.0.clone(), volume, loop_)),
+                None => match asset_server.load_state(&handle) {
+                    bevy_asset::LoadState::Failed(e) => failed.push(format!("{e}")),
+                    _ => still_pending.push((id, handle, volume, loop_)),
+                },
+            }
+        }
+    }
+
+    for e in failed {
+        tracing::warn!("[audio] failed to load queued sound: {e}");
+    }
+    if let Some(mut pending) = world.get_resource_mut::<PendingSounds>() {
+        pending.0 = still_pending;
+    }
+
+    for (id, data, volume, loop_) in ready {
+        use kira::Decibels;
+        let volume_db = 20.0_f32 * volume.max(1e-10_f32).log10();
+        let data = data.volume(Decibels(volume_db));
+        let data = if loop_ { data.loop_region(..) } else { data };
+        if let Some(mut audio) = world.get_resource_mut::<AudioWorld>() {
+            if let Some(handle) = audio.play(data) {
+                if let Some(mut handles) = world.get_resource_mut::<SoundHandles>() {
+                    handles.0.insert(id, handle);
+                }
+            }
+        }
+    }
+}
+
 fn spawn_entity(world: &mut World, params: SpawnParams) {
     let prim = match params.primitive.as_str() {
         "Sphere" => Primitive::Sphere,
@@ -2878,7 +2939,9 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
 
 #[cfg(test)]
 mod tests {
-    use super::{Name, ScriptPath, ScriptRuntimeResource, ScriptingPlugin, Transform, Vec3};
+    use super::{
+        Name, PendingSounds, ScriptPath, ScriptRuntimeResource, ScriptingPlugin, Transform, Vec3,
+    };
     use bsengine_app::new_app;
 
     #[test]
@@ -2943,6 +3006,67 @@ mod tests {
             .find(|(n, _)| n.0 == "Hero")
             .expect("Hero entity with SaveData not found");
         assert_eq!(save.get("score"), Some(b"99".as_slice()));
+
+        let _ = std::fs::remove_file(&script_path);
+    }
+
+    // `playSound` requests the sound once and keeps the handle in
+    // `PendingSounds`, polling it every frame. Re-requesting the path instead
+    // would reset the failed load back to `Loading` and restart it
+    // (`bevy_asset` 0.14.2, `server/info.rs:216-221`), so the failure could
+    // never be observed and the entry would sit in the queue forever. Driven
+    // through a real script so the actual `PlaySound` command handler runs,
+    // not an imitation of it. There is no audio device here (`AudioWorld`
+    // no-ops), so the queue is what gets asserted on, never audible output.
+    #[test]
+    fn unloadable_pending_sound_is_dropped_from_the_queue() {
+        let script_path = std::env::temp_dir().join(format!(
+            "bsengine_test_pending_sound_{}.js",
+            std::process::id()
+        ));
+        // Played once, not every frame: a script that re-requests a failed
+        // path each frame would refill the queue and mask the drop.
+        std::fs::write(
+            &script_path,
+            "var played = false;\n\
+             function onUpdate(name) {\n\
+               if (!played) {\n\
+                 played = true;\n\
+                 Bsengine.playSound(\"definitely/not/a/real/sound.wav\", { volume: 0.5 });\n\
+               }\n\
+             }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: String::new(),
+        });
+        app.world_mut().spawn((
+            Name("Speaker".to_string()),
+            ScriptPath(script_path.to_string_lossy().to_string()),
+        ));
+
+        // One frame: `PostStartup` loads the script and `Update` runs
+        // `onUpdate`, which reaches the real `PlaySound` handler. The load
+        // cannot have failed yet — `LoadState::Failed` is set in `PreUpdate` —
+        // so the request must be queued rather than resolved or dropped.
+        app.update();
+        assert_eq!(
+            app.world().resource::<PendingSounds>().0.len(),
+            1,
+            "playSound must queue the request instead of blocking on the decode"
+        );
+
+        for _ in 0..200 {
+            app.update();
+        }
+
+        assert!(
+            app.world().resource::<PendingSounds>().0.is_empty(),
+            "a sound that can never load must be dropped from the queue, not retried forever"
+        );
 
         let _ = std::fs::remove_file(&script_path);
     }


### PR DESCRIPTION
Item 24 Phase 2. Converts the engine's four asset consumers from blocking `LoadMode::Sync` to asynchronous loading, so Phase 3's file watcher becomes a small addition to an already event-driven pipeline rather than a second code path.

## Summary

All four consumers now follow one invariant: **request once, retain the handle, poll the retained handle.**

| Consumer | Pending state | Why that shape |
|---|---|---|
| glTF | `PendingGltf` component | one glTF per entity |
| Custom shaders | `PendingShaders` path-keyed map | many entities per shader |
| Skybox | `PendingSkybox` single slot | there is only ever one |
| Audio | `SoundLoads` path map + `PendingSounds` per-play queue | many concurrent plays of one path |

### The constraint everything is shaped around

`asset_server.load::<T>(path)` uses `HandleLoadingMode::Request`, and `bevy_asset-0.14.2` (`server/info.rs:212-221`) **resets a `Failed` asset to `Loading` and respawns the load** when it is requested again. `Failed` is set in `PreUpdate`; consumers run in `Update`/`PostUpdate`. So the natural-looking "re-request each frame, then check `load_state`" loop can never observe failure and leaks a filesystem task per frame — measured at 200 `Path not found` errors over 200 frames for the naive shape versus 1 for this one.

For the same reason the GPU-resource checks (`GpuMeshRegistry`, `WgpuSurfaceResource`) moved *below* request/poll/failure-detection: a real surface needs a real winit window, so an early return above them would make the give-up path untestable headlessly.

### Regressions async introduced, and fixed here

- `stopSound` and `pauseSound` arriving while a sound was still loading found nothing, did nothing, and the sound then played — **the opposite of what was asked**. Both now reach the queue. The four remaining sound-control commands stay untouched on purpose: they tune a sound rather than suppress it.
- `getSoundState` returned `""` for a queued sound, indistinguishable from an id that never played, so a script polling for completion fired its finished branch before the sound started. Now `"loading"`.
- `playSound` re-requested its path on every call, re-arming the trap above for the one consumer that hadn't adopted the invariant. Caught by the final branch review, fixed in `5fe2c71a`; the same change keeps resolved handles resident so repeat plays start on the frame they are asked for, which `5d1482b1` had claimed but not delivered.

### Cleanup

`WgpuSurface::set_skybox` (its own blocking `image::open`) is deleted now that nothing calls it, `LoadMode::Sync`'s docs no longer claim a migration that is finished, and the `Pending*` types are private to match `PendingGltf`.

## Test Plan

- [x] Workspace tests: 54 test binaries, 0 failures, no stack overflows
- [x] All 8 E2E recordings pass — idle **and** with all 8 replaying concurrently under load, re-run after the review fixes
- [x] `cargo clippy --workspace --all-targets`: only the two pre-existing `derivable_impls` warnings in `bsengine-core`
- [x] `cargo fmt --check` clean on all five touched crates (`--all` hits the known local rustfmt stack overflow; CI's own step is authoritative)
- [x] Every new test was verified to **fail** against a re-requesting/non-dropping implementation — a test that passes against the broken version certified a false property once on this branch already
- [x] Real 20s windowed run of `games/mini-arena`: no asset-load warnings; with the mesh path deliberately broken, exactly **one** warning per affected entity across ~1200 frames, confirming the give-up property holds in production and not just in tests

## Known gaps, left open deliberately

- glTF is the only consumer that does not detect `GltfAsset.path` changing mid-load. Not reachable today — nothing mutates that field in place.
- A pending entry is stranded if its entity gains a `MeshRenderer` or is despawned mid-load. Bounded by distinct-path count, not unbounded.
- Neither audio nor the skybox has E2E coverage, because no game under `games/` uses either. Both have unit tests driving the real systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
