### PR TITLE
test(asset): pin that a rename reports both the old and new path

### DIFF
--- a/crates/bsengine-asset/src/watcher.rs
+++ b/crates/bsengine-asset/src/watcher.rs
@@ -462,6 +462,75 @@ mod tests {
 
     /// Watches `watch_root` recursively, writes the nested file once, and
     /// returns everything the debouncer emitted.
+    // Item 30 sub-item D recovers a stale asset path — the kind embedded in a
+    // JS string literal — by asking the index where that path's asset went.
+    // That only works if something records the move, and today only orphan
+    // recovery does: a rename made while the watcher is running is currently
+    // reported as a change to the destination and nothing else, because
+    // `drain_asset_changes` drops the source (it no longer `is_file()`).
+    //
+    // The information is not missing, only discarded. Measured here:
+    // `notify-debouncer-full`'s `FileIdMap` stitches the backend's two halves
+    // into one `Modify(Name(Both))` carrying **both** paths, old first.
+    //
+    // This test exists so that stays true. If a platform or a `notify` upgrade
+    // ever reports a rename without the old path, sub-item D's recovery loses
+    // its only in-engine source of former paths — and would do so silently,
+    // since a rename would still look like an ordinary change to the
+    // destination.
+    #[test]
+    fn a_rename_is_reported_with_both_the_old_and_the_new_path() {
+        let root = std::env::temp_dir().join(unique("rename-probe"));
+        let _guard = make_tree(root.clone());
+
+        let (tx, rx) = mpsc::channel();
+        let mut debouncer = new_debouncer(DEBOUNCE, None, tx).unwrap();
+        debouncer
+            .watcher()
+            .watch(&root, RecursiveMode::Recursive)
+            .unwrap();
+        debouncer.cache().add_root(&root, RecursiveMode::Recursive);
+
+        std::thread::sleep(DEBOUNCE * 3);
+        while rx.try_recv().is_ok() {}
+
+        let from = root.join(nested());
+        let to = root.join("assets").join("models").join("renamed.txt");
+        std::fs::rename(&from, &to).unwrap();
+
+        let events = collect(&rx, DEBOUNCE * 3);
+        let rendered: Vec<String> = events
+            .iter()
+            .map(|e| format!("{:?} paths={:?}", e.event.kind, e.event.paths))
+            .collect();
+
+        // Deliberately not asserting the exact `EventKind`: what sub-item D
+        // needs is the *pairing*, and a backend is entitled to spell it
+        // differently. What it may not do is drop the old path, which is the
+        // only thing that makes a stale reference recoverable.
+        let paired = events
+            .iter()
+            .find(|e| e.event.paths.len() >= 2)
+            .unwrap_or_else(|| {
+                panic!(
+                    "a rename reported no event carrying both paths, so nothing \
+                     records where {from:?} went; sub-item D's recovery has no \
+                     in-engine source of former paths on this platform:\n{}",
+                    rendered.join("\n")
+                )
+            });
+
+        assert!(
+            paired.event.paths.contains(&from) && paired.event.paths.contains(&to),
+            "the paired event must name both the old and the new path, got {:?}",
+            paired.event.paths
+        );
+        assert_eq!(
+            paired.event.paths[0], from,
+            "old path must come first, or a recorder cannot tell which is which"
+        );
+    }
+
     fn probe(watch_root: &Path) -> Vec<DebouncedEvent> {
         let (tx, rx) = mpsc::channel();
         let mut debouncer = new_debouncer(DEBOUNCE, None, tx).unwrap();


### PR DESCRIPTION
A measurement, committed as a test, that de-risks item 30 sub-item D before it is built.

## Why

D recovers a stale asset path — the kind embedded in a JS string literal like `const NEXT_SCENE = "assets/scenes/level2.ron"` — by asking the index where that path's asset went. That needs **something to record the move**, and today only orphan recovery does. A rename made while the watcher is running records nothing: `drain_asset_changes` drops the source path because it no longer `is_file()`, and only reloads the destination.

So before designing D around "the index remembers former paths", the question is whether the information exists at all.

## Measured

It does — we were discarding it. `notify-debouncer-full`'s `FileIdMap` stitches the backend's two halves into a single event carrying **both** paths, old first:

```
Modify(Name(Both)) paths=[".../assets/models/thing.txt", ".../assets/models/renamed.txt"]
```

## What the test asserts, and what it deliberately does not

It asserts the **pairing** — that some event names both the old and the new path, old first — not the exact `EventKind`. A backend is entitled to spell a rename differently; it may not drop the old path, because that is the only thing making a stale reference recoverable.

This matters cross-platform, and getting it through CI is half the point: I measured on Windows, and asserting a Windows-only fact as universal is a mistake this effort already made once (PR #1754's predecessor). If Linux reports renames differently, this test says so here rather than after D is built on the assumption.

Failure is silent otherwise: a rename that loses its old path still looks like an ordinary change to the destination, so nothing would look wrong until a recovery quietly stopped working.

## Test Plan

- [x] `bsengine-asset`: 86 → 87, run 3 consecutive times (timing-dependent; 1.42–1.43 s each)
- [x] `cargo fmt --check` clean
- [ ] CI answers the Linux question

🤖 Generated with [Claude Code](https://claude.com/claude-code)
