### PR TITLE
feat: prefab system (scene-file, script, and editor instantiation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "deno_core",
  "glam 0.29.3",
  "kira",
+ "ron",
  "serde",
  "serde_json",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,6 @@ dependencies = [
  "deno_core",
  "glam 0.29.3",
  "kira",
- "ron",
  "serde",
  "serde_json",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -266,6 +266,26 @@ pub enum InspectorCmd {
         /// Edited component value to write back.
         value: Box<dyn bevy_reflect::Reflect>,
     },
+    /// Instantiate a prefab at the given world position, optionally
+    /// parented under an existing entity (by editor entity id). Routed
+    /// through the dedicated `PrefabCommandQueueResource`/
+    /// `process_prefab_commands` pipeline (`bsengine-editor`), not the
+    /// plain `EditorCommand` queue, since `bsengine_scene::instantiate_prefab`
+    /// needs `&mut World` -- see `PrefabInstantiateCommand`.
+    InstantiatePrefab {
+        /// Project-relative path to the prefab file.
+        path: String,
+        /// Explicit root name; `None` auto-generates one.
+        name: Option<String>,
+        /// World-space X position for the instantiated root.
+        x: f32,
+        /// World-space Y position for the instantiated root.
+        y: f32,
+        /// World-space Z position for the instantiated root.
+        z: f32,
+        /// Id of the entity to parent the instantiated root under, if any.
+        parent_id: Option<u64>,
+    },
 }
 
 /// Whether the editor is showing the static scene or running gameplay.

--- a/crates/bsengine-editor/Cargo.toml
+++ b/crates/bsengine-editor/Cargo.toml
@@ -26,3 +26,4 @@ tracing          = { workspace = true }
 
 [dev-dependencies]
 bsengine-app = { workspace = true }
+tempfile     = "3"

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1535,8 +1535,16 @@ fn process_reflect_commands(world: &mut World) {
 }
 
 /// Drains `PrefabCommandQueueResource` each frame and instantiates each
-/// queued prefab via `bsengine_scene::instantiate_prefab`, which needs
-/// `&mut World` directly -- see `PrefabInstantiateCommand`'s doc comment.
+/// queued prefab via `bsengine_scene::instantiate_prefab_from_path`, which
+/// needs `&mut World` directly -- see `PrefabInstantiateCommand`'s doc
+/// comment. Going through `instantiate_prefab_from_path` (rather than
+/// reading/parsing the file here and calling
+/// `bsengine_scene::instantiate_prefab` directly, as this used to) is what
+/// registers this top-level call into the crate's cycle-detection set
+/// before a nested `prefab:` reference inside the file can recurse --
+/// skipping it meant a prefab whose own child referenced its containing
+/// file silently double-spawned via drag-and-drop, since the guard only
+/// ever caught such a reference on its second encounter, not its first.
 fn process_prefab_commands(world: &mut World) {
     let cmds: Vec<PrefabInstantiateCommand> = {
         let Some(queue_res) = world.get_resource::<PrefabCommandQueueResource>() else {
@@ -1565,20 +1573,6 @@ fn process_prefab_commands(world: &mut World) {
     let project_dir = world.get_resource::<bsengine_core::ProjectDir>().cloned();
     for cmd in cmds {
         let resolved_path = bsengine_core::resolve_project_path(project_dir.as_ref(), &cmd.path);
-        let content = match std::fs::read_to_string(&resolved_path) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!("prefab: could not read '{resolved_path}': {e}");
-                continue;
-            }
-        };
-        let prefab: bsengine_scene::types::PrefabDescriptor = match ron::from_str(&content) {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::warn!("prefab: '{resolved_path}' failed to parse: {e}");
-                continue;
-            }
-        };
         let parent_entity = cmd
             .parent_id
             .and_then(|id| world.iter_entities().find(|e| e.id().index() as u64 == id))
@@ -1587,9 +1581,9 @@ fn process_prefab_commands(world: &mut World) {
             position: [cmd.x, cmd.y, cmd.z],
             ..Default::default()
         };
-        if let Err(e) = bsengine_scene::instantiate_prefab(
+        if let Err(e) = bsengine_scene::instantiate_prefab_from_path(
             world,
-            &prefab,
+            &resolved_path,
             cmd.name.as_deref(),
             Some(transform),
             parent_entity,

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1131,6 +1131,14 @@ fn build_entity_descriptors(entities: &[EntityInfo]) -> Vec<EntityDescriptor> {
                             None
                         }
                     }),
+                    // Always None: this build has no way to know whether a
+                    // live entity was originally instantiated from a
+                    // prefab (EntityInfo tracks no such provenance), and
+                    // saving that link is out of scope for prefab
+                    // instantiation -- it belongs to a future live-sync
+                    // feature that doesn't exist yet, not to any task in
+                    // this plan.
+                    prefab: None,
                 }
             })
         })

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1,8 +1,9 @@
 use crate::snapshot::{
     EditorCommand, EditorCommandQueueResource, EditorHistory, EditorHistoryResource,
-    EditorSelectionResource, EditorSnapshot, EditorSnapshotResource, EntityInfo, ReflectCommand,
-    ReflectCommandQueueResource, SharedCommandQueue, SharedHistory, SharedReflectCommandQueue,
-    SharedSelection, SharedSnapshot, Tags,
+    EditorSelectionResource, EditorSnapshot, EditorSnapshotResource, EntityInfo,
+    PrefabCommandQueueResource, PrefabInstantiateCommand, ReflectCommand,
+    ReflectCommandQueueResource, SharedCommandQueue, SharedHistory, SharedPrefabCommandQueue,
+    SharedReflectCommandQueue, SharedSelection, SharedSnapshot, Tags,
 };
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::prelude::{Commands, Entity, IntoSystemConfigs, ParamSet, Query, ResMut, World};
@@ -1533,6 +1534,71 @@ fn process_reflect_commands(world: &mut World) {
     }
 }
 
+/// Drains `PrefabCommandQueueResource` each frame and instantiates each
+/// queued prefab via `bsengine_scene::instantiate_prefab`, which needs
+/// `&mut World` directly -- see `PrefabInstantiateCommand`'s doc comment.
+fn process_prefab_commands(world: &mut World) {
+    let cmds: Vec<PrefabInstantiateCommand> = {
+        let Some(queue_res) = world.get_resource::<PrefabCommandQueueResource>() else {
+            return;
+        };
+        let mut queue = queue_res.0.lock().unwrap();
+        queue.drain(..).collect()
+    };
+    if cmds.is_empty() {
+        return;
+    }
+
+    if let (Some(snapshot_res), Some(history_res)) = (
+        world.get_resource::<EditorSnapshotResource>(),
+        world.get_resource::<EditorHistoryResource>(),
+    ) {
+        let checkpoint = snapshot_res.0.lock().unwrap().clone();
+        let mut history = history_res.0.lock().unwrap();
+        history.undo_stack.push(checkpoint);
+        history.redo_stack.clear();
+        if history.undo_stack.len() > MAX_UNDO_HISTORY {
+            history.undo_stack.remove(0);
+        }
+    }
+
+    let project_dir = world.get_resource::<bsengine_core::ProjectDir>().cloned();
+    for cmd in cmds {
+        let resolved_path = bsengine_core::resolve_project_path(project_dir.as_ref(), &cmd.path);
+        let content = match std::fs::read_to_string(&resolved_path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("prefab: could not read '{resolved_path}': {e}");
+                continue;
+            }
+        };
+        let prefab: bsengine_scene::types::PrefabDescriptor = match ron::from_str(&content) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("prefab: '{resolved_path}' failed to parse: {e}");
+                continue;
+            }
+        };
+        let parent_entity = cmd
+            .parent_id
+            .and_then(|id| world.iter_entities().find(|e| e.id().index() as u64 == id))
+            .map(|e| e.id());
+        let transform = bsengine_scene::TransformDescriptor {
+            position: [cmd.x, cmd.y, cmd.z],
+            ..Default::default()
+        };
+        if let Err(e) = bsengine_scene::instantiate_prefab(
+            world,
+            &prefab,
+            cmd.name.as_deref(),
+            Some(transform),
+            parent_entity,
+        ) {
+            tracing::warn!("prefab: '{resolved_path}' failed to instantiate: {e}");
+        }
+    }
+}
+
 fn update_editor_camera(
     inspector: Option<ResMut<InspectorState>>,
     mouse: Option<bsengine_ecs::Res<bsengine_input::MouseState>>,
@@ -1664,6 +1730,7 @@ fn apply_inspector_cmds(
     inspector: Option<ResMut<InspectorState>>,
     queue_res: Res<EditorCommandQueueResource>,
     reflect_queue_res: Res<ReflectCommandQueueResource>,
+    prefab_queue_res: Res<PrefabCommandQueueResource>,
     selection_res: Res<EditorSelectionResource>,
     mut commands: Commands,
 ) {
@@ -1800,6 +1867,16 @@ fn apply_inspector_cmds(
                     value,
                 });
             }
+            InspectorCmd::InstantiatePrefab { path, name, x, y, z, parent_id } => {
+                prefab_queue_res.0.lock().unwrap().push(PrefabInstantiateCommand {
+                    path,
+                    name,
+                    x,
+                    y,
+                    z,
+                    parent_id,
+                });
+            }
         }
     }
 }
@@ -1814,12 +1891,14 @@ impl Plugin for EditorPlugin {
         let snapshot: SharedSnapshot = Arc::new(Mutex::new(EditorSnapshot::default()));
         let cmd_queue: SharedCommandQueue = Arc::new(Mutex::new(Vec::new()));
         let reflect_cmd_queue: SharedReflectCommandQueue = Arc::new(Mutex::new(Vec::new()));
+        let prefab_cmd_queue: SharedPrefabCommandQueue = Arc::new(Mutex::new(Vec::new()));
         let selection: SharedSelection = Arc::new(Mutex::new(std::collections::HashSet::new()));
         let history: SharedHistory = Arc::new(Mutex::new(EditorHistory::default()));
 
         app.insert_resource(EditorSnapshotResource(snapshot.clone()));
         app.insert_resource(EditorCommandQueueResource(cmd_queue.clone()));
         app.insert_resource(ReflectCommandQueueResource(reflect_cmd_queue.clone()));
+        app.insert_resource(PrefabCommandQueueResource(prefab_cmd_queue.clone()));
         app.insert_resource(EditorSelectionResource(selection.clone()));
         app.insert_resource(EditorHistoryResource(history.clone()));
         app.insert_resource(InspectorState::editor());
@@ -1857,6 +1936,7 @@ impl Plugin for EditorPlugin {
         app.add_systems(Update, apply_inspector_cmds.before(process_editor_commands));
         app.add_systems(Update, process_editor_commands);
         app.add_systems(Update, process_reflect_commands.after(process_editor_commands));
+        app.add_systems(Update, process_prefab_commands.after(process_editor_commands));
         app.add_systems(Update, apply_history_action.after(process_editor_commands));
 
         // Captured once here (rather than inside the `if let` below) and cloned
@@ -92240,5 +92320,97 @@ mod tests {
             })).expect("tool should be registered")
         };
         assert!(!out.is_ok());
+    }
+
+    #[test]
+    fn process_prefab_commands_instantiates_a_queued_prefab() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("assets/prefabs")).unwrap();
+        std::fs::write(
+            root.join("assets/prefabs/enemy.ron"),
+            r#"PrefabDescriptor(entities: [EntityDescriptor(name: "Enemy", primitive: Some(Cube))])"#,
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.insert_resource(bsengine_core::ProjectDir(root.to_string_lossy().to_string()));
+
+        {
+            let queue = app.world().resource::<crate::snapshot::PrefabCommandQueueResource>();
+            queue.0.lock().unwrap().push(crate::snapshot::PrefabInstantiateCommand {
+                path: "assets/prefabs/enemy.ron".to_string(),
+                name: None,
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+                parent_id: None,
+            });
+        }
+
+        app.update();
+
+        let mut q = app.world_mut().query::<&Name>();
+        let names: Vec<String> = q.iter(app.world()).map(|n| n.0.clone()).collect();
+        assert!(
+            names.iter().any(|n| n.starts_with("Enemy#")),
+            "queued prefab command should have been instantiated by the next update, names: {names:?}"
+        );
+    }
+
+    #[test]
+    fn process_prefab_commands_pushes_undo_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("assets/prefabs")).unwrap();
+        std::fs::write(
+            root.join("assets/prefabs/enemy.ron"),
+            r#"PrefabDescriptor(entities: [EntityDescriptor(name: "Enemy", primitive: Some(Cube))])"#,
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.insert_resource(bsengine_core::ProjectDir(root.to_string_lossy().to_string()));
+        app.update();
+
+        let history_len_before = app
+            .world()
+            .resource::<crate::snapshot::EditorHistoryResource>()
+            .0
+            .lock()
+            .unwrap()
+            .undo_stack
+            .len();
+
+        {
+            let queue = app.world().resource::<crate::snapshot::PrefabCommandQueueResource>();
+            queue.0.lock().unwrap().push(crate::snapshot::PrefabInstantiateCommand {
+                path: "assets/prefabs/enemy.ron".to_string(),
+                name: None,
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+                parent_id: None,
+            });
+        }
+        app.update();
+
+        let history_len_after = app
+            .world()
+            .resource::<crate::snapshot::EditorHistoryResource>()
+            .0
+            .lock()
+            .unwrap()
+            .undo_stack
+            .len();
+        assert_eq!(
+            history_len_after,
+            history_len_before + 1,
+            "process_prefab_commands should push an undo checkpoint, same as ReflectCommand/EditorCommand do"
+        );
     }
 }

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -471,6 +471,35 @@ pub struct EditorCommandQueueResource(pub SharedCommandQueue);
 #[derive(Resource)]
 pub struct ReflectCommandQueueResource(pub SharedReflectCommandQueue);
 
+/// A queued "instantiate this prefab" request from the editor UI (e.g. an
+/// asset dragged onto the viewport). Handled by a dedicated exclusive
+/// system (`process_prefab_commands`), for the same reason `ReflectCommand`
+/// is: `bsengine_scene::instantiate_prefab` needs `&mut World`, which
+/// `process_editor_commands`'s typed system params can't provide.
+#[derive(Clone, Debug)]
+pub struct PrefabInstantiateCommand {
+    /// Project-relative path to the prefab file.
+    pub path: String,
+    /// Explicit root name; `None` auto-generates one.
+    pub name: Option<String>,
+    /// World-space X position for the instantiated root.
+    pub x: f32,
+    /// World-space Y position for the instantiated root.
+    pub y: f32,
+    /// World-space Z position for the instantiated root.
+    pub z: f32,
+    /// Editor entity id to parent the instantiated root under, if any.
+    pub parent_id: Option<u64>,
+}
+
+/// Shared handle to the pending `PrefabInstantiateCommand` queue, drained
+/// each frame by `process_prefab_commands`.
+pub type SharedPrefabCommandQueue = Arc<Mutex<Vec<PrefabInstantiateCommand>>>;
+
+/// Bevy resource exposing the shared prefab-instantiate queue to systems.
+#[derive(Resource)]
+pub struct PrefabCommandQueueResource(pub SharedPrefabCommandQueue);
+
 /// Bevy resource exposing the shared selection set to systems inside the
 /// `App`.
 #[derive(Resource)]

--- a/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/asset_browser.rs
@@ -17,6 +17,10 @@ pub enum AssetKind {
     Directory,
     /// A `.ron` scene file, double-click loads it.
     Scene,
+    /// A `.ron` file under an `assets/prefabs/` directory -- draggable
+    /// into the viewport to instantiate, distinct from `Scene` (which is
+    /// also `.ron` but double-click-loads instead).
+    Prefab,
     /// A `.js` script file, draggable onto an entity to attach it.
     Script,
     /// A `.glb`/`.gltf` model file, draggable into the viewport to spawn it.
@@ -32,13 +36,27 @@ pub enum AssetKind {
 /// here, since a bare path string can't be checked against the filesystem
 /// in a pure function — this function only looks at the extension string.
 fn categorize_by_extension(path: &Path) -> AssetKind {
+    let is_ron = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("ron"))
+        .unwrap_or(false);
+    if is_ron {
+        let under_prefabs = path
+            .components()
+            .any(|c| c.as_os_str().eq_ignore_ascii_case("prefabs"));
+        return if under_prefabs {
+            AssetKind::Prefab
+        } else {
+            AssetKind::Scene
+        };
+    }
     match path
         .extension()
         .and_then(|e| e.to_str())
         .map(|e| e.to_lowercase())
         .as_deref()
     {
-        Some("ron") => AssetKind::Scene,
         Some("js") => AssetKind::Script,
         Some("glb") | Some("gltf") => AssetKind::Mesh,
         Some("png") | Some("jpg") | Some("jpeg") => AssetKind::Texture,
@@ -326,6 +344,11 @@ impl AssetBrowserPanel {
         match kind {
             AssetKind::Directory => egui_phosphor::regular::FOLDER,
             AssetKind::Scene => egui_phosphor::regular::FILM_STRIP,
+            // No dedicated prefab icon exists in this codebase's icon set
+            // yet; reuse Mesh's icon since dragging a Prefab tile into the
+            // viewport spawns an entity the same way dragging a Mesh tile
+            // does (see viewport.rs's drop handling).
+            AssetKind::Prefab => egui_phosphor::regular::CUBE,
             AssetKind::Script => egui_phosphor::regular::FILE_JS,
             AssetKind::Mesh => egui_phosphor::regular::CUBE,
             AssetKind::Texture => egui_phosphor::regular::FILE_IMAGE,
@@ -367,7 +390,7 @@ impl AssetBrowserPanel {
                         self.pending_load_scene = Some(entry.path.to_string_lossy().to_string());
                     }
                 }
-                AssetKind::Mesh | AssetKind::Script => {
+                AssetKind::Mesh | AssetKind::Script | AssetKind::Prefab => {
                     // Sense::click_and_drag() here, not Sense::drag() alone:
                     // this interact is registered after (on top of, in
                     // hit-test z-order) `response`'s own click-sensing
@@ -429,6 +452,18 @@ mod tests {
             categorize_by_extension(Path::new("no_extension")),
             AssetKind::Other
         );
+    }
+
+    #[test]
+    fn a_ron_file_under_prefabs_is_categorized_as_prefab_not_scene() {
+        let path = std::path::Path::new("games/demo/assets/prefabs/enemy.ron");
+        assert_eq!(categorize_by_extension(path), AssetKind::Prefab);
+    }
+
+    #[test]
+    fn a_ron_file_outside_prefabs_is_still_categorized_as_scene() {
+        let path = std::path::Path::new("games/demo/assets/scenes/main.ron");
+        assert_eq!(categorize_by_extension(path), AssetKind::Scene);
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -46,6 +46,18 @@ impl EditorPanel for ViewportPanel {
                     name,
                     path: payload.path.to_string_lossy().to_string(),
                 });
+            } else if payload.kind == crate::panels::AssetKind::Prefab {
+                // Same origin-drop simplification SpawnMeshAsset already
+                // makes -- neither reads the drop location, since there's
+                // no cursor-to-world raycast wired into this panel yet.
+                insp.cmd_queue.push(InspectorCmd::InstantiatePrefab {
+                    path: payload.path.to_string_lossy().to_string(),
+                    name: None,
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                    parent_id: None,
+                });
             }
         }
 

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -1100,6 +1100,93 @@ mod tests {
         );
     }
 
+    // Proves a scene-file `prefab:` reference actually renders end to end
+    // (parse -> load the referenced .ron -> instantiate -> propagate ->
+    // draw), not just that entities appear.
+    #[test]
+    fn prefab_referenced_from_a_scene_file_renders_at_the_instantiation_points_position() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("assets/prefabs")).unwrap();
+        std::fs::create_dir_all(root.join("assets/scenes")).unwrap();
+        std::fs::write(
+            root.join("project.toml"),
+            "[project]\nname = \"Prefab Test\"\nentry_scene = \"assets/scenes/main.ron\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("assets/prefabs/blip.ron"),
+            r#"PrefabDescriptor(entities: [
+    EntityDescriptor(
+        name: "Blip",
+        primitive: Some(Cube),
+        emissive: Some((1.0, 0.0, 0.0)),
+    ),
+])"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("assets/scenes/main.ron"),
+            r#"SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Camera",
+        camera: true,
+        transform: Some((
+            position: (0.0, 0.0, 8.0),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Spawn1",
+        prefab: Some("assets/prefabs/blip.ron"),
+        transform: Some((position: (0.0, 0.0, 0.0))),
+    ),
+])"#,
+        )
+        .unwrap();
+
+        let project_dir = root.to_str().unwrap().to_string();
+        let mut app = build_test_app(&project_dir, None);
+        app.update();
+
+        // Window defaults to 1280x720 (no [window] table), so the exact
+        // screen center is always (640, 360). The camera at (0,0,8) with
+        // identity rotation looks straight down -Z, so a prefab
+        // instantiated at the world origin lands dead center on screen.
+        let pixel = crate::test_query::run_query(
+            app.world_mut(),
+            "get_pixel",
+            &json!({"x": 640, "y": 360}),
+        )
+        .expect("get_pixel should succeed once RenderPlugin has drawn a frame");
+        let r = pixel["r"].as_u64().unwrap();
+        let g = pixel["g"].as_u64().unwrap();
+        assert!(
+            r > g + 20,
+            "the prefab's emissive-red cube should render dead center, got {pixel:?}"
+        );
+
+        let mut q = app.world_mut().query::<&bsengine_scene::Name>();
+        let names: Vec<String> = q.iter(app.world()).map(|n| n.0.clone()).collect();
+        // The prefab's root (its only entity, "Blip") takes over the
+        // instantiation point's own name verbatim -- see Task 3's identical
+        // assertion and its comment for why. This prefab has no non-root
+        // entity, so there's nothing to check a suffix on here; that's
+        // already covered by Task 3's own unit tests. This test's job is
+        // purely to prove the pixel actually renders, which the assertion
+        // above already did.
+        assert_eq!(
+            names.iter().filter(|n| n.as_str() == "Spawn1").count(),
+            1,
+            "the prefab's root should be named exactly 'Spawn1', the instantiation \
+             point's own name, taken over verbatim, names: {names:?}"
+        );
+        assert_eq!(
+            names.len(),
+            2,
+            "exactly Camera and the instantiated prefab root should exist, names: {names:?}"
+        );
+    }
+
     // Regression test for the PressKey/ReleaseKey protocol commands: they
     // must route through Events<KeyInput>, not mutate Input<KeyCode>
     // directly, or edge-triggered checks (just_pressed/just_released --

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -8,10 +8,14 @@
 
 /// `ScenePlugin` and the entity-spawning logic that turns a `SceneDescriptor` into ECS entities.
 pub mod plugin;
+/// Single-prefab instantiation: turns a `PrefabDescriptor` into spawned entities by
+/// delegating to `spawn_scene_entities`.
+pub mod prefab;
 /// Serde/RON descriptor types that make up the on-disk scene file format.
 pub mod types;
 
 pub use plugin::{register_gameplay_reflect_types, spawn_scene_entities, Name, ScenePlugin};
+pub use prefab::{instantiate_prefab, next_instance_suffix};
 pub use types::{
     AssetRef, ColliderDesc, ColliderShapeDesc, DirectionalLightDescriptor, EntityDescriptor,
     PendingSceneLoad, PhysicsBodyDesc, PointLightDescriptor, Primitive, PrimitiveMesh,

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -14,7 +14,10 @@ pub mod prefab;
 /// Serde/RON descriptor types that make up the on-disk scene file format.
 pub mod types;
 
-pub use plugin::{register_gameplay_reflect_types, spawn_scene_entities, Name, ScenePlugin};
+pub use plugin::{
+    instantiate_prefab_from_path, register_gameplay_reflect_types, spawn_scene_entities, Name,
+    ScenePlugin,
+};
 pub use prefab::{instantiate_prefab, next_instance_suffix};
 pub use types::{
     AssetRef, ColliderDesc, ColliderShapeDesc, DirectionalLightDescriptor, EntityDescriptor,

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -1,5 +1,6 @@
 use crate::types::{
     AssetRef, EntityDescriptor, PhysicsBodyDesc, PrimitiveMesh, SceneDescriptor, ScriptPath,
+    TransformDescriptor,
 };
 use bevy_app::{App, Plugin, Startup};
 use bevy_ecs::prelude::{Component, Entity, IntoSystemConfigs, ReflectComponent, World};
@@ -79,6 +80,106 @@ impl Plugin for ScenePlugin {
             // hosts, are such apps.
             .after(bsengine_asset::identity::build_asset_index),
         );
+    }
+}
+
+thread_local! {
+    /// Paths of prefab files currently being resolved, on this call stack.
+    /// Threaded through nested `instantiate_prefab` → `spawn_scene_entities`
+    /// → `instantiate_prefab` recursion without changing either function's
+    /// public signature. Cleared entry-by-entry as each recursive call
+    /// returns, so a sibling prefab reference at the same level is never
+    /// mistaken for a cycle.
+    static RESOLVING_PREFABS: std::cell::RefCell<std::collections::HashSet<String>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// Removes one path from [`RESOLVING_PREFABS`] on drop, unconditionally --
+/// including on an unwinding panic partway through resolving this prefab.
+///
+/// Nothing in the reachable call graph (`spawn_scene_entities`, reflected
+/// component deserialization of scene-author-controlled data, ...) panics
+/// today, so a plain insert-call-remove sequence has never actually leaked
+/// in practice. But `RESOLVING_PREFABS` only ever clears entries one at a
+/// time -- it has no other expiry -- so the day something downstream does
+/// panic, a bare `remove(...)` statement placed after the call it guards
+/// would simply never run, permanently marking that one prefab path as
+/// "still resolving" for the rest of the process's life and turning every
+/// future legitimate reference to it into a false-positive cycle warning.
+/// An RAII guard makes the removal run on every exit path, not just the
+/// non-panicking one.
+struct ResolvingGuard(String);
+
+impl Drop for ResolvingGuard {
+    fn drop(&mut self) {
+        RESOLVING_PREFABS.with(|r| {
+            r.borrow_mut().remove(&self.0);
+        });
+    }
+}
+
+/// Resolves one `entity.prefab` reference: reads and parses the file, then
+/// instantiates it in the entity's place. Returns `None` (after logging a
+/// warning) on any failure -- missing file, parse error, bad root count,
+/// or a cycle -- so the caller can keep `spawned`'s length in lockstep
+/// with `entities` even when this entity contributes no real `Entity`.
+fn resolve_prefab_reference(
+    world: &mut World,
+    entity_name: &str,
+    prefab_path: &str,
+    transform: Option<TransformDescriptor>,
+) -> Option<Entity> {
+    let already_resolving = RESOLVING_PREFABS.with(|r| r.borrow().contains(prefab_path));
+    if already_resolving {
+        tracing::warn!(
+            "scene: entity '{entity_name}' references prefab '{prefab_path}', which is \
+             already being resolved earlier in this same instantiation chain -- skipping \
+             to avoid infinite recursion (cyclic prefab reference)"
+        );
+        return None;
+    }
+
+    let content = match std::fs::read_to_string(prefab_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                "scene: entity '{entity_name}' references prefab '{prefab_path}', which \
+                 could not be read: {e}"
+            );
+            return None;
+        }
+    };
+    let prefab: crate::types::PrefabDescriptor = match ron::from_str(&content) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                "scene: entity '{entity_name}' references prefab '{prefab_path}', which \
+                 failed to parse: {e}"
+            );
+            return None;
+        }
+    };
+
+    RESOLVING_PREFABS.with(|r| r.borrow_mut().insert(prefab_path.to_string()));
+    // Guarantees the entry above is removed on every exit from this point on
+    // -- including an unwinding panic from `instantiate_prefab` or anything
+    // it calls -- rather than only on the path that reaches a plain
+    // `remove(...)` statement after it. See `ResolvingGuard`'s own doc for
+    // why a missed removal would be a silent, permanent, process-lifetime
+    // false positive rather than a one-off glitch.
+    let _guard = ResolvingGuard(prefab_path.to_string());
+    let result =
+        crate::prefab::instantiate_prefab(world, &prefab, Some(entity_name), transform, None);
+
+    match result {
+        Ok(root) => Some(root),
+        Err(e) => {
+            tracing::warn!(
+                "scene: entity '{entity_name}' references prefab '{prefab_path}', which \
+                 failed to instantiate: {e}"
+            );
+            None
+        }
     }
 }
 
@@ -328,11 +429,39 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
             .collect()
     };
 
-    let mut spawned: Vec<Entity> = Vec::with_capacity(entities.len());
+    let mut spawned: Vec<Option<Entity>> = Vec::with_capacity(entities.len());
 
     for (entity, (gltf_path, script_path, texture_path)) in entities.iter().zip(&resolved_refs) {
+        if let Some(prefab_ref) = &entity.prefab {
+            // `resolve_asset_ref` only ever returns the path a scene *stores*
+            // (identity-resolved or not) -- exactly like it does for
+            // `gltf_path` below, which is why that branch separately joins
+            // its result with `ProjectDir` before touching the filesystem.
+            // Skipping this step here meant every project-relative
+            // `prefab:` reference (the realistic case every game under
+            // `games/*` actually uses) tried to open a path relative to
+            // wherever the process happened to be running from and failed
+            // with a plain "could not be read" I/O error.
+            let prefab_path = resolve_asset_ref(
+                world.get_resource::<AssetIndex>(),
+                project_dir.as_ref(),
+                &entity.name,
+                "prefab",
+                prefab_ref,
+            );
+            let prefab_path =
+                bsengine_core::resolve_project_path(project_dir.as_ref(), &prefab_path);
+            spawned.push(resolve_prefab_reference(
+                world,
+                &entity.name,
+                &prefab_path,
+                entity.transform.clone(),
+            ));
+            continue;
+        }
+
         let mut builder = world.spawn(Name(entity.name.clone()));
-        spawned.push(builder.id());
+        spawned.push(Some(builder.id()));
 
         if let Some(t) = &entity.transform {
             let mut rotation =
@@ -502,10 +631,13 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
     // scene is never a valid parent target.
     let name_to_entity: std::collections::HashMap<&str, Entity> = entities
         .iter()
-        .map(|e| e.name.as_str())
         .zip(spawned.iter().copied())
+        .filter_map(|(e, s)| s.map(|entity| (e.name.as_str(), entity)))
         .collect();
     for (entity, &child_entity) in entities.iter().zip(&spawned) {
+        let Some(child_entity) = child_entity else {
+            continue; // a prefab reference that failed to instantiate -- nothing to parent
+        };
         let Some(parent_name) = &entity.parent else {
             continue;
         };
@@ -642,6 +774,7 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
 mod tests {
     use super::{Name, ScenePlugin};
     use bsengine_app::new_app;
+    use bsengine_asset::test_support::{unique, ProbeDir};
     use bsengine_core::{Camera, DirectionalLight, GlobalTransform, Transform};
     use glam::Vec3;
 
@@ -843,6 +976,247 @@ mod tests {
             wheel_parent, body_entity,
             "Wheel's parent should be the Body entity"
         );
+    }
+
+    #[test]
+    fn scene_file_prefab_reference_instantiates_the_prefab() {
+        // `ProbeDir`/`unique` (not `tempfile`, which this crate does not
+        // depend on) are the exact real-filesystem-fixture pattern the
+        // `identity` submodule below already uses for a real `AssetIndex`
+        // scan; borrowed here for the same reason -- a prefab reference has
+        // to name a real file on disk, and there is no way to fake that.
+        let dir = ProbeDir(std::env::temp_dir().join(unique("scene-prefab-basic")));
+        let root = &dir.0;
+        std::fs::create_dir_all(root.join("assets/prefabs")).unwrap();
+        std::fs::write(
+            root.join("assets/prefabs/enemy.ron"),
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Gun", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        )
+        .unwrap();
+
+        let scene: crate::types::SceneDescriptor = ron::from_str(&format!(
+            r#"SceneDescriptor(entities: [
+                EntityDescriptor(
+                    name: "Spawn1",
+                    prefab: Some("{}"),
+                    transform: Some((position: (5.0, 0.0, 0.0))),
+                ),
+            ])"#,
+            root.join("assets/prefabs/enemy.ron")
+                .to_str()
+                .unwrap()
+                .replace('\\', "/")
+        ))
+        .unwrap();
+
+        // No `ProjectDir` here on purpose -- the prefab reference above is
+        // already the temp directory's absolute path, and `ProjectDir`
+        // resolution (see the dedicated test right below this one) would
+        // join it onto that absolute path rather than leave it alone.
+        let mut app = new_app();
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+        let mut q = app.world_mut().query::<&Name>();
+        let names: Vec<String> = q.iter(app.world()).map(|n| n.0.clone()).collect();
+        // The prefab's root always takes over the instantiation point's own
+        // name verbatim (no suffix) -- that's what "Spawn1: prefab: Some(...)"
+        // means: "instantiate this prefab and call the result Spawn1", not
+        // "spawn a separate Spawn1 next to an auto-named prefab root". Only
+        // *non-root* entities inside the prefab (here, "Gun") get the shared
+        // instance suffix, since only those need in-file uniqueness, not a
+        // caller-meaningful name.
+        assert_eq!(
+            names.iter().filter(|n| n.as_str() == "Spawn1").count(),
+            1,
+            "the prefab's root should be named exactly 'Spawn1' -- the \
+             instantiation point's own name, taken over verbatim -- and only \
+             once (not left behind as a separate stray entity), names: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.starts_with("Gun#")),
+            "the prefab's non-root child should have been instantiated with a \
+             shared-suffix name, names: {names:?}"
+        );
+        assert_eq!(
+            names.len(),
+            2,
+            "exactly two entities should exist: the renamed root and the child, names: {names:?}"
+        );
+    }
+
+    #[test]
+    fn scene_file_prefab_reference_resolves_against_project_dir() {
+        // The realistic case every game under `games/*` actually uses:
+        // `prefab:` written as a path relative to the project root, exactly
+        // like every other asset reference (`gltf:`, `script:`, `texture:`)
+        // already resolves against `ProjectDir` before touching the
+        // filesystem (see the `gltf_path` branch right below the prefab
+        // branch in `spawn_scene_entities`). The test above this one
+        // deliberately does not cover this: it writes the temp directory's
+        // own *absolute* path straight into `prefab: Some(...)`, so a
+        // regression that resolved `prefab:` against the process's working
+        // directory instead of `ProjectDir` would have passed that test
+        // while failing every real project's scene file.
+        let dir = ProbeDir(std::env::temp_dir().join(unique("scene-prefab-project-relative")));
+        let root = &dir.0;
+        std::fs::create_dir_all(root.join("assets/prefabs")).unwrap();
+        std::fs::write(
+            root.join("assets/prefabs/enemy.ron"),
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Gun", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        )
+        .unwrap();
+
+        // Project-relative, not the temp dir's absolute path -- the whole
+        // point of this test.
+        let scene: crate::types::SceneDescriptor = ron::from_str(
+            r#"SceneDescriptor(entities: [
+                EntityDescriptor(
+                    name: "Spawn1",
+                    prefab: Some("assets/prefabs/enemy.ron"),
+                ),
+            ])"#,
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.insert_resource(bsengine_core::ProjectDir(
+            root.to_str().unwrap().to_string(),
+        ));
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+        let mut q = app.world_mut().query::<&Name>();
+        let names: Vec<String> = q.iter(app.world()).map(|n| n.0.clone()).collect();
+        assert_eq!(
+            names.iter().filter(|n| n.as_str() == "Spawn1").count(),
+            1,
+            "a project-relative prefab reference must resolve against ProjectDir and \
+             actually instantiate -- it must not silently fail to read the file just \
+             because it isn't already an absolute path, names: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.starts_with("Gun#")),
+            "the prefab's non-root child should have instantiated too, names: {names:?}"
+        );
+        assert_eq!(
+            names.len(),
+            2,
+            "exactly two entities should exist: the renamed root and the child, names: {names:?}"
+        );
+    }
+
+    #[test]
+    fn nested_prefab_reference_instantiates_recursively() {
+        let dir = ProbeDir(std::env::temp_dir().join(unique("scene-prefab-nested")));
+        let root = &dir.0;
+        std::fs::create_dir_all(root.join("assets/prefabs")).unwrap();
+        std::fs::write(
+            root.join("assets/prefabs/wheel.ron"),
+            r#"PrefabDescriptor(entities: [EntityDescriptor(name: "WheelRoot", primitive: Some(Cube))])"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("assets/prefabs/car.ron"),
+            format!(
+                r#"PrefabDescriptor(entities: [
+                    EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                    EntityDescriptor(name: "WheelSlot", parent: Some("Body"), prefab: Some("{}")),
+                ])"#,
+                root.join("assets/prefabs/wheel.ron")
+                    .to_str()
+                    .unwrap()
+                    .replace('\\', "/")
+            ),
+        )
+        .unwrap();
+
+        let scene: crate::types::SceneDescriptor = ron::from_str(&format!(
+            r#"SceneDescriptor(entities: [
+                EntityDescriptor(name: "Spawn1", prefab: Some("{}")),
+            ])"#,
+            root.join("assets/prefabs/car.ron")
+                .to_str()
+                .unwrap()
+                .replace('\\', "/")
+        ))
+        .unwrap();
+
+        // No `ProjectDir` here either, for the same reason as the top-level
+        // test above: both prefab references (`car.ron` and, inside it,
+        // `wheel.ron`) are already absolute temp-directory paths.
+        let mut app = new_app();
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+        let mut q = app.world_mut().query::<&Name>();
+        let names: Vec<String> = q.iter(app.world()).map(|n| n.0.clone()).collect();
+        // Car's root ("Body") takes over the scene's instantiation point
+        // name "Spawn1" verbatim. Car's non-root "WheelSlot" (itself a
+        // nested prefab reference) gets the shared suffix like any other
+        // non-root entity -- "WheelSlot#N". Wheel's own root ("WheelRoot")
+        // then takes over *that* name in turn, the same rule applied one
+        // level deeper: nesting is just this same rule recursing, so the
+        // wheel's actual spawned name is "WheelSlot#N", not "WheelRoot#N".
+        assert_eq!(
+            names.iter().filter(|n| n.as_str() == "Spawn1").count(),
+            1,
+            "car's root should be renamed to the scene's instantiation point name, \
+             names: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.starts_with("WheelSlot#")),
+            "the nested prefab's root should take over its own referencing entity's \
+             (already-suffixed) name, not keep its own original name, names: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.starts_with("WheelRoot")),
+            "the wheel prefab's original entity name should not survive instantiation \
+             at all, names: {names:?}"
+        );
+    }
+
+    #[test]
+    fn cyclic_prefab_reference_fails_loudly_instead_of_recursing_forever() {
+        let dir = ProbeDir(std::env::temp_dir().join(unique("scene-prefab-cycle")));
+        let root = &dir.0;
+        std::fs::create_dir_all(root.join("assets/prefabs")).unwrap();
+        let a_path = root.join("assets/prefabs/a.ron");
+        let b_path = root.join("assets/prefabs/b.ron");
+        std::fs::write(
+            &a_path,
+            format!(
+                r#"PrefabDescriptor(entities: [EntityDescriptor(name: "A", prefab: Some("{}"))])"#,
+                b_path.to_str().unwrap().replace('\\', "/")
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            &b_path,
+            format!(
+                r#"PrefabDescriptor(entities: [EntityDescriptor(name: "B", prefab: Some("{}"))])"#,
+                a_path.to_str().unwrap().replace('\\', "/")
+            ),
+        )
+        .unwrap();
+
+        let scene: crate::types::SceneDescriptor = ron::from_str(&format!(
+            r#"SceneDescriptor(entities: [EntityDescriptor(name: "Spawn1", prefab: Some("{}"))])"#,
+            a_path.to_str().unwrap().replace('\\', "/")
+        ))
+        .unwrap();
+
+        // No `ProjectDir` here either -- same reason as the other two tests
+        // above that write an absolute prefab path straight into the RON.
+        let mut app = new_app();
+        // Must not hang/stack-overflow. spawn_scene_entities itself doesn't
+        // return a Result, so the observable contract is: it returns at
+        // all (this test having a timeout via the test harness itself is
+        // the real safety net) and logs a warning rather than crashing.
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
     }
 
     #[test]

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -118,47 +118,53 @@ impl Drop for ResolvingGuard {
     }
 }
 
-/// Resolves one `entity.prefab` reference: reads and parses the file, then
-/// instantiates it in the entity's place. Returns `None` (after logging a
-/// warning) on any failure -- missing file, parse error, bad root count,
-/// or a cycle -- so the caller can keep `spawned`'s length in lockstep
-/// with `entities` even when this entity contributes no real `Entity`.
-fn resolve_prefab_reference(
+/// Instantiates the prefab at `prefab_path` into `world`, guarded against
+/// cyclic prefab references via [`RESOLVING_PREFABS`]/[`ResolvingGuard`].
+///
+/// This is the one choke point every prefab-instantiation entry point --
+/// the scene-file `prefab:` field (via [`resolve_prefab_reference`] below),
+/// `Bsengine.instantiatePrefab` (`bsengine-scripting`), and the editor's
+/// drag-and-drop (`bsengine-editor`) -- must route its *top-level* call
+/// through, precisely so that call gets registered into
+/// [`RESOLVING_PREFABS`] before anything inside the prefab can recurse.
+///
+/// That used to only be true for the scene-file path: the other two called
+/// [`crate::prefab::instantiate_prefab`] directly with an already-parsed
+/// descriptor, which never touches `RESOLVING_PREFABS` at all (nor should
+/// it -- it has no path to key on). A prefab whose non-root child names its
+/// own containing file was still caught -- `instantiate_prefab` delegates
+/// to `spawn_scene_entities`, and a nested `prefab:` field there always
+/// comes back through `resolve_prefab_reference` -> here -- but only on the
+/// *second* encounter, since the first (top-level) call was never
+/// registered. That let the prefab's real content silently spawn twice (one
+/// extra recursion level) via those two paths, instead of once with a
+/// warning like the identical file gets via a scene file. Routing all three
+/// entry points through this function closes that gap by construction
+/// rather than by each caller remembering to register itself.
+///
+/// Returns an error (never a warning of its own -- that's each caller's
+/// job, matching how each already logs) on any failure: an unreadable file,
+/// a parse error, or a cycle.
+pub fn instantiate_prefab_from_path(
     world: &mut World,
-    entity_name: &str,
     prefab_path: &str,
-    transform: Option<TransformDescriptor>,
-) -> Option<Entity> {
+    root_name: Option<&str>,
+    root_transform: Option<TransformDescriptor>,
+    parent: Option<Entity>,
+) -> Result<Entity, String> {
     let already_resolving = RESOLVING_PREFABS.with(|r| r.borrow().contains(prefab_path));
     if already_resolving {
-        tracing::warn!(
-            "scene: entity '{entity_name}' references prefab '{prefab_path}', which is \
-             already being resolved earlier in this same instantiation chain -- skipping \
-             to avoid infinite recursion (cyclic prefab reference)"
-        );
-        return None;
+        return Err(format!(
+            "prefab '{prefab_path}' is already being resolved earlier in this same \
+             instantiation chain -- skipping to avoid infinite recursion (cyclic prefab \
+             reference)"
+        ));
     }
 
-    let content = match std::fs::read_to_string(prefab_path) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!(
-                "scene: entity '{entity_name}' references prefab '{prefab_path}', which \
-                 could not be read: {e}"
-            );
-            return None;
-        }
-    };
-    let prefab: crate::types::PrefabDescriptor = match ron::from_str(&content) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!(
-                "scene: entity '{entity_name}' references prefab '{prefab_path}', which \
-                 failed to parse: {e}"
-            );
-            return None;
-        }
-    };
+    let content = std::fs::read_to_string(prefab_path)
+        .map_err(|e| format!("prefab '{prefab_path}' could not be read: {e}"))?;
+    let prefab: crate::types::PrefabDescriptor = ron::from_str(&content)
+        .map_err(|e| format!("prefab '{prefab_path}' failed to parse: {e}"))?;
 
     RESOLVING_PREFABS.with(|r| r.borrow_mut().insert(prefab_path.to_string()));
     // Guarantees the entry above is removed on every exit from this point on
@@ -168,10 +174,22 @@ fn resolve_prefab_reference(
     // why a missed removal would be a silent, permanent, process-lifetime
     // false positive rather than a one-off glitch.
     let _guard = ResolvingGuard(prefab_path.to_string());
-    let result =
-        crate::prefab::instantiate_prefab(world, &prefab, Some(entity_name), transform, None);
+    crate::prefab::instantiate_prefab(world, &prefab, root_name, root_transform, parent)
+}
 
-    match result {
+/// Resolves one `entity.prefab` reference: instantiates the file in the
+/// entity's place via [`instantiate_prefab_from_path`]. Returns `None`
+/// (after logging a warning) on any failure -- missing file, parse error,
+/// bad root count, or a cycle -- so the caller can keep `spawned`'s length
+/// in lockstep with `entities` even when this entity contributes no real
+/// `Entity`.
+fn resolve_prefab_reference(
+    world: &mut World,
+    entity_name: &str,
+    prefab_path: &str,
+    transform: Option<TransformDescriptor>,
+) -> Option<Entity> {
+    match instantiate_prefab_from_path(world, prefab_path, Some(entity_name), transform, None) {
         Ok(root) => Some(root),
         Err(e) => {
             tracing::warn!(

--- a/crates/bsengine-scene/src/prefab.rs
+++ b/crates/bsengine-scene/src/prefab.rs
@@ -52,8 +52,11 @@ pub fn instantiate_prefab(
     root_transform: Option<TransformDescriptor>,
     parent: Option<Entity>,
 ) -> Result<Entity, String> {
-    let roots: Vec<&EntityDescriptor> =
-        prefab.entities.iter().filter(|e| e.parent.is_none()).collect();
+    let roots: Vec<&EntityDescriptor> = prefab
+        .entities
+        .iter()
+        .filter(|e| e.parent.is_none())
+        .collect();
 
     // Every entity name in the prefab must be unique, checked before any
     // rewriting happens. Without this, the rewrite step below determines
@@ -131,7 +134,9 @@ pub fn instantiate_prefab(
 
     let root_entity = {
         let mut q = world.query::<(Entity, &Name)>();
-        q.iter(world).find(|(_, n)| n.0 == final_root_name).map(|(e, _)| e)
+        q.iter(world)
+            .find(|(_, n)| n.0 == final_root_name)
+            .map(|(e, _)| e)
     };
     let Some(root_entity) = root_entity else {
         // spawn_scene_entities always spawns every entity it's given
@@ -143,7 +148,9 @@ pub fn instantiate_prefab(
     };
 
     if let Some(parent_entity) = parent {
-        world.entity_mut(root_entity).insert(bsengine_core::Parent(parent_entity));
+        world
+            .entity_mut(root_entity)
+            .insert(bsengine_core::Parent(parent_entity));
     }
 
     Ok(root_entity)
@@ -173,7 +180,9 @@ mod tests {
         let root = instantiate_prefab(app.world_mut(), &prefab, None, None, None)
             .expect("a well-formed 2-entity prefab should instantiate");
 
-        let mut q = app.world_mut().query::<(&crate::plugin::Name, Option<&bsengine_core::Parent>)>();
+        let mut q = app
+            .world_mut()
+            .query::<(&crate::plugin::Name, Option<&bsengine_core::Parent>)>();
         let rows: Vec<(String, Option<Entity>)> = q
             .iter(app.world())
             .map(|(n, p)| (n.0.clone(), p.map(|p| p.0)))
@@ -191,7 +200,10 @@ mod tests {
             .expect("Wheel should have spawned with a numeric suffix");
         let body_suffix = body_row.0.strip_prefix("Body#").unwrap();
         let wheel_suffix = wheel_row.0.strip_prefix("Wheel#").unwrap();
-        assert_eq!(body_suffix, wheel_suffix, "root and child must share one instance suffix");
+        assert_eq!(
+            body_suffix, wheel_suffix,
+            "root and child must share one instance suffix"
+        );
 
         let mut root_name_q = app.world_mut().query::<&crate::plugin::Name>();
         assert_eq!(
@@ -227,7 +239,10 @@ mod tests {
     #[test]
     fn instantiate_prefab_parents_the_root_under_a_given_entity() {
         let mut app = new_app();
-        let anchor = app.world_mut().spawn(crate::plugin::Name("Anchor".to_string())).id();
+        let anchor = app
+            .world_mut()
+            .spawn(crate::plugin::Name("Anchor".to_string()))
+            .id();
         let prefab = two_entity_prefab();
 
         let root = instantiate_prefab(app.world_mut(), &prefab, None, None, Some(anchor))
@@ -253,7 +268,10 @@ mod tests {
         .unwrap();
 
         let result = instantiate_prefab(app.world_mut(), &bad, None, None, None);
-        assert!(result.is_err(), "a prefab with no root entity must fail to instantiate");
+        assert!(
+            result.is_err(),
+            "a prefab with no root entity must fail to instantiate"
+        );
     }
 
     #[test]
@@ -268,7 +286,10 @@ mod tests {
         .unwrap();
 
         let result = instantiate_prefab(app.world_mut(), &bad, None, None, None);
-        assert!(result.is_err(), "a prefab with two root entities must fail to instantiate");
+        assert!(
+            result.is_err(),
+            "a prefab with two root entities must fail to instantiate"
+        );
     }
 
     #[test]
@@ -311,9 +332,14 @@ mod tests {
             ..Default::default()
         };
 
-        let root =
-            instantiate_prefab(app.world_mut(), &prefab, None, Some(override_transform), None)
-                .expect("instantiation should succeed");
+        let root = instantiate_prefab(
+            app.world_mut(),
+            &prefab,
+            None,
+            Some(override_transform),
+            None,
+        )
+        .expect("instantiation should succeed");
 
         let root_position = app
             .world()
@@ -327,7 +353,9 @@ mod tests {
             "root_transform must override the root's own authored transform"
         );
 
-        let mut q = app.world_mut().query::<(&crate::plugin::Name, &bsengine_core::Transform)>();
+        let mut q = app
+            .world_mut()
+            .query::<(&crate::plugin::Name, &bsengine_core::Transform)>();
         let wheel_position = q
             .iter(app.world())
             .find(|(n, _)| n.0.starts_with("Wheel#"))

--- a/crates/bsengine-scene/src/prefab.rs
+++ b/crates/bsengine-scene/src/prefab.rs
@@ -1,0 +1,343 @@
+//! Single-prefab instantiation: turns a [`PrefabDescriptor`](crate::types::PrefabDescriptor)
+//! into real spawned entities by delegating entirely to
+//! [`spawn_scene_entities`](crate::plugin::spawn_scene_entities) -- no component-attaching
+//! logic is duplicated here.
+//!
+//! This module handles a single, non-nested prefab. Wiring scene files and nested prefabs
+//! to call [`instantiate_prefab`] automatically is a later task.
+
+use crate::plugin::{spawn_scene_entities, Name};
+use crate::types::{EntityDescriptor, PrefabDescriptor, TransformDescriptor};
+use bevy_ecs::prelude::{Entity, World};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static PREFAB_INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Returns a process-wide, strictly-increasing suffix. Every call is
+/// guaranteed distinct from every other call, regardless of which of the
+/// three instantiation paths (scene file, runtime script/MCP, editor) draws
+/// it -- an atomic, not a thread-local, specifically so uniqueness holds
+/// even if two instantiations happen to run on different worker threads.
+pub fn next_instance_suffix() -> u64 {
+    PREFAB_INSTANCE_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Instantiates a prefab's entity subtree into `world`.
+///
+/// `root_name`: `None` draws a fresh unique suffix and applies it to every
+/// entity's name (`"{original}#{suffix}"`), including the root. `Some(n)`
+/// uses `n` verbatim as the root's name (no suffix) -- the caller is
+/// responsible for `n`'s uniqueness, exactly like any hand-authored scene
+/// entity name. Non-root entities in the prefab always get the shared
+/// suffix regardless of `root_name`, since they only need to be unique
+/// *within this one instantiation* (to keep `parent:` resolution correct),
+/// not globally.
+///
+/// `root_transform`: `Some(t)` overrides the prefab's own authored root
+/// transform (this is how a scene file's instantiation point places the
+/// instance); `None` keeps whatever the prefab file itself authored.
+///
+/// `parent`: if given, the instantiated root is parented under this
+/// existing entity via a real `Parent` component, in addition to (not
+/// instead of) whatever internal parent chain the prefab's own entities
+/// have among themselves.
+///
+/// Returns the spawned root `Entity`, or an error if the prefab doesn't
+/// have exactly one root entity (zero or multiple entities with no
+/// `parent:`).
+pub fn instantiate_prefab(
+    world: &mut World,
+    prefab: &PrefabDescriptor,
+    root_name: Option<&str>,
+    root_transform: Option<TransformDescriptor>,
+    parent: Option<Entity>,
+) -> Result<Entity, String> {
+    let roots: Vec<&EntityDescriptor> =
+        prefab.entities.iter().filter(|e| e.parent.is_none()).collect();
+
+    // Every entity name in the prefab must be unique, checked before any
+    // rewriting happens. Without this, the rewrite step below determines
+    // "is this the root?" by string equality against `original_root_name`
+    // (needed anyway, so a parent: reference that names the root rewrites
+    // to the same final name the root itself gets) -- so a *non-root*
+    // entity that happens to share the root's exact name (e.g. a
+    // copy-pasted entity block where `name:` was never changed) would
+    // silently be treated as the root too: both get renamed to
+    // `final_root_name`, both would receive `root_transform` if given, and
+    // whichever of the two `spawn_scene_entities` or our own post-spawn
+    // lookup happens to land on second is anyone's guess. Rejecting
+    // duplicate names outright removes the ambiguity at the source instead
+    // of trying to disambiguate it after the fact.
+    let mut seen_names = std::collections::HashSet::new();
+    for e in &prefab.entities {
+        if !seen_names.insert(e.name.as_str()) {
+            return Err(format!("prefab has a duplicate entity name: '{}'", e.name));
+        }
+    }
+
+    if roots.is_empty() {
+        return Err("prefab has no root entity (every entity names a parent)".to_string());
+    }
+    if roots.len() > 1 {
+        let names: Vec<&str> = roots.iter().map(|e| e.name.as_str()).collect();
+        return Err(format!(
+            "prefab has {} root entities, expected exactly 1: {}",
+            roots.len(),
+            names.join(", ")
+        ));
+    }
+    let original_root_name = roots[0].name.clone();
+
+    let suffix = next_instance_suffix();
+    let final_root_name = root_name
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| format!("{original_root_name}#{suffix}"));
+
+    // Rewrite every entity's name -- and every parent: reference, which
+    // names another entity *in this same original list* -- through one
+    // shared mapping, so the prefab's internal parent chain keeps
+    // resolving correctly against the renamed entities. This has to be a
+    // single function used for both roles: a parent: reference that names
+    // the original root must map to `final_root_name`, exactly like the
+    // root entity's own name does -- mapping it through the generic
+    // suffix instead (as a naive first version of this might) would
+    // silently orphan every direct child of the root, since nothing in
+    // the rewritten list would carry the plain suffixed root name any more.
+    let rewrite_name = |name: &str| -> String {
+        if name == original_root_name {
+            final_root_name.clone()
+        } else {
+            format!("{name}#{suffix}")
+        }
+    };
+    let rewritten: Vec<EntityDescriptor> = prefab
+        .entities
+        .iter()
+        .map(|e| {
+            let mut e = e.clone();
+            let is_root = e.name == original_root_name;
+            e.name = rewrite_name(&e.name);
+            e.parent = e.parent.as_ref().map(|p| rewrite_name(p));
+            if is_root {
+                if let Some(t) = root_transform.clone() {
+                    e.transform = Some(t);
+                }
+            }
+            e
+        })
+        .collect();
+
+    spawn_scene_entities(world, &rewritten);
+
+    let root_entity = {
+        let mut q = world.query::<(Entity, &Name)>();
+        q.iter(world).find(|(_, n)| n.0 == final_root_name).map(|(e, _)| e)
+    };
+    let Some(root_entity) = root_entity else {
+        // spawn_scene_entities always spawns every entity it's given
+        // (barring a bug elsewhere) -- this should be unreachable, but
+        // fail loudly rather than panic if it ever isn't.
+        return Err(format!(
+            "internal error: prefab root '{final_root_name}' was not found after spawning"
+        ));
+    };
+
+    if let Some(parent_entity) = parent {
+        world.entity_mut(root_entity).insert(bsengine_core::Parent(parent_entity));
+    }
+
+    Ok(root_entity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::PrefabDescriptor;
+    use bsengine_app::new_app;
+
+    fn two_entity_prefab() -> PrefabDescriptor {
+        ron::from_str(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Wheel", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn instantiate_prefab_spawns_root_and_child_with_a_shared_unique_suffix() {
+        let mut app = new_app();
+        let prefab = two_entity_prefab();
+
+        let root = instantiate_prefab(app.world_mut(), &prefab, None, None, None)
+            .expect("a well-formed 2-entity prefab should instantiate");
+
+        let mut q = app.world_mut().query::<(&crate::plugin::Name, Option<&bsengine_core::Parent>)>();
+        let rows: Vec<(String, Option<Entity>)> = q
+            .iter(app.world())
+            .map(|(n, p)| (n.0.clone(), p.map(|p| p.0)))
+            .collect();
+
+        // Both spawned names must share the exact same suffix (proves one
+        // shared id was drawn for the whole instance, not one per entity).
+        let body_row = rows
+            .iter()
+            .find(|(n, _)| n.starts_with("Body#"))
+            .expect("Body should have spawned with a numeric suffix");
+        let wheel_row = rows
+            .iter()
+            .find(|(n, _)| n.starts_with("Wheel#"))
+            .expect("Wheel should have spawned with a numeric suffix");
+        let body_suffix = body_row.0.strip_prefix("Body#").unwrap();
+        let wheel_suffix = wheel_row.0.strip_prefix("Wheel#").unwrap();
+        assert_eq!(body_suffix, wheel_suffix, "root and child must share one instance suffix");
+
+        let mut root_name_q = app.world_mut().query::<&crate::plugin::Name>();
+        assert_eq!(
+            root_name_q.get(app.world(), root).unwrap().0,
+            body_row.0,
+            "instantiate_prefab must return the actual spawned root entity"
+        );
+        assert_eq!(
+            wheel_row.1,
+            Some(root),
+            "Wheel's Parent must point at the spawned Body root, by its real Entity id"
+        );
+    }
+
+    #[test]
+    fn instantiate_prefab_honors_an_explicit_root_name_with_no_suffix() {
+        let mut app = new_app();
+        let prefab = two_entity_prefab();
+
+        let root = instantiate_prefab(app.world_mut(), &prefab, Some("Boss"), None, None)
+            .expect("instantiation should succeed");
+
+        let mut q = app.world_mut().query::<&crate::plugin::Name>();
+        assert_eq!(
+            q.get(app.world(), root).unwrap().0,
+            "Boss",
+            "an explicit root_name override must be used verbatim, no suffix added \
+             (the caller is responsible for its own uniqueness, exactly like any \
+             other hand-authored scene entity name)"
+        );
+    }
+
+    #[test]
+    fn instantiate_prefab_parents_the_root_under_a_given_entity() {
+        let mut app = new_app();
+        let anchor = app.world_mut().spawn(crate::plugin::Name("Anchor".to_string())).id();
+        let prefab = two_entity_prefab();
+
+        let root = instantiate_prefab(app.world_mut(), &prefab, None, None, Some(anchor))
+            .expect("instantiation should succeed");
+
+        let parent = app.world().get::<bsengine_core::Parent>(root);
+        assert_eq!(
+            parent.map(|p| p.0),
+            Some(anchor),
+            "when a parent Entity is given, the instantiated root must be parented under it"
+        );
+    }
+
+    #[test]
+    fn instantiate_prefab_rejects_zero_roots() {
+        let mut app = new_app();
+        let bad: PrefabDescriptor = ron::from_str(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "A", parent: Some("B")),
+                EntityDescriptor(name: "B", parent: Some("A")),
+            ])"#,
+        )
+        .unwrap();
+
+        let result = instantiate_prefab(app.world_mut(), &bad, None, None, None);
+        assert!(result.is_err(), "a prefab with no root entity must fail to instantiate");
+    }
+
+    #[test]
+    fn instantiate_prefab_rejects_multiple_roots() {
+        let mut app = new_app();
+        let bad: PrefabDescriptor = ron::from_str(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "RootA"),
+                EntityDescriptor(name: "RootB"),
+            ])"#,
+        )
+        .unwrap();
+
+        let result = instantiate_prefab(app.world_mut(), &bad, None, None, None);
+        assert!(result.is_err(), "a prefab with two root entities must fail to instantiate");
+    }
+
+    #[test]
+    fn instantiate_prefab_rejects_a_duplicate_entity_name() {
+        let mut app = new_app();
+        // Root-count validation alone lets this through (only one entity has
+        // no `parent:`), but the second "Body" -- a non-root entity that
+        // happens to share the root's exact name, e.g. a copy-pasted block
+        // where `name:` was never updated -- must still be caught, since
+        // nothing downstream can tell the two apart once names collide.
+        let bad: PrefabDescriptor = ron::from_str(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Body", parent: Some("Wheel"), primitive: Some(Cube)),
+            ])"#,
+        )
+        .unwrap();
+
+        let result = instantiate_prefab(app.world_mut(), &bad, None, None, None);
+        assert!(
+            result.is_err(),
+            "a prefab with two entities sharing the same name must fail to instantiate, \
+             not silently produce two entities with an identical Name component"
+        );
+    }
+
+    #[test]
+    fn instantiate_prefab_overrides_only_the_roots_transform() {
+        let mut app = new_app();
+        let prefab: PrefabDescriptor = ron::from_str(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube), transform: Some((position: (1.0, 2.0, 3.0)))),
+                EntityDescriptor(name: "Wheel", parent: Some("Body"), primitive: Some(Cube), transform: Some((position: (0.5, 0.0, 0.0)))),
+            ])"#,
+        )
+        .unwrap();
+
+        let override_transform = TransformDescriptor {
+            position: [5.0, 0.0, 0.0],
+            ..Default::default()
+        };
+
+        let root =
+            instantiate_prefab(app.world_mut(), &prefab, None, Some(override_transform), None)
+                .expect("instantiation should succeed");
+
+        let root_position = app
+            .world()
+            .get::<bsengine_core::Transform>(root)
+            .expect("root should have a Transform")
+            .position
+            .0;
+        assert_eq!(
+            root_position,
+            glam::Vec3::new(5.0, 0.0, 0.0),
+            "root_transform must override the root's own authored transform"
+        );
+
+        let mut q = app.world_mut().query::<(&crate::plugin::Name, &bsengine_core::Transform)>();
+        let wheel_position = q
+            .iter(app.world())
+            .find(|(n, _)| n.0.starts_with("Wheel#"))
+            .map(|(_, t)| t.position.0)
+            .expect("Wheel should have spawned with its own Transform");
+        assert_eq!(
+            wheel_position,
+            glam::Vec3::new(0.5, 0.0, 0.0),
+            "root_transform override must be scoped to the root only; the child keeps its \
+             own prefab-authored local transform"
+        );
+    }
+}

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -187,6 +187,22 @@ pub struct SceneDescriptor {
     pub skybox: Option<String>,
 }
 
+/// Root of a prefab file: a reusable entity subtree, instantiated by name
+/// reference from a scene file, a runtime script/MCP call, or the editor.
+///
+/// Deliberately not `SceneDescriptor` reused verbatim -- `SceneDescriptor`
+/// carries a scene-wide `skybox` field that has no meaning on a reusable
+/// entity template, and a prefab author setting it would silently do
+/// nothing once the entities are instantiated into a scene.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrefabDescriptor {
+    /// Entities in this prefab, in file order. Exactly one must have no
+    /// `parent:` (the root); this is validated at instantiation time, not
+    /// at parse time, since RON itself has no way to express the
+    /// constraint.
+    pub entities: Vec<EntityDescriptor>,
+}
+
 /// Built-in primitive mesh shapes that the runtime can spawn without an asset file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Reflect)]
 #[reflect(Default)]
@@ -297,6 +313,13 @@ pub struct EntityDescriptor {
     /// parent references are not supported.
     #[serde(default)]
     pub parent: Option<String>,
+    /// Reference to a prefab asset. If present, this descriptor acts as an
+    /// *instantiation point* rather than a normal entity: none of this
+    /// descriptor's own component fields (transform aside) are used --
+    /// instead the referenced prefab's own entity subtree is spawned in
+    /// its place. See `instantiate_prefab` in `prefab.rs`.
+    #[serde(default)]
+    pub prefab: Option<AssetRef>,
     /// Reflected components not covered by this struct's own typed fields
     /// (e.g. `AnimationStateMachine`, `NavMeshAgent`, `Shield`, `Bloom`,
     /// `ToneMap`), as (fully-qualified type path, RON-encoded value) pairs.
@@ -619,6 +642,35 @@ mod tests {
         let older: EntityDescriptor = ron::from_str(r#"EntityDescriptor(name: "Root")"#)
             .expect("a scene written before `parent` existed should still parse");
         assert_eq!(older.parent, None);
+    }
+
+    #[test]
+    fn entity_descriptor_with_prefab_deserializes_and_defaults_to_absent() {
+        let with_prefab: EntityDescriptor = ron::from_str(
+            r#"EntityDescriptor(name: "Spawn1", prefab: Some("assets/prefabs/enemy.ron"))"#,
+        )
+        .expect("a scene entity should be able to reference a prefab");
+        assert_eq!(
+            with_prefab.prefab.as_ref().map(|r| r.path().to_string()),
+            Some("assets/prefabs/enemy.ron".to_string())
+        );
+
+        let older: EntityDescriptor = ron::from_str(r#"EntityDescriptor(name: "Root")"#)
+            .expect("a scene written before `prefab` existed should still parse");
+        assert_eq!(older.prefab, None);
+    }
+
+    #[test]
+    fn prefab_descriptor_parses_a_root_and_a_child() {
+        let prefab: PrefabDescriptor = ron::from_str(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Wheel", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        )
+        .expect("a prefab file with a root and a child should parse");
+        assert_eq!(prefab.entities.len(), 2);
+        assert_eq!(prefab.entities[1].parent.as_deref(), Some("Body"));
     }
 
     #[test]

--- a/crates/bsengine-scripting/Cargo.toml
+++ b/crates/bsengine-scripting/Cargo.toml
@@ -22,10 +22,6 @@ bevy_ecs.workspace = true
 bevy_reflect.workspace = true
 deno_core.workspace = true
 glam.workspace = true
-# `Bsengine.instantiatePrefab` reads a prefab file straight from disk and
-# parses it itself (`instantiate_prefab_command` in `plugin.rs`) -- the same
-# RON format `bsengine-scene` already parses scene/prefab files with.
-ron.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/bsengine-scripting/Cargo.toml
+++ b/crates/bsengine-scripting/Cargo.toml
@@ -22,6 +22,10 @@ bevy_ecs.workspace = true
 bevy_reflect.workspace = true
 deno_core.workspace = true
 glam.workspace = true
+# `Bsengine.instantiatePrefab` reads a prefab file straight from disk and
+# parses it itself (`instantiate_prefab_command` in `plugin.rs`) -- the same
+# RON format `bsengine-scene` already parses scene/prefab files with.
+ron.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/bsengine-scripting/src/js/prelude.js
+++ b/crates/bsengine-scripting/src/js/prelude.js
@@ -196,6 +196,7 @@ var Bsengine = {
     setEmissive:    (name, r, g, b)        => Deno.core.ops.bsengine_set_emissive(name, r, g, b),
     setColor:       (name, r, g, b)        => Deno.core.ops.bsengine_set_color(name, r, g, b),
     spawn:          (params)               => Deno.core.ops.bsengine_spawn(params),
+    instantiatePrefab: (params)            => Deno.core.ops.bsengine_instantiate_prefab(params),
     destroy:        (name)                 => Deno.core.ops.bsengine_destroy(name),
     setVisible:     (name, v)              => Deno.core.ops.bsengine_set_visible(name, v),
     getVisible:     (name)                 => Deno.core.ops.bsengine_get_visible(name),

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -77,6 +77,27 @@ fn default_one() -> f32 {
     1.0
 }
 
+/// JS-provided parameters for instantiating a prefab via `Bsengine.instantiatePrefab`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct InstantiatePrefabParams {
+    /// Project-relative path to the prefab `.ron` file.
+    pub path: String,
+    /// Explicit root entity name. `None` auto-generates one from the
+    /// prefab's own root name plus a unique suffix -- same as leaving
+    /// `root_name` absent when calling `instantiate_prefab` directly.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// World-space X position for the instantiated root.
+    #[serde(default)]
+    pub x: f32,
+    /// World-space Y position for the instantiated root.
+    #[serde(default)]
+    pub y: f32,
+    /// World-space Z position for the instantiated root.
+    #[serde(default)]
+    pub z: f32,
+}
+
 /// Deferred world-mutating command produced by a `Bsengine.*` script call; queued and applied to the ECS world on the next update.
 #[derive(Clone, Debug)]
 pub enum ScriptCommand {
@@ -836,6 +857,21 @@ pub enum ScriptCommand {
     },
     /// Spawn a new entity from the given parameters.
     Spawn(SpawnParams),
+    /// Instantiate a prefab. Unlike `Spawn`, the root's final name is
+    /// already decided (computed synchronously in the op, before this
+    /// command was even queued) -- this variant just carries it through.
+    InstantiatePrefab {
+        /// Project-relative path to the prefab `.ron` file.
+        path: String,
+        /// The root entity's final name, already computed by the op.
+        name: String,
+        /// World-space X position for the instantiated root.
+        x: f32,
+        /// World-space Y position for the instantiated root.
+        y: f32,
+        /// World-space Z position for the instantiated root.
+        z: f32,
+    },
     /// Destroy a named entity.
     Destroy {
         /// Name of the entity to modify.
@@ -2565,6 +2601,51 @@ pub fn bsengine_set_color(#[string] name: String, r: f32, g: f32, b: f32) {
 #[op2]
 pub fn bsengine_spawn(#[serde] params: SpawnParams) {
     COMMAND_BUFFER.with(|c| c.borrow_mut().push(ScriptCommand::Spawn(params)));
+}
+
+/// Instantiate a prefab, returning the spawned root entity's *name*
+/// synchronously -- but not the entity itself, which does not exist yet.
+///
+/// Unlike `Bsengine.spawn` (which hands back nothing to identify its
+/// entity by), this name is decided and stable the instant the call
+/// returns: it's computed up front via `bsengine_scene::next_instance_suffix`,
+/// a `World`-free atomic counter, before the command is even queued. That
+/// makes the name itself safe to use immediately -- store it, log it, pass
+/// it to another queued `Bsengine.*` call by name.
+///
+/// What is **not** true is that the entity is queryable that same tick.
+/// The actual spawn is deferred through the same `COMMAND_BUFFER` every
+/// other `Bsengine.*` mutator uses, and `run_scripts` only drains that
+/// buffer into the `World` *after* every script's `onUpdate` for the
+/// current tick has already run -- while `getPosition` and friends read
+/// `TRANSFORM_SNAPSHOT`, which is captured *before* any of those
+/// `onUpdate`s run. So `const e = Bsengine.instantiatePrefab({...});
+/// Bsengine.getPosition(e)` on consecutive lines in the same tick reads a
+/// snapshot taken before `e` existed and returns `null` -- silently, not
+/// as an error. The name only resolves to a real, positioned entity
+/// starting the *next* tick, once that tick's `run_scripts` has both
+/// applied the deferred spawn and re-collected the snapshot from the
+/// now-current `World`.
+#[op2]
+#[string]
+pub fn bsengine_instantiate_prefab(#[serde] params: InstantiatePrefabParams) -> String {
+    let name = params.name.clone().unwrap_or_else(|| {
+        let stem = std::path::Path::new(&params.path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("Prefab");
+        format!("{stem}#{}", bsengine_scene::next_instance_suffix())
+    });
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::InstantiatePrefab {
+            path: params.path,
+            name: name.clone(),
+            x: params.x,
+            y: params.y,
+            z: params.z,
+        })
+    });
+    name
 }
 
 /// Queue destroying a named entity.
@@ -5529,6 +5610,7 @@ deno_core::extension!(
         bsengine_set_emissive,
         bsengine_set_color,
         bsengine_spawn,
+        bsengine_instantiate_prefab,
         bsengine_destroy,
         bsengine_set_visible,
         bsengine_get_visible,
@@ -10219,5 +10301,41 @@ JSON.stringify(received)
         let result = rt.eval(r#"Bsengine.asmGetState("Hero")"#).unwrap();
         assert_eq!(result, "run");
         super::ASM_STATE_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+
+    // `#[op2]`-annotated functions are not directly callable Rust functions
+    // (the macro turns the name into an `OpDecl`-producing item, consumed by
+    // the `extension!` op list) -- every other op test in this file goes
+    // through `Bsengine.*` in JS instead, so this one does too, matching
+    // e.g. `test_anim_get_state_returns_snapshot` above.
+    #[test]
+    fn bsengine_instantiate_prefab_returns_a_name_synchronously_and_queues_a_command() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+
+        let result = eval_js(
+            r#"JSON.stringify([
+                Bsengine.instantiatePrefab({ path: "assets/prefabs/enemy.ron", x: 1, y: 0, z: 0 }),
+                Bsengine.instantiatePrefab({ path: "assets/prefabs/enemy.ron", x: 2, y: 0, z: 0 }),
+            ])"#,
+        );
+
+        let names: Vec<String> = serde_json::from_str(&result)
+            .expect("instantiatePrefab must return a plain string both times");
+        assert_ne!(
+            names[0], names[1],
+            "two instantiations must get distinct names"
+        );
+        assert!(
+            names[0].starts_with("enemy#"),
+            "the default name should be the prefab file stem plus a unique suffix, got {:?}",
+            names[0]
+        );
+
+        let queued = super::COMMAND_BUFFER.with(|c| c.borrow().len());
+        assert_eq!(
+            queued, 2,
+            "both instantiations must be queued for deferred spawning"
+        );
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }
 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -1814,6 +1814,15 @@ fn run_scripts(world: &mut World) {
             ScriptCommand::Spawn(params) => {
                 spawn_entity(world, params);
             }
+            ScriptCommand::InstantiatePrefab {
+                path,
+                name,
+                x,
+                y,
+                z,
+            } => {
+                instantiate_prefab_command(world, path, name, x, y, z);
+            }
             ScriptCommand::Destroy { name } => {
                 let entity = {
                     let mut q = world.query::<(Entity, &Name)>();
@@ -2697,6 +2706,47 @@ fn spawn_entity(world: &mut World, params: SpawnParams) {
 
     if let Some(script) = params.script {
         cmd.insert(ScriptPath(script));
+    }
+}
+
+/// Reads and parses the referenced prefab file, then instantiates it with
+/// the already-decided root `name` (computed synchronously back in the op
+/// -- see `bsengine_instantiate_prefab`) and the given world position.
+/// Warns and does nothing on any failure (missing/unparseable file, bad
+/// root count) rather than panicking -- consistent with every other
+/// scene/prefab-loading failure mode in this codebase.
+pub(crate) fn instantiate_prefab_command(
+    world: &mut World,
+    path: String,
+    name: String,
+    x: f32,
+    y: f32,
+    z: f32,
+) {
+    let project_dir = world.get_resource::<ProjectDir>().cloned();
+    let resolved_path = resolve_project_path(project_dir.as_ref(), &path);
+    let content = match std::fs::read_to_string(&resolved_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("instantiatePrefab: could not read '{resolved_path}': {e}");
+            return;
+        }
+    };
+    let prefab: bsengine_scene::types::PrefabDescriptor = match ron::from_str(&content) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("instantiatePrefab: '{resolved_path}' failed to parse: {e}");
+            return;
+        }
+    };
+    let transform = bsengine_scene::TransformDescriptor {
+        position: [x, y, z],
+        ..Default::default()
+    };
+    if let Err(e) =
+        bsengine_scene::instantiate_prefab(world, &prefab, Some(&name), Some(transform), None)
+    {
+        tracing::warn!("instantiatePrefab: '{resolved_path}' failed to instantiate: {e}");
     }
 }
 
@@ -5089,5 +5139,159 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&project_dir);
+    }
+
+    /// The end-to-end counterpart to
+    /// `ops::tests::bsengine_instantiate_prefab_returns_a_name_synchronously_and_queues_a_command`:
+    /// that test proves the op returns a name and queues a command; this one
+    /// proves the queued command, once actually applied to a `World`, reads
+    /// and parses a real prefab file from disk and spawns a real entity
+    /// under the requested name and position.
+    ///
+    /// This crate has no `tempfile` dev-dependency; `bsengine_asset::test_support::{ProbeDir,
+    /// unique}` is the convention this file already uses for exactly this
+    /// need (a real temp directory, removed even if the test panics) --
+    /// see `script_probe` above for the established pattern this mirrors.
+    #[test]
+    fn instantiate_prefab_command_actually_spawns_the_prefab_into_the_world() {
+        let project = bsengine_asset::test_support::unique("instantiate-prefab-command");
+        let root = std::path::PathBuf::from(&project);
+        std::fs::create_dir_all(root.join("assets").join("prefabs")).unwrap();
+        let _guard = bsengine_asset::test_support::ProbeDir(root.clone());
+        std::fs::write(
+            root.join("assets").join("prefabs").join("enemy.ron"),
+            r#"PrefabDescriptor(entities: [EntityDescriptor(name: "Enemy", primitive: Some(Cube))])"#,
+        )
+        .unwrap();
+
+        let mut world = bevy_ecs::prelude::World::new();
+        // `ProjectDir` is `ProjectDir(pub String)`, not `PathBuf` -- see
+        // `bsengine_core::project_dir::ProjectDir`.
+        world.insert_resource(bsengine_core::ProjectDir(project.clone()));
+
+        super::instantiate_prefab_command(
+            &mut world,
+            "assets/prefabs/enemy.ron".to_string(),
+            "Boss".to_string(),
+            3.0,
+            0.0,
+            0.0,
+        );
+
+        let mut q = world.query::<(&Name, &Transform)>();
+        let (name, transform) = q
+            .iter(&world)
+            .find(|(n, _)| n.0 == "Boss")
+            .expect("the prefab root should have spawned with the given name");
+        assert_eq!(name.0, "Boss");
+        assert!((transform.position.0.x - 3.0).abs() < 1e-5);
+    }
+
+    /// The design doc's own test plan called for this ("does the actual
+    /// spawn happen on the next tick") and it was never written -- proof
+    /// that the name `Bsengine.instantiatePrefab` hands back synchronously
+    /// is not yet a queryable entity in the SAME tick, and only resolves to
+    /// one on the tick after. This is the exact timing
+    /// `bsengine_instantiate_prefab`'s doc comment describes, and the
+    /// silent-`null` failure mode a script chaining `getPosition` on the
+    /// very next line would hit if it didn't know that.
+    ///
+    /// Modelled on `pause_then_is_paused_reports_true_next_frame` above: a
+    /// script whose `onUpdate` behaves differently on its first and second
+    /// call (a `called` flag), driven across real ticks by real
+    /// `app.update()`s, with each tick's observation recorded into
+    /// `SaveData` so both can be asserted after the fact -- reading state
+    /// back out through JS/`Bsengine.getPosition` itself, not by peeking at
+    /// `COMMAND_BUFFER` or the `World` directly, so this proves what a real
+    /// script would actually observe.
+    #[test]
+    fn instantiated_prefab_position_is_not_available_until_the_next_tick() {
+        let project = bsengine_asset::test_support::unique("instantiate-prefab-tick-timing");
+        let root = std::path::PathBuf::from(&project);
+        std::fs::create_dir_all(root.join("assets").join("prefabs")).unwrap();
+        std::fs::create_dir_all(root.join("assets").join("scripts")).unwrap();
+        let _guard = bsengine_asset::test_support::ProbeDir(root.clone());
+        std::fs::write(
+            root.join("assets").join("prefabs").join("enemy.ron"),
+            r#"PrefabDescriptor(entities: [EntityDescriptor(name: "Enemy", primitive: Some(Cube))])"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("assets").join("scripts").join("driver.js"),
+            "let called = false;\n\
+             function onUpdate(name) {\n\
+                 if (!called) {\n\
+                     called = true;\n\
+                     Bsengine.instantiatePrefab({ path: \"assets/prefabs/enemy.ron\", name: \"Boss\", x: 3, y: 0, z: 0 });\n\
+                     const pos = Bsengine.getPosition(\"Boss\");\n\
+                     Bsengine.setSaveField(name, \"tick1\", pos === null ? \"null\" : \"present\");\n\
+                     return;\n\
+                 }\n\
+                 const pos = Bsengine.getPosition(\"Boss\");\n\
+                 Bsengine.setSaveField(name, \"tick2\", pos === null ? \"null\" : JSON.stringify(pos));\n\
+             }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: project.clone(),
+        });
+        app.world_mut().spawn((
+            Name("Hero".to_string()),
+            bsengine_core::SaveData::new(0),
+            ScriptPath("assets/scripts/driver.js".to_string()),
+        ));
+
+        // Three updates for the same reason `pause_then_is_paused_reports_true_next_frame`
+        // uses three: the first `app.update()` both loads the script
+        // (`PostStartup` runs before that same call's `Update`) and runs its
+        // first `onUpdate` (tick 1: `instantiatePrefab` followed immediately
+        // by the `getPosition` check, both on the same tick); the second
+        // `app.update()` runs `onUpdate` a second time (tick 2: the delayed
+        // check) -- but only after that same call's `run_scripts` has both
+        // drained tick 1's `COMMAND_BUFFER` into the `World` and re-collected
+        // `TRANSFORM_SNAPSHOT` from it, ahead of tick 2's `onUpdate`. The
+        // third is the same margin the precedent test keeps.
+        app.update();
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let mut q = world.query::<(&Name, &bsengine_core::SaveData)>();
+        let (_, save) = q
+            .iter(world)
+            .find(|(n, _)| n.0 == "Hero")
+            .expect("Hero entity with SaveData not found");
+
+        assert_eq!(
+            save.get("tick1"),
+            Some(b"null".as_slice()),
+            "in the SAME tick instantiatePrefab was called, the command has \
+             not been applied to the World yet (that only happens after every \
+             script's onUpdate for the tick has run), and TRANSFORM_SNAPSHOT \
+             was captured before this tick's onUpdate calls ran at all -- so \
+             getPosition must read this as \"entity not found\", not the \
+             pre-spawn origin or any other stand-in value"
+        );
+
+        let tick2 = save
+            .get("tick2")
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .expect("tick2 SaveData field must have been set by the second onUpdate");
+        assert_ne!(
+            tick2, "null",
+            "by the NEXT tick the deferred InstantiatePrefab command has been \
+             applied to the World, so getPosition must now find the real, \
+             spawned entity"
+        );
+        let pos: serde_json::Value = serde_json::from_str(&tick2)
+            .expect("tick2's getPosition result must have serialized as real JSON, not null");
+        assert!(
+            (pos["x"].as_f64().unwrap() - 3.0).abs() < 1e-4,
+            "the spawned entity must be at the position instantiatePrefab was \
+             called with, not the origin: {tick2}"
+        );
     }
 }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -2709,12 +2709,22 @@ fn spawn_entity(world: &mut World, params: SpawnParams) {
     }
 }
 
-/// Reads and parses the referenced prefab file, then instantiates it with
-/// the already-decided root `name` (computed synchronously back in the op
-/// -- see `bsengine_instantiate_prefab`) and the given world position.
-/// Warns and does nothing on any failure (missing/unparseable file, bad
-/// root count) rather than panicking -- consistent with every other
-/// scene/prefab-loading failure mode in this codebase.
+/// Instantiates the referenced prefab file (resolved against `ProjectDir`)
+/// with the already-decided root `name` (computed synchronously back in the
+/// op -- see `bsengine_instantiate_prefab`) and the given world position, via
+/// `bsengine_scene::instantiate_prefab_from_path` -- the same cycle-guarded
+/// entry point the scene-file `prefab:` field uses. Routing through it here
+/// (rather than reading/parsing the file and calling
+/// `bsengine_scene::instantiate_prefab` directly, as this used to) matters
+/// for more than avoiding duplicated file I/O: it's what registers this
+/// top-level call into the crate's cycle-detection set before any nested
+/// `prefab:` reference inside the file can recurse. Skipping it silently
+/// double-spawned a prefab whose own child referenced its containing file,
+/// since the cycle guard only ever caught such a reference on its *second*
+/// encounter, not its first. Warns and does nothing on any failure
+/// (missing/unparseable file, bad root count, or a cycle) rather than
+/// panicking -- consistent with every other scene/prefab-loading failure
+/// mode in this codebase.
 pub(crate) fn instantiate_prefab_command(
     world: &mut World,
     path: String,
@@ -2725,27 +2735,17 @@ pub(crate) fn instantiate_prefab_command(
 ) {
     let project_dir = world.get_resource::<ProjectDir>().cloned();
     let resolved_path = resolve_project_path(project_dir.as_ref(), &path);
-    let content = match std::fs::read_to_string(&resolved_path) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!("instantiatePrefab: could not read '{resolved_path}': {e}");
-            return;
-        }
-    };
-    let prefab: bsengine_scene::types::PrefabDescriptor = match ron::from_str(&content) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!("instantiatePrefab: '{resolved_path}' failed to parse: {e}");
-            return;
-        }
-    };
     let transform = bsengine_scene::TransformDescriptor {
         position: [x, y, z],
         ..Default::default()
     };
-    if let Err(e) =
-        bsengine_scene::instantiate_prefab(world, &prefab, Some(&name), Some(transform), None)
-    {
+    if let Err(e) = bsengine_scene::instantiate_prefab_from_path(
+        world,
+        &resolved_path,
+        Some(&name),
+        Some(transform),
+        None,
+    ) {
         tracing::warn!("instantiatePrefab: '{resolved_path}' failed to instantiate: {e}");
     }
 }
@@ -5185,6 +5185,77 @@ mod tests {
             .expect("the prefab root should have spawned with the given name");
         assert_eq!(name.0, "Boss");
         assert!((transform.position.0.x - 3.0).abs() < 1e-5);
+    }
+
+    /// Regression test for a cycle-detection gap: `instantiate_prefab_command`
+    /// used to call `bsengine_scene::instantiate_prefab` directly with an
+    /// already-parsed descriptor, which never registers the top-level path
+    /// into the crate's cycle-detection set -- only the scene-file `prefab:`
+    /// entry point did that. A nested `prefab:` reference *inside* the
+    /// loaded file still routed back through the guarded path (via
+    /// `spawn_scene_entities` -> `resolve_prefab_reference`), so a prefab
+    /// whose non-root child names its own containing file was still caught
+    /// -- but only on the *second* encounter, since the first (top-level)
+    /// call was never registered. That let the prefab's one real entity
+    /// ("Root") silently spawn twice: once as the top-level instantiation's
+    /// root, and again as the nested call's root before the guard caught the
+    /// reference one level further in.
+    ///
+    /// This fixture is deliberately a *self*-reference (a prefab whose own
+    /// child points back at the same file), not the mutual A/B cycle
+    /// `bsengine-scene`'s own `cyclic_prefab_reference_fails_loudly_instead_of_recursing_forever`
+    /// uses -- both are cycles, but a self-reference is the realistic
+    /// leftover-after-copy-paste authoring mistake this bug was found from,
+    /// and it is what actually exercises the top-level-vs-nested asymmetry:
+    /// with a two-file A/B cycle the *first* file's top-level call was never
+    /// the one under test.
+    ///
+    /// Asserts the exact entity count (1, not 2) rather than merely "did not
+    /// hang", since the pre-fix bug was silent duplication, not a hang or a
+    /// crash -- a test that only checked "returns without hanging" (like the
+    /// scene-file crate's own cyclic test) would not have caught this at
+    /// all. Mutation-verified: reverting the fix (making this call
+    /// `bsengine_scene::instantiate_prefab` directly again, as it did before)
+    /// makes this test fail with 2 entities instead of 1.
+    #[test]
+    fn instantiate_prefab_command_self_referencing_child_does_not_double_spawn() {
+        let project = bsengine_asset::test_support::unique("instantiate-prefab-command-self-cycle");
+        let root = std::path::PathBuf::from(&project);
+        std::fs::create_dir_all(root.join("assets").join("prefabs")).unwrap();
+        let _guard = bsengine_asset::test_support::ProbeDir(root.clone());
+        std::fs::write(
+            root.join("assets").join("prefabs").join("enemy.ron"),
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Root", primitive: Some(Cube)),
+                EntityDescriptor(name: "Child", parent: Some("Root"), prefab: Some("assets/prefabs/enemy.ron")),
+            ])"#,
+        )
+        .unwrap();
+
+        let mut world = bevy_ecs::prelude::World::new();
+        world.insert_resource(bsengine_core::ProjectDir(project.clone()));
+
+        super::instantiate_prefab_command(
+            &mut world,
+            "assets/prefabs/enemy.ron".to_string(),
+            "Boss".to_string(),
+            3.0,
+            0.0,
+            0.0,
+        );
+
+        let mut q = world.query::<&Name>();
+        let names: Vec<String> = q.iter(&world).map(|n| n.0.clone()).collect();
+        assert_eq!(
+            names,
+            vec!["Boss".to_string()],
+            "the self-referencing child must be cleanly skipped by the cycle guard on \
+             its FIRST encounter (exactly like the scene-file `prefab:` path already \
+             does for an identical file), spawning the prefab's real content exactly \
+             once -- not twice, which is what happened when this top-level call bypassed \
+             the cycle-guard registration and the self-reference was only caught one \
+             recursion level later. names: {names:?}"
+        );
     }
 
     /// The design doc's own test plan called for this ("does the actual


### PR DESCRIPTION
## Summary
- Adds a prefab system: `PrefabDescriptor`/`EntityDescriptor.prefab` scene format, a core `bsengine_scene::instantiate_prefab` function with nested-prefab support and cycle detection, and three instantiation paths — a scene-file `prefab:` field, a runtime `Bsengine.instantiatePrefab` script/MCP op, and editor drag-and-drop from the asset browser onto the viewport.
- Automatic unique-suffix naming (`Name#N`) lets the same prefab be instantiated repeatedly without name collisions, applied consistently to the root, all non-root entities, and their `parent:` references.
- One E2E test (`get_pixel`-based) proves the full stack renders: scene parse → prefab file load → instantiate → transform propagation → actual GPU-drawn pixel.
- Final whole-branch review caught a real cross-path bug invisible to any single commit's own review: cycle detection was only registered by the scene-file entry point, so a self-referencing prefab would silently double-spawn its content via the script/editor paths instead of being cleanly skipped. Fixed by extracting the cycle-guarded logic into a single shared `instantiate_prefab_from_path`, now used by all three entry points.

**Deliberately deferred to a follow-up PR** (per the design doc, scoped during brainstorming): Unity/Unreal-style live-linked prefab instances (override tracking), MCP `prefab_write` (creating prefabs via MCP), and an editor "Create Prefab" button.

## Test plan
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo clippy --all-targets` clean (only pre-existing, unrelated warnings)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` clean
- [x] `cargo test --workspace --exclude bsengine-editor` all green
- [x] `cargo test -p bsengine-editor` 829/829 green (isolated run, known V8-stack-size requirement)
- [x] All 8 pre-existing E2E replay recordings (mini-arena + tilt-run) PASS locally
- [x] Every commit went through implementer + spec-compliance-review + code-quality-review; a final whole-branch review found and a follow-up fix closed one real Important-severity bug (cycle-detection asymmetry, see above), mutation-verified with a new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)