### PR TITLE
feat(asset): rebuild GPU state when an asset reloads (item 24 Phase 3a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "gltf",
  "pollster",
  "tracing",
+ "wgpu",
 ]
 
 [[package]]

--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -516,10 +516,50 @@ libtest는 모든 `#[test]`를 spawn된 스레드에서 실행하고, Rust는 �
   현재 이 필드를 제자리에서 바꾸는 코드가 없어 도달 불가. 그리고 로드 중인 엔티티에
   `MeshRenderer`가 붙거나 마지막 참조 엔티티가 despawn되면 pending 항목이 고아로 남아
   핸들을 계속 붙잡는다 — 서로 다른 경로 수만큼으로 제한되므로 무한 증가는 아니다.
-- [ ] **(Phase 3)** `bevy_asset`의 `file_watcher` 피처 활성화 — 텍스처/glTF/WGSL/오디오
-  변경 시 실행 중인 게임/에디터에 자동 반영. 단, `AssetPlugin.file_path`가 `""`라 에셋
-  루트가 리포 전체(`target/` 포함)가 되므로, `<ProjectDir>/assets`로 스코프를 좁힌 워처가
-  `AssetServer::reload`를 호출하는 방식을 쓴다
+- [x] **(Phase 3a)** 에셋 데이터가 교체되면 각 소비자가 GPU 상태를 **제자리에서** 재구축 —
+  재시작 없이, 엔티티를 하나도 건드리지 않고. 이 단계는 `AssetServer::reload`를 직접 호출해
+  구동하며, 그걸 호출해 줄 파일 워처는 Phase 3b다.
+
+  **측정된 전제 — `Modified`는 강한 핸들이 살아있는 동안에만 발생한다.** 마지막 핸들이
+  풀리면 `Assets::track_assets`(PreUpdate)가 에셋을 해제하고, 그 경로에 대한
+  `AssetServer::reload`는 **조용한 no-op**이 된다. 설계 문서는 Phase 2 이전에 쓰여 이걸
+  알 수 없었지만, Phase 2 이후 핸들을 계속 쥐고 있던 소비자는 오디오뿐이었다 — glTF·셰이더·
+  스카이박스는 로드가 끝나면 핸들을 버렸으므로, 워처를 아무리 잘 만들어도 이벤트 자체가
+  오지 않았을 것이다. 그래서 "로드 후 핸들 보관"은 최적화가 아니라 **선행 조건**이다.
+  추론이 아니라 실행으로 확인했고(`reload_emits_modified_only_while_a_handle_is_retained`,
+  `bsengine-gltf`), 핸들을 쥔 채로는 `LoadedWithDependencies` + `Modified`가 나오고
+  버린 뒤에는 이벤트가 **0개**였다.
+
+  **설계 문서보다 나은 방법을 택했다.** 문서는 "핸들을 가진 모든 엔티티에서
+  `MeshRenderer.mesh_id`를 교체"하라고 했지만, `GpuMeshRegistry::register`는 호출마다 새
+  id를 할당하고 해제 API가 없어서 리로드마다 버퍼 두 개를 영구 누수시킨다(`update_vertices`는
+  정점 수가 같아야 하고 인덱스·바운드를 갱신하지 않아 메시가 실제로 바뀐 경우엔 못 쓴다).
+  대신 registry에 **같은 id 아래 내용만 교체하는** `replace`를 추가했다. `MeshRenderer.mesh_id`와
+  `Material.texture_id`가 그대로 유효하므로 엔티티를 찾을 필요가 없고, 멀티메시 glTF가
+  추가로 스폰한 엔티티까지 공짜로 갱신된다.
+
+  소비자별로: glTF는 `GltfLoaded`(핸들 + 만들어 낸 mesh/texture id)를 엔티티에 남기고
+  `rebuild_modified_gltf`가 그 id 아래를 교체한다. 셰이더는 `PendingShader::Ready(handle)`을
+  보관하고 `compile_and_store_shader`가 경로 키로 덮어쓰므로 별도 무효화가 필요 없다.
+  스카이박스는 `PendingSkyboxState::Ready(handle)`을 보관하되, 경로 비교 단축 분기가 그
+  슬롯을 지우지 않도록 고쳤다. **오디오는 프로덕션 변경이 전혀 없다** — 이미 핸들을 쥐고
+  있고 `bevy_asset`이 그 아래 데이터를 갈아끼우므로, 다음 `playSound`가 새 데이터를 쓴다
+  (가정으로 두지 않고 테스트로 고정했다).
+
+  **한계(의도적):** 리로드된 glTF의 메시/이미지 **개수**가 달라지면 겹치는 부분만 재구축하고
+  경고한다 — 나머지 엔티티는 로드 시점에 스폰된 것이라 이 방식으로 표현할 수 없다. 재시작이
+  필요하다.
+
+  **테스트 규율:** 각 소비자의 보관 테스트는 열거형 상태만 보면 안 된다는 걸 실측했다 —
+  `clone_weak` 핸들은 `matches!(Ready(_))`를 만족시키면서도 `track_assets`가 에셋을 해제하게
+  둔다. 그래서 모든 테스트가 에셋 생존과 `Modified` 발생까지 단언하며, 각각 `clone_weak`
+  변이로 실패를 확인했다.
+- [ ] **(Phase 3b)** `<ProjectDir>/assets`로 스코프를 좁힌 파일 워처가 변경을 감지해
+  `AssetServer::reload`를 호출 — 텍스처/glTF/WGSL/오디오 변경 시 실행 중인 게임/에디터에
+  자동 반영. `bevy_asset`의 `file_watcher` 피처는 쓰지 않는다: `AssetPlugin.file_path`가
+  `""`라 에셋 루트가 리포 전체(`target/`, `.git/` 포함)가 되기 때문이다. Phase 3a에서 모든
+  재구축 경로를 `reload` 직접 호출로 이미 검증해 뒀으므로, 3b에서 문제가 나면 워처 문제로
+  범위가 좁혀진다
 - [ ] **(Phase 4)** 로드 실패/누락 에셋에 대한 명확한 에러 전파 (item 23에서는
   `tracing::warn!` 후 스킵뿐이었던 것을 구조화된 조회로 확장) + Scripting API 또는 MCP
   툴로 리로드/로드 실패 상태 조회 가능

--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -548,7 +548,34 @@ libtest는 모든 `#[test]`를 spawn된 스레드에서 실행하고, Rust는 �
 
   **한계(의도적):** 리로드된 glTF의 메시/이미지 **개수**가 달라지면 겹치는 부분만 재구축하고
   경고한다 — 나머지 엔티티는 로드 시점에 스폰된 것이라 이 방식으로 표현할 수 없다. 재시작이
-  필요하다.
+  필요하다. 스킨이 새로 생기거나 사라지는 경우도 같은 부류라 경고 후 건너뛴다.
+  `AnimationPlayer.clip`은 갱신하지 않는다 — 어떤 클립을 재생할지는 `AnimationStateMachine`이
+  소유할 수 있는 결정이기 때문이며, duration만 현재 재생 중인 클립에서 다시 읽는다.
+  컴파일에 실패한 셰이더는 `CompileFailed`로 남아 프레임마다 재시도하지 않지만 핸들은 계속
+  쥐고 있다 — 고친 파일이 도착할 `Modified`가 바로 그 핸들에 실린다.
+
+  **최종 리뷰가 잡은 Critical — 스킨드 메시가 리로드를 매 프레임 덮어썼다.**
+  `update_skinned_meshes`(PostUpdate)는 로드 시점에 복제해 둔 `SkinnedMesh.rest_vertices`로
+  변형 정점을 만들어 같은 `mesh_id` 버퍼에 쓴다. 재구축은 Update에서 도니, **같은 프레임 안에서**
+  새 지오메트리가 옛 정점 기반 데이터로 덮어써졌다 — 화면상 아무 일도 일어나지 않는 조용한
+  no-op. 게다가 정점 수가 줄면 `update_vertices`에 크기 가드가 없어 wgpu `BufferOverrun` →
+  **프로세스 사망**이었다(실측: `Copy of 0..76032 would end up overrunning the bounds of the
+  Destination buffer of size 132`). 이건 가설이 아니라 `games/mini-arena`가 두 번 로드하는
+  `fox.glb`가 정확히 스킨드 에셋(skins:1, 애니메이션 3종)이라 실제로 걸리는 경로였다.
+  재구축이 `rest_vertices`/`skin`/`skin_data`/`nodes`/클립 라이브러리를 함께 갱신하도록 고쳤고,
+  `update_vertices`에는 방어선으로 길이 가드를 넣었다.
+
+  **왜 못 잡았나:** 헤드리스 테스트 헬퍼가 registry 두 개만 넣고 `GpuQueueResource`를 넣지
+  않아 `update_skinned_meshes`가 조기 반환했고, 단언이 `get_bounds`(재구축은 갱신하지만
+  덮어쓰기는 건드리지 않는 값) 대상이라 어느 쪽이든 초록이었다. 이 브랜치가 내내 경계해 온
+  "깨진 구현에서도 통과하는 테스트"가 가장 중요한 테스트에서 일어난 셈이다.
+
+  **런타임 셰이더 컴파일이 프로세스를 죽이던 것도 함께 고쳤다.** `create_shader_module`은 에러
+  스코프 없이 호출돼 WGSL 오류가 wgpu 기본 핸들러의 패닉으로 이어졌다. 시작 시점이면 "깨진
+  셰이더를 배포했다"로 끝이지만, 핫리로드는 **중간에 깨진 상태를 거치며 반복하는 것 자체가
+  목적**이라 용납할 수 없다. 이제 naga의 두 단계(파서 + `Validator`)로 미리 검증하고, 실패하면
+  경고 후 **이전 파이프라인을 그대로 둔다** — 편집 중인 오브젝트가 새까매지지 않아야 한다는
+  설계 문서의 요구사항 그대로다.
 
   **테스트 규율:** 각 소비자의 보관 테스트는 열거형 상태만 보면 안 된다는 걸 실측했다 —
   `clone_weak` 핸들은 `matches!(Ready(_))`를 만족시키면서도 `track_assets`가 에셋을 해제하게

--- a/crates/bsengine-gltf/Cargo.toml
+++ b/crates/bsengine-gltf/Cargo.toml
@@ -20,3 +20,7 @@ tracing.workspace = true
 [dev-dependencies]
 bsengine-app.workspace = true
 pollster.workspace = true
+# Tests only: `GpuMeshRegistry`/`GpuTextureRegistry` are constructed from a real
+# headless `wgpu::Device`, because the plugin only builds them when a winit
+# window exists. See `insert_headless_gpu_registries` in `plugin.rs`.
+wgpu.workspace = true

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -278,6 +278,133 @@ mod tests {
         );
     }
 
+    // Hot reload rests on `AssetEvent::Modified` reaching each consumer, and
+    // that only happens while something still holds a strong handle: once the
+    // last one drops, `Assets::track_assets` frees the asset and
+    // `AssetServer::reload` on its path becomes a silent no-op. Measured here
+    // rather than assumed, because it is the reason each consumer keeps its
+    // handle after the load resolves instead of dropping it as dead weight --
+    // a future cleanup that "tidies away" a retained handle would disable hot
+    // reload for that asset type with no other symptom.
+    #[test]
+    fn reload_emits_modified_only_while_a_handle_is_retained() {
+        use bevy_asset::{AssetEvent, AssetServer, Assets};
+        use bevy_ecs::event::{Events, ManualEventReader};
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../games/mini-arena/assets/models/fox.glb");
+        let path = fixture.to_str().unwrap().to_owned();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        // GltfPlugin is what calls init_asset::<LoadedGltf>(); without it the
+        // AssetServer panics on the first load. No entity carries GltfAsset
+        // here, so its system is inert.
+        app.add_plugins(GltfPlugin);
+
+        let handle = {
+            let server = app.world().resource::<AssetServer>();
+            server.load::<LoadedGltf>(path.clone())
+        };
+        let id = handle.id();
+
+        let mut loaded = false;
+        for _ in 0..200 {
+            app.update();
+            if app
+                .world()
+                .resource::<Assets<LoadedGltf>>()
+                .get(&handle)
+                .is_some()
+            {
+                loaded = true;
+                break;
+            }
+        }
+        assert!(
+            loaded,
+            "fixture must load before the experiment means anything"
+        );
+
+        let mut reader: ManualEventReader<AssetEvent<LoadedGltf>> = app
+            .world_mut()
+            .resource_mut::<Events<AssetEvent<LoadedGltf>>>()
+            .get_reader();
+
+        let drain = |app: &mut bevy_app::App,
+                     reader: &mut ManualEventReader<AssetEvent<LoadedGltf>>|
+         -> Vec<String> {
+            let events = app.world().resource::<Events<AssetEvent<LoadedGltf>>>();
+            reader.read(events).map(|e| format!("{e:?}")).collect()
+        };
+        let _ = drain(&mut app, &mut reader);
+
+        // --- A: handle retained ---
+        app.world().resource::<AssetServer>().reload(path.clone());
+        let mut with_handle = Vec::new();
+        for _ in 0..60 {
+            app.update();
+            with_handle.extend(drain(&mut app, &mut reader));
+        }
+        let still_present_after_reload = app
+            .world()
+            .resource::<Assets<LoadedGltf>>()
+            .get(&handle)
+            .is_some();
+
+        // --- B: handle dropped ---
+        drop(handle);
+        for _ in 0..10 {
+            app.update();
+        }
+        let present_after_drop = app
+            .world()
+            .resource::<Assets<LoadedGltf>>()
+            .get(id)
+            .is_some();
+        let _ = drain(&mut app, &mut reader);
+
+        app.world().resource::<AssetServer>().reload(path.clone());
+        let mut without_handle = Vec::new();
+        for _ in 0..60 {
+            app.update();
+            without_handle.extend(drain(&mut app, &mut reader));
+        }
+        let present_after_reload_without_handle = app
+            .world()
+            .resource::<Assets<LoadedGltf>>()
+            .get(id)
+            .is_some();
+
+        assert!(
+            with_handle.iter().any(|e| e.starts_with("Modified")),
+            "reloading a path whose handle is still held must emit \
+             AssetEvent::Modified -- that event is the whole mechanism hot \
+             reload runs on; got {with_handle:?}"
+        );
+        assert!(
+            still_present_after_reload,
+            "the asset must stay in Assets across a reload, or consumers would \
+             see it vanish rather than change"
+        );
+
+        assert!(
+            !present_after_drop,
+            "dropping the last handle must free the asset; if this ever stops \
+             being true the rest of this test proves nothing"
+        );
+        assert!(
+            without_handle.is_empty(),
+            "reloading a path with no handle held must emit nothing at all -- \
+             this is why every consumer retains its handle after the load \
+             resolves; got {without_handle:?}"
+        );
+        assert!(
+            !present_after_reload_without_handle,
+            "reload must not resurrect an asset nobody holds"
+        );
+    }
+
     // The hazard that makes LoadMode::Async different from Sync: `load`
     // hands back a Handle unconditionally, so a missing file is
     // indistinguishable from a slow one at the call site. `load_gltf_assets`

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -31,7 +31,7 @@ impl Plugin for GltfPlugin {
         use bevy_asset::AssetApp;
         app.init_asset::<LoadedGltf>()
             .register_asset_loader(crate::asset_loader::GltfSourceLoader)
-            .add_systems(Update, load_gltf_assets);
+            .add_systems(Update, (load_gltf_assets, rebuild_modified_gltf).chain());
     }
 }
 
@@ -50,6 +50,27 @@ impl Plugin for GltfPlugin {
 /// RON, the scripting API and the MCP tools are unaffected.
 #[derive(Component)]
 struct PendingGltf(bevy_asset::Handle<LoadedGltf>);
+
+/// What a resolved [`GltfAsset`] produced, kept on the entity so a later reload
+/// can rebuild it.
+///
+/// The handle is retained because `AssetEvent::Modified` only fires while a
+/// strong handle exists — drop it and `Assets::track_assets` frees the asset and
+/// `AssetServer::reload` becomes a silent no-op (measured by
+/// `reload_emits_modified_only_while_a_handle_is_retained`).
+///
+/// The ids are recorded rather than re-derived because the rebuild replaces
+/// buffer *contents* under them, leaving `MeshRenderer.mesh_id` and
+/// `Material.texture_id` untouched — so the extra entities a multi-mesh glTF
+/// spawns are updated without having to find them.
+#[derive(Component)]
+struct GltfLoaded {
+    handle: bevy_asset::Handle<LoadedGltf>,
+    /// GPU mesh ids created for this asset, in `LoadedGltf::meshes` order.
+    mesh_ids: Vec<u64>,
+    /// GPU texture ids created for this asset, in `LoadedGltf::images` order.
+    texture_ids: Vec<u64>,
+}
 
 fn load_gltf_assets(
     mut commands: Commands,
@@ -114,8 +135,14 @@ fn load_gltf_assets(
         };
 
         let mut first = true;
+        // Recorded for `GltfLoaded`. Collected across the whole loop -- including
+        // the extra entities spawned for meshes after the first -- because
+        // replacing under those ids is exactly how those entities get updated,
+        // and none of them are findable from this one later.
+        let mut mesh_ids: Vec<u64> = Vec::with_capacity(loaded.meshes.len());
         for (mesh_data, tex_idx) in loaded.meshes.iter().zip(loaded.mesh_tex_indices.iter()) {
             let mesh_id = mesh_reg.register(&mesh_data.vertices, &mesh_data.indices);
+            mesh_ids.push(mesh_id);
             let texture_id = tex_idx.and_then(|i| tex_ids.get(i).copied().flatten());
             let mat = Material {
                 texture_id,
@@ -171,6 +198,61 @@ fn load_gltf_assets(
         if first {
             commands.entity(entity).remove::<(GltfAsset, PendingGltf)>();
             warn!("GLTF {} has no meshes", asset.path);
+        } else {
+            // Inserted here rather than beside the `remove` above because the
+            // full id list is only known once the loop has run. Goes on the
+            // same entity that just got `MeshRenderer`, so `rebuild_modified_gltf`
+            // finds it. `tex_ids` is either all-`Some` (registry present) or
+            // all-`None` (absent), never mixed, so flattening keeps
+            // `LoadedGltf::images` order intact.
+            commands.entity(entity).insert(GltfLoaded {
+                handle: pending.0.clone(),
+                mesh_ids,
+                texture_ids: tex_ids.iter().flatten().copied().collect(),
+            });
+        }
+    }
+}
+
+/// Rebuilds GPU state for a glTF whose asset data was replaced.
+///
+/// Replaces buffer contents under the ids recorded at load time, so no entity
+/// is touched. A structural change (different mesh or image count) cannot be
+/// expressed this way — those entities were spawned at load time — so it warns
+/// and rebuilds the overlap rather than pretending to succeed.
+fn rebuild_modified_gltf(
+    mut events: bevy_ecs::prelude::EventReader<bevy_asset::AssetEvent<LoadedGltf>>,
+    query: Query<&GltfLoaded>,
+    gltf_assets: Res<bevy_asset::Assets<LoadedGltf>>,
+    mut mesh_registry: Option<ResMut<GpuMeshRegistry>>,
+    mut tex_registry: Option<ResMut<GpuTextureRegistry>>,
+) {
+    for event in events.read() {
+        let bevy_asset::AssetEvent::Modified { id } = event else {
+            continue;
+        };
+        for loaded in query.iter().filter(|l| l.handle.id() == *id) {
+            let Some(data) = gltf_assets.get(&loaded.handle) else {
+                continue;
+            };
+            if let Some(reg) = mesh_registry.as_mut() {
+                if data.meshes.len() != loaded.mesh_ids.len() {
+                    warn!(
+                        "reloaded glTF now has {} mesh(es), was {} -- rebuilding \
+                         the overlap only; a structural change needs a restart",
+                        data.meshes.len(),
+                        loaded.mesh_ids.len()
+                    );
+                }
+                for (mesh_id, mesh_data) in loaded.mesh_ids.iter().zip(data.meshes.iter()) {
+                    reg.replace(*mesh_id, &mesh_data.vertices, &mesh_data.indices);
+                }
+            }
+            if let Some(reg) = tex_registry.as_mut() {
+                for (tex_id, img) in loaded.texture_ids.iter().zip(data.images.iter()) {
+                    reg.replace(*tex_id, img.width, img.height, &img.rgba);
+                }
+            }
         }
     }
 }
@@ -402,6 +484,198 @@ mod tests {
         assert!(
             !present_after_reload_without_handle,
             "reload must not resurrect an asset nobody holds"
+        );
+    }
+
+    /// Inserts real `GpuMeshRegistry`/`GpuTextureRegistry` resources built on a
+    /// real headless `wgpu` device.
+    ///
+    /// These are not stand-ins: they are the same types the renderer uses,
+    /// backed by an actual adapter, doing real buffer and texture uploads. The
+    /// plugin only builds them next to a swapchain surface, which needs a winit
+    /// window (see `with_rhi_plugin_but_no_window_gltf_asset_stays`), and
+    /// `WgpuRHI`'s device is `pub(crate)` — so a headless test has to construct
+    /// them here or the entire GPU-side load path, and therefore every claim
+    /// hot reload rests on, is untestable.
+    fn insert_headless_gpu_registries(app: &mut bevy_app::App) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::None,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .expect("a headless adapter; the rest of this suite already requires one");
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("bsengine-gltf test device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::default(),
+            },
+            None,
+        ))
+        .expect("headless device request");
+        let device = std::sync::Arc::new(device);
+        let queue = std::sync::Arc::new(queue);
+        app.insert_resource(GpuMeshRegistry::new(device.clone()));
+        app.insert_resource(GpuTextureRegistry::new(device, queue));
+    }
+
+    #[test]
+    fn a_loaded_gltf_keeps_its_handle_so_a_reload_can_reach_it() {
+        use bevy_asset::{AssetEvent, AssetServer, Assets};
+        use bevy_ecs::event::{Events, ManualEventReader};
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../games/mini-arena/assets/models/fox.glb");
+        let path = fixture.to_str().unwrap().to_owned();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(GltfPlugin);
+        insert_headless_gpu_registries(&mut app);
+        let e = app.world_mut().spawn(GltfAsset::new(path.clone())).id();
+
+        for _ in 0..200 {
+            app.update();
+            if app.world().get::<GltfLoaded>(e).is_some() {
+                break;
+            }
+        }
+
+        let loaded = app.world().get::<GltfLoaded>(e).expect(
+            "a resolved glTF must record what it created, or a reload \
+             has nothing to rebuild",
+        );
+        assert!(
+            !loaded.mesh_ids.is_empty(),
+            "the recorded mesh ids are what hot reload replaces in place"
+        );
+        let asset_id = loaded.handle.id();
+        let recorded_mesh_ids = loaded.mesh_ids.clone();
+        let recorded_texture_ids = loaded.texture_ids.clone();
+        assert_eq!(
+            app.world().get::<MeshRenderer>(e).map(|m| m.mesh_id),
+            recorded_mesh_ids.first().copied(),
+            "GltfLoaded must sit on the same entity as MeshRenderer and record \
+             the id that entity actually draws, or the rebuild would refresh \
+             geometry nothing is rendering"
+        );
+
+        // The texture ids are stored flattened out of a `Vec<Option<u64>>`, so
+        // a miscount here would silently misalign the rebuild's zip against
+        // `LoadedGltf::images` and repaint meshes with the wrong image.
+        let image_count = app
+            .world()
+            .resource::<Assets<LoadedGltf>>()
+            .get(asset_id)
+            .expect("the retained handle keeps the asset alive")
+            .images
+            .len();
+        assert_eq!(
+            recorded_texture_ids.len(),
+            image_count,
+            "every image the load uploaded must be recorded, in images order"
+        );
+
+        // Read Modified specifically, rather than `Events::len() > 0`: the
+        // buffer still holds the events the *load* emitted, so a bare length
+        // check would pass even if the reload reached nothing at all.
+        let mut reader: ManualEventReader<AssetEvent<LoadedGltf>> = app
+            .world_mut()
+            .resource_mut::<Events<AssetEvent<LoadedGltf>>>()
+            .get_reader();
+        {
+            let events = app.world().resource::<Events<AssetEvent<LoadedGltf>>>();
+            let _ = reader.read(events).count();
+        }
+
+        // Registry ids are handed out sequentially, so a probe taken either
+        // side of the reload detects any id allocated in between.
+        let (probe_v, probe_i) = bsengine_rhi_wgpu::triangle_vertices();
+        let probe_before = app
+            .world_mut()
+            .resource_mut::<GpuMeshRegistry>()
+            .register(&probe_v, &probe_i);
+
+        app.world().resource::<AssetServer>().reload(path);
+        let mut saw_modified = false;
+        for _ in 0..60 {
+            app.update();
+            let events = app.world().resource::<Events<AssetEvent<LoadedGltf>>>();
+            if reader
+                .read(events)
+                .any(|ev| matches!(ev, AssetEvent::Modified { id } if *id == asset_id))
+            {
+                saw_modified = true;
+                break;
+            }
+        }
+        assert!(
+            saw_modified,
+            "reloading a loaded glTF must emit AssetEvent::Modified for the \
+             retained handle; none means the handle was dropped and hot reload \
+             is impossible for glTF"
+        );
+
+        // The whole design in one assertion: the rebuild swaps buffer contents
+        // under the ids the load already handed out, so nothing has to find the
+        // entities -- including the extra ones a multi-mesh glTF spawns, which
+        // are unreachable from here.
+        let probe_after = app
+            .world_mut()
+            .resource_mut::<GpuMeshRegistry>()
+            .register(&probe_v, &probe_i);
+        assert_eq!(
+            probe_after,
+            probe_before + 1,
+            "the reload allocated fresh mesh ids instead of replacing in place; \
+             MeshRenderer.mesh_id would now point at the pre-reload geometry"
+        );
+        for id in &recorded_mesh_ids {
+            assert!(
+                app.world().resource::<GpuMeshRegistry>().get(*id).is_some(),
+                "recorded mesh id {id} is gone from the registry after a reload"
+            );
+        }
+
+        // Reloading the file reproduces identical geometry, so it cannot show
+        // that the rebuild reached the GPU at all. Replacing the asset's data
+        // -- which is what a changed file amounts to -- makes the effect
+        // visible under the id recorded at load time.
+        let bounds_before = app
+            .world()
+            .resource::<GpuMeshRegistry>()
+            .get_bounds(recorded_mesh_ids[0])
+            .expect("a recorded id must be live before the rebuild");
+        {
+            let mut assets = app.world_mut().resource_mut::<Assets<LoadedGltf>>();
+            let data = assets
+                .get_mut(asset_id)
+                .expect("the retained handle keeps the asset mutable in place");
+            for v in &mut data.meshes[0].vertices {
+                v.position[0] *= 10.0;
+            }
+        }
+        // `Assets::asset_events` flushes in PostUpdate, so the Modified event
+        // lands in the *next* Update, where rebuild_modified_gltf reads it.
+        for _ in 0..5 {
+            app.update();
+        }
+        let bounds_after = app
+            .world()
+            .resource::<GpuMeshRegistry>()
+            .get_bounds(recorded_mesh_ids[0])
+            .expect("a recorded id must survive the rebuild");
+        assert_ne!(
+            bounds_before, bounds_after,
+            "the id recorded at load time still holds the pre-reload geometry: \
+             the rebuild never reached the GPU, so a hot reload would change \
+             nothing on screen"
         );
     }
 

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -220,9 +220,20 @@ fn load_gltf_assets(
 /// is touched. A structural change (different mesh or image count) cannot be
 /// expressed this way — those entities were spawned at load time — so it warns
 /// and rebuilds the overlap rather than pretending to succeed.
+///
+/// It also refreshes the CPU-side skinning state, which is not an optional
+/// extra: `update_skinned_meshes` runs in PostUpdate and overwrites the very
+/// buffer replaced here, re-deriving it from `SkinnedMesh.rest_vertices`. Leave
+/// that at its load-time value and the reload is stomped in the same frame it
+/// landed. See [`refresh_skinning`].
 fn rebuild_modified_gltf(
     mut events: bevy_ecs::prelude::EventReader<bevy_asset::AssetEvent<LoadedGltf>>,
-    query: Query<&GltfLoaded>,
+    mut query: Query<(
+        &GltfLoaded,
+        Option<&mut SkinnedMesh>,
+        Option<&mut AnimationClipLibrary>,
+        Option<&mut AnimationPlayer>,
+    )>,
     gltf_assets: Res<bevy_asset::Assets<LoadedGltf>>,
     mut mesh_registry: Option<ResMut<GpuMeshRegistry>>,
     mut tex_registry: Option<ResMut<GpuTextureRegistry>>,
@@ -231,7 +242,9 @@ fn rebuild_modified_gltf(
         let bevy_asset::AssetEvent::Modified { id } = event else {
             continue;
         };
-        for loaded in query.iter().filter(|l| l.handle.id() == *id) {
+        for (loaded, skinned, library, player) in
+            query.iter_mut().filter(|(l, ..)| l.handle.id() == *id)
+        {
             let Some(data) = gltf_assets.get(&loaded.handle) else {
                 continue;
             };
@@ -245,15 +258,111 @@ fn rebuild_modified_gltf(
                     );
                 }
                 for (mesh_id, mesh_data) in loaded.mesh_ids.iter().zip(data.meshes.iter()) {
-                    reg.replace(*mesh_id, &mesh_data.vertices, &mesh_data.indices);
+                    if !reg.replace(*mesh_id, &mesh_data.vertices, &mesh_data.indices) {
+                        warn!(
+                            "mesh id {mesh_id} recorded at load time is no longer \
+                             registered; whatever draws it keeps the pre-reload geometry"
+                        );
+                    }
                 }
             }
             if let Some(reg) = tex_registry.as_mut() {
+                if data.images.len() != loaded.texture_ids.len() {
+                    warn!(
+                        "reloaded glTF now has {} image(s), was {} -- rebuilding \
+                         the overlap only; a structural change needs a restart",
+                        data.images.len(),
+                        loaded.texture_ids.len()
+                    );
+                }
                 for (tex_id, img) in loaded.texture_ids.iter().zip(data.images.iter()) {
-                    reg.replace(*tex_id, img.width, img.height, &img.rgba);
+                    if !reg.replace(*tex_id, img.width, img.height, &img.rgba) {
+                        warn!(
+                            "texture id {tex_id} recorded at load time is no longer \
+                             loaded; whatever samples it keeps the pre-reload pixels"
+                        );
+                    }
                 }
             }
+            refresh_skinning(data, skinned, library, player);
         }
+    }
+}
+
+/// Re-derives an entity's CPU-side skinning state from reloaded asset data.
+///
+/// Must mirror what `load_gltf_assets` builds for the *first* mesh — the only
+/// one that gets skinning — so the two have to be kept in step. It exists
+/// because `update_skinned_meshes` (PostUpdate) re-uploads the same GPU buffer
+/// `rebuild_modified_gltf` just replaced, deforming from `rest_vertices`: a
+/// stale rest pose discards the reload one schedule later, and a stale rest
+/// pose that is *longer* than the rebuilt buffer is a wgpu `BufferOverrun`.
+///
+/// `mesh_id` is deliberately left alone — the rebuild swapped contents under it,
+/// so it still names the buffer this entity draws — and so is `player.clip`, in
+/// case an `AnimationStateMachine` chose it. Only `player.duration` is re-taken,
+/// since `AnimationPlayer::tick` wraps on it when looping and is a no-op at
+/// `<= 0`, so an edited clip length would otherwise never take effect.
+///
+/// Gaining or losing a skin across a reload is a structural change of the same
+/// kind as a changed mesh count: it would mean inserting or removing components
+/// on an entity the reload has no other reason to touch. Both warn and leave the
+/// entity as it is, matching what this system already does for extra meshes.
+fn refresh_skinning(
+    data: &LoadedGltf,
+    skinned: Option<bevy_ecs::prelude::Mut<SkinnedMesh>>,
+    library: Option<bevy_ecs::prelude::Mut<AnimationClipLibrary>>,
+    player: Option<bevy_ecs::prelude::Mut<AnimationPlayer>>,
+) {
+    // Same gate as the load path: a skin only counts if the first mesh carries
+    // per-vertex bindings *and* the document defines a skin to bind them to.
+    let reloaded_skin = data
+        .meshes
+        .first()
+        .and_then(|m| m.skin.clone())
+        .filter(|_| !data.skins.is_empty());
+
+    let Some(mut skinned) = skinned else {
+        if reloaded_skin.is_some() {
+            warn!(
+                "reloaded glTF gained a skin, but it was imported without one -- \
+                 it stays unskinned; attaching skinning needs a restart"
+            );
+        }
+        return;
+    };
+    let (Some(mesh_data), Some(skin_verts)) = (data.meshes.first(), reloaded_skin) else {
+        // Deliberately leaves rest_vertices alone rather than half-updating it:
+        // the entity keeps deforming its pre-reload pose. If that pose no longer
+        // fits the rebuilt buffer, `GpuMeshRegistry::update_vertices` refuses
+        // the upload rather than letting wgpu panic.
+        warn!(
+            "reloaded glTF no longer has a skinned first mesh -- the entity keeps \
+             its pre-reload rest pose and skeleton; removing skinning needs a restart"
+        );
+        return;
+    };
+
+    skinned.rest_vertices = mesh_data.vertices.clone();
+    skinned.skin = skin_verts;
+    skinned.skin_data = data.skins[0].clone();
+    skinned.nodes = data.nodes.clone();
+
+    let Some(mut library) = library else {
+        return;
+    };
+    *library = AnimationClipLibrary::from_clips(data.animations.clone());
+
+    let Some(mut player) = player else {
+        return;
+    };
+    match library.clips.get(&player.clip) {
+        Some(clip) => player.duration = clip.duration.max(0.0),
+        None => warn!(
+            "reloaded glTF no longer defines clip '{}'; the player keeps it and \
+             the mesh holds the rebuilt rest pose until another clip is selected",
+            player.clip
+        ),
     }
 }
 
@@ -497,6 +606,13 @@ mod tests {
     /// `WgpuRHI`'s device is `pub(crate)` — so a headless test has to construct
     /// them here or the entire GPU-side load path, and therefore every claim
     /// hot reload rests on, is untestable.
+    ///
+    /// `GpuQueueResource` is inserted for the same reason, and is not optional
+    /// dressing: `update_skinned_meshes` (PostUpdate) early-returns without it,
+    /// so a helper that supplies only the two registries silently excludes the
+    /// skinning system from every test built on it. `WgpuRHIPlugin` inserts all
+    /// three together at surface-creation time, so supplying a strict subset
+    /// here would be a configuration the engine itself never produces.
     fn insert_headless_gpu_registries(app: &mut bevy_app::App) {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
@@ -521,7 +637,8 @@ mod tests {
         let device = std::sync::Arc::new(device);
         let queue = std::sync::Arc::new(queue);
         app.insert_resource(GpuMeshRegistry::new(device.clone()));
-        app.insert_resource(GpuTextureRegistry::new(device, queue));
+        app.insert_resource(GpuTextureRegistry::new(device, queue.clone()));
+        app.insert_resource(bsengine_rhi_wgpu::GpuQueueResource(queue));
     }
 
     #[test]
@@ -676,6 +793,291 @@ mod tests {
             "the id recorded at load time still holds the pre-reload geometry: \
              the rebuild never reached the GPU, so a hot reload would change \
              nothing on screen"
+        );
+    }
+
+    /// Boots an app with *both* halves of the skinned-glTF pipeline —
+    /// `GltfPlugin` (Update: load, then rebuild on `Modified`) and
+    /// `SkinnedMeshPlugin` (PostUpdate: deform and re-upload) — loads `fox.glb`
+    /// onto one entity, and runs until it resolves into `GltfLoaded` +
+    /// `SkinnedMesh`.
+    ///
+    /// This is the shipping configuration, not a contrived one:
+    /// `bsengine-runtime/src/main.rs` adds both plugins, and `fox.glb` — the
+    /// only glTF `games/mini-arena/assets/scenes/main.ron` loads — is skinned
+    /// (one skin, `JOINTS_0` on its primitive, three clips).
+    ///
+    /// Returns the app, the entity, and the asset id, and asserts on the way out
+    /// that `update_skinned_meshes` cannot early-return or skip this entity —
+    /// see the block at the end for why that matters.
+    fn load_skinned_fox() -> (bevy_app::App, Entity, bevy_asset::AssetId<LoadedGltf>) {
+        use crate::skinned_mesh::{AnimationClipLibrary, SkinnedMesh, SkinnedMeshPlugin};
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../games/mini-arena/assets/models/fox.glb");
+        let path = fixture.to_str().unwrap().to_owned();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(GltfPlugin);
+        app.add_plugins(SkinnedMeshPlugin);
+        insert_headless_gpu_registries(&mut app);
+        let e = app.world_mut().spawn(GltfAsset::new(path)).id();
+
+        for _ in 0..200 {
+            app.update();
+            if app.world().get::<SkinnedMesh>(e).is_some() {
+                break;
+            }
+        }
+        let asset_id = app
+            .world()
+            .get::<GltfLoaded>(e)
+            .expect("fox.glb must resolve into GltfLoaded within 200 frames")
+            .handle
+            .id();
+        assert!(
+            app.world().get::<SkinnedMesh>(e).is_some(),
+            "fox.glb is skinned, so the import must attach SkinnedMesh -- without \
+             it the reload-vs-skinning interaction under test cannot arise at all"
+        );
+
+        // `update_skinned_meshes` returns before touching anything unless both
+        // GPU resources are present, and `continue`s past any entity whose
+        // player names a clip its library lacks. Pinning all of that here is
+        // what makes the tests below statements about the *interaction*: the
+        // branch's original helper inserted only the two registries, so the
+        // skinning system never ran under it and the buffer it stomps every
+        // frame was invisible to every test built on it.
+        assert!(
+            app.world().get_resource::<GpuMeshRegistry>().is_some(),
+            "update_skinned_meshes early-returns without GpuMeshRegistry"
+        );
+        assert!(
+            app.world()
+                .get_resource::<bsengine_rhi_wgpu::GpuQueueResource>()
+                .is_some(),
+            "update_skinned_meshes early-returns without GpuQueueResource -- \
+             omitting it is what hid this whole class of defect"
+        );
+        let clip = app
+            .world()
+            .get::<AnimationPlayer>(e)
+            .expect("a skinned glTF import attaches an AnimationPlayer")
+            .clip
+            .clone();
+        assert!(
+            app.world()
+                .get::<AnimationClipLibrary>(e)
+                .expect("a skinned glTF import attaches its clip library")
+                .clips
+                .contains_key(&clip),
+            "the player's clip must resolve in the library, or update_skinned_meshes \
+             skips this entity and never uploads"
+        );
+
+        (app, e, asset_id)
+    }
+
+    /// `rebuild_modified_gltf` (Update) and `update_skinned_meshes` (PostUpdate)
+    /// both own the same GPU vertex buffer: the first replaces its contents from
+    /// the reloaded asset, the second overwrites them every frame from
+    /// `SkinnedMesh.rest_vertices` — a `clone()` taken at *load* time. So unless
+    /// the rebuild also refreshes that CPU-side copy (and the skin, skeleton and
+    /// clips beside it), PostUpdate stomps the fresh geometry with vertices
+    /// derived from the pre-reload data in the very frame the reload landed, and
+    /// hot reload is silently a no-op for every skinned glTF — which is every
+    /// glTF the shipping game loads.
+    #[test]
+    fn reloading_a_skinned_gltf_refreshes_the_rest_pose_the_skinner_deforms_from() {
+        use crate::skinned_mesh::{AnimationClipLibrary, SkinnedMesh};
+        use bevy_asset::Assets;
+
+        let (mut app, e, asset_id) = load_skinned_fox();
+
+        // A re-export moves geometry, skin weights, skeleton and clip lengths
+        // together, so all five are changed here. Mutating the asset in place is
+        // how a changed file is expressed without a second .glb on disk:
+        // `Assets::get_mut` is what queues `AssetEvent::Modified`, the only
+        // trigger `rebuild_modified_gltf` has.
+        {
+            let mut assets = app.world_mut().resource_mut::<Assets<LoadedGltf>>();
+            let data = assets
+                .get_mut(asset_id)
+                .expect("the retained handle keeps the asset mutable in place");
+            for v in &mut data.meshes[0].vertices {
+                v.position[1] += 100.0;
+            }
+            for s in data.meshes[0]
+                .skin
+                .as_mut()
+                .expect("fox.glb's first primitive carries JOINTS_0/WEIGHTS_0")
+            {
+                // += rather than = : guaranteed different from whatever was
+                // imported, so a stale copy cannot coincidentally match.
+                s.weights[0] += 1.0;
+            }
+            data.nodes[0].translation[0] += 7.0;
+            data.skins[0].inverse_bind_matrices[0][3][0] += 5.0;
+            for clip in &mut data.animations {
+                clip.duration += 1.0;
+            }
+        }
+        // `Assets::asset_events` flushes in PostUpdate, so the Modified event
+        // lands in the *next* Update where rebuild_modified_gltf reads it; the
+        // PostUpdate after that is where a stale rest pose would stomp it.
+        for _ in 0..5 {
+            app.update();
+        }
+
+        let (expected_positions, expected_skin, expected_nodes, expected_ibm, expected_clips) = {
+            let assets = app.world().resource::<Assets<LoadedGltf>>();
+            let data = assets.get(asset_id).expect("the asset outlives the reload");
+            (
+                data.meshes[0]
+                    .vertices
+                    .iter()
+                    .map(|v| v.position)
+                    .collect::<Vec<_>>(),
+                data.meshes[0]
+                    .skin
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|s| (s.joints, s.weights))
+                    .collect::<Vec<_>>(),
+                data.nodes.clone(),
+                data.skins[0].inverse_bind_matrices[0],
+                data.animations
+                    .iter()
+                    .map(|c| (c.name.clone(), c.duration))
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        let skinned = app
+            .world()
+            .get::<SkinnedMesh>(e)
+            .expect("the entity keeps its SkinnedMesh across a reload");
+        assert_eq!(
+            skinned
+                .rest_vertices
+                .iter()
+                .map(|v| v.position)
+                .collect::<Vec<_>>(),
+            expected_positions,
+            "rest_vertices still holds the pre-reload geometry, so \
+             update_skinned_meshes re-derives from it every PostUpdate and \
+             re-uploads into the very buffer rebuild_modified_gltf just replaced \
+             -- the reload is discarded in the frame it landed"
+        );
+        assert_eq!(
+            skinned
+                .skin
+                .iter()
+                .map(|s| (s.joints, s.weights))
+                .collect::<Vec<_>>(),
+            expected_skin,
+            "the per-vertex skin is stale: re-weighted vertices would deform \
+             through the old bindings"
+        );
+        assert_eq!(
+            skinned.nodes, expected_nodes,
+            "the node hierarchy is stale: a re-exported skeleton would animate \
+             from the old bind pose"
+        );
+        assert_eq!(
+            skinned.skin_data.inverse_bind_matrices[0], expected_ibm,
+            "the skin's inverse bind matrices are stale"
+        );
+
+        let library = app
+            .world()
+            .get::<AnimationClipLibrary>(e)
+            .expect("the entity keeps its clip library across a reload");
+        for (name, duration) in &expected_clips {
+            assert_eq!(
+                library.clips.get(name).map(|c| c.duration),
+                Some(*duration),
+                "clip '{name}' is stale: an edited animation would play at its \
+                 pre-reload length"
+            );
+        }
+        let player = app
+            .world()
+            .get::<AnimationPlayer>(e)
+            .expect("the entity keeps its AnimationPlayer across a reload");
+        assert_eq!(
+            player.duration, library.clips[&player.clip].duration,
+            "the player's duration must follow the reloaded clip: `tick` wraps on \
+             it when looping and is a no-op at <= 0, so a stale duration keeps \
+             playback on the old clip length"
+        );
+    }
+
+    /// The case that kills the process rather than merely looking wrong: a
+    /// reload that *shrinks* a skinned mesh. `replace` sizes the new vertex
+    /// buffer to the new data, while `update_vertices` writes at offset 0, so a
+    /// stale (longer) rest pose is a wgpu `BufferOverrun` — and since nothing in
+    /// this codebase installs an error scope or `on_uncaptured_error`, that
+    /// reaches wgpu's default handler, which panics.
+    ///
+    /// Reaching the assertions at all is therefore half of what this test
+    /// measures; the other half is that the two halves of `SkinnedMesh` stay the
+    /// same length, since `update_skinned_meshes` zips them and a half-refreshed
+    /// pair would silently upload a truncated mesh.
+    #[test]
+    fn a_skinned_gltf_that_loses_vertices_on_reload_neither_panics_nor_desyncs() {
+        use crate::skinned_mesh::SkinnedMesh;
+        use bevy_asset::Assets;
+
+        let (mut app, e, asset_id) = load_skinned_fox();
+
+        let before = app
+            .world()
+            .get::<SkinnedMesh>(e)
+            .expect("loaded above")
+            .rest_vertices
+            .len();
+        assert!(
+            before > 3,
+            "the fixture must start with more vertices than the reload leaves, \
+             or nothing shrinks and this test proves nothing (was {before})"
+        );
+
+        {
+            let mut assets = app.world_mut().resource_mut::<Assets<LoadedGltf>>();
+            let data = assets
+                .get_mut(asset_id)
+                .expect("the retained handle keeps the asset mutable in place");
+            data.meshes[0].vertices.truncate(3);
+            data.meshes[0]
+                .skin
+                .as_mut()
+                .expect("fox.glb's first primitive is skinned")
+                .truncate(3);
+            data.meshes[0].indices = vec![0, 1, 2];
+        }
+        for _ in 0..5 {
+            app.update();
+        }
+
+        let skinned = app
+            .world()
+            .get::<SkinnedMesh>(e)
+            .expect("the entity keeps its SkinnedMesh across a reload");
+        assert_eq!(
+            skinned.rest_vertices.len(),
+            3,
+            "the rest pose must shrink with the asset; a longer one is written \
+             straight past the end of the buffer replace just rebuilt"
+        );
+        assert_eq!(
+            skinned.skin.len(),
+            skinned.rest_vertices.len(),
+            "rest_vertices and skin are zipped every frame -- refreshing one \
+             without the other silently uploads the shorter of the two"
         );
     }
 

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -282,12 +282,22 @@ fn rebuild_modified_shaders(
     }
 }
 
-/// Whether the skybox named by [`PendingSkybox`] is still loading or was
-/// given up on.
+/// Whether the skybox named by [`PendingSkybox`] is still loading, has
+/// arrived, or was given up on.
 #[derive(Debug)]
 enum PendingSkyboxState {
     /// Requested; waiting for `Assets<TextureAsset>` to have it.
     Loading(bevy_asset::Handle<bsengine_asset::TextureAsset>),
+    /// Image decoded and the handle retained. Kept rather than dropped because
+    /// `AssetEvent::Modified` only fires while a strong handle exists; dropping
+    /// it here would make `AssetServer::reload` on this path a silent no-op
+    /// (measured by `reload_emits_modified_only_while_a_handle_is_retained` in
+    /// `bsengine-gltf`).
+    ///
+    /// Says nothing about the *upload*, which needs a GPU the decode does not:
+    /// an image that arrives before `WgpuSurfaceResource` exists is `Ready`
+    /// with nothing uploaded, and this arm uploads it once one shows up.
+    Ready(bevy_asset::Handle<bsengine_asset::TextureAsset>),
     /// The load failed. Kept so the warning fires once and the path is never
     /// re-requested -- re-requesting a failed path restarts it, which is why a
     /// re-requesting poll loop can never see the failure.
@@ -337,13 +347,20 @@ fn upload_pending_skybox(
     };
     let wanted = skybox_path.0.as_deref();
 
-    // Already showing exactly what's asked for. Any request still in flight is
-    // for a path nobody wants any more, so let it go.
+    // Already showing exactly what's asked for. A `Ready` slot naming that same
+    // path is the uploaded skybox's own retained handle -- clearing it frees
+    // the image and turns the next `AssetServer::reload` into a silent no-op,
+    // so it stays. Anything else in the slot is a request for a path nobody
+    // wants any more, so let it go.
     if surface
         .as_ref()
         .is_some_and(|s| s.0.loaded_skybox_path() == wanted)
     {
-        if pending.0.is_some() {
+        let holds_the_wanted_skybox = match (&pending.0, wanted) {
+            (Some((path, PendingSkyboxState::Ready(_))), Some(wanted)) => path == wanted,
+            _ => false,
+        };
+        if pending.0.is_some() && !holds_the_wanted_skybox {
             pending.0 = None;
         }
         return;
@@ -371,6 +388,21 @@ fn upload_pending_skybox(
     let in_flight = match &pending.0 {
         Some((_, PendingSkyboxState::GaveUp)) => return,
         Some((_, PendingSkyboxState::Loading(handle))) => Some(handle.clone()),
+        // Image in hand, handle retained: nothing left to request, and never
+        // re-requested. Reaching here at all means the dedupe check above found
+        // the surface *not* showing this path -- i.e. the image arrived before
+        // `WgpuSurfaceResource` did -- so upload it now if a surface has since
+        // appeared. That makes the dedupe check match from the next frame on,
+        // so this runs exactly once.
+        Some((_, PendingSkyboxState::Ready(handle))) => {
+            if let (Some(tex), Some(surface)) = (texture_assets.get(handle), surface.as_mut()) {
+                surface
+                    .0
+                    .set_skybox_from_rgba(tex.width, tex.height, &tex.data);
+                surface.0.set_loaded_skybox_path(wanted);
+            }
+            return;
+        }
         None => None,
     };
 
@@ -386,9 +418,11 @@ fn upload_pending_skybox(
     };
 
     if let Some(tex) = texture_assets.get(&handle) {
-        // The pixels are here; only the upload needs the GPU. Without a
-        // surface, stay `Loading` and retry next frame — the load itself is
-        // done, so this costs nothing.
+        // The pixels are here; only the upload needs the GPU. The slot becomes
+        // `Ready` either way: `Ready` is what retains the handle, and staying
+        // `Loading` until a surface exists would leave hot reload switched off
+        // for exactly as long. The `Ready` arm above picks the upload up
+        // instead.
         if let Some(surface) = surface.as_mut() {
             surface
                 .0
@@ -398,11 +432,56 @@ fn upload_pending_skybox(
             // the dedupe check above is what stops this re-uploading every
             // frame.
             surface.0.set_loaded_skybox_path(wanted);
-            pending.0 = None;
         }
+        pending.0 = Some((wanted.to_string(), PendingSkyboxState::Ready(handle)));
     } else if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(&handle) {
         tracing::warn!("skybox: cannot read '{wanted}': {e}");
         pending.0 = Some((wanted.to_string(), PendingSkyboxState::GaveUp));
+    }
+}
+
+/// Re-uploads the skybox when its image is replaced.
+///
+/// `set_skybox_from_rgba` rebuilds the texture, sampler, bind groups and
+/// pipeline around the new pixels and replaces `WgpuSurface::skybox` wholesale,
+/// so no explicit invalidation is needed.
+///
+/// Separate from `upload_pending_skybox` rather than folded into it because
+/// that function returns early the moment the surface already shows the wanted
+/// path -- which is every reloadable skybox. A reload is the one case where
+/// re-uploading the path already on screen is the whole point.
+///
+/// Without a `WgpuSurfaceResource` this does nothing and leaves the `Ready`
+/// state alone: the image is already in `Assets` and the handle is still
+/// retained, so the next reload is reached just the same.
+fn rebuild_modified_skybox(
+    mut events: bevy_ecs::prelude::EventReader<
+        bevy_asset::AssetEvent<bsengine_asset::TextureAsset>,
+    >,
+    mut surface: Option<ResMut<WgpuSurfaceResource>>,
+    texture_assets: Res<bevy_asset::Assets<bsengine_asset::TextureAsset>>,
+    pending: Res<PendingSkybox>,
+) {
+    for event in events.read() {
+        let bevy_asset::AssetEvent::Modified { id } = event else {
+            continue;
+        };
+        let Some((path, PendingSkyboxState::Ready(handle))) = pending.0.as_ref() else {
+            continue;
+        };
+        if handle.id() != *id {
+            continue;
+        }
+        let Some(tex) = texture_assets.get(handle) else {
+            continue;
+        };
+        let Some(surface) = surface.as_mut() else {
+            continue;
+        };
+        surface
+            .0
+            .set_skybox_from_rgba(tex.width, tex.height, &tex.data);
+        surface.0.set_loaded_skybox_path(path);
     }
 }
 
@@ -675,6 +754,7 @@ impl Plugin for RenderPlugin {
                     compile_pending_shaders,
                     rebuild_modified_shaders,
                     upload_pending_skybox,
+                    rebuild_modified_skybox,
                     render_frame,
                 )
                     .chain(),
@@ -810,6 +890,56 @@ mod tests {
             "rebuild_modified_shaders (index {rebuild_idx}) must run before \
              render_frame (index {render_idx}) so a shader recompiled this frame \
              is the one drawn with; actual PostUpdate order: {names:?}"
+        );
+    }
+
+    // Same structural argument again, for the skybox's reload half.
+    // `rebuild_modified_skybox` must sit *after* `upload_pending_skybox`
+    // (which is what puts the slot into `Ready`, the only state the rebuild
+    // looks at -- ahead of it, the very first Modified event would find an
+    // empty slot) and *before* `render_frame` (or the frame draws the stale
+    // sky the reload was meant to replace). Both are `.chain()` edges today;
+    // a reorder that starves the rebuild has to fail here.
+    #[test]
+    fn rebuild_modified_skybox_runs_between_upload_and_render_frame() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(RenderPlugin);
+        // Schedules are only populated with their executable system list
+        // after at least one run.
+        app.update();
+
+        let schedule = app
+            .get_schedule(bevy_app::PostUpdate)
+            .expect("RenderPlugin registers systems into PostUpdate");
+        let names: Vec<String> = schedule
+            .systems()
+            .expect("schedule is initialized after app.update()")
+            .map(|(_, system)| system.name().to_string())
+            .collect();
+
+        let find = |needle: &str| {
+            names
+                .iter()
+                .position(|n| n.contains(needle))
+                .unwrap_or_else(|| panic!("{needle} not found in PostUpdate: {names:?}"))
+        };
+        let upload_idx = find("upload_pending_skybox");
+        let rebuild_idx = find("rebuild_modified_skybox");
+        let render_idx = find("render_frame");
+
+        assert!(
+            upload_idx < rebuild_idx,
+            "upload_pending_skybox (index {upload_idx}) must run before \
+             rebuild_modified_skybox (index {rebuild_idx}): it is what records \
+             the Ready handle the rebuild matches Modified events against; \
+             actual PostUpdate order: {names:?}"
+        );
+        assert!(
+            rebuild_idx < render_idx,
+            "rebuild_modified_skybox (index {rebuild_idx}) must run before \
+             render_frame (index {render_idx}) so a skybox re-uploaded this \
+             frame is the one drawn; actual PostUpdate order: {names:?}"
         );
     }
 
@@ -951,6 +1081,130 @@ mod tests {
             matches!(pending, Some(PendingShader::GaveUp)),
             "an unloadable shader path must end up given up on, got {pending:?}"
         );
+    }
+
+    /// A valid 1×1 RGBA PNG. The repo ships no image files, and this test needs
+    /// one that actually decodes -- a failed load ends in `GaveUp`, which holds
+    /// no handle and would make the assertion below vacuous.
+    const MINIMAL_PNG_1X1: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+        0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0xf8,
+        0xcf, 0xc0, 0xf0, 0x1f, 0x00, 0x05, 0x00, 0x01, 0xff, 0x89, 0x99, 0x3d, 0x1d, 0x00, 0x00,
+        0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+
+    // The skybox half of the same precondition
+    // `a_compiled_shader_keeps_its_handle_so_a_reload_can_reach_it` pins for
+    // shaders: `AssetEvent::Modified` only fires while a strong handle to the
+    // asset still exists, so the moment the last one drops,
+    // `Assets::track_assets` frees the image in PreUpdate and
+    // `AssetServer::reload` on that path is a silent no-op. `Ready` -- which
+    // retains the handle instead of clearing the slot on a successful upload --
+    // is what makes `rebuild_modified_skybox` reachable at all.
+    //
+    // There is no `WgpuSurfaceResource` here (a real one needs a real winit
+    // window; see `compile_pending_shaders_runs_before_render_frame`), so the
+    // upload itself cannot run and the re-uploaded skybox cannot be observed.
+    // `Ready` therefore means "image decoded and handle retained", reached
+    // whether or not the upload happened -- and the two assertions after it,
+    // not the state alone, are what prove the retention is real: a `clone_weak`
+    // handle satisfies `Ready(_)` while still letting the image be freed.
+    #[test]
+    fn an_uploaded_skybox_keeps_its_handle_so_a_reload_can_reach_it() {
+        use bevy_asset::{AssetEvent, AssetServer, Assets};
+        use bevy_ecs::event::{Events, ManualEventReader};
+        use bsengine_asset::TextureAsset;
+
+        let dir = std::env::temp_dir().join(format!(
+            "bsengine_test_skybox_reload_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let png = dir.join("sky.png");
+        std::fs::write(&png, MINIMAL_PNG_1X1).unwrap();
+        let path = png.to_string_lossy().to_string();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+        app.insert_resource(bsengine_core::SkyboxPath(Some(path.clone())));
+
+        let mut ready = false;
+        for _ in 0..200 {
+            app.update();
+            if matches!(
+                app.world().resource::<PendingSkybox>().0,
+                Some((_, PendingSkyboxState::Ready(_)))
+            ) {
+                ready = true;
+                break;
+            }
+        }
+        assert!(
+            ready,
+            "the skybox slot must end up Ready, still holding its handle -- \
+             clearing it frees the asset and makes reload a silent no-op"
+        );
+
+        let asset_id = {
+            let pending = &app.world().resource::<PendingSkybox>().0;
+            let Some((_, PendingSkyboxState::Ready(handle))) = pending else {
+                unreachable!("just asserted Ready")
+            };
+            handle.id()
+        };
+
+        // A few more frames so `track_assets` (PreUpdate) has had every chance
+        // to free the image. It only survives this if something still holds a
+        // *strong* handle to it.
+        for _ in 0..5 {
+            app.update();
+        }
+        assert!(
+            app.world()
+                .resource::<Assets<TextureAsset>>()
+                .get(asset_id)
+                .is_some(),
+            "the retained handle must keep the image alive; a weak one lets \
+             track_assets free it, and reload then has nothing to reload"
+        );
+
+        // Read `Modified` specifically, and only events emitted after this
+        // point: the buffer still holds the `Added`/`LoadedWithDependencies`
+        // events the initial load emitted, so a bare length check would pass
+        // even if the reload reached nothing at all.
+        let mut reader: ManualEventReader<AssetEvent<TextureAsset>> = app
+            .world_mut()
+            .resource_mut::<Events<AssetEvent<TextureAsset>>>()
+            .get_reader();
+        {
+            let events = app.world().resource::<Events<AssetEvent<TextureAsset>>>();
+            let _ = reader.read(events).count();
+        }
+
+        app.world().resource::<AssetServer>().reload(path);
+        let mut saw_modified = false;
+        for _ in 0..60 {
+            app.update();
+            let events = app.world().resource::<Events<AssetEvent<TextureAsset>>>();
+            if reader
+                .read(events)
+                .any(|ev| matches!(ev, AssetEvent::Modified { id } if *id == asset_id))
+            {
+                saw_modified = true;
+                break;
+            }
+        }
+        assert!(
+            saw_modified,
+            "reloading a skybox whose handle is retained must emit \
+             AssetEvent::Modified for it; none means the handle was dropped \
+             and hot reload is impossible for the skybox"
+        );
+
+        let _ = std::fs::remove_file(&png);
     }
 
     // The skybox equivalent of the shader test above, and for the same

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -108,6 +108,16 @@ fn propagate_children(
 enum PendingShader {
     /// Requested; waiting for `Assets<ShaderSource>` to have it.
     Loading(bevy_asset::Handle<crate::shader_asset::ShaderSource>),
+    /// Source loaded and the handle retained. Kept rather than dropped because
+    /// `AssetEvent::Modified` only fires while a strong handle exists; dropping
+    /// it here would make `AssetServer::reload` on this path a silent no-op
+    /// (measured by `reload_emits_modified_only_while_a_handle_is_retained` in
+    /// `bsengine-gltf`).
+    ///
+    /// Says nothing about the *compile*, which needs a GPU the load does not:
+    /// a source that arrives before `WgpuSurfaceResource` exists is `Ready`
+    /// with no pipeline behind it, and this arm compiles it once one shows up.
+    Ready(bevy_asset::Handle<crate::shader_asset::ShaderSource>),
     /// The load failed. Kept so the warning fires once rather than per frame,
     /// and so the path is never re-requested -- re-requesting a failed path
     /// resets it to `Loading` and starts the load over, which is why a
@@ -169,17 +179,36 @@ fn compile_pending_shaders(
         match pending.0.get(&cs.path) {
             // Requested already -- poll the handle we kept. Never re-request.
             Some(PendingShader::Loading(handle)) => {
-                if let Some(src) = shader_assets.get(handle) {
-                    // The source is here; only the compile needs the GPU.
-                    // Without a surface, stay `Loading` and retry next frame
-                    // — the load itself is done, so this costs nothing.
+                // Cloned so the state can be written back below (a `Handle` is
+                // refcounted, so this is a bump, not a copy of the source).
+                let handle = handle.clone();
+                if let Some(src) = shader_assets.get(&handle) {
+                    // The source is here; only the compile needs the GPU. The
+                    // path becomes `Ready` either way: `Ready` is what retains
+                    // the handle, and staying `Loading` until a surface exists
+                    // would leave hot reload switched off for exactly as long.
+                    // The `Ready` arm below picks the compile up instead.
                     if let Some(surface) = surface.as_mut() {
                         surface.0.compile_and_store_shader(&cs.path, &src.0);
-                        pending.0.remove(&cs.path);
                     }
-                } else if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(handle) {
+                    pending
+                        .0
+                        .insert(cs.path.clone(), PendingShader::Ready(handle));
+                } else if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(&handle) {
                     tracing::warn!("[custom_shader] cannot read '{}': {e}", cs.path);
                     pending.0.insert(cs.path.clone(), PendingShader::GaveUp);
+                }
+            }
+            // Source in hand, handle retained: nothing left to request, and
+            // never re-requested. Reaching here at all means the early-skip
+            // above found no compiled pipeline for this path -- i.e. the
+            // source arrived before `WgpuSurfaceResource` did -- so compile it
+            // now if a surface has since appeared. `compile_and_store_shader`
+            // always stores, so the skip fires from the next frame on and this
+            // runs exactly once.
+            Some(PendingShader::Ready(handle)) => {
+                if let (Some(src), Some(surface)) = (shader_assets.get(handle), surface.as_mut()) {
+                    surface.0.compile_and_store_shader(&cs.path, &src.0);
                 }
             }
             Some(PendingShader::GaveUp) => {}
@@ -203,6 +232,52 @@ fn compile_pending_shaders(
                     pending.0.insert(cs.path.clone(), PendingShader::GaveUp);
                 }
             },
+        }
+    }
+}
+
+/// Recompiles a custom shader whose source was replaced.
+///
+/// `compile_and_store_shader` inserts into `custom_pipelines` keyed by path, so
+/// recompiling overwrites the old pipeline; no explicit invalidation is needed.
+/// That also makes one recompile per path enough no matter how many entities
+/// name it -- [`PendingShaders`] is keyed by path, and `render_frame` looks the
+/// pipeline up by path too.
+///
+/// Separate from `compile_pending_shaders` rather than folded into it because
+/// that function skips any path the surface has already compiled -- which is
+/// every reloadable one. A reload is the one case where recompiling an
+/// already-compiled path is the whole point.
+///
+/// Without a `WgpuSurfaceResource` this does nothing and leaves the `Ready`
+/// state alone: the source is already in `Assets` and the handle is still
+/// retained, so the next reload is reached just the same.
+fn rebuild_modified_shaders(
+    mut events: bevy_ecs::prelude::EventReader<
+        bevy_asset::AssetEvent<crate::shader_asset::ShaderSource>,
+    >,
+    mut surface: Option<ResMut<WgpuSurfaceResource>>,
+    shader_assets: Res<bevy_asset::Assets<crate::shader_asset::ShaderSource>>,
+    pending: Res<PendingShaders>,
+) {
+    for event in events.read() {
+        let bevy_asset::AssetEvent::Modified { id } = event else {
+            continue;
+        };
+        for (path, state) in pending.0.iter() {
+            let PendingShader::Ready(handle) = state else {
+                continue;
+            };
+            if handle.id() != *id {
+                continue;
+            }
+            let Some(src) = shader_assets.get(handle) else {
+                continue;
+            };
+            let Some(surface) = surface.as_mut() else {
+                continue;
+            };
+            surface.0.compile_and_store_shader(path, &src.0);
         }
     }
 }
@@ -598,6 +673,7 @@ impl Plugin for RenderPlugin {
                     propagate_roots,
                     propagate_children,
                     compile_pending_shaders,
+                    rebuild_modified_shaders,
                     upload_pending_skybox,
                     render_frame,
                 )
@@ -684,6 +760,167 @@ mod tests {
             "upload_pending_skybox (index {skybox_idx}) must run before render_frame \
              (index {render_idx}) so a skybox uploaded this frame is available to its \
              has_skybox check; actual PostUpdate order: {names:?}"
+        );
+    }
+
+    // Same structural argument as the test above, for the reload half.
+    // `rebuild_modified_shaders` must sit *after* `compile_pending_shaders`
+    // (which is what puts a path into `Ready`, the only state the rebuild
+    // looks at -- ahead of it, the very first Modified event would find an
+    // empty map) and *before* `render_frame` (or the frame draws with the
+    // stale pipeline the reload was meant to replace). Both are `.chain()`
+    // edges today; a reorder that starves the rebuild has to fail here.
+    #[test]
+    fn rebuild_modified_shaders_runs_between_compile_and_render_frame() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(RenderPlugin);
+        // Schedules are only populated with their executable system list
+        // after at least one run.
+        app.update();
+
+        let schedule = app
+            .get_schedule(bevy_app::PostUpdate)
+            .expect("RenderPlugin registers systems into PostUpdate");
+        let names: Vec<String> = schedule
+            .systems()
+            .expect("schedule is initialized after app.update()")
+            .map(|(_, system)| system.name().to_string())
+            .collect();
+
+        let find = |needle: &str| {
+            names
+                .iter()
+                .position(|n| n.contains(needle))
+                .unwrap_or_else(|| panic!("{needle} not found in PostUpdate: {names:?}"))
+        };
+        let compile_idx = find("compile_pending_shaders");
+        let rebuild_idx = find("rebuild_modified_shaders");
+        let render_idx = find("render_frame");
+
+        assert!(
+            compile_idx < rebuild_idx,
+            "compile_pending_shaders (index {compile_idx}) must run before \
+             rebuild_modified_shaders (index {rebuild_idx}): it is what records \
+             the Ready handle the rebuild matches Modified events against; \
+             actual PostUpdate order: {names:?}"
+        );
+        assert!(
+            rebuild_idx < render_idx,
+            "rebuild_modified_shaders (index {rebuild_idx}) must run before \
+             render_frame (index {render_idx}) so a shader recompiled this frame \
+             is the one drawn with; actual PostUpdate order: {names:?}"
+        );
+    }
+
+    // The precondition for shader hot reload, and the only part of it a
+    // headless test can reach. `AssetEvent::Modified` only fires while a
+    // strong handle to the asset still exists: drop the last one and
+    // `Assets::track_assets` frees the asset in PreUpdate, after which
+    // `AssetServer::reload` on that path is a silent no-op (measured by
+    // `reload_emits_modified_only_while_a_handle_is_retained` in
+    // bsengine-gltf). So `Ready` -- which retains the handle -- is what makes
+    // `rebuild_modified_shaders` reachable at all.
+    //
+    // There is no `WgpuSurfaceResource` here (a real one needs a real winit
+    // window; see `compile_pending_shaders_runs_before_render_frame`), so the
+    // compile itself cannot run and the recompiled pipeline cannot be
+    // observed. `Ready` therefore means "source loaded and handle retained",
+    // reached whether or not the compile happened -- and the reload assertion
+    // below, not the state alone, is what proves the retention is real: a
+    // `clone_weak` handle would satisfy `Ready(_)` while still letting the
+    // asset be freed.
+    #[test]
+    fn a_compiled_shader_keeps_its_handle_so_a_reload_can_reach_it() {
+        use bevy_asset::{AssetEvent, AssetServer, Assets};
+        use bevy_ecs::event::{Events, ManualEventReader};
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../games/mini-arena/assets/shaders/glow.wgsl");
+        let path = fixture.to_str().unwrap().to_owned();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+        app.world_mut()
+            .spawn(bsengine_core::CustomShader { path: path.clone() });
+
+        let mut ready = false;
+        for _ in 0..200 {
+            app.update();
+            if matches!(
+                app.world().resource::<PendingShaders>().0.get(&path),
+                Some(PendingShader::Ready(_))
+            ) {
+                ready = true;
+                break;
+            }
+        }
+        assert!(
+            ready,
+            "a shader whose source has loaded must end up Ready, holding its \
+             handle -- without it AssetEvent::Modified can never fire for it"
+        );
+
+        let asset_id = {
+            let pending = app.world().resource::<PendingShaders>();
+            let Some(PendingShader::Ready(handle)) = pending.0.get(&path) else {
+                unreachable!("just asserted Ready")
+            };
+            handle.id()
+        };
+
+        // A few more frames so `track_assets` (PreUpdate) has had every chance
+        // to free the source. It only survives this if something still holds a
+        // *strong* handle to it.
+        for _ in 0..5 {
+            app.update();
+        }
+        assert!(
+            app.world()
+                .resource::<Assets<crate::shader_asset::ShaderSource>>()
+                .get(asset_id)
+                .is_some(),
+            "the retained handle must keep the source alive; a weak one lets \
+             track_assets free it, and reload then has nothing to reload"
+        );
+
+        // Read `Modified` specifically, and only events emitted after this
+        // point: the buffer still holds the `Added`/`LoadedWithDependencies`
+        // events the initial load emitted, so a bare length check would pass
+        // even if the reload reached nothing at all.
+        let mut reader: ManualEventReader<AssetEvent<crate::shader_asset::ShaderSource>> = app
+            .world_mut()
+            .resource_mut::<Events<AssetEvent<crate::shader_asset::ShaderSource>>>()
+            .get_reader();
+        {
+            let events = app
+                .world()
+                .resource::<Events<AssetEvent<crate::shader_asset::ShaderSource>>>();
+            let _ = reader.read(events).count();
+        }
+
+        app.world().resource::<AssetServer>().reload(path);
+        let mut saw_modified = false;
+        for _ in 0..60 {
+            app.update();
+            let events = app
+                .world()
+                .resource::<Events<AssetEvent<crate::shader_asset::ShaderSource>>>();
+            if reader
+                .read(events)
+                .any(|ev| matches!(ev, AssetEvent::Modified { id } if *id == asset_id))
+            {
+                saw_modified = true;
+                break;
+            }
+        }
+        assert!(
+            saw_modified,
+            "reloading a shader whose handle is retained must emit \
+             AssetEvent::Modified for it; none means the handle was dropped \
+             and hot reload is impossible for custom shaders"
         );
     }
 

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -118,11 +118,42 @@ enum PendingShader {
     /// a source that arrives before `WgpuSurfaceResource` exists is `Ready`
     /// with no pipeline behind it, and this arm compiles it once one shows up.
     Ready(bevy_asset::Handle<crate::shader_asset::ShaderSource>),
+    /// The source loaded but does not compile, and the handle is retained.
+    ///
+    /// Distinct from `Ready` so the compile is *not* retried every frame: the
+    /// file is broken, recompiling it next frame produces the same failure and
+    /// the same warning, which is the per-frame noise this whole loop was
+    /// restructured to avoid. Distinct from `GaveUp` because a broken shader is
+    /// not a dead end -- the handle is still held, so editing the file emits
+    /// `AssetEvent::Modified` and `rebuild_modified_shaders` retries from here,
+    /// promoting the path back to `Ready` when it compiles. Retry is driven by
+    /// the content changing, not by the frame clock.
+    ///
+    /// Says nothing about what is on screen: `compile_and_store_shader` leaves
+    /// `custom_pipelines` untouched when it fails, so a shader that compiled
+    /// once and was then edited into a broken state keeps drawing with its last
+    /// working pipeline.
+    CompileFailed(bevy_asset::Handle<crate::shader_asset::ShaderSource>),
     /// The load failed. Kept so the warning fires once rather than per frame,
     /// and so the path is never re-requested -- re-requesting a failed path
     /// resets it to `Loading` and starts the load over, which is why a
     /// re-requesting poll loop can never see the failure.
     GaveUp,
+}
+
+/// The state a path takes after a compile attempt: `Ready` on success, so the
+/// normal reload path applies, and `CompileFailed` on failure, so no frame
+/// retries it until the file changes. Both keep the handle -- dropping it on
+/// failure would stop `AssetEvent::Modified` from ever firing again for the
+/// path, which is exactly the event the fix has to arrive on.
+fn state_after_compile(
+    result: Result<(), String>,
+    handle: bevy_asset::Handle<crate::shader_asset::ShaderSource>,
+) -> PendingShader {
+    match result {
+        Ok(()) => PendingShader::Ready(handle),
+        Err(_) => PendingShader::CompileFailed(handle),
+    }
 }
 
 /// Shader loads in flight, keyed by path.
@@ -184,16 +215,20 @@ fn compile_pending_shaders(
                 let handle = handle.clone();
                 if let Some(src) = shader_assets.get(&handle) {
                     // The source is here; only the compile needs the GPU. The
-                    // path becomes `Ready` either way: `Ready` is what retains
-                    // the handle, and staying `Loading` until a surface exists
-                    // would leave hot reload switched off for exactly as long.
-                    // The `Ready` arm below picks the compile up instead.
-                    if let Some(surface) = surface.as_mut() {
-                        surface.0.compile_and_store_shader(&cs.path, &src.0);
-                    }
-                    pending
-                        .0
-                        .insert(cs.path.clone(), PendingShader::Ready(handle));
+                    // path leaves `Loading` either way -- both states below
+                    // retain the handle, and staying `Loading` until a surface
+                    // exists would leave hot reload switched off for exactly as
+                    // long. With no surface the compile is merely deferred, not
+                    // failed, so that case is `Ready` and the arm below picks
+                    // it up once a surface appears.
+                    let state = match surface.as_mut() {
+                        Some(surface) => state_after_compile(
+                            surface.0.compile_and_store_shader(&cs.path, &src.0),
+                            handle,
+                        ),
+                        None => PendingShader::Ready(handle),
+                    };
+                    pending.0.insert(cs.path.clone(), state);
                 } else if let bevy_asset::LoadState::Failed(e) = asset_server.load_state(&handle) {
                     tracing::warn!("[custom_shader] cannot read '{}': {e}", cs.path);
                     pending.0.insert(cs.path.clone(), PendingShader::GaveUp);
@@ -203,14 +238,26 @@ fn compile_pending_shaders(
             // never re-requested. Reaching here at all means the early-skip
             // above found no compiled pipeline for this path -- i.e. the
             // source arrived before `WgpuSurfaceResource` did -- so compile it
-            // now if a surface has since appeared. `compile_and_store_shader`
-            // always stores, so the skip fires from the next frame on and this
-            // runs exactly once.
+            // now if a surface has since appeared. A successful compile stores
+            // the pipeline, so the skip fires from the next frame on and this
+            // runs exactly once; a failed one moves the path to `CompileFailed`
+            // instead, which the arm below leaves alone, so a broken file is
+            // not recompiled (and re-warned about) every frame either.
             Some(PendingShader::Ready(handle)) => {
-                if let (Some(src), Some(surface)) = (shader_assets.get(handle), surface.as_mut()) {
-                    surface.0.compile_and_store_shader(&cs.path, &src.0);
+                let handle = handle.clone();
+                if let (Some(src), Some(surface)) = (shader_assets.get(&handle), surface.as_mut()) {
+                    let state = state_after_compile(
+                        surface.0.compile_and_store_shader(&cs.path, &src.0),
+                        handle,
+                    );
+                    pending.0.insert(cs.path.clone(), state);
                 }
             }
+            // Broken source, already reported once. Nothing here can change
+            // that verdict -- only a new revision of the file can, and that
+            // arrives as `AssetEvent::Modified`, which
+            // `rebuild_modified_shaders` acts on.
+            Some(PendingShader::CompileFailed(_)) => {}
             Some(PendingShader::GaveUp) => {}
             None => match bsengine_asset::load(
                 bsengine_asset::LoadMode::Async,
@@ -249,35 +296,56 @@ fn compile_pending_shaders(
 /// every reloadable one. A reload is the one case where recompiling an
 /// already-compiled path is the whole point.
 ///
-/// Without a `WgpuSurfaceResource` this does nothing and leaves the `Ready`
-/// state alone: the source is already in `Assets` and the handle is still
-/// retained, so the next reload is reached just the same.
+/// Without a `WgpuSurfaceResource` this does nothing and leaves the state
+/// alone: the source is already in `Assets` and the handle is still retained,
+/// so the next reload is reached just the same.
+///
+/// `CompileFailed` paths are rebuilt as readily as `Ready` ones -- this is the
+/// only place a broken shader can recover, because it is the only signal that
+/// the file's *content* changed. `compile_pending_shaders` deliberately never
+/// retries them, so skipping them here would make a single typo permanent for
+/// the rest of the run.
 fn rebuild_modified_shaders(
     mut events: bevy_ecs::prelude::EventReader<
         bevy_asset::AssetEvent<crate::shader_asset::ShaderSource>,
     >,
     mut surface: Option<ResMut<WgpuSurfaceResource>>,
     shader_assets: Res<bevy_asset::Assets<crate::shader_asset::ShaderSource>>,
-    pending: Res<PendingShaders>,
+    mut pending: ResMut<PendingShaders>,
 ) {
     for event in events.read() {
         let bevy_asset::AssetEvent::Modified { id } = event else {
             continue;
         };
-        for (path, state) in pending.0.iter() {
-            let PendingShader::Ready(handle) = state else {
-                continue;
-            };
-            if handle.id() != *id {
-                continue;
-            }
-            let Some(src) = shader_assets.get(handle) else {
+        // Matched paths are collected before compiling: the compile's verdict
+        // is written back into `pending`, which cannot happen while iterating
+        // it. One event names one asset, so this is a one-element vector in
+        // every realistic case, and it is allocated per *edit*, not per frame.
+        let rebuilt: Vec<(
+            String,
+            bevy_asset::Handle<crate::shader_asset::ShaderSource>,
+        )> = pending
+            .0
+            .iter()
+            .filter_map(|(path, state)| match state {
+                PendingShader::Ready(handle) | PendingShader::CompileFailed(handle)
+                    if handle.id() == *id =>
+                {
+                    Some((path.clone(), handle.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        for (path, handle) in rebuilt {
+            let Some(src) = shader_assets.get(&handle) else {
                 continue;
             };
             let Some(surface) = surface.as_mut() else {
                 continue;
             };
-            surface.0.compile_and_store_shader(path, &src.0);
+            let state =
+                state_after_compile(surface.0.compile_and_store_shader(&path, &src.0), handle);
+            pending.0.insert(path, state);
         }
     }
 }
@@ -1051,6 +1119,148 @@ mod tests {
             "reloading a shader whose handle is retained must emit \
              AssetEvent::Modified for it; none means the handle was dropped \
              and hot reload is impossible for custom shaders"
+        );
+    }
+
+    // A shader whose *source* loads but does not compile must not be
+    // recompiled every frame: the file is broken, the next attempt fails
+    // identically, and the only visible effect is one warning per frame. The
+    // pipeline is what `compile_and_store_shader` refuses to store, and that
+    // cannot be observed here (no `WgpuSurfaceResource`; a real one needs a
+    // real winit window -- see `compile_pending_shaders_runs_before_render_frame`),
+    // so this pins the two properties on this side of the boundary that make
+    // "retry on content change, never on the frame clock" work: the state is
+    // stable across frames, and the handle it holds still routes
+    // `AssetEvent::Modified` so the fixed file can reach
+    // `rebuild_modified_shaders`.
+    #[test]
+    fn a_shader_that_failed_to_compile_is_not_retried_every_frame_but_stays_reloadable() {
+        use bevy_asset::{AssetEvent, AssetServer, Assets};
+        use bevy_ecs::event::{Events, ManualEventReader};
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../games/mini-arena/assets/shaders/glow.wgsl");
+        let path = fixture.to_str().unwrap().to_owned();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(RenderPlugin);
+        app.world_mut()
+            .spawn(bsengine_core::CustomShader { path: path.clone() });
+
+        let mut asset_id = None;
+        for _ in 0..200 {
+            app.update();
+            if let Some(PendingShader::Ready(handle)) =
+                app.world().resource::<PendingShaders>().0.get(&path)
+            {
+                asset_id = Some(handle.id());
+                break;
+            }
+        }
+        let asset_id = asset_id.expect("the fixture shader's source must load");
+
+        // Stand in for what a surface would have done with a broken file: the
+        // same handle, moved to the state a failed compile records.
+        {
+            let mut pending = app.world_mut().resource_mut::<PendingShaders>();
+            let Some(PendingShader::Ready(handle)) = pending.0.get(&path) else {
+                unreachable!("just asserted Ready")
+            };
+            let handle = handle.clone();
+            pending
+                .0
+                .insert(path.clone(), PendingShader::CompileFailed(handle));
+        }
+
+        for _ in 0..20 {
+            app.update();
+        }
+        let state = app.world().resource::<PendingShaders>().0.get(&path);
+        assert!(
+            matches!(state, Some(PendingShader::CompileFailed(h)) if h.id() == asset_id),
+            "a shader that failed to compile must stay CompileFailed, holding \
+             the same handle: anything that moves it back to Ready or Loading \
+             makes the next frame compile the same broken file again, one \
+             warning per frame forever; got {state:?}"
+        );
+        assert!(
+            app.world()
+                .resource::<Assets<crate::shader_asset::ShaderSource>>()
+                .get(asset_id)
+                .is_some(),
+            "CompileFailed must retain a strong handle; dropping it lets \
+             track_assets free the source, and the fix the user is about to \
+             type can never arrive as AssetEvent::Modified"
+        );
+
+        // Only events emitted from here on: the buffer still holds the load's
+        // own Added/LoadedWithDependencies events.
+        let mut reader: ManualEventReader<AssetEvent<crate::shader_asset::ShaderSource>> = app
+            .world_mut()
+            .resource_mut::<Events<AssetEvent<crate::shader_asset::ShaderSource>>>()
+            .get_reader();
+        {
+            let events = app
+                .world()
+                .resource::<Events<AssetEvent<crate::shader_asset::ShaderSource>>>();
+            let _ = reader.read(events).count();
+        }
+
+        app.world().resource::<AssetServer>().reload(path);
+        let mut saw_modified = false;
+        for _ in 0..60 {
+            app.update();
+            let events = app
+                .world()
+                .resource::<Events<AssetEvent<crate::shader_asset::ShaderSource>>>();
+            if reader
+                .read(events)
+                .any(|ev| matches!(ev, AssetEvent::Modified { id } if *id == asset_id))
+            {
+                saw_modified = true;
+                break;
+            }
+        }
+        assert!(
+            saw_modified,
+            "editing a shader that previously failed to compile must still emit \
+             AssetEvent::Modified for it -- that event is the only thing \
+             rebuild_modified_shaders acts on, and without it a single typo \
+             would be permanent for the rest of the run"
+        );
+    }
+
+    // The pure half of the same rule, checked directly because no test in this
+    // workspace can run a real compile (that needs a GPU surface). Recording a
+    // failure as `Ready` is what would put the compile back on the frame clock;
+    // dropping the handle is what would make the failure permanent.
+    #[test]
+    fn a_failed_compile_is_recorded_as_compile_failed_and_keeps_its_handle() {
+        use bevy_asset::{AssetServer, Handle};
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(RenderPlugin);
+        let handle: Handle<crate::shader_asset::ShaderSource> = app
+            .world()
+            .resource::<AssetServer>()
+            .load("some/shader.wgsl".to_owned());
+
+        let ok = super::state_after_compile(Ok(()), handle.clone());
+        assert!(
+            matches!(&ok, PendingShader::Ready(h) if h.id() == handle.id()),
+            "a successful compile must land in Ready, got {ok:?}"
+        );
+
+        let failed = super::state_after_compile(Err("bad wgsl".to_string()), handle.clone());
+        assert!(
+            matches!(&failed, PendingShader::CompileFailed(h) if h.id() == handle.id()),
+            "a failed compile must land in CompileFailed holding the same \
+             handle -- Ready would have the next frame recompile the same \
+             broken source, and a dropped handle would stop the fix from ever \
+             arriving as Modified; got {failed:?}"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/mesh.rs
+++ b/crates/bsengine-rhi-wgpu/src/mesh.rs
@@ -70,7 +70,31 @@ impl GpuMeshRegistry {
     pub fn register(&mut self, vertices: &[Vertex], indices: &[u32]) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
+        let mesh = self.build(vertices, indices);
+        self.meshes.insert(id, mesh);
+        id
+    }
 
+    /// Rebuilds an already-registered mesh's buffers from new data, keeping its
+    /// id. Returns whether `id` was registered.
+    ///
+    /// Hot reload uses this rather than `register` because `MeshRenderer` stores
+    /// the id: replacing contents under the same id updates every entity drawing
+    /// that mesh at once, including the extra entities a multi-mesh glTF spawns.
+    /// `register` would also leak, since the registry never frees.
+    ///
+    /// Unlike [`GpuMeshRegistry::update_vertices`] this handles a changed vertex
+    /// or index count, and recomputes bounds.
+    pub fn replace(&mut self, id: u64, vertices: &[Vertex], indices: &[u32]) -> bool {
+        if !self.meshes.contains_key(&id) {
+            return false;
+        }
+        let mesh = self.build(vertices, indices);
+        self.meshes.insert(id, mesh);
+        true
+    }
+
+    fn build(&self, vertices: &[Vertex], indices: &[u32]) -> GpuMesh {
         let vertex_buffer = self
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -85,18 +109,12 @@ impl GpuMeshRegistry {
                 contents: bytemuck::cast_slice(indices),
                 usage: wgpu::BufferUsages::INDEX,
             });
-
-        let bounds = compute_bounding_sphere(vertices);
-        self.meshes.insert(
-            id,
-            GpuMesh {
-                vertex_buffer,
-                index_buffer,
-                index_count: indices.len() as u32,
-                bounds,
-            },
-        );
-        id
+        GpuMesh {
+            vertex_buffer,
+            index_buffer,
+            index_count: indices.len() as u32,
+            bounds: compute_bounding_sphere(vertices),
+        }
     }
 
     /// Looks up a previously registered mesh by id.
@@ -446,5 +464,48 @@ mod tests {
         // update_vertices doesn't panic against a real buffer/queue and that
         // the mesh is still registered afterward with the same id.
         assert!(registry.get(id).is_some());
+    }
+
+    #[test]
+    fn replace_swaps_geometry_under_the_same_id() {
+        use crate::rhi::WgpuRHI;
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless device");
+        let device = std::sync::Arc::new(rhi.device);
+        let mut reg = GpuMeshRegistry::new(device);
+
+        let (tri_v, tri_i) = triangle_vertices();
+        let id = reg.register(&tri_v, &tri_i);
+        let before = reg.get_bounds(id).expect("just registered");
+
+        let (cube_v, cube_i) = cube_vertices();
+        assert!(
+            reg.replace(id, &cube_v, &cube_i),
+            "replace must report success for an id that exists"
+        );
+
+        assert_eq!(
+            reg.get(id).map(|m| m.index_count),
+            Some(cube_i.len() as u32),
+            "replace must update index_count, or draws would use the old count"
+        );
+        let after = reg.get_bounds(id).expect("still registered after replace");
+        assert_ne!(
+            before, after,
+            "replace must recompute bounds -- stale bounds silently break culling"
+        );
+    }
+
+    #[test]
+    fn replace_reports_failure_for_an_unknown_id() {
+        use crate::rhi::WgpuRHI;
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless device");
+        let device = std::sync::Arc::new(rhi.device);
+        let mut reg = GpuMeshRegistry::new(device);
+        let (v, i) = triangle_vertices();
+        assert!(
+            !reg.replace(9999, &v, &i),
+            "replace must not silently create a mesh under an id nobody allocated"
+        );
+        assert!(reg.get(9999).is_none());
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/mesh.rs
+++ b/crates/bsengine-rhi-wgpu/src/mesh.rs
@@ -2,6 +2,7 @@ use bsengine_ecs::Resource;
 use glam::Vec3;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tracing::warn;
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
@@ -85,6 +86,12 @@ impl GpuMeshRegistry {
     ///
     /// Unlike [`GpuMeshRegistry::update_vertices`] this handles a changed vertex
     /// or index count, and recomputes bounds.
+    ///
+    /// The returned flag is `#[must_use]` because `false` means an id a caller
+    /// recorded at load time is no longer registered — the exact invariant
+    /// replace-in-place hot reload rests on. Dropping it turns that into a
+    /// reload that appears to work and silently keeps the old geometry.
+    #[must_use]
     pub fn replace(&mut self, id: u64, vertices: &[Vertex], indices: &[u32]) -> bool {
         if !self.meshes.contains_key(&id) {
             return false;
@@ -127,14 +134,42 @@ impl GpuMeshRegistry {
         self.meshes.get(&id).map(|m| m.bounds)
     }
 
-    /// Overwrites a previously registered mesh's vertex buffer contents in place
-    /// (same vertex count as at `register` time — this does not resize the
-    /// buffer). Used by CPU-side skeletal skinning to re-upload deformed
-    /// vertex positions/normals each frame without re-registering a new mesh id.
-    pub fn update_vertices(&mut self, queue: &wgpu::Queue, id: u64, vertices: &[Vertex]) {
-        if let Some(mesh) = self.meshes.get(&id) {
-            queue.write_buffer(&mesh.vertex_buffer, 0, bytemuck::cast_slice(vertices));
+    /// Overwrites a previously registered mesh's vertex buffer contents in
+    /// place, without resizing it. Used by CPU-side skeletal skinning to
+    /// re-upload deformed vertex positions/normals each frame without
+    /// re-registering a new mesh id. Returns whether the upload happened.
+    ///
+    /// `vertices` must be exactly as long as the buffer the mesh *currently*
+    /// holds — the count from the most recent `register` or
+    /// [`GpuMeshRegistry::replace`], which after a hot reload need not be the
+    /// original one. A mismatch is refused with a warning rather than handed to
+    /// wgpu: a longer upload is a `BufferOverrun`, and since nothing in this
+    /// codebase installs an error scope or `on_uncaptured_error`, that reaches
+    /// wgpu's default handler, which panics the process. A shorter one would
+    /// leave stale vertices in the tail. Use [`GpuMeshRegistry::replace`] when
+    /// the count genuinely changed.
+    pub fn update_vertices(&mut self, queue: &wgpu::Queue, id: u64, vertices: &[Vertex]) -> bool {
+        let Some(mesh) = self.meshes.get(&id) else {
+            return false;
+        };
+        if vertices.is_empty() {
+            // Nothing to upload, and not a caller error worth warning about:
+            // `create_buffer_init` never allocates below COPY_BUFFER_ALIGNMENT,
+            // so an empty mesh's buffer can never match an empty upload anyway.
+            return false;
         }
+        let incoming = std::mem::size_of_val(vertices) as wgpu::BufferAddress;
+        if incoming != mesh.vertex_buffer.size() {
+            warn!(
+                "refusing to upload {incoming} bytes of vertex data into mesh {id}'s \
+                 {} byte buffer; the mesh was rebuilt at a different vertex count \
+                 and whatever holds this data has not caught up",
+                mesh.vertex_buffer.size()
+            );
+            return false;
+        }
+        queue.write_buffer(&mesh.vertex_buffer, 0, bytemuck::cast_slice(vertices));
+        true
     }
 }
 
@@ -464,6 +499,70 @@ mod tests {
         // update_vertices doesn't panic against a real buffer/queue and that
         // the mesh is still registered afterward with the same id.
         assert!(registry.get(id).is_some());
+    }
+
+    /// The hot-reload path can hand `update_vertices` a rest pose that no longer
+    /// matches the buffer, because `replace` resizes and `update_vertices` does
+    /// not. wgpu turns a too-long `write_buffer` into a validation error, and
+    /// with no error scope or `on_uncaptured_error` anywhere in this codebase
+    /// that reaches wgpu's default handler, which *panics* — so without this
+    /// guard a mesh that loses vertices on reload kills the running game.
+    /// Defence in depth: the glTF rebuild is supposed to keep the two in step,
+    /// but "supposed to" is not an acceptable distance from a dead process.
+    #[test]
+    fn update_vertices_refuses_a_size_mismatch_instead_of_overrunning_the_buffer() {
+        use crate::rhi::WgpuRHI;
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless device");
+        let device = std::sync::Arc::new(rhi.device);
+        let mut reg = GpuMeshRegistry::new(device);
+        let (verts, indices) = triangle_vertices();
+        let id = reg.register(&verts, &indices);
+
+        assert!(
+            reg.update_vertices(&rhi.queue, id, &verts),
+            "an exactly-sized upload must still go through, or skinning stops \
+             uploading anything at all"
+        );
+
+        let mut too_many = verts.clone();
+        too_many.extend_from_slice(&verts);
+        assert!(
+            !reg.update_vertices(&rhi.queue, id, &too_many),
+            "an oversized upload must be refused here rather than handed to \
+             wgpu, which panics the process on BufferOverrun"
+        );
+
+        assert!(
+            !reg.update_vertices(&rhi.queue, id, &verts[..1]),
+            "an undersized upload must be refused too -- it would write past \
+             nothing but leave the tail holding stale vertices"
+        );
+        assert!(
+            !reg.update_vertices(&rhi.queue, id, &[]),
+            "an empty upload has nothing to write"
+        );
+        assert!(
+            !reg.update_vertices(&rhi.queue, 9999, &verts),
+            "an unknown id must report failure, not silently succeed"
+        );
+
+        // The guard must track `replace`, not the original register: after a
+        // reload shrinks the mesh, the *new* count is what fits.
+        let (cube_v, cube_i) = cube_vertices();
+        assert!(reg.replace(id, &cube_v, &cube_i));
+        assert!(
+            !reg.update_vertices(&rhi.queue, id, &verts),
+            "the pre-replace count must no longer fit"
+        );
+        assert!(
+            reg.update_vertices(&rhi.queue, id, &cube_v),
+            "the post-replace count must fit; a guard keyed to the register-time \
+             count would reject every upload for the rest of the mesh's life"
+        );
+        assert!(
+            reg.get(id).is_some(),
+            "a refused upload must not drop the mesh"
+        );
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2515,9 +2515,63 @@ impl WgpuSurface {
             .resize_targets(&self.device, &self.depth_view, width, height);
     }
 
+    /// Checks that `wgsl` is a shader `wgpu` will accept, without touching the
+    /// GPU. `path` only labels the message.
+    ///
+    /// Both halves of `wgpu`'s own front end are run, in its order: naga's WGSL
+    /// parser (syntax and name resolution), then `naga::valid::Validator`
+    /// (everything the parser lets through). The second half is not optional --
+    /// `parse_str` alone accepts a vertex entry point with no
+    /// `@builtin(position)` output, a `return` whose type does not match the
+    /// declared one, and two globals sharing a `@binding`; all three are
+    /// rejected by the validator, which is exactly what
+    /// `wgpu::Device::create_shader_module` runs internally. Pre-checking only
+    /// the parse would leave those three cases reaching the device.
+    ///
+    /// Capabilities are `naga::valid::Capabilities::all` rather than the ones
+    /// this device actually reports, so this pass can never reject a shader the
+    /// device would have accepted. Capability-gated features (`f16`, push
+    /// constants, ...) are left to the device, whose verdict
+    /// [`Self::compile_and_store_shader`] captures with an error scope rather
+    /// than letting it panic.
+    pub fn validate_wgsl(path: &str, wgsl: &str) -> Result<(), String> {
+        let module = wgpu::naga::front::wgsl::parse_str(wgsl)
+            .map_err(|e| e.emit_to_string_with_path(wgsl, path))?;
+        wgpu::naga::valid::Validator::new(
+            wgpu::naga::valid::ValidationFlags::all(),
+            wgpu::naga::valid::Capabilities::all(),
+        )
+        .validate(&module)
+        .map(|_| ())
+        .map_err(|e| e.emit_to_string_with_path(wgsl, path))
+    }
+
     /// Compiles a WGSL custom shader and stores it as a render pipeline keyed
     /// by `path`, replacing any previously compiled pipeline for that path.
-    pub fn compile_and_store_shader(&mut self, path: &str, wgsl: &str) {
+    ///
+    /// Returns `Err` with the reason if the source does not compile, having
+    /// left `custom_pipelines` untouched -- so a shader edited into a broken
+    /// intermediate state keeps drawing with its last working pipeline instead
+    /// of vanishing. Callers use that to avoid re-attempting a compile that
+    /// cannot succeed until the file changes again.
+    ///
+    /// Nothing here may panic on bad *content*: hot reload recompiles at
+    /// runtime from whatever the file currently says, and a half-typed shader
+    /// must not take the running game down with it. `wgpu`'s default uncaptured
+    /// error handler panics, so the two device calls are wrapped in a
+    /// validation error scope. The naga pre-pass above is what produces a
+    /// readable message (line, column, offending token); the error scope is the
+    /// backstop for what a device-independent pre-pass cannot know -- capability
+    /// gaps, a renamed `vs_main`/`fs_main`, bindings that do not match
+    /// `pipeline_layout`.
+    pub fn compile_and_store_shader(&mut self, path: &str, wgsl: &str) -> Result<(), String> {
+        if let Err(e) = Self::validate_wgsl(path, wgsl) {
+            tracing::warn!(
+                "[custom_shader] '{path}' is not valid WGSL; keeping the previously compiled pipeline:\n{e}"
+            );
+            return Err(e);
+        }
+        self.device.push_error_scope(wgpu::ErrorFilter::Validation);
         let shader = self
             .device
             .create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -2589,7 +2643,19 @@ impl WgpuSurface {
                 multiview: None,
                 cache: None,
             });
+        // `pop_error_scope`'s future is already resolved on every native
+        // backend (wgpu-core reports validation errors synchronously into the
+        // error sink and hands back a ready future), so this neither blocks nor
+        // needs the device polled.
+        if let Some(err) = pollster::block_on(self.device.pop_error_scope()) {
+            let msg = err.to_string();
+            tracing::warn!(
+                "[custom_shader] the GPU device rejected '{path}'; keeping the previously compiled pipeline: {msg}"
+            );
+            return Err(msg);
+        }
         self.custom_pipelines.insert(path.to_string(), pipeline);
+        Ok(())
     }
 
     /// Whether a custom shader has already been compiled and stored for `path`.
@@ -2797,6 +2863,129 @@ mod tests {
 }
 "#;
         let _module = WgpuSurface::compile_shader(&rhi.device, wgsl);
+    }
+
+    /// The shape `compile_and_store_shader` builds a pipeline from: a vertex
+    /// entry named `vs_main` and a fragment entry named `fs_main`.
+    const VALID_CUSTOM_WGSL: &str = r#"
+@vertex fn vs_main(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4<f32> {
+    return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+@fragment fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}
+"#;
+
+    #[test]
+    fn validate_wgsl_accepts_a_valid_custom_shader() {
+        assert_eq!(
+            WgpuSurface::validate_wgsl("assets/glow.wgsl", VALID_CUSTOM_WGSL),
+            Ok(()),
+            "the shader shape custom pipelines are built from must pass \
+             validation; if it does not, hot reload rejects every edit"
+        );
+    }
+
+    // The message has to be good enough to fix the shader from, not just
+    // "error": this fires while someone is mid-edit, and the log line is all
+    // they get. Asserts on the concrete line:column and the offending token so
+    // a regression to a bare "invalid shader" string fails here.
+    #[test]
+    fn validate_wgsl_rejects_a_syntax_error_naming_line_column_and_token() {
+        let broken = r#"
+@fragment fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 0.0 1.0);
+}
+"#;
+        let err = WgpuSurface::validate_wgsl("assets/broken.wgsl", broken)
+            .expect_err("a missing argument separator is not valid WGSL");
+        assert!(
+            err.contains("assets/broken.wgsl:3:36"),
+            "the error must locate the mistake by path, line and column; got: {err}"
+        );
+        assert!(
+            err.contains("expected ')'"),
+            "the error must say what was expected where; got: {err}"
+        );
+    }
+
+    // The half that `naga::front::wgsl::parse_str` alone would miss, and the
+    // reason `validate_wgsl` runs `Validator` as well: all three of these parse
+    // cleanly and are rejected only by validation -- which is precisely what
+    // `create_shader_module` runs on the device, where a rejection panics the
+    // process. Delete the `Validator` call and this test fails.
+    #[test]
+    fn validate_wgsl_rejects_what_parsing_alone_accepts() {
+        let vertex_without_position = r#"
+@vertex fn vs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+"#;
+        let wrong_return_type = r#"
+@fragment fn fs_main() -> @location(0) vec4<f32> {
+    return 1.0;
+}
+"#;
+        let conflicting_bindings = r#"
+@group(0) @binding(0) var<uniform> a: vec4<f32>;
+@group(0) @binding(0) var<uniform> b: vec4<f32>;
+@fragment fn fs_main() -> @location(0) vec4<f32> {
+    return a + b;
+}
+"#;
+        for (src, expected_fragment) in [
+            (vertex_without_position, "@builtin(position)"),
+            (
+                wrong_return_type,
+                "does not match the function return value",
+            ),
+            (conflicting_bindings, "conflict with other resource"),
+        ] {
+            assert!(
+                wgpu::naga::front::wgsl::parse_str(src).is_ok(),
+                "precondition: this source is supposed to parse and fail only \
+                 in validation, which is what makes it a test of the validator \
+                 pass; it no longer parses: {src}"
+            );
+            let err = WgpuSurface::validate_wgsl("assets/broken.wgsl", src)
+                .expect_err("the validator rejects this, so validate_wgsl must too");
+            assert!(
+                err.contains(expected_fragment),
+                "expected the validator's reason ({expected_fragment}) in: {err}"
+            );
+        }
+    }
+
+    // `compile_and_store_shader` cannot be called without a real
+    // `WgpuSurface` (which needs a real winit window -- see
+    // `compile_pending_shaders_runs_before_render_frame` in bsengine-render),
+    // so this pins the mechanism it relies on at the level a test can reach: a
+    // validation error scope turns a device rejection into a returned error
+    // instead of the default uncaptured-error handler's panic. Without the
+    // scope this test aborts the process rather than failing.
+    #[test]
+    fn a_validation_error_scope_captures_a_device_rejection_instead_of_panicking() {
+        let rhi = pollster::block_on(WgpuRHI::new_headless()).expect("headless rhi");
+
+        rhi.device.push_error_scope(wgpu::ErrorFilter::Validation);
+        let _module = WgpuSurface::compile_shader(
+            &rhi.device,
+            "@fragment fn fs_main() -> @location(0) vec4<f32> { return vec4<f32>(0.0 1.0); }",
+        );
+        let err = pollster::block_on(rhi.device.pop_error_scope());
+        assert!(
+            err.is_some(),
+            "a broken shader must surface as a captured error; None means the \
+             rejection went to the uncaptured handler, which panics"
+        );
+
+        rhi.device.push_error_scope(wgpu::ErrorFilter::Validation);
+        let _module = WgpuSurface::compile_shader(&rhi.device, VALID_CUSTOM_WGSL);
+        assert!(
+            pollster::block_on(rhi.device.pop_error_scope()).is_none(),
+            "a valid shader must leave the scope empty; otherwise every reload \
+             would be treated as a failure and no pipeline would ever update"
+        );
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/texture.rs
+++ b/crates/bsengine-rhi-wgpu/src/texture.rs
@@ -91,6 +91,12 @@ impl GpuTextureRegistry {
     /// Hot reload uses this rather than `load_from_rgba` because `Material`
     /// stores the id: replacing under the same id updates every material using
     /// the texture at once. The new image may have different dimensions.
+    ///
+    /// The returned flag is `#[must_use]` for the same reason as
+    /// `GpuMeshRegistry::replace`: `false` means an id a caller recorded at load
+    /// time is no longer loaded, and dropping it turns that into a reload that
+    /// appears to work and silently keeps the old pixels.
+    #[must_use]
     pub fn replace(&mut self, id: u64, width: u32, height: u32, rgba: &[u8]) -> bool {
         if !self.textures.contains_key(&id) {
             return false;

--- a/crates/bsengine-rhi-wgpu/src/texture.rs
+++ b/crates/bsengine-rhi-wgpu/src/texture.rs
@@ -6,6 +6,8 @@ struct GpuTexture {
     _texture: wgpu::Texture,
     _view: wgpu::TextureView,
     bind_group: wgpu::BindGroup,
+    width: u32,
+    height: u32,
 }
 
 /// Owns every GPU texture uploaded for the running app, keyed by a registry-assigned id.
@@ -71,15 +73,34 @@ impl GpuTextureRegistry {
         let img = image::load_from_memory(bytes).map_err(|e| format!("image decode: {e}"))?;
         let rgba = img.to_rgba8();
         let (width, height) = rgba.dimensions();
-        Ok(self.upload_rgba(width, height, &rgba))
+        Ok(self.load_from_rgba(width, height, &rgba))
     }
 
     /// Uploads already-decoded RGBA8 pixel data as a new texture and returns its assigned id.
     pub fn load_from_rgba(&mut self, width: u32, height: u32, rgba: &[u8]) -> u64 {
-        self.upload_rgba(width, height, rgba)
+        let tex = self.build(width, height, rgba);
+        let id = self.next_id;
+        self.next_id += 1;
+        self.textures.insert(id, tex);
+        id
     }
 
-    fn upload_rgba(&mut self, width: u32, height: u32, rgba: &[u8]) -> u64 {
+    /// Rebuilds an already-loaded texture from new pixels, keeping its id.
+    /// Returns whether `id` was loaded.
+    ///
+    /// Hot reload uses this rather than `load_from_rgba` because `Material`
+    /// stores the id: replacing under the same id updates every material using
+    /// the texture at once. The new image may have different dimensions.
+    pub fn replace(&mut self, id: u64, width: u32, height: u32, rgba: &[u8]) -> bool {
+        if !self.textures.contains_key(&id) {
+            return false;
+        }
+        let tex = self.build(width, height, rgba);
+        self.textures.insert(id, tex);
+        true
+    }
+
+    fn build(&self, width: u32, height: u32, rgba: &[u8]) -> GpuTexture {
         let texture = self.device.create_texture(&wgpu::TextureDescriptor {
             label: Some("user texture"),
             size: wgpu::Extent3d {
@@ -123,22 +144,23 @@ impl GpuTextureRegistry {
                 },
             ],
         });
-        let id = self.next_id;
-        self.next_id += 1;
-        self.textures.insert(
-            id,
-            GpuTexture {
-                _texture: texture,
-                _view: view,
-                bind_group,
-            },
-        );
-        id
+        GpuTexture {
+            _texture: texture,
+            _view: view,
+            bind_group,
+            width,
+            height,
+        }
     }
 
     /// Looks up a previously loaded texture's bind group by id.
     pub fn get_bind_group(&self, id: u64) -> Option<&wgpu::BindGroup> {
         self.textures.get(&id).map(|t| &t.bind_group)
+    }
+
+    /// Looks up a previously loaded texture's pixel dimensions by id.
+    pub fn get_size(&self, id: u64) -> Option<(u32, u32)> {
+        self.textures.get(&id).map(|t| (t.width, t.height))
     }
 }
 
@@ -163,5 +185,36 @@ mod tests {
     fn load_invalid_bytes_returns_err() {
         let mut reg = make_registry();
         assert!(reg.load_from_bytes(b"not an image").is_err());
+    }
+
+    #[test]
+    fn replace_swaps_texture_contents_under_the_same_id() {
+        let mut reg = make_registry();
+
+        let id = reg.load_from_rgba(1, 1, &[255, 0, 0, 255]);
+        assert!(reg.get_bind_group(id).is_some());
+
+        assert!(
+            reg.replace(id, 2, 2, &[0u8; 16]),
+            "replace must report success for an id that exists"
+        );
+        assert!(
+            reg.get_bind_group(id).is_some(),
+            "the id must still resolve after replace -- Material.texture_id \
+             stores it and is not rewritten"
+        );
+        assert_eq!(
+            reg.get_size(id),
+            Some((2, 2)),
+            "replace must actually rebuild the texture with the new dimensions \
+             -- a no-op that returns true would leave the old 1x1 texture in place"
+        );
+    }
+
+    #[test]
+    fn replace_reports_failure_for_an_unknown_texture_id() {
+        let mut reg = make_registry();
+        assert!(!reg.replace(9999, 1, 1, &[0, 0, 0, 255]));
+        assert!(reg.get_bind_group(9999).is_none());
     }
 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -3477,6 +3477,195 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    // Audio is the one asset consumer this phase adds no rebuild code to, and
+    // that is a claim worth pinning rather than assuming. It holds only
+    // because `SoundLoads` already retains a *strong* handle in `Ready` (for
+    // repeat plays — see the test above) and `bevy_asset` swaps the newly
+    // decoded data in under that same handle, so the next `playSound` picks
+    // up the edited file with nothing written here. Break either half and the
+    // claim collapses silently: if a reload evicted the entry, or if a future
+    // cleanup downgraded the retained handle to a weak one, `track_assets`
+    // would free the sound, the next `playSound` would go back to disk, and
+    // audio would need the same rebuild system glTF, shaders and the skybox
+    // got.
+    //
+    // No audio device is involved. `AudioWorld` no-ops here as everywhere
+    // else in these tests; every assertion is about `SoundLoads`,
+    // `Assets<AudioSourceAsset>` and the asset events, never about sound.
+    #[test]
+    fn reloading_a_resident_sound_replaces_it_rather_than_evicting_it() {
+        use bevy_asset::{AssetEvent, AssetServer, Assets};
+        use bevy_ecs::event::{Events, ManualEventReader};
+        use bsengine_audio::AudioSourceAsset;
+
+        let dir =
+            std::env::temp_dir().join(format!("bsengine_test_sound_reload_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sound_path = dir.join("blip.flac");
+        std::fs::write(&sound_path, MINIMAL_FLAC_SILENCE).unwrap();
+        // Backslashes would be escapes inside the JS string literal below;
+        // Windows accepts forward slashes just as happily.
+        let sound_path_js = sound_path.to_string_lossy().replace('\\', "/");
+
+        let script_path = dir.join("play_once.js");
+        std::fs::write(
+            &script_path,
+            format!(
+                "var played = false;\n\
+                 function onUpdate(name) {{\n\
+                   if (played) {{ return; }}\n\
+                   played = true;\n\
+                   Bsengine.playSound(\"{sound_path_js}\", {{}});\n\
+                 }}"
+            ),
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: String::new(),
+        });
+        app.world_mut().spawn((
+            Name("Speaker".to_string()),
+            ScriptPath(script_path.to_string_lossy().to_string()),
+        ));
+
+        // Loops until the play has genuinely *resolved*, not merely until the
+        // queue looks empty: an empty queue is equally what "the script has
+        // not run yet" and "the load gave up" look like, and reloading from
+        // either of those states would make every assertion below vacuous.
+        let mut frames = 0;
+        loop {
+            app.update();
+            frames += 1;
+            let resolved = matches!(
+                app.world().resource::<SoundLoads>().0.values().next(),
+                Some(SoundLoad::Ready(_))
+            );
+            if resolved && app.world().resource::<PendingSounds>().0.is_empty() {
+                break;
+            }
+            assert!(
+                frames < 300,
+                "the sound never resolved (is MINIMAL_FLAC_SILENCE still \
+                 decodable?); SoundLoads was {:?}",
+                app.world().resource::<SoundLoads>().0
+            );
+        }
+
+        // Only the *id* is carried across the reload, never a clone of the
+        // handle: a strong clone held by the test would keep the asset alive
+        // on its own, and the liveness assertion at the end would then pass
+        // even if `SoundLoads` had stopped retaining anything at all.
+        let (resolved_path, asset_id) = {
+            let loads = app.world().resource::<SoundLoads>();
+            assert_eq!(
+                loads.0.len(),
+                1,
+                "exactly one path was played, got {:?}",
+                loads.0
+            );
+            let (path, load) = loads.0.iter().next().unwrap();
+            let SoundLoad::Ready(handle) = load else {
+                unreachable!("the loop above only exits on Ready, got {load:?}")
+            };
+            (path.clone(), handle.id())
+        };
+        assert_eq!(
+            resolved_path, sound_path_js,
+            "the map is keyed by exactly the string handed to AssetServer, so \
+             any other key here means the reload below would name a different \
+             asset and silently do nothing"
+        );
+        assert!(
+            app.world()
+                .resource::<Assets<AudioSourceAsset>>()
+                .get(asset_id)
+                .is_some(),
+            "the sound must be resident before the reload, or nothing measured \
+             after it means anything"
+        );
+
+        let mut reader: ManualEventReader<AssetEvent<AudioSourceAsset>> = app
+            .world_mut()
+            .resource_mut::<Events<AssetEvent<AudioSourceAsset>>>()
+            .get_reader();
+        // Discards the Added/LoadedWithDependencies of the original load, so
+        // only what the reload itself emits is counted.
+        {
+            let events = app
+                .world()
+                .resource::<Events<AssetEvent<AudioSourceAsset>>>();
+            let _ = reader.read(events).count();
+        }
+
+        app.world()
+            .resource::<AssetServer>()
+            .reload(resolved_path.clone());
+
+        // 60 frames is far more than the reload needs; the number is chosen
+        // for the other half of this test. `Assets::track_assets` runs every
+        // `PreUpdate` and frees an asset the frame after its last strong
+        // handle drops, so a merely-weak retained handle gets ~60 chances to
+        // be collected before the liveness assertion below runs.
+        let mut events_seen: Vec<String> = Vec::new();
+        let mut modified_ours = false;
+        for _ in 0..60 {
+            app.update();
+            let events = app
+                .world()
+                .resource::<Events<AssetEvent<AudioSourceAsset>>>();
+            for event in reader.read(events) {
+                if matches!(event, AssetEvent::Modified { id } if *id == asset_id) {
+                    modified_ours = true;
+                }
+                events_seen.push(format!("{event:?}"));
+            }
+        }
+
+        // How we know the reload was not a silent no-op: `Modified` is emitted
+        // only when the freshly decoded data is actually inserted under the
+        // existing id, and that insertion *is* "the next playSound uses the
+        // new file". Without this the remaining assertions would also hold for
+        // a reload that never happened.
+        assert!(
+            modified_ours,
+            "reloading the retained sound must emit AssetEvent::Modified for \
+             its id -- otherwise the reload did nothing and this test proves \
+             nothing; events seen were {events_seen:?}"
+        );
+
+        let loads = app.world().resource::<SoundLoads>();
+        let Some(SoundLoad::Ready(handle)) = loads.0.get(&resolved_path) else {
+            panic!(
+                "a reload must leave the path Ready, not evict or downgrade it; \
+                 got {:?}",
+                loads.0.get(&resolved_path)
+            );
+        };
+        assert_eq!(
+            handle.id(),
+            asset_id,
+            "the reload must replace the data under the existing id rather \
+             than mint a second asset the retained handle no longer names"
+        );
+        // The assertion that actually measures retention. The `Ready` check
+        // above is not enough on its own: a weak handle satisfies it while
+        // still letting `track_assets` free the sound underneath.
+        assert!(
+            app.world()
+                .resource::<Assets<AudioSourceAsset>>()
+                .get(handle)
+                .is_some(),
+            "the retained handle must still resolve after the reload -- if it \
+             does not, the next playSound goes back to disk and audio needs \
+             rebuild code after all"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // A sound that has been asked for but has not started yet must report
     // `"loading"`, not `""`. `""` is what `getSoundState` returns for an id
     // that was never played at all, so a script polling for "has my sound


### PR DESCRIPTION
Item 24 Phase 3a. When an already-loaded asset's data is replaced, each consumer rebuilds its GPU state **in place** — no restart, and without touching any entity. Reloads are driven by calling `AssetServer::reload` directly; the filesystem watcher that will call it is Phase 3b.

## Summary

| Consumer | Retains | Rebuild |
|---|---|---|
| glTF | `GltfLoaded { handle, mesh_ids, texture_ids }` | `rebuild_modified_gltf` |
| Custom shaders | `PendingShader::Ready(handle)` | `rebuild_modified_shaders` |
| Skybox | `PendingSkyboxState::Ready(handle)` | `rebuild_modified_skybox` |
| Audio | `SoundLoads::Ready(handle)` — already there | none needed (pinned by a test) |

Plus two RHI primitives: `GpuMeshRegistry::replace` and `GpuTextureRegistry::replace`, which rebuild a resource under its **existing** id.

### Two premises, both measured rather than assumed

**Retention is a prerequisite, not an optimisation.** `AssetEvent::Modified` only fires while a strong handle exists; drop the last one and `Assets::track_assets` frees the asset and `reload` becomes a silent no-op. Measured in `ddf847ad`: handle held → `LoadedWithDependencies` + `Modified`; handle dropped → **zero** events. After Phase 2 only audio still held its handle, so glTF, shaders and the skybox could never have received an event no matter how good a watcher was.

**Replacing under a stable id beats swapping ids on entities.** The design doc called for swapping `MeshRenderer.mesh_id` on every entity holding the handle. `GpuMeshRegistry::register` allocates a fresh id per call and the registry never frees, so that leaks two buffers per reload — and after Phase 2 no entity holds the handle anyway. Replacing contents under the recorded id keeps `MeshRenderer.mesh_id` and `Material.texture_id` valid, so nothing has to find entities, including the extra entities a multi-mesh glTF spawns.

### Two defects the final review caught, both fixed here

**A skinned glTF reload was silently discarded, and could kill the process.** `update_skinned_meshes` (PostUpdate) rebuilds deformed vertices from `SkinnedMesh.rest_vertices` — a copy taken at load time — and writes them to the same `mesh_id` buffer, stomping the rebuild in the same frame it landed. With a shrinking mesh, `update_vertices` had no size guard and wgpu's default handler panicked: `Copy of 0..76032 would end up overrunning the bounds of the Destination buffer of size 132`. Not hypothetical — `fox.glb`, the only glTF `games/mini-arena` loads, is skinned. The rebuild now refreshes the skinning state, and `update_vertices` warns and skips instead of overrunning.

**Worth noting why no test caught it:** the headless helper never inserted `GpuQueueResource`, so the system early-returned, and the assertion targeted `get_bounds` — recomputed by the rebuild, untouched by the overwrite — so it was green either way.

**A reloaded shader with a WGSL error killed the process.** `create_shader_module` ran with no error scope. Tolerable at startup; not for a feature whose entire purpose is iterating through intermediate broken states. Both naga halves (parser + `Validator`) now pre-validate, and a failure warns and leaves the previous pipeline live, as the design doc's error-handling section requires. A failed compile parks in `CompileFailed(handle)` — no per-frame retry, but the handle stays so the fix's `Modified` still arrives.

## Test Plan

- [x] Workspace tests: 54 test binaries, 0 failures, no stack overflows
- [x] All 8 E2E recordings pass — idle **and** with all 8 replaying concurrently under load, re-run after the review fixes
- [x] `cargo clippy --workspace --all-targets`: only the two pre-existing `derivable_impls` warnings in `bsengine-core`
- [x] `cargo fmt --check` clean on all four touched crates
- [x] Every retention test mutation-verified, including the subtle `clone_weak` case — a weakly retained handle satisfies `matches!(Ready(_))` while still letting `track_assets` free the asset, so the tests assert asset liveness and `Modified` emission, not just the enum state

## Known limitations, deliberate

- A reloaded glTF that gains or loses meshes, images, or skinning rebuilds the overlap and warns; those entities were spawned at load time and a restart is needed.
- `AnimationPlayer.clip` is not reset — an `AnimationStateMachine` may own that choice. Only its duration is re-read.
- `rebuild_modified_shaders` and `rebuild_modified_skybox` are covered only by ordering tests; exercising their bodies needs a real winit window.
- Retained handles keep each distinct asset's decoded CPU payload resident for the process lifetime. Bounded by distinct paths in use, not by reload count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
