### PR TITLE
fix(core): the remaining reflect wrappers can be deserialized

### DIFF
--- a/crates/bsengine-core/src/reflect_degrees.rs
+++ b/crates/bsengine-core/src/reflect_degrees.rs
@@ -19,7 +19,9 @@
 //! `SpotLight.inner_angle_degrees`/`outer_angle_degrees` ("PR C-3") is the
 //! second. Both Camera and SpotLight now store their angle fields in
 //! degrees internally.
-use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
+use bevy_reflect::{
+    impl_reflect_value, prelude::ReflectDefault, ReflectDeserialize, ReflectSerialize,
+};
 
 /// Reflectable `f32` wrapper representing an angle in degrees, used to signal
 /// to the generic reflected-field editor that a field should render as an angle.
@@ -52,7 +54,30 @@ impl From<ReflectDegrees> for f32 {
     }
 }
 
-impl_reflect_value!((in bsengine_core::reflect_degrees) ReflectDegrees(Debug, PartialEq, Default));
+// Serialised as the bare float it wraps, so a scene writes `30.0`.
+//
+// `Serialize`/`Deserialize` in the list below are what register
+// `ReflectDeserialize`, and without it any component holding this type fails
+// to deserialize -- silently, taking the whole component with it.
+impl serde::Serialize for ReflectDegrees {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serde::Serialize::serialize(&self.0, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ReflectDegrees {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self(f32::deserialize(deserializer)?))
+    }
+}
+
+impl_reflect_value!((in bsengine_core::reflect_degrees) ReflectDegrees(
+    Debug,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize
+));
 
 #[cfg(test)]
 mod tests {

--- a/crates/bsengine-core/src/reflect_glam.rs
+++ b/crates/bsengine-core/src/reflect_glam.rs
@@ -19,10 +19,12 @@
 //! The macro's custom-path form, `impl_reflect_value!((in crate_name::module) Type(...))`, is the
 //! documented way to reflect a local type: the bare `Type` resolves normally in this scope, while
 //! `(in ...)` only supplies the string used for `reflect_type_path()`.
-use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
+use bevy_reflect::{
+    impl_reflect_value, prelude::ReflectDefault, ReflectDeserialize, ReflectSerialize,
+};
 
 macro_rules! reflect_glam_wrapper {
-    ($doc:expr, $wrapper:ident, $inner:ty) => {
+    ($doc:expr, $wrapper:ident, $inner:ty, $array:ty) => {
         #[doc = $doc]
         #[derive(Debug, Clone, Copy, PartialEq, Default)]
         pub struct $wrapper(pub $inner);
@@ -52,34 +54,86 @@ macro_rules! reflect_glam_wrapper {
                 value.0
             }
         }
+
+        // Serialised as a plain sequence of floats, so a scene writes
+        // `(1.0, 2.0, 3.0)`. Hand-written rather than derived to keep `glam`'s
+        // optional `serde` feature off: these are two to sixteen f32s and
+        // nothing about the representation needs `glam` to know how.
+        //
+        // The point of having them at all is `ReflectDeserialize`, registered
+        // below. `impl_reflect_value!` makes each wrapper an *opaque* leaf as
+        // far as reflection is concerned, and an opaque type without that data
+        // cannot be deserialised -- which takes the whole containing component
+        // down silently, with a warning and no error.
+        impl serde::Serialize for $wrapper {
+            #[allow(clippy::needless_borrow)]
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serde::Serialize::serialize(&self.0.to_array(), serializer)
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $wrapper {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let raw = <$array>::deserialize(deserializer)?;
+                Ok(Self(<$inner>::from_array(raw)))
+            }
+        }
     };
 }
 
 reflect_glam_wrapper!(
     "Reflectable wrapper around a `glam::Vec2`.",
     ReflectVec2,
-    glam::Vec2
+    glam::Vec2,
+    [f32; 2]
 );
 reflect_glam_wrapper!(
     "Reflectable wrapper around a `glam::Vec3`.",
     ReflectVec3,
-    glam::Vec3
+    glam::Vec3,
+    [f32; 3]
 );
 reflect_glam_wrapper!(
     "Reflectable wrapper around a `glam::Vec4`.",
     ReflectVec4,
-    glam::Vec4
+    glam::Vec4,
+    [f32; 4]
 );
 reflect_glam_wrapper!(
     "Reflectable wrapper around a `glam::Quat`.",
     ReflectQuat,
-    glam::Quat
+    glam::Quat,
+    [f32; 4]
 );
 
-impl_reflect_value!((in bsengine_core::reflect_glam) ReflectVec2(Debug, PartialEq, Default));
-impl_reflect_value!((in bsengine_core::reflect_glam) ReflectVec3(Debug, PartialEq, Default));
-impl_reflect_value!((in bsengine_core::reflect_glam) ReflectVec4(Debug, PartialEq, Default));
-impl_reflect_value!((in bsengine_core::reflect_glam) ReflectQuat(Debug, PartialEq, Default));
+impl_reflect_value!((in bsengine_core::reflect_glam) ReflectVec2(
+    Debug,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize
+));
+impl_reflect_value!((in bsengine_core::reflect_glam) ReflectVec3(
+    Debug,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize
+));
+impl_reflect_value!((in bsengine_core::reflect_glam) ReflectVec4(
+    Debug,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize
+));
+impl_reflect_value!((in bsengine_core::reflect_glam) ReflectQuat(
+    Debug,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize
+));
 
 #[cfg(test)]
 mod tests {

--- a/crates/bsengine-core/src/reflect_mat4.rs
+++ b/crates/bsengine-core/src/reflect_mat4.rs
@@ -6,7 +6,9 @@
 //! reason documented in `reflect_glam.rs`: neither `Reflect` nor `glam::Mat4`
 //! is local to this crate, so `Reflect` can't be implemented for `Mat4`
 //! directly.
-use bevy_reflect::{impl_reflect_value, prelude::ReflectDefault};
+use bevy_reflect::{
+    impl_reflect_value, prelude::ReflectDefault, ReflectDeserialize, ReflectSerialize,
+};
 
 /// Reflectable wrapper around a `glam::Mat4`.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -38,7 +40,32 @@ impl From<ReflectMat4> for glam::Mat4 {
     }
 }
 
-impl_reflect_value!((in bsengine_core::reflect_mat4) ReflectMat4(Debug, PartialEq, Default));
+// Serialised as sixteen floats in column-major order, which is `to_cols_array`'s
+// own layout. Hand-written to keep glam's serde feature off.
+//
+// Registered with `Serialize`/`Deserialize` for the same reason as the other
+// wrappers: an opaque reflect type without `ReflectDeserialize` cannot be
+// deserialized, and its absence takes the containing component down silently.
+impl serde::Serialize for ReflectMat4 {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serde::Serialize::serialize(&self.0.to_cols_array(), serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ReflectMat4 {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <[f32; 16]>::deserialize(deserializer)?;
+        Ok(Self(glam::Mat4::from_cols_array(&raw)))
+    }
+}
+
+impl_reflect_value!((in bsengine_core::reflect_mat4) ReflectMat4(
+    Debug,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize
+));
 
 #[cfg(test)]
 mod tests {

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -613,6 +613,82 @@ mod tests {
     }
 
     #[test]
+    fn every_reflect_wrapper_can_be_authored_in_a_scene() {
+        // `impl_reflect_value!` makes these opaque leaf types, and an opaque
+        // type can only be deserialized through `ReflectDeserialize`. Without
+        // it the whole *containing component* comes back absent -- a warning in
+        // the log, no error, and an entity quietly missing what the scene said
+        // it had. `ReflectColor` had exactly that until item 28 tripped over
+        // it; this covers the siblings so the next one is caught here rather
+        // than in a game.
+        //
+        // Driven through real components, because the wrappers are only
+        // reachable that way: Transform holds two ReflectVec3s and a
+        // ReflectQuat, SpotLight a ReflectDegrees.
+        //
+        // ReflectVec2, ReflectVec4 and ReflectMat4 are fixed the same way but
+        // cannot be covered here: no component has a field of those types, so
+        // there is nothing to author. They are done for uniformity -- six
+        // near-identical wrappers where three behave differently is its own
+        // trap.
+        // `Follow` is deliberately not in this list even though it holds a
+        // ReflectVec3: its other field is a `bevy_ecs::entity::Entity`, which
+        // has no ReflectDeserialize either -- and should not. An entity id is a
+        // runtime handle, so a scene naming one would be pointing at whichever
+        // entity happened to land in that slot. Not authorable is the right
+        // answer there, and it is a different fact from the one this test is
+        // about.
+        let cases: [(&str, &str); 2] = [
+            (
+                "bsengine_core::transform::Transform",
+                "(position: (1.0, 2.0, 3.0), rotation: (0.0, 0.0, 0.0, 1.0), scale: (1.0, 1.0, 1.0))",
+            ),
+            (
+                "bsengine_core::light::SpotLight",
+                "(color: (1.0, 1.0, 1.0), intensity: 1.0, range: 10.0, inner_angle_degrees: 15.0, outer_angle_degrees: 30.0)",
+            ),
+        ];
+
+        for (path, value) in cases {
+            // Built rather than parsed: nesting a RON value inside a RON
+            // string inside a Rust raw string is three levels of quoting for
+            // no gain.
+            let mut scene: crate::types::SceneDescriptor =
+                ron::from_str(r#"SceneDescriptor(entities: [EntityDescriptor(name: "E")])"#)
+                    .expect("the base scene should parse");
+            scene.entities[0].components = vec![(path.to_string(), value.to_string())];
+
+            let mut app = new_app();
+            super::register_gameplay_reflect_types(&mut app);
+            super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+            let entity = app
+                .world()
+                .iter_entities()
+                .next()
+                .expect("the entity should exist")
+                .id();
+            let registry = app
+                .world()
+                .resource::<bevy_ecs::reflect::AppTypeRegistry>()
+                .clone();
+            let registry = registry.read();
+            let registration = registry
+                .get_with_type_path(path)
+                .unwrap_or_else(|| panic!("{path} is not registered for reflection"));
+            let reflect_component = registration
+                .data::<bevy_ecs::reflect::ReflectComponent>()
+                .unwrap_or_else(|| panic!("{path} has no ReflectComponent"));
+            assert!(
+                reflect_component
+                    .reflect(app.world().entity(entity))
+                    .is_some(),
+                "{path} did not survive deserialization -- one of its fields is an                  opaque wrapper with no ReflectDeserialize"
+            );
+        }
+    }
+
+    #[test]
     fn mini_arenas_hit_spark_emitter_survives_deserialization() {
         // A reflected component can fail to deserialize *silently*: the scene
         // parses, the entity spawns, a warning goes to the log and the


### PR DESCRIPTION
Follow-up to item 28, which found `ReflectColor` had no `ReflectDeserialize` — and therefore that **any component holding one failed to deserialize**, silently: a warning in the log, no error, and the component simply absent on the spawned entity.

Its five siblings had the same gap. `Transform` is among the components affected.

## What changed

All six wrappers (`ReflectVec2/3/4`, `ReflectQuat`, `ReflectDegrees`, `ReflectMat4`) now serialize as the floats they wrap and register `Serialize`/`Deserialize`. Hand-written rather than derived so glam's optional `serde` feature stays off — these are one to sixteen f32s, and nothing about the representation needs glam to know how. The four in `reflect_glam.rs` share a macro, so the impls go in once.

`ReflectVec2`, `ReflectVec4` and `ReflectMat4` have no component fields today, so the guard cannot reach them. Fixed anyway: six near-identical wrappers where three behave differently is its own trap.

## Proven before fixed, and one case withdrawn

The Red test used `Follow` (holds a `ReflectVec3`) and failed as expected. After the fix it **still** failed — because `Follow`'s other field is a `bevy_ecs::entity::Entity`, which has no `ReflectDeserialize` either.

That one is not a gap. An entity id is a runtime handle, so a scene naming one would point at whichever entity happened to land in that slot; **not authorable is the correct answer**, and the test case was wrong rather than the engine. It now drives `Transform` and `SpotLight` instead, and the reasoning is recorded in the test so the next person does not "fix" it.

## Test Plan

- [x] Red first: `Transform` and `SpotLight` both failed to deserialize before the change
- [x] Mutation-verified twice — dropping the registration from the glam macro fails it, and dropping it from `ReflectDegrees` alone fails it
- [x] Workspace tests no failures; `bsengine-editor` 825 passed
- [x] All 8 E2E replays pass
- [x] `clippy --workspace --all-targets` no errors; `fmt --check` clean; `catalog --check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)