### PR TITLE
Entity hierarchy: name-based scene parenting + RenderPlugin propagation fix

### DIFF
--- a/crates/bsengine-core/src/parent.rs
+++ b/crates/bsengine-core/src/parent.rs
@@ -39,4 +39,41 @@ mod tests {
         assert!((pos.y - 1.0).abs() < 1e-5, "y={}", pos.y);
         assert!(pos.z.abs() < 1e-5, "z={}", pos.z);
     }
+
+    #[test]
+    fn grandchild_inherits_grandparent_and_parent_translation() {
+        let mut world = World::new();
+
+        let grandparent = world
+            .spawn((
+                crate::Transform::from_position(glam::Vec3::new(10.0, 0.0, 0.0)),
+                crate::GlobalTransform::default(),
+            ))
+            .id();
+
+        let parent = world
+            .spawn((
+                crate::Transform::from_position(glam::Vec3::new(0.0, 1.0, 0.0)),
+                crate::GlobalTransform::default(),
+                Parent(grandparent),
+            ))
+            .id();
+
+        let child = world
+            .spawn((
+                crate::Transform::from_position(glam::Vec3::new(0.0, 0.0, 1.0)),
+                crate::GlobalTransform::default(),
+                Parent(parent),
+            ))
+            .id();
+
+        crate::propagate_global_transforms(&mut world);
+
+        let child_gt = world.get::<crate::GlobalTransform>(child).unwrap();
+        let pos = child_gt.0.w_axis.truncate();
+        // grandparent (10,0,0) + parent-local (0,1,0) + child-local (0,0,1)
+        assert!((pos.x - 10.0).abs() < 1e-5, "x={}", pos.x);
+        assert!((pos.y - 1.0).abs() < 1e-5, "y={}", pos.y);
+        assert!((pos.z - 1.0).abs() < 1e-5, "z={}", pos.z);
+    }
 }

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1038,6 +1038,11 @@ fn spawn_entity_from_info(world: &mut World, info: &EntityInfo) -> Entity {
 /// scene files). GLTF paths are not tracked by `EntityInfo` and are
 /// intentionally left `None` here.
 fn build_entity_descriptors(entities: &[EntityInfo]) -> Vec<EntityDescriptor> {
+    let id_to_name: std::collections::HashMap<u64, &str> = entities
+        .iter()
+        .filter_map(|e| Some((e.id, e.name.as_deref()?)))
+        .collect();
+
     entities
         .iter()
         .filter_map(|e| {
@@ -1114,10 +1119,18 @@ fn build_entity_descriptors(entities: &[EntityInfo]) -> Vec<EntityDescriptor> {
                     collider: e.physics_body.as_ref().map(|p| p.collider.clone()),
                     linear_damping: e.physics_body.as_ref().and_then(|p| p.linear_damping),
                     angular_damping: e.physics_body.as_ref().and_then(|p| p.angular_damping),
-                    // Placeholder unblocking compilation for `EntityDescriptor.parent`
-                    // (scene-hierarchy plan, Task 2). The editor save path doesn't yet
-                    // read/write a parent reference from `InspectorState` — that's Task 4.
-                    parent: None,
+                    parent: e.parent_id.and_then(|pid| match id_to_name.get(&pid) {
+                        Some(name) => Some(name.to_string()),
+                        None => {
+                            tracing::warn!(
+                                "scene save: entity '{}' is parented to entity {pid}, which has \
+                                 no Name component, so this scene file cannot preserve that \
+                                 parent link",
+                                e.name.as_deref().unwrap_or("<unnamed>")
+                            );
+                            None
+                        }
+                    }),
                 }
             })
         })
@@ -29408,7 +29421,7 @@ fn parse_vec3_input(v: &serde_json::Value) -> Option<[f32; 3]> {
 
 #[cfg(test)]
 mod tests {
-    use super::EditorPlugin;
+    use super::{build_entity_descriptors, EditorPlugin};
     use bsengine_app::new_app;
     use bsengine_core::{InspectorCmd, InspectorState, Parent, Transform};
     use bsengine_mcp::{McpPlugin, McpRegistryResource};
@@ -29418,7 +29431,7 @@ mod tests {
 
     use crate::snapshot::{
         EditorCommand, EditorCommandQueueResource, EditorSelectionResource, EditorSnapshotResource,
-        Tags,
+        EntityInfo, Tags,
     };
 
     #[test]
@@ -29438,6 +29451,71 @@ mod tests {
 
         let registry = app.world().resource::<bsengine_core::EditorPanelRegistry>();
         assert!(registry.0.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn build_entity_descriptors_resolves_parent_id_to_the_parents_name() {
+        let entities = vec![
+            EntityInfo {
+                id: 1,
+                name: Some("Body".to_string()),
+                parent_id: None,
+                ..Default::default()
+            },
+            EntityInfo {
+                id: 2,
+                name: Some("Wheel".to_string()),
+                parent_id: Some(1),
+                ..Default::default()
+            },
+        ];
+
+        let descriptors = build_entity_descriptors(&entities);
+        let wheel = descriptors
+            .iter()
+            .find(|d| d.name == "Wheel")
+            .expect("Wheel should be in the output");
+        assert_eq!(wheel.parent.as_deref(), Some("Body"));
+
+        let body = descriptors
+            .iter()
+            .find(|d| d.name == "Body")
+            .expect("Body should be in the output");
+        assert_eq!(body.parent, None, "Body has no parent_id, so no parent name");
+    }
+
+    #[test]
+    fn build_entity_descriptors_warns_and_drops_parent_link_when_parent_has_no_name() {
+        // Ensures the tracing subscriber exists even when this test runs in
+        // isolation (e.g. via a `cargo test <name>` filter), so the warn!
+        // below is actually visible under `--nocapture`.
+        bsengine_core::init_logging();
+
+        let entities = vec![
+            // e.g. a spawned point light: has an id but no Name component.
+            EntityInfo {
+                id: 1,
+                name: None,
+                parent_id: None,
+                ..Default::default()
+            },
+            EntityInfo {
+                id: 2,
+                name: Some("Wheel".to_string()),
+                parent_id: Some(1),
+                ..Default::default()
+            },
+        ];
+
+        let descriptors = build_entity_descriptors(&entities);
+        let wheel = descriptors
+            .iter()
+            .find(|d| d.name == "Wheel")
+            .expect("Wheel should be in the output");
+        assert_eq!(
+            wheel.parent, None,
+            "parent entity has no Name, so the link can't be preserved in the scene file"
+        );
     }
 
     #[test]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1114,6 +1114,10 @@ fn build_entity_descriptors(entities: &[EntityInfo]) -> Vec<EntityDescriptor> {
                     collider: e.physics_body.as_ref().map(|p| p.collider.clone()),
                     linear_damping: e.physics_body.as_ref().and_then(|p| p.linear_damping),
                     angular_damping: e.physics_body.as_ref().and_then(|p| p.angular_damping),
+                    // Placeholder unblocking compilation for `EntityDescriptor.parent`
+                    // (scene-hierarchy plan, Task 2). The editor save path doesn't yet
+                    // read/write a parent reference from `InspectorState` — that's Task 4.
+                    parent: None,
                 }
             })
         })

--- a/crates/bsengine-mcp/src/game_tools.rs
+++ b/crates/bsengine-mcp/src/game_tools.rs
@@ -35,6 +35,15 @@ SceneDescriptor(entities: [
     emissive: Some((0.0, 0.0, 0.0)), // optional: self-illumination color; default black (none)
     script: Some("assets/scripts/player.js"),  // relative to game root
   ),
+  EntityDescriptor(
+    name: "Wheel",
+    parent: Some("Player"),    // optional: name of another entity in this same scene file;
+                                // this entity's transform becomes relative to the parent's.
+                                // Absent means a root entity. Unknown/self-referential names
+                                // are dropped with a warning at load time, not a hard error.
+    primitive: Some(Cube),
+    transform: Some((position: (1.0, 0.0, 0.0))),  // relative to Player, not world space
+  ),
 ])
 
 Rules:
@@ -43,6 +52,7 @@ Rules:
 - primitive: Some(Cube) renders a white cube; use color to tint it
 - look_at on a camera entity auto-computes rotation to face the target point
 - color sets the albedo/surface color; emissive makes the entity glow
+- parent makes this entity's transform relative to another entity by name (same scene file only)
 - name is the key used by JS Bsengine.getPosition/setPosition"#;
 
 const SCRIPT_API_DOCS: &str = r#"BSEngine JavaScript API (runs in V8 via Deno Core):

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1,9 +1,9 @@
 use bevy_app::{App, Plugin, PostUpdate, Update};
-use bevy_ecs::prelude::{Entity, EventReader, IntoSystemConfigs, ParamSet, Query, ResMut, Without};
+use bevy_ecs::prelude::{EventReader, IntoSystemConfigs, ParamSet, Query, ResMut};
 use bsengine_core::{
     AmbientOcclusion, Bloom, Camera, CustomShader, DirectionalLight, EditorPanelRegistry,
-    EditorPlayState, GlobalTransform, HudTexts, InspectorState, Material, Parent, PointLight,
-    SkyboxPath, SpotLight, Time, ToneMap, Transform, UiState, Visible,
+    EditorPlayState, GlobalTransform, HudTexts, InspectorState, Material, PointLight, SkyboxPath,
+    SpotLight, Time, ToneMap, Transform, UiState, Visible,
 };
 use bsengine_ecs::Res;
 use bsengine_input::{Input, KeyCode, KeyInput, MouseButton, MouseState};
@@ -13,7 +13,6 @@ use bsengine_rhi_wgpu::{
 };
 use bsengine_window::WindowResized;
 use glam::{Mat4, Vec3, Vec4};
-use std::collections::HashMap;
 
 use crate::components::MeshRenderer;
 
@@ -72,30 +71,6 @@ fn spot_light_entry(sl: &SpotLight, gt: Option<&GlobalTransform>, t: &Transform)
         range: sl.range,
         inner_angle: sl.inner_angle_degrees.to_radians(),
         outer_angle: sl.outer_angle_degrees.to_radians(),
-    }
-}
-
-/// Pass 1: root entities (no Parent) get GlobalTransform = local Transform.
-fn propagate_roots(mut query: Query<(&Transform, &mut GlobalTransform), Without<Parent>>) {
-    for (t, mut gt) in query.iter_mut() {
-        gt.0 = t.to_matrix().into();
-    }
-}
-
-/// Pass 2: children get GlobalTransform = parent's GT * local Transform.
-/// Uses ParamSet to safely read root GlobalTransforms and write child GlobalTransforms.
-fn propagate_children(
-    mut set: ParamSet<(
-        Query<(Entity, &GlobalTransform), Without<Parent>>,
-        Query<(&Transform, &mut GlobalTransform, &Parent)>,
-    )>,
-) {
-    let parent_mats: HashMap<Entity, Mat4> = set.p0().iter().map(|(e, gt)| (e, gt.0 .0)).collect();
-
-    for (t, mut gt, parent) in set.p1().iter_mut() {
-        if let Some(&mat) = parent_mats.get(&parent.0) {
-            gt.0 = (mat * t.to_matrix()).into();
-        }
     }
 }
 
@@ -847,8 +822,7 @@ impl Plugin for RenderPlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    propagate_roots,
-                    propagate_children,
+                    bsengine_core::propagate_global_transforms,
                     compile_pending_shaders,
                     rebuild_modified_shaders,
                     upload_pending_skybox,
@@ -865,7 +839,7 @@ mod tests {
     use super::{CompileStatus, PendingShader, PendingShaders, PendingSkybox, RenderPlugin};
     use crate::components::MeshRenderer;
     use bsengine_app::new_app;
-    use bsengine_core::{Camera, Material, PointLight, Transform};
+    use bsengine_core::{Camera, GlobalTransform, Material, Parent, PointLight, Transform};
     use bsengine_rhi_wgpu::WgpuRHIPlugin;
     use bsengine_window::WindowResized;
     use glam::Vec3;
@@ -1038,6 +1012,48 @@ mod tests {
             "rebuild_modified_skybox (index {rebuild_idx}) must run before \
              render_frame (index {render_idx}) so a skybox re-uploaded this \
              frame is the one drawn; actual PostUpdate order: {names:?}"
+        );
+    }
+
+    #[test]
+    fn grandchild_transform_reflects_grandparent_and_parent_after_one_update() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(RenderPlugin);
+
+        let grandparent = app
+            .world_mut()
+            .spawn((
+                Transform::from_position(Vec3::new(10.0, 0.0, 0.0)),
+                GlobalTransform::default(),
+            ))
+            .id();
+        let parent = app
+            .world_mut()
+            .spawn((
+                Transform::from_position(Vec3::new(0.0, 1.0, 0.0)),
+                GlobalTransform::default(),
+                Parent(grandparent),
+            ))
+            .id();
+        let child = app
+            .world_mut()
+            .spawn((
+                Transform::from_position(Vec3::new(0.0, 0.0, 1.0)),
+                GlobalTransform::default(),
+                Parent(parent),
+            ))
+            .id();
+
+        app.update();
+
+        let child_gt = app.world().get::<GlobalTransform>(child).unwrap();
+        let pos = child_gt.0.w_axis.truncate();
+        assert!(
+            (pos - Vec3::new(10.0, 1.0, 1.0)).length() < 1e-4,
+            "grandchild GlobalTransform should reflect both ancestors after one RenderPlugin \
+             update, got {pos:?} (this fails today because RenderPlugin's transform \
+             propagation is one-level-only)"
         );
     }
 

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -530,6 +530,7 @@ pub fn run_replay_mode(project_dir: &str, log_path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy_ecs::prelude::Entity;
     use bsengine_input::Input;
 
     fn write_two_scene_project() -> tempfile::TempDir {
@@ -988,6 +989,114 @@ mod tests {
             decoded.height(),
             result["height"].as_u64().unwrap() as u32,
             "decoded PNG height should match the reported height"
+        );
+    }
+
+    // Proves a scene-file `parent:` chain actually renders, not just that it
+    // parses into a Parent component (Task 3's own tests already cover
+    // that): moving only the grandparent's Transform must move the child on
+    // screen, even though the scene file never names the grandparent on the
+    // child directly -- only Parent -> GrandParent, one level at a time.
+    #[test]
+    fn moving_a_grandparent_moves_the_grandchild_on_screen() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("assets/scenes")).unwrap();
+        std::fs::write(
+            root.join("project.toml"),
+            "[project]\nname = \"Hierarchy Test\"\nentry_scene = \"assets/scenes/hierarchy.ron\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("assets/scenes/hierarchy.ron"),
+            r#"SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Camera",
+        camera: true,
+        transform: Some((
+            position: (0.0, 0.0, 8.0),
+        )),
+    ),
+    EntityDescriptor(
+        name: "GrandParent",
+        transform: Some((
+            position: (0.0, 0.0, 0.0),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Parent",
+        parent: Some("GrandParent"),
+        transform: Some((
+            position: (2.0, 0.0, 0.0),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Child",
+        parent: Some("Parent"),
+        primitive: Some(Cube),
+        emissive: Some((1.0, 0.0, 0.0)),
+        transform: Some((
+            position: (0.0, 0.0, 0.0),
+        )),
+    ),
+])"#,
+        )
+        .unwrap();
+
+        let project_dir = root.to_str().unwrap().to_string();
+        let mut app = build_test_app(&project_dir, None);
+        app.update();
+
+        // Window defaults to 1280x720 (no [window] table -- see
+        // WindowSection::default() in scene_systems.rs), so the exact
+        // screen center is always (640, 360).
+        let before = crate::test_query::run_query(
+            app.world_mut(),
+            "get_pixel",
+            &json!({"x": 640, "y": 360}),
+        )
+        .expect("get_pixel should succeed once RenderPlugin has drawn a frame");
+        let before_r = before["r"].as_u64().unwrap();
+        let before_g = before["g"].as_u64().unwrap();
+        assert!(
+            before_r <= before_g + 20,
+            "GrandParent is at the origin, so Child sits at world x=2 -- off the \
+             camera's center axis (x=0) and should not read as red at the center \
+             pixel yet, got {before:?}"
+        );
+
+        // Move only the grandparent. Child's world position becomes
+        // GrandParent(-2,0,0) + Parent-local(2,0,0) + Child-local(0,0,0) =
+        // (0,0,0) -- dead center of a camera looking straight down -Z.
+        let mut grandparent_query = app.world_mut().query::<(&bsengine_scene::Name, Entity)>();
+        let grandparent = grandparent_query
+            .iter(app.world())
+            .find(|(n, _)| n.0 == "GrandParent")
+            .map(|(_, e)| e)
+            .expect("GrandParent should have spawned from the scene file");
+        app.world_mut()
+            .get_mut::<bsengine_core::Transform>(grandparent)
+            .unwrap()
+            .position = glam::Vec3::new(-2.0, 0.0, 0.0).into();
+
+        app.update();
+
+        let after = crate::test_query::run_query(
+            app.world_mut(),
+            "get_pixel",
+            &json!({"x": 640, "y": 360}),
+        )
+        .expect("get_pixel should succeed once RenderPlugin has drawn a frame");
+        let after_r = after["r"].as_u64().unwrap();
+        let after_g = after["g"].as_u64().unwrap();
+        assert!(
+            after_r > after_g + 20,
+            "after moving only GrandParent's Transform, Child (parented to Parent, \
+             which is parented to GrandParent -- never parented to GrandParent \
+             directly) should now be dead center and red. This is what proves a \
+             scene-file parent chain actually renders through more than one \
+             level, not just that spawn_scene_entities attaches a Parent \
+             component. got {after:?}"
         );
     }
 

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -2,7 +2,7 @@ use crate::types::{
     AssetRef, EntityDescriptor, PhysicsBodyDesc, PrimitiveMesh, SceneDescriptor, ScriptPath,
 };
 use bevy_app::{App, Plugin, Startup};
-use bevy_ecs::prelude::{Component, IntoSystemConfigs, ReflectComponent, World};
+use bevy_ecs::prelude::{Component, Entity, IntoSystemConfigs, ReflectComponent, World};
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use bsengine_asset::{AssetGuid, AssetIndex};
@@ -328,8 +328,11 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
             .collect()
     };
 
+    let mut spawned: Vec<Entity> = Vec::with_capacity(entities.len());
+
     for (entity, (gltf_path, script_path, texture_path)) in entities.iter().zip(&resolved_refs) {
         let mut builder = world.spawn(Name(entity.name.clone()));
+        spawned.push(builder.id());
 
         if let Some(t) = &entity.transform {
             let mut rotation =
@@ -489,6 +492,42 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
                         ),
                     }
                 }
+            }
+        }
+    }
+
+    // Pass 3: resolve `parent: Some(name)` into a real `Parent(Entity)` now
+    // that every entity in this call has spawned. A name map built only from
+    // entities spawned *by this call* -- an entity left over from a previous
+    // scene is never a valid parent target.
+    let name_to_entity: std::collections::HashMap<&str, Entity> = entities
+        .iter()
+        .map(|e| e.name.as_str())
+        .zip(spawned.iter().copied())
+        .collect();
+    for (entity, &child_entity) in entities.iter().zip(&spawned) {
+        let Some(parent_name) = &entity.parent else {
+            continue;
+        };
+        if parent_name == &entity.name {
+            tracing::warn!(
+                "scene: entity '{}' names itself as its own parent; leaving it a root",
+                entity.name
+            );
+            continue;
+        }
+        match name_to_entity.get(parent_name.as_str()) {
+            Some(&parent_entity) => {
+                world
+                    .entity_mut(child_entity)
+                    .insert(bsengine_core::Parent(parent_entity));
+            }
+            None => {
+                tracing::warn!(
+                    "scene: entity '{}' names parent '{parent_name}', which does not exist \
+                     in this scene; leaving it a root",
+                    entity.name
+                );
             }
         }
     }
@@ -761,6 +800,75 @@ mod tests {
 
         let mut query = app.world_mut().query::<&bsengine_core::Material>();
         assert_eq!(query.iter(app.world()).count(), 1);
+    }
+
+    #[test]
+    fn parent_field_resolves_to_a_real_parent_component() {
+        let scene: crate::types::SceneDescriptor = ron::from_str(
+            r#"SceneDescriptor(entities: [
+                EntityDescriptor(name: "Body"),
+                EntityDescriptor(name: "Wheel", parent: Some("Body")),
+            ])"#,
+        )
+        .expect("a scene entity naming its parent should parse");
+
+        let mut app = new_app();
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+        let mut query = app.world_mut().query::<(
+            bevy_ecs::prelude::Entity,
+            &Name,
+            Option<&bsengine_core::Parent>,
+        )>();
+        let rows: Vec<(
+            bevy_ecs::prelude::Entity,
+            String,
+            Option<bevy_ecs::prelude::Entity>,
+        )> = query
+            .iter(app.world())
+            .map(|(e, n, p)| (e, n.0.clone(), p.map(|p| p.0)))
+            .collect();
+
+        let body_entity = rows
+            .iter()
+            .find(|(_, name, _)| name == "Body")
+            .map(|(e, _, _)| *e)
+            .expect("Body should have spawned");
+        let wheel_parent = rows
+            .iter()
+            .find(|(_, name, _)| name == "Wheel")
+            .and_then(|(_, _, p)| *p)
+            .expect("Wheel should have a Parent component");
+        assert_eq!(
+            wheel_parent, body_entity,
+            "Wheel's parent should be the Body entity"
+        );
+    }
+
+    #[test]
+    fn unresolvable_or_self_named_parent_leaves_the_entity_a_root() {
+        let scene: crate::types::SceneDescriptor = ron::from_str(
+            r#"SceneDescriptor(entities: [
+                EntityDescriptor(name: "Typo", parent: Some("Doesnt Exist")),
+                EntityDescriptor(name: "SelfRef", parent: Some("SelfRef")),
+            ])"#,
+        )
+        .expect("a scene should parse even with an unresolvable parent name");
+
+        let mut app = new_app();
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+        let mut query = app
+            .world_mut()
+            .query::<(&Name, Option<&bsengine_core::Parent>)>();
+        for (name, parent) in query.iter(app.world()) {
+            assert!(
+                parent.is_none(),
+                "{} should have no Parent component (unresolvable or self-referential), got {:?}",
+                name.0,
+                parent.map(|p| p.0)
+            );
+        }
     }
 
     #[test]

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -289,6 +289,14 @@ pub struct EntityDescriptor {
     /// below it puts the entity in the sorted transparent pass.
     #[serde(default)]
     pub opacity: Option<f32>,
+    /// Name of this entity's parent, if any. Resolved against the other
+    /// entities in the same scene file after all of them have spawned — see
+    /// `spawn_scene_entities` in `plugin.rs`. Absent (the default) means a
+    /// root entity, exactly as every scene written before this field
+    /// existed. Must name an entity in the *same* scene file; cross-scene
+    /// parent references are not supported.
+    #[serde(default)]
+    pub parent: Option<String>,
     /// Reflected components not covered by this struct's own typed fields
     /// (e.g. `AnimationStateMachine`, `NavMeshAgent`, `Shield`, `Bloom`,
     /// `ToneMap`), as (fully-qualified type path, RON-encoded value) pairs.
@@ -598,6 +606,19 @@ mod tests {
         let ron_str = r#"EntityDescriptor(name: "Cam", camera: true)"#;
         let entity: EntityDescriptor = ron::from_str(ron_str).unwrap();
         assert!(entity.camera);
+    }
+
+    #[test]
+    fn entity_descriptor_with_parent_deserializes_and_defaults_to_absent() {
+        let with_parent: EntityDescriptor =
+            ron::from_str(r#"EntityDescriptor(name: "Wheel", parent: Some("Body"))"#)
+                .expect("a scene entity should be able to name its parent");
+        assert_eq!(with_parent.parent.as_deref(), Some("Body"));
+
+        // Every scene written before this field existed must still parse.
+        let older: EntityDescriptor = ron::from_str(r#"EntityDescriptor(name: "Root")"#)
+            .expect("a scene written before `parent` existed should still parse");
+        assert_eq!(older.parent, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes a real production bug: `RenderPlugin` only propagated transforms one level deep (`propagate_roots`/`propagate_children`), silently leaving any grandchild's `GlobalTransform` stale in both the windowed and headless runtimes. Replaced with the existing, already-correct, already-unit-tested `bsengine_core::propagate_global_transforms` (8-iteration fixed-point convergence, arbitrary depth), which had zero production callers until this PR.
- Adds a name-based `parent: Option<String>` field to the scene file format, resolved into a real ECS `Parent(Entity)` at spawn time (self-reference/unresolvable names warn and leave the entity a root).
- Closes the round-trip on the editor save path: `parent_id` (already tracked per-frame) resolves back to the parent's name when writing a scene, with a warning if the parent has no `Name` (e.g. a spawned light).
- Adds an E2E test proving the whole stack together (scene parse → name resolution → multi-level propagation → actual rendered GPU pixels via `get_pixel`), by moving a grandparent and confirming a grandchild attached through an intermediate parent visibly moves on screen.
- Updates the MCP `scene_write`/`game_create` tool description to document the new `parent` field — this feature specifically chose name references over nested syntax so an AI agent could author them easily via MCP; the tool docs an agent actually reads had been missed.

This is prerequisite infrastructure for the hierarchical prefab system (next planned work), not the prefab system itself.

## Test plan

- [x] `cargo build --all` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets` — clean (only pre-existing warnings in untouched files)
- [x] `cargo run -p bsengine-catalog -- --check` — clean, no new component/op registrations
- [x] Full workspace test suite (excluding `bsengine-editor`, isolated separately) — all passing
- [x] `bsengine-editor` isolated (`RUST_MIN_STACK=8388608`) — 827/827 passing
- [x] All 8 pre-existing E2E replay recordings (mini-arena, tilt-run ×7) — PASS, confirming no regression from the `RenderPlugin` rewrite
- [x] New E2E hierarchy test — PASS

Each commit was independently reviewed for spec compliance and code quality (two commits went through a fix-up + re-review round), followed by a final whole-branch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)