### PR TITLE
feat: headless E2E test runtime and MCP sessions gain offscreen pixel/screenshot verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
 name = "bsengine-runtime"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "bevy_app",
  "bevy_ecs",
  "bsengine-app",
@@ -1130,6 +1131,7 @@ dependencies = [
  "bsengine-scripting",
  "bsengine-window",
  "glam 0.29.3",
+ "image",
  "kira",
  "ron",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ glam              = "0.29"
 mint              = "0.5"
 gltf              = "1"
 image             = { version = "0.25", default-features = false, features = ["png", "jpeg", "hdr"] }
+base64            = "0.22"
 # Must stay on the version bevy_asset's own `file_watcher` feature requires, so
 # the workspace never holds two copies of notify.
 notify-debouncer-full = "0.3.1"

--- a/apps/bsengine-editor-app/src/main.rs
+++ b/apps/bsengine-editor-app/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
         // editor ever grows an open-a-project flow that swaps it, this scan
         // and the watcher both need rerunning, together.
         .add_plugins(AssetIdentityPlugin)
-        .add_plugins(WgpuRHIPlugin)
+        .add_plugins(WgpuRHIPlugin::windowed())
         .add_plugins(WindowPlugin {
             descriptor: WindowDescriptor {
                 title: "BSEngine Editor".to_string(),

--- a/crates/bsengine-app/src/main.rs
+++ b/crates/bsengine-app/src/main.rs
@@ -16,7 +16,7 @@ use glam::{Quat, Vec3};
 
 fn main() {
     new_app()
-        .add_plugins(WgpuRHIPlugin)
+        .add_plugins(WgpuRHIPlugin::windowed())
         .add_plugins(WindowPlugin::default())
         .add_plugins(InputPlugin)
         .add_plugins(RenderPlugin)

--- a/crates/bsengine-app/tests/render_pipeline.rs
+++ b/crates/bsengine-app/tests/render_pipeline.rs
@@ -16,7 +16,7 @@ fn count_frames(mut count: ResMut<FrameCount>) {
 fn render_pipeline_runs_multiple_frames() {
     let mut app = new_app();
     app.add_plugins(AssetPlugin)
-        .add_plugins(WgpuRHIPlugin)
+        .add_plugins(WgpuRHIPlugin::windowed())
         .add_plugins(RenderPlugin)
         .init_resource::<FrameCount>()
         .add_systems(Update, count_frames);
@@ -32,7 +32,7 @@ fn render_pipeline_runs_multiple_frames() {
 fn rhi_resource_accessible_after_plugin() {
     let mut app = new_app();
     app.add_plugins(AssetPlugin)
-        .add_plugins(WgpuRHIPlugin)
+        .add_plugins(WgpuRHIPlugin::windowed())
         .add_plugins(RenderPlugin);
 
     app.update();

--- a/crates/bsengine-demo/src/main.rs
+++ b/crates/bsengine-demo/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
             resizable: true,
         },
     });
-    app.add_plugins(WgpuRHIPlugin);
+    app.add_plugins(WgpuRHIPlugin::windowed());
     app.add_plugins(RenderPlugin);
     app.add_plugins(GltfPlugin);
     app.add_systems(Update, (setup, spin));

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -399,7 +399,7 @@ mod tests {
     fn gltf_plugin_builds_and_runs() {
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(GltfPlugin);
         app.update();
     }
@@ -424,7 +424,7 @@ mod tests {
         // returns early and the GltfAsset marker stays on the entity.
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(GltfPlugin);
         let e = app.world_mut().spawn(GltfAsset::new("bad.gltf")).id();
         app.update();
@@ -440,7 +440,7 @@ mod tests {
         // Task 7, once a real .glb fixture exists).
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(GltfPlugin);
         let e = app.world_mut().spawn(GltfAsset::new("missing.gltf")).id();
         app.update();
@@ -465,7 +465,7 @@ mod tests {
 
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(GltfPlugin);
 
         let handle = {
@@ -791,7 +791,7 @@ mod tests {
 
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(GltfPlugin);
         insert_headless_gpu_registries(&mut app);
         let e = app.world_mut().spawn(GltfAsset::new(path.clone())).id();
@@ -958,7 +958,7 @@ mod tests {
 
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(GltfPlugin);
         app.add_plugins(SkinnedMeshPlugin);
         insert_headless_gpu_registries(&mut app);
@@ -1291,7 +1291,7 @@ mod tests {
     fn missing_gltf_is_given_up_on_instead_of_retried_forever() {
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(GltfPlugin);
         let e = app
             .world_mut()

--- a/crates/bsengine-mcp/src/server.rs
+++ b/crates/bsengine-mcp/src/server.rs
@@ -119,9 +119,7 @@ impl McpServer {
         match reg.execute(&name, args) {
             Ok(out) => {
                 if out.is_ok() {
-                    json!({
-                        "content": [{ "type": "text", "text": out.content.to_string() }],
-                    })
+                    json!({ "content": [content_block(&out.content)] })
                 } else {
                     json!({
                         "content": [{ "type": "text", "text": out.error.unwrap_or_default() }],
@@ -143,6 +141,19 @@ impl McpServer {
             "error": { "code": code, "message": message },
         })
     }
+}
+
+/// A successful tool output's MCP content block. A `screenshot` query's
+/// `{"format": "png", "data_base64": "..."}` becomes a standard MCP image
+/// block so a client renders it as a picture instead of a wall of base64
+/// text; everything else keeps going out as text, exactly as before.
+fn content_block(content: &Value) -> Value {
+    if content.get("format").and_then(|v| v.as_str()) == Some("png") {
+        if let Some(data) = content.get("data_base64").and_then(|v| v.as_str()) {
+            return json!({ "type": "image", "data": data, "mimeType": "image/png" });
+        }
+    }
+    json!({ "type": "text", "text": content.to_string() })
 }
 
 #[cfg(test)]
@@ -205,6 +216,49 @@ mod tests {
         let content = resp["result"]["content"].as_array().unwrap();
         assert_eq!(content[0]["type"], "text");
         assert!(content[0]["text"].as_str().unwrap().contains("pong"));
+    }
+
+    #[test]
+    fn tools_call_wraps_a_png_payload_as_an_image_content_block() {
+        let mut reg = McpToolRegistry::new();
+        reg.register(McpTool {
+            name: "fake_screenshot".to_string(),
+            description: "test".to_string(),
+            input_schema: None,
+            handler: Box::new(|_| {
+                McpToolOutput::success(json!({
+                    "width": 1,
+                    "height": 1,
+                    "format": "png",
+                    "data_base64": "iVBORw0KGgo=",
+                }))
+            }),
+        });
+        let server = McpServer::new(Arc::new(Mutex::new(reg)));
+        let resp = server
+            .handle_message(json!({
+                "jsonrpc": "2.0", "id": 7,
+                "method": "tools/call",
+                "params": { "name": "fake_screenshot", "arguments": {} }
+            }))
+            .unwrap();
+        let content = &resp["result"]["content"][0];
+        assert_eq!(content["type"], "image");
+        assert_eq!(content["mimeType"], "image/png");
+        assert_eq!(content["data"], "iVBORw0KGgo=");
+    }
+
+    #[test]
+    fn tools_call_still_wraps_non_png_output_as_text() {
+        let server = make_server();
+        let resp = server
+            .handle_message(json!({
+                "jsonrpc": "2.0", "id": 8,
+                "method": "tools/call",
+                "params": { "name": "ping", "arguments": {} }
+            }))
+            .unwrap();
+        assert_eq!(resp["result"]["content"][0]["type"], "text");
     }
 
     #[test]

--- a/crates/bsengine-mcp/src/test_tools.rs
+++ b/crates/bsengine-mcp/src/test_tools.rs
@@ -205,10 +205,10 @@ fn asset_status_tool(registry: Arc<SessionRegistry>) -> McpTool {
             \"failed: \" plus the reason. Spell `path` project-relative, exactly as a \
             scene or script spells it — e.g. \"assets/sounds/hit.wav\", the same string \
             you would pass to Bsengine.playSound. (The engine's own fully-qualified key, \
-            this session's project directory followed by that, also works.) NOTE: a \
-            --test session builds no renderer and no glTF importer, so meshes, shaders \
-            and textures are never requested there and read \"unknown\" no matter how \
-            they are spelled; sounds and scripts are requested and are tracked. When the \
+            this session's project directory followed by that, also works.) A \
+            --test session now builds a renderer and a glTF importer too, so meshes, \
+            shaders and textures are requested and tracked exactly as sounds and scripts \
+            already were. When the \
             answer is \"unknown\", the result also carries `known_paths`: every path this \
             session does know about, so a spelling mistake is visible rather than \
             guessable. Also available as the get_asset_status query tool, so \

--- a/crates/bsengine-mcp/tests/test_tools.rs
+++ b/crates/bsengine-mcp/tests/test_tools.rs
@@ -105,6 +105,106 @@ fn full_session_round_trip() {
     assert!(out.is_ok(), "{:?}", out.error);
 }
 
+#[test]
+fn get_pixel_and_screenshot_work_through_test_query_state() {
+    let tools = test_tools(test_registry());
+
+    let start = find(&tools, "test_session_start");
+    let out = (start.handler)(json!({"game": "cube-evader"}));
+    assert!(out.is_ok(), "{:?}", out.error);
+    let session_id = out.content["session_id"].as_str().unwrap().to_string();
+
+    let step = find(&tools, "test_step");
+    let out = (step.handler)(json!({"session_id": session_id, "frames": 1}));
+    assert!(out.is_ok(), "{:?}", out.error);
+
+    let query = find(&tools, "test_query_state");
+    let out = (query.handler)(json!({
+        "session_id": session_id,
+        "tool": "get_pixel",
+        "args": {"x": 0, "y": 0},
+    }));
+    assert!(out.is_ok(), "{:?}", out.error);
+    assert!(out.content["luma"].is_number(), "{:?}", out.content);
+
+    let out = (query.handler)(json!({
+        "session_id": session_id,
+        "tool": "screenshot",
+        "args": {},
+    }));
+    assert!(out.is_ok(), "{:?}", out.error);
+    assert_eq!(out.content["format"], "png");
+    assert!(out.content["data_base64"].is_string());
+}
+
+/// The property `get_pixel_and_screenshot_work_through_test_query_state` does
+/// not cover: that a real `screenshot` payload from a real running game,
+/// wrapped by a real `McpServer::handle_message`'s `tools/call` path, comes
+/// out as an MCP image content block. That test calls `test_query_state`'s
+/// handler directly, bypassing `handle_message`/`content_block` entirely, so
+/// nothing proved the two halves — real PNG bytes, and the JSON-RPC layer
+/// that recognizes them — actually compose. `server.rs`'s own
+/// `tools_call_wraps_a_png_payload_as_an_image_content_block` proves
+/// `content_block`'s detection logic against a synthetic fixture; this proves
+/// the same wrapping against the genuine `screenshot` tool's output.
+#[test]
+fn screenshot_reaches_an_mcp_client_as_an_image_content_block() {
+    use std::sync::Mutex;
+
+    use bsengine_mcp::{McpServer, McpToolRegistry};
+
+    let tools = test_tools(test_registry());
+
+    // Session lifecycle via direct handler calls, same pattern as every
+    // other test in this file — the part under test is the query call, not
+    // session setup.
+    let start = find(&tools, "test_session_start");
+    let out = (start.handler)(json!({"game": "cube-evader"}));
+    assert!(out.is_ok(), "{:?}", out.error);
+    let session_id = out.content["session_id"].as_str().unwrap().to_string();
+
+    let step = find(&tools, "test_step");
+    let out = (step.handler)(json!({"session_id": session_id, "frames": 1}));
+    assert!(out.is_ok(), "{:?}", out.error);
+
+    // Now hand the same tools (still bound to the session that's live above)
+    // to a real McpServer, and drive the screenshot query the way an actual
+    // MCP client would: a JSON-RPC tools/call request through handle_message.
+    let mut registry = McpToolRegistry::new();
+    for tool in tools {
+        registry.register(tool);
+    }
+    let server = McpServer::new(Arc::new(Mutex::new(registry)));
+
+    let resp = server
+        .handle_message(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "test_query_state",
+                "arguments": {
+                    "session_id": session_id,
+                    "tool": "screenshot",
+                    "args": {},
+                },
+            },
+        }))
+        .expect("tools/call must produce a response");
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "tools/call reported an error: {resp:?}"
+    );
+    let content = &resp["result"]["content"][0];
+    assert_eq!(content["type"], "image", "{resp:?}");
+    assert_eq!(content["mimeType"], "image/png", "{resp:?}");
+    assert!(
+        content["data"].as_str().is_some_and(|d| !d.is_empty()),
+        "the image block must carry real PNG bytes, not an empty placeholder: {resp:?}"
+    );
+}
+
 // Being present in `passthrough_specs()` is not the same as reaching an MCP
 // client: the tool only works if the assembled list carries it and its
 // `child_cmd` is a command the runtime actually parses. Drive it against a

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1069,7 +1069,7 @@ mod tests {
 
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(RenderPlugin);
         app.world_mut()
             .spawn(bsengine_core::CustomShader { path: path.clone() });
@@ -1177,7 +1177,7 @@ mod tests {
 
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(RenderPlugin);
         app.world_mut()
             .spawn(bsengine_core::CustomShader { path: path.clone() });
@@ -1389,7 +1389,7 @@ mod tests {
     fn missing_shader_is_given_up_on_instead_of_retried_forever() {
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(RenderPlugin);
         app.world_mut().spawn(bsengine_core::CustomShader {
             path: "definitely/not/a/real/shader.wgsl".to_string(),
@@ -1470,7 +1470,7 @@ mod tests {
 
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(RenderPlugin);
         app.insert_resource(bsengine_core::SkyboxPath(Some(path.clone())));
 
@@ -1578,7 +1578,7 @@ mod tests {
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
         app.add_plugins(AssetStatusPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(RenderPlugin);
         app.insert_resource(bsengine_core::SkyboxPath(Some(path.clone())));
 
@@ -1610,7 +1610,7 @@ mod tests {
     fn missing_skybox_is_given_up_on_instead_of_retried_forever() {
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(RenderPlugin);
         app.insert_resource(bsengine_core::SkyboxPath(Some(
             "definitely/not/a/real/sky.png".to_string(),
@@ -1666,7 +1666,7 @@ mod tests {
     fn skybox_path_change_mid_load_requests_the_new_path_instead() {
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(RenderPlugin);
         app.insert_resource(bsengine_core::SkyboxPath(Some("first/sky.png".to_string())));
 
@@ -1715,7 +1715,7 @@ mod tests {
     fn turning_the_skybox_off_mid_load_drops_the_in_flight_request() {
         let mut app = new_app();
         app.add_plugins(bsengine_asset::AssetPlugin);
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(RenderPlugin);
         app.insert_resource(bsengine_core::SkyboxPath(Some("some/sky.png".to_string())));
 
@@ -1743,7 +1743,7 @@ mod tests {
     #[test]
     fn render_plugin_runs_with_rhi_headless() {
         let mut app = new_app();
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(bsengine_asset::AssetPlugin);
         app.add_plugins(RenderPlugin);
         app.update();
@@ -1754,7 +1754,7 @@ mod tests {
     #[test]
     fn camera_aspect_updates_on_window_resize() {
         let mut app = new_app();
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(bsengine_asset::AssetPlugin);
         app.add_plugins(RenderPlugin);
 
@@ -1773,7 +1773,7 @@ mod tests {
     #[test]
     fn render_plugin_accepts_point_lights() {
         let mut app = new_app();
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(bsengine_asset::AssetPlugin);
         app.add_plugins(RenderPlugin);
         app.world_mut().spawn((
@@ -1790,7 +1790,7 @@ mod tests {
     #[test]
     fn render_plugin_uses_pbr_material() {
         let mut app = new_app();
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(bsengine_asset::AssetPlugin);
         app.add_plugins(RenderPlugin);
         app.world_mut().spawn((
@@ -1810,7 +1810,7 @@ mod tests {
     fn render_plugin_accepts_spot_lights() {
         use bsengine_core::SpotLight;
         let mut app = new_app();
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         app.add_plugins(bsengine_asset::AssetPlugin);
         app.add_plugins(RenderPlugin);
         app.world_mut().spawn((

--- a/crates/bsengine-rhi-wgpu/src/plugin.rs
+++ b/crates/bsengine-rhi-wgpu/src/plugin.rs
@@ -19,9 +19,45 @@ pub struct RhiResource(pub Arc<dyn RHI>);
 #[derive(Resource)]
 pub struct GpuQueueResource(pub Arc<wgpu::Queue>);
 
-/// Bevy plugin that initializes the wgpu RHI, creates the swapchain surface,
-/// and wires up window-resize handling.
-pub struct WgpuRHIPlugin;
+/// Where `WgpuRHIPlugin` gets its render target from.
+#[derive(Clone, Copy, Debug)]
+pub enum SurfaceMode {
+    /// Wait for a `WindowHandle` resource (produced by `bsengine_window`'s
+    /// winit event loop) and build a swapchain surface from it. A surface
+    /// that fails to build only warns -- the windowed runtime keeps running
+    /// with no renderer rather than crashing on a bad adapter.
+    Windowed,
+    /// Build an offscreen render target immediately, no window needed.
+    /// Failing to get an adapter is a hard error: the headless test runtime
+    /// exists specifically to render and read pixels back, so a silent
+    /// no-renderer fallback here would make every pixel query fail with no
+    /// clue why.
+    Offscreen {
+        /// Render target width, in pixels.
+        width: u32,
+        /// Render target height, in pixels.
+        height: u32,
+    },
+}
+
+/// Bevy plugin that initializes the wgpu RHI, creates the render target
+/// (swapchain or offscreen texture), and wires up window-resize handling.
+pub struct WgpuRHIPlugin(pub SurfaceMode);
+
+impl WgpuRHIPlugin {
+    /// A surface built from a `WindowHandle`, once one appears. The mode
+    /// every call site used before offscreen rendering existed.
+    pub fn windowed() -> Self {
+        Self(SurfaceMode::Windowed)
+    }
+
+    /// A surface built immediately from an offscreen texture of `width` x
+    /// `height` pixels, no window required. Panics at `Startup` if no
+    /// adapter can rasterise -- see `SurfaceMode::Offscreen`.
+    pub fn offscreen(width: u32, height: u32) -> Self {
+        Self(SurfaceMode::Offscreen { width, height })
+    }
+}
 
 impl Plugin for WgpuRHIPlugin {
     fn build(&self, app: &mut App) {
@@ -29,30 +65,54 @@ impl Plugin for WgpuRHIPlugin {
             pollster::block_on(WgpuRHI::new_headless()).expect("Failed to initialize WgpuRHI");
         app.insert_resource(RhiResource(Arc::new(rhi)));
         app.add_event::<WindowResized>();
-        app.add_systems(Startup, create_surface_system);
+        let mode = self.0;
+        app.add_systems(Startup, move |world: &mut World| {
+            create_surface_system(world, mode)
+        });
         app.add_systems(Update, handle_window_resize);
     }
 }
 
-fn create_surface_system(world: &mut World) {
-    let handle = world.get_resource::<WindowHandle>().cloned();
-    if let Some(handle) = handle {
-        match pollster::block_on(WgpuSurface::new(handle.0)) {
-            Ok(surface) => {
-                let registry = GpuMeshRegistry::new(surface.device.clone());
-                let tex_registry =
-                    GpuTextureRegistry::new(surface.device.clone(), surface.queue.clone());
-                world.insert_resource(GpuQueueResource(surface.queue.clone()));
-                world.insert_resource(WgpuSurfaceResource(surface));
-                world.insert_resource(registry);
-                world.insert_resource(tex_registry);
-                tracing::info!("wgpu surface, mesh registry, and texture registry ready");
-            }
-            Err(e) => {
-                tracing::warn!("wgpu surface not created: {e}");
+fn create_surface_system(world: &mut World, mode: SurfaceMode) {
+    let surface = match mode {
+        SurfaceMode::Windowed => {
+            let handle = world.get_resource::<WindowHandle>().cloned();
+            match handle {
+                Some(handle) => match pollster::block_on(WgpuSurface::new(handle.0)) {
+                    Ok(surface) => Some(surface),
+                    Err(e) => {
+                        tracing::warn!("wgpu surface not created: {e}");
+                        None
+                    }
+                },
+                None => None,
             }
         }
-    }
+        SurfaceMode::Offscreen { width, height } => {
+            match pollster::block_on(WgpuSurface::new_offscreen(width, height)) {
+                Ok(surface) => Some(surface),
+                Err(e) => panic!(
+                    "could not create an offscreen wgpu renderer: {e}\n\
+                     The headless test runtime needs an adapter that can actually \
+                     rasterise. On Linux CI that is mesa-vulkan-drivers (lavapipe); on \
+                     Windows it is normally the D3D12 WARP adapter. If this environment \
+                     has neither, that is the finding worth reporting -- do not silence \
+                     it by skipping."
+                ),
+            }
+        }
+    };
+
+    let Some(surface) = surface else {
+        return;
+    };
+    let registry = GpuMeshRegistry::new(surface.device.clone());
+    let tex_registry = GpuTextureRegistry::new(surface.device.clone(), surface.queue.clone());
+    world.insert_resource(GpuQueueResource(surface.queue.clone()));
+    world.insert_resource(WgpuSurfaceResource(surface));
+    world.insert_resource(registry);
+    world.insert_resource(tex_registry);
+    tracing::info!("wgpu surface, mesh registry, and texture registry ready");
 }
 
 fn handle_window_resize(
@@ -71,20 +131,43 @@ fn handle_window_resize(
 #[cfg(test)]
 mod tests {
     use super::{RhiResource, WgpuRHIPlugin};
+    use crate::surface::WgpuSurfaceResource;
     use bsengine_app::new_app;
 
     #[test]
     fn wgpu_rhi_plugin_registers_rhi_resource() {
         let mut app = new_app();
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         assert!(app.world().get_resource::<RhiResource>().is_some());
     }
 
     #[test]
     fn rhi_resource_can_create_mesh() {
         let mut app = new_app();
-        app.add_plugins(WgpuRHIPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
         let rhi = app.world().resource::<RhiResource>();
         let _mesh = rhi.0.create_mesh();
+    }
+
+    #[test]
+    fn windowed_mode_creates_no_surface_without_a_window_handle() {
+        let mut app = new_app();
+        app.add_plugins(WgpuRHIPlugin::windowed());
+        app.update();
+        assert!(
+            app.world().get_resource::<WgpuSurfaceResource>().is_none(),
+            "windowed mode must wait for a WindowHandle before creating a surface"
+        );
+    }
+
+    #[test]
+    fn offscreen_mode_creates_a_surface_with_no_window_handle() {
+        let mut app = new_app();
+        app.add_plugins(WgpuRHIPlugin::offscreen(64, 64));
+        app.update();
+        assert!(
+            app.world().get_resource::<WgpuSurfaceResource>().is_some(),
+            "offscreen mode must create a WgpuSurfaceResource without a WindowHandle"
+        );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -802,6 +802,16 @@ impl WgpuSurface {
         }
     }
 
+    /// The width of the render target, in pixels.
+    pub fn width(&self) -> u32 {
+        self.output.width()
+    }
+
+    /// The height of the render target, in pixels.
+    pub fn height(&self) -> u32 {
+        self.output.height()
+    }
+
     /// This renderer's GPU device, for callers that must put resources on the
     /// same device -- a `GpuMeshRegistry`, for one.
     pub fn device_arc(&self) -> Arc<wgpu::Device> {

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2744,6 +2744,29 @@ impl WgpuSurface {
         self.queue.submit(std::iter::once(encoder.finish()));
         if let Some(frame) = presentable {
             frame.present();
+        } else {
+            // Offscreen mode (headless E2E replays, MCP test sessions) has no
+            // swapchain to present to, so nothing else provides the
+            // backpressure `present()` gives the windowed path above --
+            // every `submit()` here would otherwise queue GPU work with zero
+            // synchronization between frames. Submitting faster than the GPU
+            // retires work can wrap wgpu-hal's D3D12 command-allocator ring
+            // before the GPU has finished an allocator's previous use,
+            // producing a hard D3D12 validation error (COMMAND_ALLOCATOR_SYNC
+            // / OBJECT_DELETED_WHILE_STILL_IN_USE) -- reproduced by every one
+            // of this workspace's E2E replays on Windows CI once offscreen
+            // rendering was turned on for the headless test runtime.
+            //
+            // Has to be inline here, not in `WgpuSurface`'s `Drop` impl: both
+            // teardown paths that hit this bug skip Rust destructors
+            // entirely -- an E2E replay's process exits via
+            // `std::process::exit` (`bsengine-runtime/src/main.rs`), and an
+            // MCP session's child is torn down via `Child::kill`
+            // (`bsengine-mcp/src/session.rs`) -- so a `Drop`-based wait alone
+            // (tried first; still present below, for the paths that *do*
+            // drop normally, e.g. this crate's own tests) never runs on
+            // either failing path.
+            self.device.poll(wgpu::Maintain::Wait);
         }
         Ok(clicked)
     }
@@ -2922,17 +2945,18 @@ impl WgpuSurface {
 
 impl Drop for WgpuSurface {
     fn drop(&mut self) {
-        // Every frame submits GPU work via `queue.submit` in `render_frame`.
-        // The windowed path gets implicit backpressure from `frame.present()`
-        // and the swapchain's PresentMode::Fifo; the offscreen path (headless
-        // E2E replays, MCP test sessions) has no swapchain and nothing to
-        // present, so nothing else ever waits for the GPU to catch up. Without
-        // this, dropping a WgpuSurface right after the last frame's submit can
-        // release the device/queue/staging buffers while the GPU still has
-        // that work in flight -- on Windows this is a hard D3D12 validation
-        // error (COMMAND_ALLOCATOR_SYNC / OBJECT_DELETED_WHILE_STILL_IN_USE),
-        // reproduced by every one of this workspace's E2E replays once
-        // offscreen rendering was turned on for the headless test runtime.
+        // Defense in depth for hosts that drop a WgpuSurface normally --
+        // this crate's own tests build an offscreen surface and let it go
+        // out of scope at the end of the test function, which does run
+        // Drop. It does NOT cover headless E2E replays or MCP test
+        // sessions: both tear their process down by means that skip Rust
+        // destructors entirely (`std::process::exit` in
+        // `bsengine-runtime/src/main.rs`, `Child::kill` in
+        // `bsengine-mcp/src/session.rs`), so this never runs on either of
+        // those paths. `render_frame`'s inline `device.poll(Maintain::Wait)`
+        // on the offscreen branch (see there) is what actually covers those
+        // -- this Drop impl alone was tried first and confirmed
+        // insufficient: CI failed identically with only this in place.
         self.device.poll(wgpu::Maintain::Wait);
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2920,6 +2920,23 @@ impl WgpuSurface {
     }
 }
 
+impl Drop for WgpuSurface {
+    fn drop(&mut self) {
+        // Every frame submits GPU work via `queue.submit` in `render_frame`.
+        // The windowed path gets implicit backpressure from `frame.present()`
+        // and the swapchain's PresentMode::Fifo; the offscreen path (headless
+        // E2E replays, MCP test sessions) has no swapchain and nothing to
+        // present, so nothing else ever waits for the GPU to catch up. Without
+        // this, dropping a WgpuSurface right after the last frame's submit can
+        // release the device/queue/staging buffers while the GPU still has
+        // that work in flight -- on Windows this is a hard D3D12 validation
+        // error (COMMAND_ALLOCATOR_SYNC / OBJECT_DELETED_WHILE_STILL_IN_USE),
+        // reproduced by every one of this workspace's E2E replays once
+        // offscreen rendering was turned on for the headless test runtime.
+        self.device.poll(wgpu::Maintain::Wait);
+    }
+}
+
 /// ECS resource wrapping the app's [`WgpuSurface`].
 #[derive(Resource)]
 pub struct WgpuSurfaceResource(pub WgpuSurface);

--- a/crates/bsengine-runtime/Cargo.toml
+++ b/crates/bsengine-runtime/Cargo.toml
@@ -26,6 +26,8 @@ bsengine-network   = { workspace = true }
 bsengine-editor    = { workspace = true }
 bsengine-scripting = { workspace = true }
 bsengine-window    = { workspace = true }
+image           = { workspace = true }
+base64          = { workspace = true }
 bevy_ecs        = { workspace = true }
 kira            = { workspace = true }
 ron             = { workspace = true }

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -172,7 +172,7 @@ fn run_windowed(project_dir: &str) {
         // Startup system runs — the same arrangement `AssetWatcherPlugin`
         // relies on above.
         .add_plugins(AssetIdentityPlugin)
-        .add_plugins(WgpuRHIPlugin)
+        .add_plugins(WgpuRHIPlugin::windowed())
         .add_plugins(WindowPlugin {
             descriptor: WindowDescriptor {
                 title,

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -30,7 +30,7 @@ pub struct ProjectSection {
     pub entry_scene: String,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize)]
 pub struct WindowSection {
     #[serde(default)]
     pub title: Option<String>,
@@ -40,6 +40,25 @@ pub struct WindowSection {
     pub height: u32,
     #[serde(default = "default_true")]
     pub resizable: bool,
+}
+
+// Not `#[derive(Default)]`: a derived impl gives every field its type's
+// zero value (width/height: 0, resizable: false), which disagrees with the
+// field-level `#[serde(default = "default_width")]` etc. above. The two
+// have to agree, because `ProjectManifest.window` is itself
+// `#[serde(default)]` -- a `project.toml` that omits `[window]` entirely
+// falls back to this impl, while one with a present-but-empty `[window]`
+// table falls back to the field-level defaults. Reusing the same functions
+// here is what makes "table absent" and "table empty" mean the same thing.
+impl Default for WindowSection {
+    fn default() -> Self {
+        Self {
+            title: None,
+            width: default_width(),
+            height: default_height(),
+            resizable: default_true(),
+        }
+    }
 }
 
 fn default_width() -> u32 {
@@ -259,6 +278,36 @@ pub fn resolve_physics_bodies_world(world: &mut World) {
 mod tests {
     use super::Name;
     use bsengine_core::HudTexts;
+
+    /// `ProjectManifest.window` is `#[serde(default)]`, so a `project.toml`
+    /// that omits `[window]` entirely (every hand-written fixture in this
+    /// file and most of `test_mode.rs`'s do) falls back to
+    /// `WindowSection::default()` rather than the field-level
+    /// `#[serde(default = "default_width")]`/etc. those two must agree, or
+    /// "no `[window]` table" silently means something different from
+    /// "`[window]` table present but empty" -- which is exactly what
+    /// happened when `WindowSection` derived its `Default` instead of
+    /// defining one: the derived impl gives `width: 0, height: 0`, and once
+    /// `build_test_app` started feeding those straight into
+    /// `WgpuRHIPlugin::offscreen`, every minimal `project.toml` in this
+    /// codebase's own tests crashed wgpu with "Dimension X is zero".
+    #[test]
+    fn window_section_defaults_to_1280x720_when_window_table_is_absent() {
+        let manifest: super::ProjectManifest = toml::from_str(
+            "[project]\nname = \"Test\"\nentry_scene = \"assets/scenes/a.ron\"\n",
+        )
+        .expect("a project.toml with no [window] table must still parse");
+        assert_eq!(
+            manifest.window.width, 1280,
+            "width must fall back to the same default a present-but-empty \
+             [window] table gets, not the derived Default's 0"
+        );
+        assert_eq!(
+            manifest.window.height, 720,
+            "height must fall back to the same default a present-but-empty \
+             [window] table gets, not the derived Default's 0"
+        );
+    }
 
     /// A two-scene project where scene A's script chains to scene B on its
     /// first `onUpdate`, and each scene's script announces itself through the

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -293,10 +293,9 @@ mod tests {
     /// codebase's own tests crashed wgpu with "Dimension X is zero".
     #[test]
     fn window_section_defaults_to_1280x720_when_window_table_is_absent() {
-        let manifest: super::ProjectManifest = toml::from_str(
-            "[project]\nname = \"Test\"\nentry_scene = \"assets/scenes/a.ron\"\n",
-        )
-        .expect("a project.toml with no [window] table must still parse");
+        let manifest: super::ProjectManifest =
+            toml::from_str("[project]\nname = \"Test\"\nentry_scene = \"assets/scenes/a.ron\"\n")
+                .expect("a project.toml with no [window] table must still parse");
         assert_eq!(
             manifest.window.width, 1280,
             "width must fall back to the same default a present-but-empty \

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -958,6 +958,39 @@ mod tests {
         );
     }
 
+    #[test]
+    fn screenshot_returns_a_decodable_png() {
+        let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
+        let mut app = build_test_app(&project_dir, None);
+        app.update();
+
+        let result = crate::test_query::run_query(app.world_mut(), "screenshot", &json!({}))
+            .expect("screenshot should succeed once RenderPlugin has drawn a frame");
+        let data_base64 = result["data_base64"]
+            .as_str()
+            .expect("screenshot should return a data_base64 string");
+        use base64::Engine;
+        let png_bytes = base64::engine::general_purpose::STANDARD
+            .decode(data_base64)
+            .expect("data_base64 should be valid base64");
+        assert!(
+            png_bytes.starts_with(&[0x89, b'P', b'N', b'G']),
+            "screenshot bytes should start with the PNG magic number"
+        );
+
+        let decoded = image::load_from_memory(&png_bytes).expect("PNG should actually decode");
+        assert_eq!(
+            decoded.width(),
+            result["width"].as_u64().unwrap() as u32,
+            "decoded PNG width should match the reported width"
+        );
+        assert_eq!(
+            decoded.height(),
+            result["height"].as_u64().unwrap() as u32,
+            "decoded PNG height should match the reported height"
+        );
+    }
+
     // Regression test for the PressKey/ReleaseKey protocol commands: they
     // must route through Events<KeyInput>, not mutate Input<KeyCode>
     // directly, or edge-triggered checks (just_pressed/just_released --

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -943,6 +943,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn get_pixel_reads_the_last_rendered_frame() {
+        let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
+        let mut app = build_test_app(&project_dir, None);
+        app.update();
+
+        let result =
+            crate::test_query::run_query(app.world_mut(), "get_pixel", &json!({"x": 0, "y": 0}))
+                .expect("get_pixel should succeed once RenderPlugin has drawn a frame");
+        assert!(
+            result.get("luma").and_then(|v| v.as_f64()).is_some(),
+            "get_pixel should report a luma value, got {result:?}"
+        );
+    }
+
     // Regression test for the PressKey/ReleaseKey protocol commands: they
     // must route through Events<KeyInput>, not mutate Input<KeyCode>
     // directly, or edge-triggered checks (just_pressed/just_released --

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -17,6 +17,10 @@ use bsengine_scene::ScenePlugin;
 use bsengine_scripting::{ScriptingPlugin, KEY_MAPPINGS};
 use serde_json::{json, Value};
 
+use bsengine_gltf::{GltfPlugin, SkinnedMeshPlugin};
+use bsengine_render::RenderPlugin;
+use bsengine_rhi_wgpu::WgpuRHIPlugin;
+
 use crate::scene_systems::{register_scene_systems, ProjectManifest};
 use crate::test_protocol::{Command, CommandResponse};
 use crate::test_query::{eval_op, eval_path, run_query};
@@ -57,17 +61,21 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>) -> App {
         // mode most likely to be automating that check — the same
         // registered-nowhere failure this plugin's absence caused before.
         //
-        // What it records here today is narrower than in the windowed
-        // runtime, and worth knowing before someone concludes it is broken:
-        // this app has no `RenderPlugin`, `GltfPlugin` or `SkinnedMeshPlugin`,
-        // so nothing ever requests a mesh, a shader or a texture. Replaying
-        // `games/mini-arena` records zero paths, while the same game windowed
-        // records its `fox.glb` and `glow.wgsl` as `Loaded`. Sounds *are*
-        // requested here (`AudioPlugin` and `playSound` are both present), so
-        // those are tracked. The distinction matters: an empty map means
-        // "genuinely nothing was requested", which is a true answer, whereas
-        // a missing resource would have meant "the engine cannot say" while
-        // sounding identical to a script.
+        // Historical note, since this comment predates the `RenderPlugin`/
+        // `GltfPlugin`/`SkinnedMeshPlugin` stack added below: before those
+        // existed here, nothing in this app ever requested a mesh, a shader
+        // or a texture, so replaying `games/mini-arena` recorded zero such
+        // paths while the same game windowed recorded its `fox.glb` and
+        // `glow.wgsl` as `Loaded`. See
+        // `mini_arenas_fox_mesh_loads_now_that_rendering_is_on` below for the
+        // regression test that closed that gap; mesh/shader/texture requests
+        // are tracked here the same as in the windowed runtime now. Sounds
+        // were always tracked too (`AudioPlugin` and `playSound` are both
+        // present). The distinction below still matters for anything this
+        // app genuinely never requests: an empty map means "genuinely
+        // nothing was requested", which is a true answer, whereas a missing
+        // resource would have meant "the engine cannot say" while sounding
+        // identical to a script.
         .add_plugins(AssetStatusPlugin)
         // Here for a blunter reason than the status plugin above: this app
         // adds `ScenePlugin`, and a scene is where an asset reference lives.
@@ -86,9 +94,33 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>) -> App {
         // Costs one walk of `<project_dir>/assets` at Startup, no thread and
         // no per-frame work, so a replay stays as reproducible as it was.
         .add_plugins(AssetIdentityPlugin)
+        // The point of this task: renders every frame now, offscreen
+        // instead of not at all. `WgpuRHIPlugin::offscreen` takes its
+        // dimensions from `manifest.window` rather than a fixed constant so
+        // a headless run renders at the same resolution the windowed
+        // runtime would actually open a window at -- letting the two modes
+        // diverge here would undermine any pixel comparison built on top of
+        // this later. `RenderPlugin`, `GltfPlugin` and `SkinnedMeshPlugin`
+        // are what actually request and draw a mesh or texture; without
+        // them `get_asset_status` could never answer anything about a
+        // `.glb`, which is the gap
+        // `mini_arenas_fox_mesh_loads_now_that_rendering_is_on` below closes.
+        //
+        // Both this block's position (between `PhysicsPlugin` and
+        // `NavMeshPlugin`) and its internal order deliberately mirror
+        // `main.rs`'s windowed chain -- a headless GPU stack built in a
+        // different order than the real runtime is a regression that would
+        // pass every test here while behaving differently windowed.
+        .add_plugins(WgpuRHIPlugin::offscreen(
+            manifest.window.width,
+            manifest.window.height,
+        ))
         .add_plugins(InputPlugin)
         .add_plugins(AudioPlugin)
         .add_plugins(PhysicsPlugin)
+        .add_plugins(RenderPlugin)
+        .add_plugins(GltfPlugin)
+        .add_plugins(SkinnedMeshPlugin)
         .add_plugins(NavMeshPlugin)
         // Same two as the windowed runtime, and for the reason item 11/12
         // recorded: a plugin present in one host and absent in the other is a
@@ -883,6 +915,32 @@ mod tests {
             "error must report how many frames were consumed, got {error:?}"
         );
         assert_eq!(frame, 2, "frames stepped before giving up must be counted");
+    }
+
+    // mini-arena is the one recording whose scene names a real mesh
+    // (fox.glb) and a real texture (the floor). Until this task, the
+    // headless app built no RenderPlugin/GltfPlugin, so nothing here ever
+    // requested either and get_asset_status answered "unknown" for both no
+    // matter how they were spelled -- see game_content.rs's
+    // mini_arenas_floor_is_textured for the test that had to work around
+    // that gap by reading the scene file directly instead.
+    #[test]
+    fn mini_arenas_fox_mesh_loads_now_that_rendering_is_on() {
+        let project_dir = format!("{}/../../games/mini-arena", env!("CARGO_MANIFEST_DIR"));
+        let mut app = build_test_app(&project_dir, None);
+        let mut status = Value::Null;
+        for _ in 0..200 {
+            app.update();
+            status = crate::test_query::get_asset_status(app.world_mut(), "assets/models/fox.glb");
+            if status == json!("loaded") {
+                break;
+            }
+        }
+        assert_eq!(
+            status,
+            json!("loaded"),
+            "fox.glb should load now that build_test_app includes GltfPlugin; last status: {status}"
+        );
     }
 
     // Regression test for the PressKey/ReleaseKey protocol commands: they

--- a/crates/bsengine-runtime/src/test_query.rs
+++ b/crates/bsengine-runtime/src/test_query.rs
@@ -6,6 +6,7 @@
 use bevy_ecs::world::World;
 use bsengine_asset::{AssetStatus, AssetStatuses};
 use bsengine_core::{HudTexts, ProjectDir, Transform, Visible};
+use bsengine_rhi_wgpu::WgpuSurfaceResource;
 use bsengine_scene::Name;
 use bsengine_scripting::ops::render_asset_status;
 use serde_json::{json, Value};
@@ -133,6 +134,30 @@ pub fn get_known_asset_paths(world: &mut World) -> Value {
     json!(paths)
 }
 
+/// Reads one pixel from the most recently rendered frame, as sRGB-encoded
+/// RGBA plus a perceptual brightness (`luma`) computed the same way
+/// `bsengine-rhi-wgpu`'s pixel test harness does. Errors when no renderer is
+/// attached (no `WgpuSurfaceResource` -- a host with no `WgpuRHIPlugin`, or
+/// one still waiting on a `WindowHandle`) or when `x`/`y` fall outside the
+/// frame.
+pub fn get_pixel(world: &mut World, x: u32, y: u32) -> Result<Value, String> {
+    let surface = world
+        .get_resource::<WgpuSurfaceResource>()
+        .ok_or_else(|| "no renderer attached: get_pixel needs a WgpuSurfaceResource".to_string())?;
+    let width = surface.0.width();
+    let height = surface.0.height();
+    if x >= width || y >= height {
+        return Err(format!(
+            "pixel ({x}, {y}) is outside the {width}x{height} frame"
+        ));
+    }
+    let data = surface.0.read_pixels()?;
+    let i = ((y * width + x) * 4) as usize;
+    let (r, g, b, a) = (data[i], data[i + 1], data[i + 2], data[i + 3]);
+    let luma = 0.2126 * r as f32 + 0.7152 * g as f32 + 0.0722 * b as f32;
+    Ok(json!({ "r": r, "g": g, "b": b, "a": a, "luma": luma }))
+}
+
 pub fn run_query(world: &mut World, tool: &str, args: &Value) -> Result<Value, String> {
     match tool {
         "get_transform" => {
@@ -165,6 +190,19 @@ pub fn run_query(world: &mut World, tool: &str, args: &Value) -> Result<Value, S
             Ok(get_asset_status(world, path))
         }
         "get_known_asset_paths" => Ok(get_known_asset_paths(world)),
+        "get_pixel" => {
+            let x = args
+                .get("x")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| "get_pixel requires integer 'x'".to_string())?
+                as u32;
+            let y = args
+                .get("y")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| "get_pixel requires integer 'y'".to_string())?
+                as u32;
+            get_pixel(world, x, y)
+        }
         other => Err(format!("unknown query tool: {other}")),
     }
 }
@@ -404,5 +442,12 @@ mod tests {
     #[test]
     fn eval_op_unknown_operator_errors() {
         assert!(eval_op(&json!(1), "~=", &json!(1)).is_err());
+    }
+
+    #[test]
+    fn run_query_get_pixel_errors_when_no_renderer_is_attached() {
+        let mut world = World::new();
+        let err = run_query(&mut world, "get_pixel", &json!({"x": 0, "y": 0})).unwrap_err();
+        assert!(err.contains("renderer"), "unhelpful error: {err}");
     }
 }

--- a/crates/bsengine-runtime/src/test_query.rs
+++ b/crates/bsengine-runtime/src/test_query.rs
@@ -115,10 +115,11 @@ pub fn get_asset_status(world: &mut World, path: &str) -> Value {
 /// # Why this exists next to [`get_asset_status`]
 ///
 /// `"unknown"` is the one answer that is indistinguishable from a typo. It is
-/// also the answer a caller gets for a path this app genuinely never requested
-/// — and in `--test` mode that is a large, non-obvious set, because the
-/// headless app builds no `RenderPlugin` and no `GltfPlugin`, so no mesh,
-/// shader or texture is ever asked for (see `test_mode::build_test_app`).
+/// also the answer a caller gets for a path this app genuinely never requested.
+/// `--test` mode carries `RenderPlugin`/`GltfPlugin` (see
+/// `test_mode::build_test_app`), so meshes, shaders and textures are asked
+/// for exactly as they are in the windowed runtime; "unknown" here means
+/// what it says.
 /// Handing back the keys the engine *does* hold turns "I cannot tell which of
 /// those two happened" into a fact the caller can read, without a second
 /// guess at the spelling.

--- a/crates/bsengine-runtime/src/test_query.rs
+++ b/crates/bsengine-runtime/src/test_query.rs
@@ -3,6 +3,7 @@
 //! `World` — no scripting/V8 involvement — using the same shapes as the
 //! `Bsengine.*` JS getters for consistency.
 
+use base64::Engine;
 use bevy_ecs::world::World;
 use bsengine_asset::{AssetStatus, AssetStatuses};
 use bsengine_core::{HudTexts, ProjectDir, Transform, Visible};
@@ -158,6 +159,38 @@ pub fn get_pixel(world: &mut World, x: u32, y: u32) -> Result<Value, String> {
     Ok(json!({ "r": r, "g": g, "b": b, "a": a, "luma": luma }))
 }
 
+/// Encodes the most recently rendered frame as a PNG, base64-encoded so it
+/// travels as one JSON string field. Errors when no renderer is attached (no
+/// `WgpuSurfaceResource`), when the buffer `read_pixels()` returns doesn't
+/// match the surface's own width/height (shouldn't happen in practice --
+/// `read_pixels` always returns exactly `width*height*4` bytes, but this
+/// turns a future contract violation into a clean error instead of a panic
+/// in `RgbaImage::from_raw`), or if PNG encoding itself fails.
+pub fn screenshot(world: &mut World) -> Result<Value, String> {
+    let surface = world.get_resource::<WgpuSurfaceResource>().ok_or_else(|| {
+        "no renderer attached: screenshot needs a WgpuSurfaceResource".to_string()
+    })?;
+    let width = surface.0.width();
+    let height = surface.0.height();
+    let data = surface.0.read_pixels()?;
+    let image = image::RgbaImage::from_raw(width, height, data)
+        .ok_or_else(|| "read_pixels returned a buffer the wrong size for the frame".to_string())?;
+    let mut png_bytes = Vec::new();
+    image
+        .write_to(
+            &mut std::io::Cursor::new(&mut png_bytes),
+            image::ImageFormat::Png,
+        )
+        .map_err(|e| format!("failed to encode PNG: {e}"))?;
+    let data_base64 = base64::engine::general_purpose::STANDARD.encode(&png_bytes);
+    Ok(json!({
+        "width": width,
+        "height": height,
+        "format": "png",
+        "data_base64": data_base64,
+    }))
+}
+
 pub fn run_query(world: &mut World, tool: &str, args: &Value) -> Result<Value, String> {
     match tool {
         "get_transform" => {
@@ -203,6 +236,7 @@ pub fn run_query(world: &mut World, tool: &str, args: &Value) -> Result<Value, S
                 as u32;
             get_pixel(world, x, y)
         }
+        "screenshot" => screenshot(world),
         other => Err(format!("unknown query tool: {other}")),
     }
 }
@@ -448,6 +482,13 @@ mod tests {
     fn run_query_get_pixel_errors_when_no_renderer_is_attached() {
         let mut world = World::new();
         let err = run_query(&mut world, "get_pixel", &json!({"x": 0, "y": 0})).unwrap_err();
+        assert!(err.contains("renderer"), "unhelpful error: {err}");
+    }
+
+    #[test]
+    fn run_query_screenshot_errors_when_no_renderer_is_attached() {
+        let mut world = World::new();
+        let err = run_query(&mut world, "screenshot", &json!({})).unwrap_err();
         assert!(err.contains("renderer"), "unhelpful error: {err}");
     }
 }

--- a/crates/bsengine-runtime/tests/game_content.rs
+++ b/crates/bsengine-runtime/tests/game_content.rs
@@ -44,11 +44,10 @@ fn mini_arenas_pickup_is_transparent() {
 
 #[test]
 fn mini_arenas_floor_is_textured() {
-    // No replay can check this. The headless test app deliberately runs without
-    // RenderPlugin, so nothing there ever requests a texture and
-    // `get_asset_status` correctly answers "unknown" for every image -- the
-    // absence is documented in test_mode.rs, not an oversight. That leaves the
-    // scene file itself as the only place to assert the claim.
+    // A replay can now confirm the texture actually loads (see test_mode.rs's
+    // mini_arenas_fox_mesh_loads_now_that_rendering_is_on and get_asset_status),
+    // but that only proves *a* texture loaded, not that the scene names the
+    // *right* one at the *right* entity. This stays as the check for that.
     let scene = load("games/mini-arena/assets/scenes/main.ron");
     let ground = scene
         .entities

--- a/games/cube-evader/src/main.rs
+++ b/games/cube-evader/src/main.rs
@@ -5,7 +5,7 @@ use bsengine_window::{WindowDescriptor, WindowPlugin};
 
 fn main() {
     new_app()
-        .add_plugins(WgpuRHIPlugin)
+        .add_plugins(WgpuRHIPlugin::windowed())
         .add_plugins(WindowPlugin {
             descriptor: WindowDescriptor {
                 title: "Cube Evader".to_string(),

--- a/games/cube-roller/src/main.rs
+++ b/games/cube-roller/src/main.rs
@@ -36,7 +36,7 @@ struct Item;
 
 fn main() {
     new_app()
-        .add_plugins(WgpuRHIPlugin)
+        .add_plugins(WgpuRHIPlugin::windowed())
         .add_plugins(WindowPlugin {
             descriptor: WindowDescriptor {
                 title: "Cube Roller".to_string(),


### PR DESCRIPTION
## Summary

AI가 자신이 만든 게임을 실제로 "볼" 수 있게 한다. 지금까지 리플레이 프로토콜은 `get_transform`/`get_hud_text` 같은 7개 query로만 관측 가능했고, 렌더링·머티리얼·파티클은 검증할 수 없었다.

- `WgpuRHIPlugin`에 오프스크린 서피스 모드를 추가하고, 헤드리스 테스트 앱(`bsengine-runtime --test`, E2E 리플레이와 MCP 테스트 세션이 공유)이 항상 실제 GPU로 프레임을 렌더링하도록 바꿨다.
- 새 쿼리 두 개(`get_pixel`, `screenshot`)를 기존 `run_query` 디스패처에 추가 — 새 MCP 툴 없이도 `test_query_state`/`test_assert`/`test_wait_until`과 리플레이 로그가 그 위에서 바로 동작한다.
- MCP 서버가 `screenshot`의 PNG 응답을 표준 MCP 이미지 콘텐츠 블록으로 감싸도록 확장 — MCP 클라이언트가 실제 이미지를 받는다(base64 텍스트가 아니라).
- 도중에 진짜 버그(`WindowSection::default()`가 자기 자신의 필드별 serde 기본값과 어긋남, 프로덕션 windowed 런타임에도 영향)를 발견해 root-cause 수정.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` 클린
- [x] `cargo clippy --all-targets` 에러 0 (사전 존재 무관 경고만)
- [x] 컴포넌트 카탈로그 체크 (R1/R2) PASS
- [x] `cargo test --workspace --exclude bsengine-editor`: 1158 passed, 0 failed
- [x] `cargo test -p bsengine-editor` (격리): 825 passed, 0 failed
- [x] E2E 리플레이 8개 전부 PASS
- [x] 각 태스크 독립 스펙 준수 검토 + 코드 품질 검토 통과 (Important 이슈 발견된 3곳 전부 수정·재검토 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)