### PR TITLE
Prefab override tracking: preserve manual edits across push-sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,19 +76,26 @@ jobs:
         shell: pwsh
         run: echo "RUSTY_V8_ARCHIVE=$env:USERPROFILE\.rusty_v8\rusty_v8.lib.gz" >> $env:GITHUB_ENV
 
-      # `timeout-minutes` plus short per-request apt timeouts/retries are both
-      # needed: GitHub's ubuntu-latest runners pre-configure
-      # azure.archive.ubuntu.com as a mirror, and when that mirror is
-      # degraded, apt's default timeout/retry behavior can leave this step
-      # hanging for a very long time with no output (observed: 40+ minutes,
-      # 3 runs in a row) instead of falling back to a working mirror quickly.
-      # A short per-request timeout makes each failed attempt against a bad
-      # mirror fail fast so apt moves on; the step-level timeout is a
-      # last-resort backstop in case that still isn't enough.
+      # GitHub's ubuntu-latest runners pre-configure azure.archive.ubuntu.com
+      # as a mirror, and it has been degraded: apt-get update against it hung
+      # for 40+ minutes with zero output across 3 consecutive runs (confirmed
+      # via live web-UI logs -- archive.ubuntu.com succeeded in the same run).
+      # Per-request timeout/retry options (Acquire::http::Timeout, Retries)
+      # only partially helped -- a follow-up run still stalled silently for
+      # the full 5-minute step timeout on what looks like a DNS/connect-level
+      # hang those options don't fully bound. Dropping the broken mirror from
+      # apt's sources entirely, in favor of the one already proven to work,
+      # is more decisive than tuning timeouts against a host that may not
+      # respond at all. `|| true` on the sed calls: harmless if a particular
+      # sources file/format doesn't exist (e.g. a future non-noble image).
+      # `timeout-minutes` stays as a backstop in case of a *different* future
+      # mirror problem.
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         timeout-minutes: 5
         run: |
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get -o Acquire::Retries=2 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
           sudo apt-get install -y mesa-vulkan-drivers libasound2-dev libudev-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,20 @@ jobs:
         shell: pwsh
         run: echo "RUSTY_V8_ARCHIVE=$env:USERPROFILE\.rusty_v8\rusty_v8.lib.gz" >> $env:GITHUB_ENV
 
+      # `timeout-minutes` plus short per-request apt timeouts/retries are both
+      # needed: GitHub's ubuntu-latest runners pre-configure
+      # azure.archive.ubuntu.com as a mirror, and when that mirror is
+      # degraded, apt's default timeout/retry behavior can leave this step
+      # hanging for a very long time with no output (observed: 40+ minutes,
+      # 3 runs in a row) instead of falling back to a working mirror quickly.
+      # A short per-request timeout makes each failed attempt against a bad
+      # mirror fail fast so apt moves on; the step-level timeout is a
+      # last-resort backstop in case that still isn't enough.
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=2 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
           sudo apt-get install -y mesa-vulkan-drivers libasound2-dev libudev-dev
 
       - name: Format check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,6 +1158,7 @@ dependencies = [
  "glam 0.29.3",
  "ron",
  "serde",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -121,7 +121,7 @@ pub use network_id::{NetworkAuthority, NetworkId};
 pub use parent::Parent;
 pub use particles::{Particle, ParticleEmitter, Rng};
 pub use pause_state::PauseState;
-pub use prefab_instance::PrefabInstance;
+pub use prefab_instance::{PrefabInstance, PrefabInstanceBaseline};
 pub use project_dir::{resolve_project_path, ProjectDir};
 pub use reflect_color::ReflectColor;
 pub use reflect_degrees::ReflectDegrees;

--- a/crates/bsengine-core/src/prefab_instance.rs
+++ b/crates/bsengine-core/src/prefab_instance.rs
@@ -69,7 +69,10 @@ mod tests {
             })
             .id();
         assert_eq!(
-            world.get::<PrefabInstanceBaseline>(entity).unwrap().synced_ron,
+            world
+                .get::<PrefabInstanceBaseline>(entity)
+                .unwrap()
+                .synced_ron,
             "PrefabDescriptor(entities: [])"
         );
     }

--- a/crates/bsengine-core/src/prefab_instance.rs
+++ b/crates/bsengine-core/src/prefab_instance.rs
@@ -28,3 +28,49 @@ pub struct PrefabInstance {
     /// `PrefabInstantiateCommand::path` already use.
     pub source_path: String,
 }
+
+/// Records the source prefab file's exact text as of the last successful
+/// instantiation or push-sync of this instance, so a later push-sync can
+/// tell "the user changed this field" (live value differs from what's
+/// recorded here) apart from "this field still matches what the prefab
+/// said last time" (safe to overwrite with the new file's value).
+///
+/// Attached only to the instance root, same lifecycle as [`PrefabInstance`]
+/// (see that type's doc comment for why root-only is sufficient). A single
+/// `String` field, so `Reflect` derivation is trivial and it round-trips
+/// through the scene-save `extra_components` mechanism the same way
+/// `PrefabInstance` already does -- no new persistence code, and it
+/// survives an editor restart.
+///
+/// Deliberately has no `ReflectDefault` / `#[reflect(Default)]`, for the
+/// same reason `PrefabInstance` doesn't: this is bookkeeping the resync
+/// machinery attaches itself, not something meaningful to attach by hand
+/// from the Inspector's "Add Component" picker.
+#[derive(Component, Clone, Debug, Reflect)]
+#[reflect(Component)]
+pub struct PrefabInstanceBaseline {
+    /// The source prefab file's RON text, exactly as read from disk, at the
+    /// last successful sync. Re-parsed on demand by the resync algorithm --
+    /// never compared as text, only as the parsed value it represents.
+    pub synced_ron: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::world::World;
+
+    #[test]
+    fn prefab_instance_baseline_can_be_inserted_and_read_back() {
+        let mut world = World::new();
+        let entity = world
+            .spawn(PrefabInstanceBaseline {
+                synced_ron: "PrefabDescriptor(entities: [])".to_string(),
+            })
+            .id();
+        assert_eq!(
+            world.get::<PrefabInstanceBaseline>(entity).unwrap().synced_ron,
+            "PrefabDescriptor(entities: [])"
+        );
+    }
+}

--- a/crates/bsengine-editor/src/lib.rs
+++ b/crates/bsengine-editor/src/lib.rs
@@ -15,6 +15,12 @@
 /// Registers the editor's ECS systems, resources, and the `EditorCommand`/
 /// `ReflectCommand` processing loop into a Bevy `App`.
 pub mod plugin;
+/// Field-level merge logic for prefab push-sync: snapshots a live instance's
+/// current state and decides, per field, which values a resync should
+/// preserve (user overrides) vs. adopt from the prefab's new content.
+/// Internal wiring for `prefab_watcher.rs`'s resync, not a public API of
+/// this crate.
+pub(crate) mod prefab_merge;
 /// Despawn-and-reinstantiate resync for prefab instances whose source file
 /// changed on disk, and the file watcher (`PrefabWatcherPlugin`) that
 /// detects those changes.

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1386,7 +1386,7 @@ fn populate_reflected_component_snapshot(world: &mut World) {
 /// referenced entity may not have spawned yet). `GlobalTransform` is
 /// recomputed every frame by `propagate_global_transforms`, not authored
 /// state.
-fn excluded_from_extra_components() -> std::collections::HashSet<std::any::TypeId> {
+pub(crate) fn excluded_from_extra_components() -> std::collections::HashSet<std::any::TypeId> {
     [
         std::any::TypeId::of::<Transform>(),
         std::any::TypeId::of::<GlobalTransform>(),

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -118,6 +118,100 @@ fn snapshot_extra_components(
     components
 }
 
+/// The core rule: a live value that still equals the baseline hasn't been
+/// touched since the last sync, so it's safe to adopt the new file's value.
+/// A live value that differs from the baseline is an override and wins,
+/// regardless of what the new file says.
+fn resolve_field<T: Clone + PartialEq>(live: &T, baseline: &T, new: &T) -> T {
+    if live == baseline {
+        new.clone()
+    } else {
+        live.clone()
+    }
+}
+
+/// Merges this PR's representative field set for one matched entity (present
+/// in `live`, `baseline`, and `new` alike). `name` always comes from `live`
+/// unchanged -- matching is by name already, so there's nothing to resolve
+/// there. Every field this PR doesn't yet cover (see the plan's "Scope for
+/// this plan" note) is left at `EntityDescriptor::default()`'s value on the
+/// returned descriptor; callers must never treat that as "adopt an
+/// explicit clear" for those fields -- `apply_merged_descriptor` (a later
+/// task) only ever touches the fields this function actually resolves.
+pub(crate) fn merge_entity_descriptor(
+    live: &bsengine_scene::EntityDescriptor,
+    baseline: &bsengine_scene::EntityDescriptor,
+    new: &bsengine_scene::EntityDescriptor,
+) -> bsengine_scene::EntityDescriptor {
+    bsengine_scene::EntityDescriptor {
+        name: live.name.clone(),
+        transform: resolve_field(&live.transform, &baseline.transform, &new.transform),
+        primitive: resolve_field(&live.primitive, &baseline.primitive, &new.primitive),
+        emissive: resolve_field(&live.emissive, &baseline.emissive, &new.emissive),
+        color: resolve_field(&live.color, &baseline.color, &new.color),
+        opacity: resolve_field(&live.opacity, &baseline.opacity, &new.opacity),
+        components: merge_components(&live.components, &baseline.components, &new.components),
+        ..Default::default()
+    }
+}
+
+/// Same rule as `resolve_field`, applied per reflected-component type path
+/// rather than to one value: a key whose live value still matches its
+/// baseline value adopts the new file's value for that key (which may be
+/// absent -- the source removed that component -- in which case the merged
+/// result omits the key too, so `apply_merged_descriptor` removes it). A key
+/// with no baseline entry at all (the user attached a component the prefab
+/// never had, or it predates override tracking) is always kept as-is,
+/// whatever `new` says. A key present in baseline but missing from `live`
+/// (the user detached a prefab-provided component) stays removed -- the
+/// removal itself is the override, and is not undone just because `new`
+/// still has that key.
+fn merge_components(
+    live: &[(String, String)],
+    baseline: &[(String, String)],
+    new: &[(String, String)],
+) -> Vec<(String, String)> {
+    // A plain `fn` item (rather than a closure) so the elided lifetime ties
+    // the returned map's borrows to the single input slice, per fn lifetime
+    // elision rules -- a closure with this same signature fails to compile
+    // because closures don't get that elision and each occurrence of `&str`
+    // is inferred as its own independent lifetime.
+    fn to_map(pairs: &[(String, String)]) -> std::collections::HashMap<&str, &str> {
+        pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect()
+    }
+    let live_map = to_map(live);
+    let baseline_map = to_map(baseline);
+    let new_map = to_map(new);
+
+    let mut all_keys: Vec<&str> = live_map
+        .keys()
+        .chain(baseline_map.keys())
+        .chain(new_map.keys())
+        .copied()
+        .collect();
+    all_keys.sort_unstable();
+    all_keys.dedup();
+
+    let mut result = Vec::new();
+    for key in all_keys {
+        let resolved = match baseline_map.get(key) {
+            Some(&b) => match live_map.get(key) {
+                Some(&l) if l == b => new_map.get(key).copied(),
+                Some(&l) => Some(l),
+                None => None,
+            },
+            None => match live_map.get(key) {
+                Some(&l) => Some(l),
+                None => new_map.get(key).copied(),
+            },
+        };
+        if let Some(v) = resolved {
+            result.push((key.to_string(), v.to_string()));
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -210,6 +304,114 @@ mod tests {
                 .any(|(type_path, _)| type_path.ends_with("Shield")),
             "components: {:?}",
             desc.components
+        );
+    }
+
+    #[test]
+    fn resolve_field_adopts_new_when_live_still_matches_baseline() {
+        assert_eq!(resolve_field(&"live", &"live", &"new"), "new");
+    }
+
+    #[test]
+    fn resolve_field_keeps_live_when_it_differs_from_baseline() {
+        assert_eq!(resolve_field(&"overridden", &"baseline", &"new"), "overridden");
+    }
+
+    #[test]
+    fn merge_entity_descriptor_adopts_unoverridden_fields_and_keeps_overridden_ones() {
+        let baseline = bsengine_scene::EntityDescriptor {
+            name: "Barrel".to_string(),
+            primitive: Some(bsengine_scene::Primitive::Cube),
+            color: Some([1.0, 0.0, 0.0]),
+            ..Default::default()
+        };
+        let new = bsengine_scene::EntityDescriptor {
+            name: "Barrel".to_string(),
+            primitive: Some(bsengine_scene::Primitive::Sphere), // author changed the shape
+            color: Some([1.0, 0.0, 0.0]),                       // unchanged
+            ..Default::default()
+        };
+        let live = bsengine_scene::EntityDescriptor {
+            name: "Barrel".to_string(),
+            primitive: Some(bsengine_scene::Primitive::Cube), // matches baseline -> adopt new
+            color: Some([0.0, 1.0, 0.0]),                     // user recolored it -> keep live
+            ..Default::default()
+        };
+
+        let merged = merge_entity_descriptor(&live, &baseline, &new);
+
+        assert_eq!(
+            merged.primitive,
+            Some(bsengine_scene::Primitive::Sphere),
+            "unoverridden field must pick up the new file's value"
+        );
+        assert_eq!(
+            merged.color,
+            Some([0.0, 1.0, 0.0]),
+            "overridden field must keep the user's live value, ignoring the new file"
+        );
+    }
+
+    #[test]
+    fn merge_components_adopts_a_new_value_for_an_unoverridden_component() {
+        let baseline = vec![("pkg::Shield".to_string(), "(hp: 10)".to_string())];
+        let new = vec![("pkg::Shield".to_string(), "(hp: 20)".to_string())];
+        let live = baseline.clone(); // untouched since sync
+
+        let merged = merge_components(&live, &baseline, &new);
+        assert_eq!(merged, vec![("pkg::Shield".to_string(), "(hp: 20)".to_string())]);
+    }
+
+    #[test]
+    fn merge_components_keeps_a_user_modified_component_value() {
+        let baseline = vec![("pkg::Shield".to_string(), "(hp: 10)".to_string())];
+        let new = vec![("pkg::Shield".to_string(), "(hp: 20)".to_string())];
+        let live = vec![("pkg::Shield".to_string(), "(hp: 999)".to_string())]; // user edited it
+
+        let merged = merge_components(&live, &baseline, &new);
+        assert_eq!(merged, vec![("pkg::Shield".to_string(), "(hp: 999)".to_string())]);
+    }
+
+    #[test]
+    fn merge_components_always_keeps_a_user_attached_component_with_no_baseline_entry() {
+        let baseline: Vec<(String, String)> = vec![];
+        let new: Vec<(String, String)> = vec![];
+        let live = vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())];
+
+        let merged = merge_components(&live, &baseline, &new);
+        assert_eq!(merged, vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())]);
+    }
+
+    #[test]
+    fn merge_components_adopts_a_brand_new_component_the_prefab_author_added() {
+        let baseline: Vec<(String, String)> = vec![];
+        let new = vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())];
+        let live: Vec<(String, String)> = vec![];
+
+        let merged = merge_components(&live, &baseline, &new);
+        assert_eq!(merged, vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())]);
+    }
+
+    #[test]
+    fn merge_components_adopts_a_removal_when_unoverridden() {
+        let baseline = vec![("pkg::Shield".to_string(), "(hp: 10)".to_string())];
+        let new: Vec<(String, String)> = vec![]; // author removed the component
+        let live = baseline.clone(); // untouched since sync
+
+        let merged = merge_components(&live, &baseline, &new);
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn merge_components_does_not_resurrect_a_component_the_user_detached() {
+        let baseline = vec![("pkg::Shield".to_string(), "(hp: 10)".to_string())];
+        let new = baseline.clone(); // source unchanged
+        let live: Vec<(String, String)> = vec![]; // user detached it
+
+        let merged = merge_components(&live, &baseline, &new);
+        assert!(
+            merged.is_empty(),
+            "a component the user removed must not come back just because the source still has it"
         );
     }
 }

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -389,6 +389,278 @@ fn apply_merged_components(
     }
 }
 
+/// Collects every live entity transitively parented under `root` that
+/// belongs to *this* instance -- i.e. stops at (and excludes) any
+/// descendant carrying its own `PrefabInstance` whose source path isn't in
+/// `own_source_paths`. Read-only twin of `prefab_watcher::despawn_subtree`'s
+/// traversal (never mutates `world`); see that function's doc comment for
+/// the full rationale on `own_source_paths` (nested-reference vs.
+/// foreign-reparented-instance). Takes `&mut World`, not `&World`, purely
+/// because `World::query` itself requires it in this bevy_ecs version (0.14)
+/// -- exactly like `despawn_subtree` right next to it, which is `&mut World`
+/// for the same structural reason despite also never writing through it
+/// until its own final despawn pass.
+fn collect_own_descendants(
+    world: &mut World,
+    root: Entity,
+    own_source_paths: &std::collections::HashSet<String>,
+) -> Vec<Entity> {
+    let mut children_q = world.query::<(Entity, &bsengine_core::Parent)>();
+    let mut visited = std::collections::HashSet::new();
+    let mut result = Vec::new();
+    let mut frontier = vec![root];
+    while let Some(cur) = frontier.pop() {
+        if !visited.insert(cur) {
+            continue;
+        }
+        if cur != root {
+            result.push(cur);
+        }
+        for (child, parent) in children_q.iter(world) {
+            if parent.0 != cur {
+                continue;
+            }
+            if let Some(instance) = world.get::<bsengine_core::PrefabInstance>(child) {
+                if !own_source_paths.contains(&instance.source_path) {
+                    continue;
+                }
+            }
+            frontier.push(child);
+        }
+    }
+    result
+}
+
+/// Whether a matched entity is a nested prefab reference whose reference
+/// itself changed between `baseline` and `new` -- if so, it must be
+/// despawned and freshly re-resolved rather than field-merged (its own
+/// fields, like `primitive`, mean nothing; what matters is `prefab:` and the
+/// instantiation-time `transform:` override `resolve_prefab_reference`
+/// consumes). An unchanged reference is left alone entirely: the nested
+/// subtree is independently owned by its own `PrefabInstance`/baseline and
+/// resyncs only when *its* file changes, exactly as today.
+fn nested_reference_changed(
+    baseline: &bsengine_scene::EntityDescriptor,
+    new: &bsengine_scene::EntityDescriptor,
+) -> bool {
+    let baseline_path = baseline.prefab.as_ref().map(|p| p.path());
+    let new_path = new.prefab.as_ref().map(|p| p.path());
+    baseline_path != new_path || baseline.transform != new.transform
+}
+
+/// Returns the shared instance suffix to stamp onto a freshly-spawned
+/// entity's display name, drawing a fresh one via
+/// `bsengine_scene::next_instance_suffix()` the first time this instance
+/// needs one -- i.e. `*suffix` is still `None` because `collect_own_descendants`
+/// found no existing non-root live entity to recover one from (a
+/// single-root instance gaining its very first child during this very
+/// resync). Every entity spawned within one `resync_instance` call must
+/// share one suffix, exactly like a normal `instantiate_prefab` call gives
+/// its whole subtree one shared suffix -- otherwise a later resync's
+/// `instance_suffix` recovery (which trusts "any one" live child to speak
+/// for the whole instance) would find an inconsistent value depending on
+/// which child it happened to look at, and every differently-suffixed
+/// sibling would silently fail `strip_instance_suffix`'s tail match and be
+/// treated as if the user had deleted it.
+fn suffixed_name(raw_name: &str, suffix: &mut Option<String>) -> String {
+    let s = suffix.get_or_insert_with(|| bsengine_scene::next_instance_suffix().to_string());
+    format!("{raw_name}#{s}")
+}
+
+/// Materializes an entity from `descriptor` that has no live counterpart yet
+/// -- either because `new` just introduced it, or because a matched entity's
+/// nested-reference status changed and its old subtree was already despawned
+/// by the caller. Resolves it as a nested prefab reference when
+/// `descriptor.prefab` is set (the same way `spawn_scene_entities` branches),
+/// otherwise spawns it plainly via `spawn_single_entity`. Centralized here so
+/// both call sites below get prefab-reference handling for free instead of
+/// one of them silently treating a `prefab:` field as a plain field (which
+/// `spawn_single_entity` explicitly does not understand -- see its own doc
+/// comment).
+///
+/// `spawned_name` is the already-suffixed display name to give the spawned
+/// entity (see `suffixed_name`) -- never `descriptor.name` (the file's raw,
+/// unsuffixed spelling) directly, mirroring how every other non-root entity
+/// in an instance is named. For a nested reference this becomes the nested
+/// prefab's own root name verbatim (`instantiate_prefab`'s `root_name`
+/// contract), exactly like `spawn_scene_entities`'s own `entity.prefab`
+/// branch passes its (already-suffixed, since it's a non-root entity of the
+/// outer file) `entity.name` straight through.
+fn spawn_or_resolve_entity(
+    world: &mut World,
+    spawned_name: &str,
+    descriptor: &bsengine_scene::EntityDescriptor,
+) -> Option<Entity> {
+    match &descriptor.prefab {
+        Some(prefab_ref) => match bsengine_scene::instantiate_prefab_reference(
+            world,
+            spawned_name,
+            prefab_ref,
+            descriptor.transform.clone(),
+        ) {
+            Ok(fresh) => Some(fresh),
+            Err(e) => {
+                tracing::warn!(
+                    "prefab live-sync: entity '{spawned_name}' references a prefab that failed \
+                     to instantiate during resync: {e}"
+                );
+                None
+            }
+        },
+        None => {
+            let mut renamed = descriptor.clone();
+            renamed.name = spawned_name.to_string();
+            Some(bsengine_scene::spawn_single_entity(world, &renamed))
+        }
+    }
+}
+
+/// Patches one prefab instance rooted at `root` in place: merges the root's
+/// own representative fields, then walks every non-root entity named in
+/// `baseline`/`new`, applying the structural + field-level rules described
+/// in this module's doc comment and the design spec. Returns an error only
+/// if `baseline` or `new` isn't a validly-structured prefab (exactly one
+/// root) -- the caller (`resync_prefab_instances`) already validates `new`
+/// before calling this, so in practice only a corrupt baseline can trigger
+/// this.
+pub(crate) fn resync_instance(
+    world: &mut World,
+    root: Entity,
+    baseline: &bsengine_scene::types::PrefabDescriptor,
+    new: &bsengine_scene::types::PrefabDescriptor,
+    own_source_paths: &std::collections::HashSet<String>,
+) -> Result<(), String> {
+    let registry = world
+        .resource::<bevy_ecs::reflect::AppTypeRegistry>()
+        .clone();
+    let registry = registry.read();
+
+    let baseline_root = bsengine_scene::validate_prefab_descriptor(baseline)?;
+    let new_root = bsengine_scene::validate_prefab_descriptor(new)?;
+
+    let root_live = snapshot_entity_as_descriptor(world, &registry, root);
+    let mut root_merged = merge_entity_descriptor(&root_live, baseline_root, new_root);
+    // The root's placement was never meant to come from the prefab asset in
+    // the first place -- this predates override tracking (see the existing
+    // `transform_override` capture/reapply in `resync_prefab_instances`
+    // before this feature) and the design spec calls it out explicitly:
+    // Name/Transform/Parent are never diffed for the root, unconditionally,
+    // regardless of override status. `merge_entity_descriptor` has no way to
+    // know it's being called for a root vs. a regular entity, so it applies
+    // the general per-field rule to `transform` like any other field; this
+    // overwrites that back to the live value every time, after the fact,
+    // rather than teaching the general-purpose merge function about roots.
+    root_merged.transform = root_live.transform.clone();
+    apply_merged_descriptor(world, root, &registry, &root_live, &root_merged);
+
+    let own_descendants = collect_own_descendants(world, root, own_source_paths);
+    let mut suffix = instance_suffix(world, &own_descendants);
+
+    let mut resolved_by_raw_name: std::collections::HashMap<String, Entity> =
+        std::collections::HashMap::new();
+    if let Some(suffix) = &suffix {
+        for &e in &own_descendants {
+            if let Some(name) = world.get::<bsengine_scene::Name>(e) {
+                if let Some((raw, tail)) = strip_instance_suffix(&name.0) {
+                    if tail == suffix {
+                        resolved_by_raw_name.insert(raw.to_string(), e);
+                    }
+                }
+            }
+        }
+    }
+
+    let baseline_by_name: std::collections::HashMap<&str, &bsengine_scene::EntityDescriptor> =
+        baseline
+            .entities
+            .iter()
+            .filter(|e| e.name != baseline_root.name)
+            .map(|e| (e.name.as_str(), e))
+            .collect();
+    let new_by_name: std::collections::HashMap<&str, &bsengine_scene::EntityDescriptor> = new
+        .entities
+        .iter()
+        .filter(|e| e.name != new_root.name)
+        .map(|e| (e.name.as_str(), e))
+        .collect();
+
+    let mut all_names: Vec<&str> = baseline_by_name
+        .keys()
+        .chain(new_by_name.keys())
+        .copied()
+        .collect();
+    all_names.sort_unstable();
+    all_names.dedup();
+
+    let mut spawned_needing_parent: Vec<(Entity, Option<String>)> = Vec::new();
+
+    for raw_name in all_names {
+        let in_baseline = baseline_by_name.get(raw_name).copied();
+        let in_new = new_by_name.get(raw_name).copied();
+        let live_entity = resolved_by_raw_name.get(raw_name).copied();
+
+        match (in_baseline, in_new, live_entity) {
+            (Some(_), None, Some(live_e)) => {
+                crate::prefab_watcher::despawn_subtree(world, live_e, own_source_paths);
+                resolved_by_raw_name.remove(raw_name);
+            }
+            (Some(_), None, None) | (Some(_), Some(_), None) => {
+                // Already gone (cascaded from a removed ancestor, or the
+                // user deleted it directly) -- respected either way.
+            }
+            (Some(b), Some(n), Some(live_e)) if b.prefab.is_some() || n.prefab.is_some() => {
+                if nested_reference_changed(b, n) {
+                    crate::prefab_watcher::despawn_subtree(world, live_e, own_source_paths);
+                    resolved_by_raw_name.remove(raw_name);
+                    // `n.prefab` may itself be `None` here -- the entity was a
+                    // nested reference in `baseline` but the author converted
+                    // it to a plain entity in `new`. `spawn_or_resolve_entity`
+                    // handles both cases; this call site must not assume
+                    // `n.prefab.is_some()` just because the *match guard*
+                    // above required *either* side to have it.
+                    let spawned_name = suffixed_name(raw_name, &mut suffix);
+                    if let Some(fresh) = spawn_or_resolve_entity(world, &spawned_name, n) {
+                        resolved_by_raw_name.insert(raw_name.to_string(), fresh);
+                        spawned_needing_parent.push((fresh, n.parent.clone()));
+                    }
+                }
+                // else: unchanged reference, left entirely alone.
+            }
+            (Some(b), Some(n), Some(live_e)) => {
+                let live_desc = snapshot_entity_as_descriptor(world, &registry, live_e);
+                let merged = merge_entity_descriptor(&live_desc, b, n);
+                apply_merged_descriptor(world, live_e, &registry, &live_desc, &merged);
+            }
+            (None, Some(n), _) => {
+                let spawned_name = suffixed_name(raw_name, &mut suffix);
+                if let Some(fresh) = spawn_or_resolve_entity(world, &spawned_name, n) {
+                    resolved_by_raw_name.insert(raw_name.to_string(), fresh);
+                    spawned_needing_parent.push((fresh, n.parent.clone()));
+                }
+            }
+            (None, None, _) => unreachable!("raw_name is drawn from baseline's or new's own keys"),
+        }
+    }
+
+    for (entity, parent_raw_name) in spawned_needing_parent {
+        let Some(parent_raw_name) = parent_raw_name else {
+            continue; // no parent: field -> a genuine root within this instance (shouldn't happen since only the file's own root has no parent, and non-root entities always name one) -- leave unparented rather than guess
+        };
+        if let Some(&parent_entity) = resolved_by_raw_name.get(parent_raw_name.as_str()) {
+            world.entity_mut(entity).insert(bsengine_core::Parent(parent_entity));
+        } else if parent_raw_name == new_root.name {
+            world.entity_mut(entity).insert(bsengine_core::Parent(root));
+        } else {
+            tracing::warn!(
+                "prefab live-sync: freshly-spawned entity names parent '{parent_raw_name}', \
+                 which does not exist in the resynced prefab; leaving it unparented"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -756,5 +1028,303 @@ mod tests {
     fn instance_suffix_is_none_with_no_children() {
         let app = new_app();
         assert_eq!(instance_suffix(app.world(), &[]), None);
+    }
+
+    fn parse(ron_str: &str) -> bsengine_scene::types::PrefabDescriptor {
+        ron::from_str(ron_str).unwrap()
+    }
+
+    #[test]
+    fn resync_instance_preserves_an_overridden_transform_while_updating_a_sibling_field() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Barrel", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // User manually moves Barrel and never touches its primitive.
+        let barrel = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Barrel#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        app.world_mut().entity_mut(barrel).insert(bsengine_core::Transform {
+            position: glam::Vec3::new(5.0, 0.0, 0.0).into(),
+            ..Default::default()
+        });
+
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Barrel", parent: Some("Body"), primitive: Some(Sphere)),
+            ])"#,
+        );
+
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        let barrel_after = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Barrel#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        assert_eq!(
+            barrel_after, barrel,
+            "an entity with no structural change must keep its live Entity id, not respawn"
+        );
+        assert_eq!(
+            app.world().get::<bsengine_core::Transform>(barrel_after).unwrap().position.0.to_array(),
+            [5.0, 0.0, 0.0],
+            "the user's manual transform override must survive the resync"
+        );
+        assert_eq!(
+            app.world().get::<bsengine_scene::PrimitiveMesh>(barrel_after).unwrap().0,
+            bsengine_scene::Primitive::Sphere,
+            "the unoverridden primitive field must still update to the new file's value"
+        );
+    }
+
+    #[test]
+    fn resync_instance_preserves_a_manually_added_child_entity() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let flag = app
+            .world_mut()
+            .spawn((
+                bsengine_scene::Name("Flag".to_string()),
+                bsengine_core::Parent(root),
+            ))
+            .id();
+
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Sphere)),
+            ])"#,
+        );
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        assert!(
+            app.world().get_entity(flag).is_some(),
+            "a manually-added child entity must survive an unrelated field update on its siblings"
+        );
+    }
+
+    #[test]
+    fn resync_instance_cascade_deletes_a_removed_entity_even_with_overrides_under_it() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Barrel", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let barrel = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Barrel#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        // Override Barrel's own field, and add a manual child under it -- both
+        // must be swept away when the source removes Barrel entirely.
+        app.world_mut()
+            .entity_mut(barrel)
+            .insert(bsengine_scene::PrimitiveMesh(bsengine_scene::Primitive::Sphere));
+        let flag = app
+            .world_mut()
+            .spawn((bsengine_scene::Name("Flag".to_string()), bsengine_core::Parent(barrel)))
+            .id();
+
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+            ])"#,
+        );
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        assert!(app.world().get_entity(barrel).is_none(), "Barrel must be despawned");
+        assert!(
+            app.world().get_entity(flag).is_none(),
+            "Flag must cascade-despawn with its parent, despite being a manual addition"
+        );
+    }
+
+    #[test]
+    fn resync_instance_does_not_resurrect_a_user_deleted_prefab_authored_entity() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Barrel", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let barrel = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Barrel#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        app.world_mut().despawn(barrel); // user deletes it directly
+
+        let new = baseline.clone(); // source unchanged, still has Barrel
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        let barrel_count = {
+            let mut q = app.world_mut().query::<&bsengine_scene::Name>();
+            q.iter(app.world()).filter(|n| n.0.starts_with("Barrel#")).count()
+        };
+        assert_eq!(barrel_count, 0, "a user-deleted prefab-authored entity must not come back");
+    }
+
+    #[test]
+    fn resync_instance_never_adopts_the_new_files_root_transform_even_when_unoverridden() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube), transform: Some((position: (0.0, 0.0, 0.0)))),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            Some(bsengine_scene::TransformDescriptor {
+                position: [10.0, 0.0, 0.0], // the instance's own placement in the scene
+                ..Default::default()
+            }),
+            None,
+        )
+        .unwrap();
+
+        // The author moves the prefab's own authored root transform -- this must
+        // never affect a placed instance's position, overridden or not; a
+        // prefab instance's placement is never prefab-owned.
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube), transform: Some((position: (99.0, 99.0, 99.0)))),
+            ])"#,
+        );
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        assert_eq!(
+            app.world().get::<bsengine_core::Transform>(root).unwrap().position.0.to_array(),
+            [10.0, 0.0, 0.0],
+            "the root's transform must stay exactly what the instance had, ignoring the new file \
+             entirely -- root transform is never diffed, unlike every other representative field"
+        );
+    }
+
+    #[test]
+    fn resync_instance_spawns_a_brand_new_entity_the_source_added() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Scope", parent: Some("Body"), primitive: Some(Sphere)),
+            ])"#,
+        );
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        let scope = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Scope#"))
+                .map(|(e, _)| e)
+        };
+        assert!(scope.is_some(), "the newly-added Scope entity must be spawned");
+        assert_eq!(
+            app.world().get::<bsengine_core::Parent>(scope.unwrap()).map(|p| p.0),
+            Some(root),
+            "the new entity must be parented correctly"
+        );
     }
 }

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -1,0 +1,215 @@
+//! Field-level merge for prefab push-sync: given a live instance's current
+//! state, the prefab content it was last synced against (baseline), and the
+//! prefab's current content (new), decides -- per field, per entity -- which
+//! value should end up live. See `docs/superpowers/specs/2026-08-19-prefab-override-tracking-design.md`
+//! for the full design; this module implements its "diff/patch algorithm"
+//! section.
+//!
+//! The core rule, applied throughout this module: a live value that still
+//! equals the baseline adopts the new file's value; a live value that
+//! differs from the baseline is an override and is left untouched. The one
+//! exception -- whole-entity structural removal always wins regardless of
+//! overrides -- lives in `resync_instance` (a later task), not in this
+//! file's per-field logic.
+
+use bevy_ecs::prelude::{Entity, World};
+use bevy_reflect::TypeRegistry;
+
+/// Snapshots a live entity's current state into an [`EntityDescriptor`],
+/// covering this PR's representative field set (`transform`, `primitive`,
+/// `emissive`/`color`/`opacity`, and the reflected `components` catalog) plus
+/// `name`. Every other `EntityDescriptor` field is left at its `Default`
+/// (`None`/`false`/empty) -- deliberately: those fields belong to a follow-up
+/// PR's field groups and must never be treated as "live has explicitly
+/// cleared this" by the merge logic that reads this snapshot's output.
+pub(crate) fn snapshot_entity_as_descriptor(
+    world: &World,
+    registry: &TypeRegistry,
+    entity: Entity,
+) -> bsengine_scene::EntityDescriptor {
+    let name = world
+        .get::<bsengine_scene::Name>(entity)
+        .map(|n| n.0.clone())
+        .unwrap_or_default();
+
+    let transform = world
+        .get::<bsengine_core::Transform>(entity)
+        .map(|t| bsengine_scene::TransformDescriptor {
+            position: t.position.0.to_array(),
+            rotation: t.rotation.0.to_array(),
+            scale: t.scale.0.to_array(),
+        });
+
+    let primitive = world
+        .get::<bsengine_scene::PrimitiveMesh>(entity)
+        .map(|p| p.0.clone());
+
+    let material = world.get::<bsengine_core::Material>(entity);
+    let emissive = material.map(|m| m.emissive.0.to_array());
+    let color = material.map(|m| m.base_color.0.to_array());
+    let opacity = material.map(|m| m.opacity);
+
+    let components = snapshot_extra_components(world, registry, entity);
+
+    bsengine_scene::EntityDescriptor {
+        name,
+        transform,
+        primitive,
+        emissive,
+        color,
+        opacity,
+        components,
+        ..Default::default()
+    }
+}
+
+/// Type IDs this module's snapshot must never surface as a generic
+/// "components:" catalog entry: everything `excluded_from_extra_components`
+/// already excludes (it's already handled by a dedicated `EntityDescriptor`
+/// field, or holds a raw `Entity` reference), plus the two prefab-tracking
+/// components themselves -- neither is meaningful as an attach/detach-able
+/// gameplay component, and both are managed entirely by `resync_instance`'s
+/// own top-level logic, not by the generic field merge.
+fn merge_excluded_component_types() -> std::collections::HashSet<std::any::TypeId> {
+    let mut excluded = crate::plugin::excluded_from_extra_components();
+    excluded.insert(std::any::TypeId::of::<bsengine_core::PrefabInstance>());
+    excluded.insert(std::any::TypeId::of::<bsengine_core::PrefabInstanceBaseline>());
+    excluded
+}
+
+/// Serializes every registered reflected component on `entity`, other than
+/// the ones `merge_excluded_component_types` excludes, into
+/// `(type_path, ron)` pairs -- the same technique
+/// `populate_snapshot_extra_components` (`bsengine-editor/src/plugin.rs`)
+/// already uses for the Inspector's own live-entity snapshot, scoped here to
+/// one entity instead of the whole world.
+fn snapshot_extra_components(
+    world: &World,
+    registry: &TypeRegistry,
+    entity: Entity,
+) -> Vec<(String, String)> {
+    let excluded = merge_excluded_component_types();
+    let Some(entity_ref) = world.get_entity(entity) else {
+        return Vec::new();
+    };
+    let mut components = Vec::new();
+    for registration in registry.iter() {
+        if excluded.contains(&registration.type_id()) {
+            continue;
+        }
+        let Some(reflect_component) = registration.data::<bevy_ecs::reflect::ReflectComponent>()
+        else {
+            continue;
+        };
+        let Some(value) = reflect_component.reflect(entity_ref) else {
+            continue;
+        };
+        let serializer = bevy_reflect::serde::TypedReflectSerializer::new(value, registry);
+        match ron::ser::to_string(&serializer) {
+            Ok(ron_str) => {
+                components.push((registration.type_info().type_path().to_string(), ron_str));
+            }
+            Err(e) => tracing::warn!(
+                "prefab live-sync: failed to snapshot component '{}' on entity {entity:?}: {e}",
+                registration.type_info().type_path()
+            ),
+        }
+    }
+    components
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_app::new_app;
+
+    // `TypeRegistry` itself is not `Clone` (only the `Arc<RwLock<..>>`
+    // wrapper `TypeRegistryArc` is); return the cheap-to-clone Arc wrapper
+    // and let each call site take its own read lock, the same pattern
+    // `populate_snapshot_extra_components` in `plugin.rs` uses.
+    fn registry(world: &World) -> bevy_reflect::TypeRegistryArc {
+        world
+            .resource::<bevy_ecs::reflect::AppTypeRegistry>()
+            .0
+            .clone()
+    }
+
+    #[test]
+    fn snapshot_captures_transform_primitive_and_material() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        let entity = app
+            .world_mut()
+            .spawn((
+                bsengine_scene::Name("Body".to_string()),
+                bsengine_core::Transform {
+                    position: glam::Vec3::new(1.0, 2.0, 3.0).into(),
+                    ..Default::default()
+                },
+                bsengine_scene::PrimitiveMesh(bsengine_scene::Primitive::Sphere),
+                bsengine_core::Material {
+                    opacity: 0.5,
+                    ..Default::default()
+                },
+            ))
+            .id();
+
+        let reg = registry(app.world());
+        let reg = reg.read();
+        let desc = snapshot_entity_as_descriptor(app.world(), &reg, entity);
+
+        assert_eq!(desc.name, "Body");
+        assert_eq!(
+            desc.transform.as_ref().unwrap().position,
+            [1.0, 2.0, 3.0]
+        );
+        assert_eq!(desc.primitive, Some(bsengine_scene::Primitive::Sphere));
+        assert_eq!(desc.opacity, Some(0.5));
+    }
+
+    #[test]
+    fn snapshot_omits_fields_the_entity_has_no_component_for() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        let entity = app
+            .world_mut()
+            .spawn(bsengine_scene::Name("Empty".to_string()))
+            .id();
+
+        let reg = registry(app.world());
+        let reg = reg.read();
+        let desc = snapshot_entity_as_descriptor(app.world(), &reg, entity);
+
+        assert_eq!(desc.transform, None);
+        assert_eq!(desc.primitive, None);
+        assert_eq!(desc.emissive, None);
+        assert_eq!(desc.color, None);
+        assert_eq!(desc.opacity, None);
+    }
+
+    #[test]
+    fn snapshot_captures_an_arbitrary_reflected_component_in_the_components_catalog() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        app.register_type::<bsengine_core::Shield>();
+        let entity = app
+            .world_mut()
+            .spawn((
+                bsengine_scene::Name("Hero".to_string()),
+                bsengine_core::Shield::default(),
+            ))
+            .id();
+
+        let reg = registry(app.world());
+        let reg = reg.read();
+        let desc = snapshot_entity_as_descriptor(app.world(), &reg, entity);
+
+        assert!(
+            desc.components
+                .iter()
+                .any(|(type_path, _)| type_path.ends_with("Shield")),
+            "components: {:?}",
+            desc.components
+        );
+    }
+}

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -15,6 +15,33 @@
 use bevy_ecs::prelude::{Entity, World};
 use bevy_reflect::TypeRegistry;
 
+/// Splits `live_name` at its last `'#'` into `(base, suffix)`, requiring the
+/// suffix to be non-empty and all-ASCII-digit -- the exact shape
+/// `instantiate_prefab`'s `rewrite_name` closure produces
+/// (`format!("{name}#{suffix}")` with `suffix: u64`). Returns `None` for
+/// anything else, e.g. a hand-authored name that happens to contain `'#'`
+/// followed by non-digits, or no `'#'` at all.
+fn strip_instance_suffix(live_name: &str) -> Option<(&str, &str)> {
+    let (base, tail) = live_name.rsplit_once('#')?;
+    if !tail.is_empty() && tail.bytes().all(|b| b.is_ascii_digit()) {
+        Some((base, tail))
+    } else {
+        None
+    }
+}
+
+/// Recovers this instance's shared naming suffix from any one of its
+/// children -- every child of one `instantiate_prefab` call shares the exact
+/// same suffix by construction, so the first one found is as good as any.
+/// `None` if `children` is empty (a single-entity prefab, nothing to match)
+/// or if, unexpectedly, none of them have a suffixed `Name`.
+fn instance_suffix(world: &World, children: &[Entity]) -> Option<String> {
+    children.iter().find_map(|&child| {
+        let name = world.get::<bsengine_scene::Name>(child)?;
+        strip_instance_suffix(&name.0).map(|(_, suffix)| suffix.to_string())
+    })
+}
+
 /// Snapshots a live entity's current state into an [`EntityDescriptor`],
 /// covering this PR's representative field set (`transform`, `primitive`,
 /// `emissive`/`color`/`opacity`, and the reflected `components` catalog) plus
@@ -701,5 +728,33 @@ mod tests {
         apply_merged_descriptor(app.world_mut(), entity, &reg, &live, &merged);
 
         assert!(app.world().get::<bsengine_core::Shield>(entity).is_some());
+    }
+
+    #[test]
+    fn strip_instance_suffix_splits_at_the_last_hash_when_the_tail_is_numeric() {
+        assert_eq!(strip_instance_suffix("Barrel#42"), Some(("Barrel", "42")));
+        assert_eq!(strip_instance_suffix("My#Weird#Name#7"), Some(("My#Weird#Name", "7")));
+    }
+
+    #[test]
+    fn strip_instance_suffix_rejects_a_non_numeric_or_missing_tail() {
+        assert_eq!(strip_instance_suffix("NoHashAtAll"), None);
+        assert_eq!(strip_instance_suffix("Trailing#"), None);
+        assert_eq!(strip_instance_suffix("NotDigits#abc"), None);
+    }
+
+    #[test]
+    fn instance_suffix_is_recovered_from_any_one_matching_child() {
+        let mut app = new_app();
+        let a = app.world_mut().spawn(bsengine_scene::Name("Barrel#7".to_string())).id();
+        let b = app.world_mut().spawn(bsengine_scene::Name("Scope#7".to_string())).id();
+
+        assert_eq!(instance_suffix(app.world(), &[a, b]), Some("7".to_string()));
+    }
+
+    #[test]
+    fn instance_suffix_is_none_with_no_children() {
+        let app = new_app();
+        assert_eq!(instance_suffix(app.world(), &[]), None);
     }
 }

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -407,21 +407,38 @@ fn apply_merged_components(
 }
 
 /// Collects every live entity transitively parented under `root` that
-/// belongs to *this* instance -- i.e. stops at (and excludes) any
-/// descendant carrying its own `PrefabInstance` whose source path isn't in
-/// `own_source_paths`. Read-only twin of `prefab_watcher::despawn_subtree`'s
-/// traversal (never mutates `world`); see that function's doc comment for
-/// the full rationale on `own_source_paths` (nested-reference vs.
-/// foreign-reparented-instance). Takes `&mut World`, not `&World`, purely
-/// because `World::query` itself requires it in this bevy_ecs version (0.14)
-/// -- exactly like `despawn_subtree` right next to it, which is `&mut World`
-/// for the same structural reason despite also never writing through it
-/// until its own final despawn pass.
-fn collect_own_descendants(
-    world: &mut World,
-    root: Entity,
-    own_source_paths: &std::collections::HashSet<String>,
-) -> Vec<Entity> {
+/// belongs to *this* instance's own raw-name diffing -- i.e. every
+/// descendant is still recorded (including a nested `prefab:` reference's
+/// own root entity itself, which -- like any other entity -- has a raw name
+/// the structural-diff loop needs to be able to look up), but the walk never
+/// descends *past* a descendant carrying its own `PrefabInstance`,
+/// unconditionally, regardless of whether that descendant's source path
+/// happens to be a member of `own_source_paths`. This is deliberately
+/// *stricter* than `prefab_watcher::despawn_subtree`'s traversal, which this
+/// function used to reuse verbatim: `despawn_subtree` needs to keep
+/// descending into a legitimate nested `prefab:` reference this same outer
+/// file authors (so a resync of the outer file can cascade into it when the
+/// reference itself changed), but this function's job is only to discover
+/// *this* instance's own raw-name-matchable entities for the structural-diff
+/// loop -- which, per the design spec's nested-boundary exclusion, never
+/// needs to reach *inside* any nested instance's own subtree, own-authored
+/// or not (though it does still need the boundary entity itself, to diff its
+/// own `prefab:` field against baseline/new -- see `nested_reference_changed`).
+/// Reusing `despawn_subtree`'s gate here didn't cause a live bug (traversal
+/// order + suffix-matching happened to avoid collisions), but it was relying
+/// on an implicit, non-obvious invariant instead of a boundary the
+/// function's own purpose actually requires -- see the final whole-branch
+/// review's "Minor" finding on this function. Note `root` itself always
+/// carries a `PrefabInstance` too (it's this whole instance's own tracking
+/// component) but must never be treated as a stop-boundary for its own
+/// children -- the `cur != root` guard on the stop-check exists precisely so
+/// this function still walks root's immediate structure instead of returning
+/// empty. Takes `&mut World`, not `&World`, purely because `World::query`
+/// itself requires it in this bevy_ecs version (0.14) -- exactly like
+/// `despawn_subtree` right next to it, which is `&mut World` for the same
+/// structural reason despite also never writing through it until its own
+/// final despawn pass.
+fn collect_own_descendants(world: &mut World, root: Entity) -> Vec<Entity> {
     let mut children_q = world.query::<(Entity, &bsengine_core::Parent)>();
     let mut visited = std::collections::HashSet::new();
     let mut result = Vec::new();
@@ -433,14 +450,12 @@ fn collect_own_descendants(
         if cur != root {
             result.push(cur);
         }
+        if cur != root && world.get::<bsengine_core::PrefabInstance>(cur).is_some() {
+            continue; // record the boundary entity, but never descend past it
+        }
         for (child, parent) in children_q.iter(world) {
             if parent.0 != cur {
                 continue;
-            }
-            if let Some(instance) = world.get::<bsengine_core::PrefabInstance>(child) {
-                if !own_source_paths.contains(&instance.source_path) {
-                    continue;
-                }
             }
             frontier.push(child);
         }
@@ -570,7 +585,7 @@ pub(crate) fn resync_instance(
     root_merged.transform = root_live.transform.clone();
     apply_merged_descriptor(world, root, &registry, &root_live, &root_merged);
 
-    let own_descendants = collect_own_descendants(world, root, own_source_paths);
+    let own_descendants = collect_own_descendants(world, root);
     let mut suffix = instance_suffix(world, &own_descendants);
 
     let mut resolved_by_raw_name: std::collections::HashMap<String, Entity> =
@@ -614,7 +629,27 @@ pub(crate) fn resync_instance(
     for raw_name in all_names {
         let in_baseline = baseline_by_name.get(raw_name).copied();
         let in_new = new_by_name.get(raw_name).copied();
-        let live_entity = resolved_by_raw_name.get(raw_name).copied();
+        // `.filter(...)` re-validates liveness rather than trusting the map's
+        // stored value: `resolved_by_raw_name` is only ever pruned for the
+        // *specific* raw_name a `despawn_subtree` call was triggered for
+        // (see the two `resolved_by_raw_name.remove(raw_name)` calls below),
+        // but `despawn_subtree` itself cascades and despawns every live
+        // descendant of that entity too -- including ones that are
+        // *themselves* separately-declared names in this same prefab (a
+        // 3+-level hierarchy, e.g. a removed "Barrel" whose live child
+        // "Scope" is still a distinct key in `all_names`). Without this
+        // check, such a descendant's map entry is stale by the time this
+        // loop reaches its own raw_name, and the `(Some(_), Some(_),
+        // Some(live_e))` arm below would call `apply_merged_descriptor` on a
+        // dead `Entity`, which panics inside `World::entity_mut`. Filtering
+        // here instead routes it into the existing `(Some(_), Some(_),
+        // None) => already gone, respected` arm -- exactly the outcome the
+        // design spec's structural-removal rule already intends, since this
+        // entity's removal cascaded precisely like an explicit deletion.
+        let live_entity = resolved_by_raw_name
+            .get(raw_name)
+            .copied()
+            .filter(|&e| world.get_entity(e).is_some());
 
         match (in_baseline, in_new, live_entity) {
             (Some(_), None, Some(live_e)) => {
@@ -1412,6 +1447,98 @@ mod tests {
                 .map(|p| p.0),
             Some(root),
             "the new entity must be parented correctly"
+        );
+    }
+
+    #[test]
+    fn resync_instance_does_not_panic_when_a_removed_entitys_cascade_hits_a_still_declared_descendant(
+    ) {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        // Three-level hierarchy: Body -> Barrel -> Scope. `new` removes
+        // Barrel entirely and re-declares Scope directly under Body instead
+        // -- an ordinary "delete the middle entity, reparent its children up
+        // one level" edit, requiring no overrides. This reproduces the
+        // final-review panic: `despawn_subtree(world, barrel, ..)` cascades
+        // and despawns *both* Barrel and its live child Scope, but only
+        // `"Barrel"`'s own key was ever pruned from `resolved_by_raw_name`.
+        // When the structural-diff loop later reached `"Scope"`'s own
+        // raw_name (alphabetically after `"Barrel"`), it read a stale,
+        // already-despawned `Entity` for it and `apply_merged_descriptor`
+        // panicked inside `World::entity_mut`.
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Barrel", parent: Some("Body"), primitive: Some(Cube)),
+                EntityDescriptor(name: "Scope", parent: Some("Barrel"), primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let barrel = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Barrel#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        let scope = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Scope#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Scope", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        );
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
+
+        // Must not panic -- reaching the assertions below is itself the
+        // primary regression proof.
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        assert!(
+            app.world().get_entity(barrel).is_none(),
+            "Barrel must be despawned -- the source removed it"
+        );
+        assert!(
+            app.world().get_entity(scope).is_none(),
+            "the original live Scope entity must be gone too: it was a live descendant of \
+             Barrel at the moment Barrel's structural removal cascaded, and the design spec's \
+             removal rule is unconditional (\"that entity's entire live subtree is despawned... \
+             regardless of... manually-added children under it\") -- Scope being independently \
+             re-declared under Body in `new` does not exempt it from a cascade it was already \
+             caught in. Consistent with rule 6 (\"a user-deleted, still-prefab-authored entity \
+             is not resurrected\"): once the liveness check finds Scope's raw_name has no live \
+             entity left, it is respected as already-gone rather than freshly respawned"
+        );
+
+        let scope_count = {
+            let mut q = app.world_mut().query::<&bsengine_scene::Name>();
+            q.iter(app.world())
+                .filter(|n| n.0.starts_with("Scope#"))
+                .count()
+        };
+        assert_eq!(
+            scope_count, 0,
+            "no fresh replacement Scope entity should have been spawned under Body either -- \
+             the cascade-despawn is respected as a deletion, not treated as \"new entity the \
+             source added\" just because Scope's raw_name still resolves in `new`"
         );
     }
 }

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -59,13 +59,13 @@ pub(crate) fn snapshot_entity_as_descriptor(
         .map(|n| n.0.clone())
         .unwrap_or_default();
 
-    let transform = world
-        .get::<bsengine_core::Transform>(entity)
-        .map(|t| bsengine_scene::TransformDescriptor {
+    let transform = world.get::<bsengine_core::Transform>(entity).map(|t| {
+        bsengine_scene::TransformDescriptor {
             position: t.position.0.to_array(),
             rotation: t.rotation.0.to_array(),
             scale: t.scale.0.to_array(),
-        });
+        }
+    });
 
     let primitive = world
         .get::<bsengine_scene::PrimitiveMesh>(entity)
@@ -204,7 +204,10 @@ fn merge_components(
     // because closures don't get that elision and each occurrence of `&str`
     // is inferred as its own independent lifetime.
     fn to_map(pairs: &[(String, String)]) -> std::collections::HashMap<&str, &str> {
-        pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect()
     }
     let live_map = to_map(live);
     let baseline_map = to_map(baseline);
@@ -272,7 +275,9 @@ pub(crate) fn apply_merged_descriptor(
             ));
         }
         None => {
-            world.entity_mut(entity).remove::<bsengine_core::Transform>();
+            world
+                .entity_mut(entity)
+                .remove::<bsengine_core::Transform>();
         }
     }
 
@@ -283,7 +288,9 @@ pub(crate) fn apply_merged_descriptor(
                 .insert(bsengine_scene::PrimitiveMesh(p.clone()));
         }
         None => {
-            world.entity_mut(entity).remove::<bsengine_scene::PrimitiveMesh>();
+            world
+                .entity_mut(entity)
+                .remove::<bsengine_scene::PrimitiveMesh>();
         }
     }
 
@@ -315,7 +322,13 @@ pub(crate) fn apply_merged_descriptor(
         world.entity_mut(entity).remove::<bsengine_core::Material>();
     }
 
-    apply_merged_components(world, entity, registry, &live.components, &merged.components);
+    apply_merged_components(
+        world,
+        entity,
+        registry,
+        &live.components,
+        &merged.components,
+    );
 }
 
 /// Reflection-based attach/detach for the `components:` catalog: removes
@@ -373,7 +386,11 @@ fn apply_merged_components(
                 match serde::de::DeserializeSeed::deserialize(de, &mut deserializer) {
                     Ok(value) => {
                         let mut entity_mut = world.entity_mut(entity);
-                        reflect_component.apply_or_insert(&mut entity_mut, value.as_ref(), registry);
+                        reflect_component.apply_or_insert(
+                            &mut entity_mut,
+                            value.as_ref(),
+                            registry,
+                        );
                     }
                     Err(e) => tracing::warn!(
                         "prefab live-sync: entity {entity:?} merged component '{type_path}' \
@@ -647,7 +664,9 @@ pub(crate) fn resync_instance(
             continue; // no parent: field -> a genuine root within this instance (shouldn't happen since only the file's own root has no parent, and non-root entities always name one) -- leave unparented rather than guess
         };
         if let Some(&parent_entity) = resolved_by_raw_name.get(parent_raw_name.as_str()) {
-            world.entity_mut(entity).insert(bsengine_core::Parent(parent_entity));
+            world
+                .entity_mut(entity)
+                .insert(bsengine_core::Parent(parent_entity));
         } else if parent_raw_name == new_root.name {
             world.entity_mut(entity).insert(bsengine_core::Parent(root));
         } else {
@@ -702,10 +721,7 @@ mod tests {
         let desc = snapshot_entity_as_descriptor(app.world(), &reg, entity);
 
         assert_eq!(desc.name, "Body");
-        assert_eq!(
-            desc.transform.as_ref().unwrap().position,
-            [1.0, 2.0, 3.0]
-        );
+        assert_eq!(desc.transform.as_ref().unwrap().position, [1.0, 2.0, 3.0]);
         assert_eq!(desc.primitive, Some(bsengine_scene::Primitive::Sphere));
         assert_eq!(desc.opacity, Some(0.5));
     }
@@ -763,7 +779,10 @@ mod tests {
 
     #[test]
     fn resolve_field_keeps_live_when_it_differs_from_baseline() {
-        assert_eq!(resolve_field(&"overridden", &"baseline", &"new"), "overridden");
+        assert_eq!(
+            resolve_field(&"overridden", &"baseline", &"new"),
+            "overridden"
+        );
     }
 
     #[test]
@@ -808,7 +827,10 @@ mod tests {
         let live = baseline.clone(); // untouched since sync
 
         let merged = merge_components(&live, &baseline, &new);
-        assert_eq!(merged, vec![("pkg::Shield".to_string(), "(hp: 20)".to_string())]);
+        assert_eq!(
+            merged,
+            vec![("pkg::Shield".to_string(), "(hp: 20)".to_string())]
+        );
     }
 
     #[test]
@@ -818,7 +840,10 @@ mod tests {
         let live = vec![("pkg::Shield".to_string(), "(hp: 999)".to_string())]; // user edited it
 
         let merged = merge_components(&live, &baseline, &new);
-        assert_eq!(merged, vec![("pkg::Shield".to_string(), "(hp: 999)".to_string())]);
+        assert_eq!(
+            merged,
+            vec![("pkg::Shield".to_string(), "(hp: 999)".to_string())]
+        );
     }
 
     #[test]
@@ -828,7 +853,10 @@ mod tests {
         let live = vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())];
 
         let merged = merge_components(&live, &baseline, &new);
-        assert_eq!(merged, vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())]);
+        assert_eq!(
+            merged,
+            vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())]
+        );
     }
 
     #[test]
@@ -838,7 +866,10 @@ mod tests {
         let live: Vec<(String, String)> = vec![];
 
         let merged = merge_components(&live, &baseline, &new);
-        assert_eq!(merged, vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())]);
+        assert_eq!(
+            merged,
+            vec![("pkg::Shield".to_string(), "(hp: 5)".to_string())]
+        );
     }
 
     #[test]
@@ -892,11 +923,19 @@ mod tests {
         apply_merged_descriptor(app.world_mut(), entity, &reg, &live, &merged);
 
         assert_eq!(
-            app.world().get::<bsengine_scene::PrimitiveMesh>(entity).unwrap().0,
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(entity)
+                .unwrap()
+                .0,
             bsengine_scene::Primitive::Sphere
         );
         assert_eq!(
-            app.world().get::<bsengine_core::Material>(entity).unwrap().base_color.0.to_array(),
+            app.world()
+                .get::<bsengine_core::Material>(entity)
+                .unwrap()
+                .base_color
+                .0
+                .to_array(),
             [0.0, 1.0, 0.0]
         );
     }
@@ -924,7 +963,9 @@ mod tests {
         apply_merged_descriptor(app.world_mut(), entity, &reg, &live, &merged);
 
         assert!(
-            app.world().get::<bsengine_scene::PrimitiveMesh>(entity).is_none(),
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(entity)
+                .is_none(),
             "PrimitiveMesh must be removed when the merged descriptor no longer has a primitive"
         );
     }
@@ -958,7 +999,11 @@ mod tests {
         apply_merged_descriptor(app.world_mut(), entity, &reg, &live, &merged);
 
         let material = app.world().get::<bsengine_core::Material>(entity).unwrap();
-        assert_eq!(material.base_color.0.to_array(), [0.0, 0.0, 1.0], "color must update");
+        assert_eq!(
+            material.base_color.0.to_array(),
+            [0.0, 0.0, 1.0],
+            "color must update"
+        );
         assert_eq!(
             material.texture_id,
             Some(42),
@@ -1005,7 +1050,10 @@ mod tests {
     #[test]
     fn strip_instance_suffix_splits_at_the_last_hash_when_the_tail_is_numeric() {
         assert_eq!(strip_instance_suffix("Barrel#42"), Some(("Barrel", "42")));
-        assert_eq!(strip_instance_suffix("My#Weird#Name#7"), Some(("My#Weird#Name", "7")));
+        assert_eq!(
+            strip_instance_suffix("My#Weird#Name#7"),
+            Some(("My#Weird#Name", "7"))
+        );
     }
 
     #[test]
@@ -1018,8 +1066,14 @@ mod tests {
     #[test]
     fn instance_suffix_is_recovered_from_any_one_matching_child() {
         let mut app = new_app();
-        let a = app.world_mut().spawn(bsengine_scene::Name("Barrel#7".to_string())).id();
-        let b = app.world_mut().spawn(bsengine_scene::Name("Scope#7".to_string())).id();
+        let a = app
+            .world_mut()
+            .spawn(bsengine_scene::Name("Barrel#7".to_string()))
+            .id();
+        let b = app
+            .world_mut()
+            .spawn(bsengine_scene::Name("Scope#7".to_string()))
+            .id();
 
         assert_eq!(instance_suffix(app.world(), &[a, b]), Some("7".to_string()));
     }
@@ -1063,10 +1117,12 @@ mod tests {
                 .map(|(e, _)| e)
                 .unwrap()
         };
-        app.world_mut().entity_mut(barrel).insert(bsengine_core::Transform {
-            position: glam::Vec3::new(5.0, 0.0, 0.0).into(),
-            ..Default::default()
-        });
+        app.world_mut()
+            .entity_mut(barrel)
+            .insert(bsengine_core::Transform {
+                position: glam::Vec3::new(5.0, 0.0, 0.0).into(),
+                ..Default::default()
+            });
 
         let new = parse(
             r#"PrefabDescriptor(entities: [
@@ -1091,12 +1147,20 @@ mod tests {
             "an entity with no structural change must keep its live Entity id, not respawn"
         );
         assert_eq!(
-            app.world().get::<bsengine_core::Transform>(barrel_after).unwrap().position.0.to_array(),
+            app.world()
+                .get::<bsengine_core::Transform>(barrel_after)
+                .unwrap()
+                .position
+                .0
+                .to_array(),
             [5.0, 0.0, 0.0],
             "the user's manual transform override must survive the resync"
         );
         assert_eq!(
-            app.world().get::<bsengine_scene::PrimitiveMesh>(barrel_after).unwrap().0,
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(barrel_after)
+                .unwrap()
+                .0,
             bsengine_scene::Primitive::Sphere,
             "the unoverridden primitive field must still update to the new file's value"
         );
@@ -1177,10 +1241,15 @@ mod tests {
         // must be swept away when the source removes Barrel entirely.
         app.world_mut()
             .entity_mut(barrel)
-            .insert(bsengine_scene::PrimitiveMesh(bsengine_scene::Primitive::Sphere));
+            .insert(bsengine_scene::PrimitiveMesh(
+                bsengine_scene::Primitive::Sphere,
+            ));
         let flag = app
             .world_mut()
-            .spawn((bsengine_scene::Name("Flag".to_string()), bsengine_core::Parent(barrel)))
+            .spawn((
+                bsengine_scene::Name("Flag".to_string()),
+                bsengine_core::Parent(barrel),
+            ))
             .id();
 
         let new = parse(
@@ -1192,7 +1261,10 @@ mod tests {
             std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
         resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
 
-        assert!(app.world().get_entity(barrel).is_none(), "Barrel must be despawned");
+        assert!(
+            app.world().get_entity(barrel).is_none(),
+            "Barrel must be despawned"
+        );
         assert!(
             app.world().get_entity(flag).is_none(),
             "Flag must cascade-despawn with its parent, despite being a manual addition"
@@ -1236,9 +1308,14 @@ mod tests {
 
         let barrel_count = {
             let mut q = app.world_mut().query::<&bsengine_scene::Name>();
-            q.iter(app.world()).filter(|n| n.0.starts_with("Barrel#")).count()
+            q.iter(app.world())
+                .filter(|n| n.0.starts_with("Barrel#"))
+                .count()
         };
-        assert_eq!(barrel_count, 0, "a user-deleted prefab-authored entity must not come back");
+        assert_eq!(
+            barrel_count, 0,
+            "a user-deleted prefab-authored entity must not come back"
+        );
     }
 
     #[test]
@@ -1277,7 +1354,12 @@ mod tests {
         resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
 
         assert_eq!(
-            app.world().get::<bsengine_core::Transform>(root).unwrap().position.0.to_array(),
+            app.world()
+                .get::<bsengine_core::Transform>(root)
+                .unwrap()
+                .position
+                .0
+                .to_array(),
             [10.0, 0.0, 0.0],
             "the root's transform must stay exactly what the instance had, ignoring the new file \
              entirely -- root transform is never diffed, unlike every other representative field"
@@ -1320,9 +1402,14 @@ mod tests {
                 .find(|(_, n)| n.0.starts_with("Scope#"))
                 .map(|(e, _)| e)
         };
-        assert!(scope.is_some(), "the newly-added Scope entity must be spawned");
+        assert!(
+            scope.is_some(),
+            "the newly-added Scope entity must be spawned"
+        );
         assert_eq!(
-            app.world().get::<bsengine_core::Parent>(scope.unwrap()).map(|p| p.0),
+            app.world()
+                .get::<bsengine_core::Parent>(scope.unwrap())
+                .map(|p| p.0),
             Some(root),
             "the new entity must be parented correctly"
         );

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -212,6 +212,156 @@ fn merge_components(
     result
 }
 
+/// Makes `entity`'s live components match `merged` for this PR's
+/// representative field set, using `live` only to know what's currently
+/// attached (so removal is a real `remove::<T>()` call rather than a no-op
+/// insert of "nothing"). Idempotent: re-applying the same `merged` twice is
+/// harmless, since every field write is "make it equal this value," not "add
+/// this diff" -- this is what lets a later task's resync orchestrator call
+/// this unconditionally for every matched entity rather than first checking
+/// whether anything actually changed.
+pub(crate) fn apply_merged_descriptor(
+    world: &mut World,
+    entity: Entity,
+    registry: &TypeRegistry,
+    live: &bsengine_scene::EntityDescriptor,
+    merged: &bsengine_scene::EntityDescriptor,
+) {
+    match &merged.transform {
+        Some(t) => {
+            world.entity_mut(entity).insert((
+                bsengine_core::Transform {
+                    position: glam::Vec3::from(t.position).into(),
+                    rotation: glam::Quat::from_xyzw(
+                        t.rotation[0],
+                        t.rotation[1],
+                        t.rotation[2],
+                        t.rotation[3],
+                    )
+                    .into(),
+                    scale: glam::Vec3::from(t.scale).into(),
+                },
+                bsengine_core::GlobalTransform::default(),
+            ));
+        }
+        None => {
+            world.entity_mut(entity).remove::<bsengine_core::Transform>();
+        }
+    }
+
+    match &merged.primitive {
+        Some(p) => {
+            world
+                .entity_mut(entity)
+                .insert(bsengine_scene::PrimitiveMesh(p.clone()));
+        }
+        None => {
+            world.entity_mut(entity).remove::<bsengine_scene::PrimitiveMesh>();
+        }
+    }
+
+    if merged.emissive.is_some() || merged.color.is_some() || merged.opacity.is_some() {
+        // `Material` also carries `texture_id`/`metallic`/`roughness`, none of
+        // which this PR's field set tracks (texture is a follow-up PR's
+        // field group). Blindly inserting a fresh `Material { ..Default::default() }`
+        // would silently wipe those out-of-scope fields to their defaults --
+        // e.g. destroying a `texture:`-driven `texture_id` -- every time this
+        // entity's Material is touched by a resync for an unrelated reason
+        // (opacity is always "tracked," so this branch fires whenever a
+        // Material exists at all). Read the entity's current Material first
+        // and only overwrite the three fields this merge actually resolved.
+        let mut material = world
+            .get::<bsengine_core::Material>(entity)
+            .cloned()
+            .unwrap_or_default();
+        if let Some(e) = merged.emissive {
+            material.emissive = glam::Vec3::from(e).into();
+        }
+        if let Some(c) = merged.color {
+            material.base_color = glam::Vec3::from(c).into();
+        }
+        if let Some(o) = merged.opacity {
+            material.opacity = o;
+        }
+        world.entity_mut(entity).insert(material);
+    } else {
+        world.entity_mut(entity).remove::<bsengine_core::Material>();
+    }
+
+    apply_merged_components(world, entity, registry, &live.components, &merged.components);
+}
+
+/// Reflection-based attach/detach for the `components:` catalog: removes
+/// every live key `merged` no longer has, then inserts/overwrites every key
+/// `merged` does have. Mirrors the two existing hand-rolled reflection
+/// call-sites this codebase already has for the same primitives --
+/// `spawn_scene_entities`'s `components:` loop (`apply_or_insert`) and
+/// `process_reflect_commands`'s `RemoveComponentByType`/`AttachComponentByType`
+/// handlers (`bsengine-editor/src/plugin.rs`) -- rather than inventing a
+/// third calling convention.
+fn apply_merged_components(
+    world: &mut World,
+    entity: Entity,
+    registry: &TypeRegistry,
+    live_components: &[(String, String)],
+    merged_components: &[(String, String)],
+) {
+    let merged_keys: std::collections::HashSet<&str> =
+        merged_components.iter().map(|(k, _)| k.as_str()).collect();
+
+    for (type_path, _) in live_components {
+        if merged_keys.contains(type_path.as_str()) {
+            continue;
+        }
+        let Some(registration) = registry.get_with_type_path(type_path) else {
+            continue;
+        };
+        let Some(reflect_component) = registration.data::<bevy_ecs::reflect::ReflectComponent>()
+        else {
+            continue;
+        };
+        let mut entity_mut = world.entity_mut(entity);
+        reflect_component.remove(&mut entity_mut);
+    }
+
+    for (type_path, value_ron) in merged_components {
+        let Some(registration) = registry.get_with_type_path(type_path) else {
+            tracing::warn!(
+                "prefab live-sync: entity {entity:?} merged component references unknown \
+                 reflected type path '{type_path}'"
+            );
+            continue;
+        };
+        let Some(reflect_component) = registration.data::<bevy_ecs::reflect::ReflectComponent>()
+        else {
+            tracing::warn!(
+                "prefab live-sync: entity {entity:?} type path '{type_path}' is not a \
+                 registered Component"
+            );
+            continue;
+        };
+        let de = bevy_reflect::serde::TypedReflectDeserializer::new(registration, registry);
+        match ron::de::Deserializer::from_str(value_ron) {
+            Ok(mut deserializer) => {
+                match serde::de::DeserializeSeed::deserialize(de, &mut deserializer) {
+                    Ok(value) => {
+                        let mut entity_mut = world.entity_mut(entity);
+                        reflect_component.apply_or_insert(&mut entity_mut, value.as_ref(), registry);
+                    }
+                    Err(e) => tracing::warn!(
+                        "prefab live-sync: entity {entity:?} merged component '{type_path}' \
+                         RON value doesn't match its shape: {e}"
+                    ),
+                }
+            }
+            Err(e) => tracing::warn!(
+                "prefab live-sync: entity {entity:?} merged component '{type_path}' RON parse \
+                 error: {e}"
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -413,5 +563,143 @@ mod tests {
             merged.is_empty(),
             "a component the user removed must not come back just because the source still has it"
         );
+    }
+
+    #[test]
+    fn apply_merged_descriptor_updates_an_adopted_field_and_leaves_an_overridden_one() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        let entity = app
+            .world_mut()
+            .spawn((
+                bsengine_scene::Name("Barrel".to_string()),
+                bsengine_scene::PrimitiveMesh(bsengine_scene::Primitive::Cube),
+                bsengine_core::Material {
+                    base_color: glam::Vec3::new(0.0, 1.0, 0.0).into(),
+                    ..Default::default()
+                },
+            ))
+            .id();
+
+        let reg = registry(app.world());
+        let reg = reg.read();
+        let live = snapshot_entity_as_descriptor(app.world(), &reg, entity);
+        let merged = bsengine_scene::EntityDescriptor {
+            primitive: Some(bsengine_scene::Primitive::Sphere), // adopted change
+            color: live.color,                                  // kept as-is (override)
+            ..live.clone()
+        };
+
+        apply_merged_descriptor(app.world_mut(), entity, &reg, &live, &merged);
+
+        assert_eq!(
+            app.world().get::<bsengine_scene::PrimitiveMesh>(entity).unwrap().0,
+            bsengine_scene::Primitive::Sphere
+        );
+        assert_eq!(
+            app.world().get::<bsengine_core::Material>(entity).unwrap().base_color.0.to_array(),
+            [0.0, 1.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn apply_merged_descriptor_removes_a_component_the_merge_dropped() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        let entity = app
+            .world_mut()
+            .spawn((
+                bsengine_scene::Name("Barrel".to_string()),
+                bsengine_scene::PrimitiveMesh(bsengine_scene::Primitive::Cube),
+            ))
+            .id();
+
+        let reg = registry(app.world());
+        let reg = reg.read();
+        let live = snapshot_entity_as_descriptor(app.world(), &reg, entity);
+        let merged = bsengine_scene::EntityDescriptor {
+            primitive: None, // the prefab author removed the primitive field, unoverridden
+            ..live.clone()
+        };
+
+        apply_merged_descriptor(app.world_mut(), entity, &reg, &live, &merged);
+
+        assert!(
+            app.world().get::<bsengine_scene::PrimitiveMesh>(entity).is_none(),
+            "PrimitiveMesh must be removed when the merged descriptor no longer has a primitive"
+        );
+    }
+
+    #[test]
+    fn apply_merged_descriptor_preserves_material_fields_outside_this_prs_scope() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        let entity = app
+            .world_mut()
+            .spawn((
+                bsengine_scene::Name("Barrel".to_string()),
+                bsengine_core::Material {
+                    texture_id: Some(42),
+                    metallic: 0.7,
+                    roughness: 0.3,
+                    base_color: glam::Vec3::new(1.0, 0.0, 0.0).into(),
+                    ..Default::default()
+                },
+            ))
+            .id();
+
+        let reg = registry(app.world());
+        let reg = reg.read();
+        let live = snapshot_entity_as_descriptor(app.world(), &reg, entity);
+        let merged = bsengine_scene::EntityDescriptor {
+            color: Some([0.0, 0.0, 1.0]), // only color is adopted from `new`
+            ..live.clone()
+        };
+
+        apply_merged_descriptor(app.world_mut(), entity, &reg, &live, &merged);
+
+        let material = app.world().get::<bsengine_core::Material>(entity).unwrap();
+        assert_eq!(material.base_color.0.to_array(), [0.0, 0.0, 1.0], "color must update");
+        assert_eq!(
+            material.texture_id,
+            Some(42),
+            "texture_id is outside this PR's field set and must survive untouched"
+        );
+        assert_eq!(material.metallic, 0.7, "metallic must survive untouched");
+        assert_eq!(material.roughness, 0.3, "roughness must survive untouched");
+    }
+
+    #[test]
+    fn apply_merged_descriptor_attaches_and_detaches_reflected_components_per_the_merged_catalog() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        app.register_type::<bsengine_core::Shield>();
+        let entity = app
+            .world_mut()
+            .spawn(bsengine_scene::Name("Hero".to_string()))
+            .id();
+        // A scratch entity that already has `Shield` attached, so its snapshot
+        // gives us the component's *real* reflected type path -- rather than
+        // hardcoding a guess at "bsengine_core::shield::Shield" -- to build
+        // `merged.components` from.
+        let shield_entity = app.world_mut().spawn(bsengine_core::Shield::default()).id();
+
+        let reg = registry(app.world());
+        let reg = reg.read();
+        let live = snapshot_entity_as_descriptor(app.world(), &reg, entity);
+        let shield_snapshot = snapshot_entity_as_descriptor(app.world(), &reg, shield_entity);
+        let shield_component = shield_snapshot
+            .components
+            .into_iter()
+            .find(|(type_path, _)| type_path.ends_with("Shield"))
+            .expect("scratch entity's snapshot must contain its Shield component");
+        let merged = bsengine_scene::EntityDescriptor {
+            components: vec![shield_component],
+            ..live.clone()
+        };
+
+        apply_merged_descriptor(app.world_mut(), entity, &reg, &live, &merged);
+
+        assert!(app.world().get::<bsengine_core::Shield>(entity).is_some());
     }
 }

--- a/crates/bsengine-editor/src/prefab_watcher.rs
+++ b/crates/bsengine-editor/src/prefab_watcher.rs
@@ -1531,7 +1531,9 @@ mod tests {
         .unwrap();
 
         let old_nested_root = {
-            let mut q = app.world_mut().query::<(Entity, &bsengine_core::PrefabInstance)>();
+            let mut q = app
+                .world_mut()
+                .query::<(Entity, &bsengine_core::PrefabInstance)>();
             q.iter(app.world())
                 .find(|(_, i)| i.source_path == nested_a_path)
                 .map(|(e, _)| e)
@@ -1682,7 +1684,9 @@ mod tests {
         );
 
         let new_widget = {
-            let mut q = app.world_mut().query::<(Entity, &Name, &bsengine_core::PrefabInstance)>();
+            let mut q = app
+                .world_mut()
+                .query::<(Entity, &Name, &bsengine_core::PrefabInstance)>();
             q.iter(app.world())
                 .find(|(_, n, _)| n.0.starts_with("Widget#"))
                 .map(|(e, _, i)| (e, i.source_path.clone()))

--- a/crates/bsengine-editor/src/prefab_watcher.rs
+++ b/crates/bsengine-editor/src/prefab_watcher.rs
@@ -258,29 +258,50 @@ pub(crate) fn resync_prefab_instances(world: &mut World, changed_source_path: &s
             );
             continue;
         }
-        let Some(name) = world.get::<Name>(root).map(|n| n.0.clone()) else {
-            continue;
-        };
-        let transform_override = world.get::<Transform>(root).map(|t| TransformDescriptor {
-            position: t.position.0.to_array(),
-            rotation: t.rotation.0.to_array(),
-            scale: t.scale.0.to_array(),
-        });
-        let parent = world.get::<Parent>(root).map(|p| p.0);
 
-        despawn_subtree(world, root, &own_source_paths);
+        let baseline_ron = world
+            .get::<bsengine_core::PrefabInstanceBaseline>(root)
+            .map(|b| b.synced_ron.clone());
+        let baseline: Option<bsengine_scene::types::PrefabDescriptor> =
+            baseline_ron.as_deref().and_then(|s| ron::from_str(s).ok());
 
-        if let Err(e) = bsengine_scene::instantiate_prefab_from_path(
-            world,
-            &resolved_path,
-            Some(&name),
-            transform_override,
-            parent,
-        ) {
-            tracing::warn!(
-                "prefab live-sync: failed to resync instance '{name}' of \
-                 '{changed_source_path}': {e}"
-            );
+        match baseline {
+            Some(baseline) => {
+                match crate::prefab_merge::resync_instance(
+                    world,
+                    root,
+                    &baseline,
+                    &prefab,
+                    &own_source_paths,
+                ) {
+                    Ok(()) => {
+                        world
+                            .entity_mut(root)
+                            .insert(bsengine_core::PrefabInstanceBaseline {
+                                synced_ron: content.clone(),
+                            });
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "prefab live-sync: failed to merge-resync an instance of \
+                             '{changed_source_path}': {e}"
+                        );
+                    }
+                }
+            }
+            None => {
+                tracing::warn!(
+                    "prefab live-sync: an instance of '{changed_source_path}' has no recorded \
+                     baseline (likely a scene saved before override tracking existed); leaving \
+                     its fields untouched this time and recording a fresh baseline so tracking \
+                     begins from the next change"
+                );
+                world
+                    .entity_mut(root)
+                    .insert(bsengine_core::PrefabInstanceBaseline {
+                        synced_ron: content.clone(),
+                    });
+            }
         }
     }
 }

--- a/crates/bsengine-editor/src/prefab_watcher.rs
+++ b/crates/bsengine-editor/src/prefab_watcher.rs
@@ -540,7 +540,7 @@ mod tests {
     ])"#;
 
     #[test]
-    fn resync_preserves_the_instances_name_transform_and_parent() {
+    fn resync_preserves_the_instances_name_transform_and_parent_and_patches_in_place() {
         let dir = tempfile::tempdir().unwrap();
         let project_dir = ProjectDir(dir.path().to_string_lossy().to_string());
         let source_path = write_prefab(dir.path(), "turret", TURRET_V1);
@@ -572,9 +572,10 @@ mod tests {
             .find(|(_, n)| n.0 == "MyTurret")
             .map(|(e, _)| e)
             .expect("the resynced instance must keep its exact original name");
-        assert_ne!(
+        assert_eq!(
             new_root, old_root,
-            "resync must spawn a fresh entity, not reuse the old id"
+            "an instance whose fields aren't overridden must patch in place, keeping the \
+             same Entity id across a resync rather than respawning"
         );
 
         let transform = app.world().get::<Transform>(new_root).unwrap();
@@ -839,9 +840,10 @@ mod tests {
                 .map(|(e, _)| e)
                 .expect("a resynced nested instance must still exist")
         };
-        assert_ne!(
+        assert_eq!(
             nested_root_after, nested_root_before,
-            "the nested subtree must have been despawned and re-instantiated"
+            "the nested subtree's root has no overridden fields, so it must patch in place \
+             rather than respawn"
         );
         assert_eq!(
             app.world().get::<Parent>(nested_root_after).map(|p| p.0),
@@ -889,9 +891,10 @@ mod tests {
                 .map(|(e, _)| e)
                 .expect("a resynced outer instance must still exist under the same name")
         };
-        assert_ne!(
+        assert_eq!(
             outer_root_after, outer_root_before,
-            "the whole outer subtree must have been despawned and re-instantiated"
+            "the outer root has no overridden fields, so it must patch in place rather than \
+             respawn"
         );
 
         let names: Vec<String> = app
@@ -913,7 +916,9 @@ mod tests {
         };
         assert_eq!(
             nested_instance_count, 1,
-            "resyncing the outer file must re-resolve its nested prefab reference exactly once"
+            "the nested prefab reference is unchanged between OUTER_V1 and OUTER_V2, so it \
+             must be left alone entirely rather than re-resolved -- the original nested \
+             instance survives untouched, not despawned-and-recreated"
         );
     }
 
@@ -934,9 +939,18 @@ mod tests {
         // -- so live-sync's own protection against collateral despawn has to
         // recognize the *whole* chain as part of outer's own composition,
         // not just its direct child, or a grand-nested instance (inner.ron
-        // here) gets wrongly protected from outer's despawn, orphaned under
-        // a despawned entity, while outer's re-instantiation creates a
-        // second, fresh one -- leaking a zombie.
+        // here) would be wrongly protected from a despawn that does need to
+        // reach it, leaving it orphaned under a despawned entity while a
+        // second, fresh one gets created alongside it -- a leaked zombie.
+        // In this specific test that despawn never actually happens: the
+        // MiddleRef entry is byte-for-byte unchanged between outer.ron's two
+        // versions, so nested_reference_changed leaves the whole
+        // middle.ron/inner.ron chain alone rather than despawning and
+        // recreating it. The single surviving inner.ron instance below is
+        // therefore the original one, left untouched -- not a fresh
+        // replacement -- but the deep own_source_paths tracking this test
+        // guards is still what a despawn reaching into a nested chain would
+        // rely on.
         write_prefab(
             dir.path(),
             "inner",
@@ -1002,7 +1016,8 @@ mod tests {
         assert_eq!(
             inner_instance_count, 1,
             "resyncing the outer file must not leave a zombie grand-nested inner.ron \
-             instance behind alongside the freshly re-resolved one: {names:?}"
+             instance behind alongside the original one, which was left alone rather than \
+             recreated since MiddleRef didn't change: {names:?}"
         );
     }
 
@@ -1081,7 +1096,8 @@ mod tests {
     }
 
     #[test]
-    fn resync_warns_rather_than_panics_when_a_matching_root_is_a_live_descendant_of_another() {
+    fn resync_independently_patches_two_instances_of_the_same_source_even_when_one_is_a_live_child_of_the_other(
+    ) {
         let dir = tempfile::tempdir().unwrap();
         let project_dir = ProjectDir(dir.path().to_string_lossy().to_string());
         let source_path = write_prefab(dir.path(), "turret", TURRET_V1);
@@ -1109,11 +1125,23 @@ mod tests {
         .unwrap();
 
         // Two instances of the *same* source path, with B a live descendant
-        // of A -- exercises the `world.get_entity(root).is_none()` branch at
-        // the top of the `for root in roots` loop (B is swept up as a normal
-        // part of A's real despawn_subtree, since both share
-        // `protected_source_path`, so by the time the loop reaches B's own
-        // entry in `roots` it is already gone).
+        // of A. Under the old despawn-everything design, B got destroyed as
+        // collateral damage of A's despawn_subtree walk (B's own
+        // PrefabInstance shares A's own source path, so despawn_subtree's
+        // "foreign source path" protection doesn't apply to it -- only a
+        // *foreign* source path is protected). Under the new patch-in-place
+        // design, A's own resync never despawns anything for a plain
+        // field-level merge -- collect_own_descendants walking from A still
+        // finds B_root (same not-foreign reasoning), but B_root's Name
+        // ("InstanceB") doesn't match any raw name in the turret prefab's own
+        // entity list, so the structural-diff loop (which only ever iterates
+        // over names drawn from baseline/new) never touches B at all -- B
+        // simply survives, untouched, exactly where it was. And since B
+        // itself also carries a PrefabInstanceBaseline (every real
+        // instantiation gets one), resync_prefab_instances's own top-level
+        // loop -- which finds *every* root with a matching
+        // PrefabInstance.source_path, and both A and B qualify -- resyncs B
+        // independently too, picking up the same file change A did.
         app.world_mut()
             .entity_mut(instance_b_root)
             .insert(Parent(instance_a_root));
@@ -1130,12 +1158,13 @@ mod tests {
             .collect();
         assert!(
             names.contains(&"InstanceA".to_string()),
-            "InstanceA must have been resynced successfully: {names:?}"
+            "InstanceA must still exist: {names:?}"
         );
         assert!(
-            !names.contains(&"InstanceB".to_string()),
-            "InstanceB was a live descendant of InstanceA and got swept up in A's real \
-             despawn (same source path, so not protected); it must not reappear: {names:?}"
+            names.contains(&"InstanceB".to_string()),
+            "InstanceB has no overridden fields, so unlike the old despawn-everything resync, \
+             it must survive being a live child of InstanceA and patch in place independently, \
+             rather than being swept up as collateral: {names:?}"
         );
 
         let instance_count = {
@@ -1145,8 +1174,14 @@ mod tests {
                 .count()
         };
         assert_eq!(
-            instance_count, 1,
-            "exactly one live instance of the shared source path should remain: {names:?}"
+            instance_count, 2,
+            "both independent instances of the shared source path must remain: {names:?}"
+        );
+
+        let scope_count = names.iter().filter(|n| n.starts_with("Scope#")).count();
+        assert_eq!(
+            scope_count, 2,
+            "both instances must independently pick up the new Scope child: {names:?}"
         );
     }
 
@@ -1189,9 +1224,9 @@ mod tests {
              sibling entity untouched"
         );
         assert!(
-            app.world().get_entity(standalone_root).is_none(),
-            "the standalone top-level nested instance must have been despawned and \
-             re-instantiated fresh, not left as the old entity"
+            app.world().get_entity(standalone_root).is_some(),
+            "the standalone top-level nested instance has no overridden fields, so it must \
+             patch in place (same Entity id) rather than respawn"
         );
 
         let names: Vec<String> = app
@@ -1432,6 +1467,134 @@ mod tests {
             nested_instance_found,
             "a brand-new nested prefab reference must be resolved via instantiate_prefab_from_path, \
              not silently spawned as an empty plain entity"
+        );
+    }
+
+    #[test]
+    fn resync_prefab_instances_preserves_an_override_end_to_end_through_the_real_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = ProjectDir(dir.path().to_string_lossy().to_string());
+        let source_path = write_prefab(dir.path(), "turret", TURRET_V1);
+
+        let mut app = new_app();
+        app.insert_resource(project_dir.clone());
+        register(&mut app);
+
+        let resolved = bsengine_core::resolve_project_path(Some(&project_dir), &source_path);
+        bsengine_scene::instantiate_prefab_from_path(
+            app.world_mut(),
+            &resolved,
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let barrel = {
+            let mut q = app.world_mut().query::<(Entity, &Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Barrel#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        app.world_mut()
+            .entity_mut(barrel)
+            .insert(bsengine_scene::PrimitiveMesh(
+                bsengine_scene::Primitive::Sphere,
+            ));
+
+        write_prefab(dir.path(), "turret", TURRET_V2); // adds Scope, doesn't touch Barrel's primitive
+        resync_prefab_instances(app.world_mut(), &source_path);
+
+        assert_eq!(
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(barrel)
+                .unwrap()
+                .0,
+            bsengine_scene::Primitive::Sphere,
+            "the manually-overridden primitive must survive a real end-to-end resync"
+        );
+        let names: Vec<String> = app
+            .world_mut()
+            .query::<&Name>()
+            .iter(app.world())
+            .map(|n| n.0.clone())
+            .collect();
+        assert!(
+            names.iter().any(|n| n.starts_with("Scope#")),
+            "the new Scope child must still appear: {names:?}"
+        );
+    }
+
+    #[test]
+    fn resync_prefab_instances_falls_back_gracefully_with_no_recorded_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = ProjectDir(dir.path().to_string_lossy().to_string());
+        let source_path = write_prefab(dir.path(), "turret", TURRET_V1);
+
+        let mut app = new_app();
+        app.insert_resource(project_dir.clone());
+        register(&mut app);
+
+        let resolved = bsengine_core::resolve_project_path(Some(&project_dir), &source_path);
+        let root = bsengine_scene::instantiate_prefab_from_path(
+            app.world_mut(),
+            &resolved,
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+        // Simulate a scene saved before this feature existed: strip the baseline
+        // that instantiate_prefab_from_path would normally have attached.
+        app.world_mut()
+            .entity_mut(root)
+            .remove::<bsengine_core::PrefabInstanceBaseline>();
+
+        write_prefab(dir.path(), "turret", TURRET_V2);
+        resync_prefab_instances(app.world_mut(), &source_path);
+
+        assert!(
+            app.world().get_entity(root).is_some(),
+            "an instance with no baseline must not be despawned outright"
+        );
+        assert!(
+            app.world()
+                .get::<bsengine_core::PrefabInstanceBaseline>(root)
+                .is_some(),
+            "a baseline must be recorded after this fallback resync, so tracking begins next time"
+        );
+
+        // Second change: now that a baseline exists, override tracking works normally.
+        let barrel = {
+            let mut q = app.world_mut().query::<(Entity, &Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Barrel#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        app.world_mut()
+            .entity_mut(barrel)
+            .insert(bsengine_scene::PrimitiveMesh(
+                bsengine_scene::Primitive::Sphere,
+            ));
+        write_prefab(
+            dir.path(),
+            "turret",
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Barrel", parent: Some("Body"), primitive: Some(Cube)),
+                EntityDescriptor(name: "Scope", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        );
+        resync_prefab_instances(app.world_mut(), &source_path);
+        assert_eq!(
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(barrel)
+                .unwrap()
+                .0,
+            bsengine_scene::Primitive::Sphere,
+            "override tracking must be active starting from the self-healed baseline"
         );
     }
 }

--- a/crates/bsengine-editor/src/prefab_watcher.rs
+++ b/crates/bsengine-editor/src/prefab_watcher.rs
@@ -142,7 +142,7 @@ fn collect_nested_prefab_source_paths(
 /// already-tolerated state elsewhere in this codebase (plain
 /// `EditorCommand::Despawn` doesn't cascade to children either) -- and a
 /// warning is logged so this is never silent.
-fn despawn_subtree(
+pub(crate) fn despawn_subtree(
     world: &mut World,
     root: Entity,
     own_source_paths: &std::collections::HashSet<String>,
@@ -1353,6 +1353,64 @@ mod tests {
         assert!(
             app.world().get::<PrefabInstance>(resynced.0).is_some(),
             "the resynced root must still carry PrefabInstance"
+        );
+    }
+
+    // Lives here rather than in `prefab_merge`'s own test module because it
+    // needs `write_prefab`/`ProjectDir`/`tempfile`, which are already set up
+    // in this module -- see Task 8's plan for why duplicating them into
+    // `prefab_merge.rs` instead was the less-preferred option.
+    #[test]
+    fn resync_instance_resolves_a_brand_new_nested_prefab_reference() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = ProjectDir(dir.path().to_string_lossy().to_string());
+        app.insert_resource(project_dir.clone());
+        let nested_path = write_prefab(
+            dir.path(),
+            "nested",
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "NestedRoot", primitive: Some(Cube)),
+            ])"#,
+        );
+
+        let baseline: bsengine_scene::types::PrefabDescriptor = ron::from_str(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+            ])"#,
+        )
+        .unwrap();
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let new: bsengine_scene::types::PrefabDescriptor = ron::from_str(&format!(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "NestedRef", parent: Some("Body"), prefab: Some("{nested_path}")),
+            ])"#
+        ))
+        .unwrap();
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
+        crate::prefab_merge::resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths)
+            .unwrap();
+
+        let nested_instance_found = {
+            let mut q = app.world_mut().query::<&bsengine_core::PrefabInstance>();
+            q.iter(app.world()).any(|i| i.source_path == nested_path)
+        };
+        assert!(
+            nested_instance_found,
+            "a brand-new nested prefab reference must be resolved via instantiate_prefab_from_path, \
+             not silently spawned as an empty plain entity"
         );
     }
 }

--- a/crates/bsengine-editor/src/prefab_watcher.rs
+++ b/crates/bsengine-editor/src/prefab_watcher.rs
@@ -1489,6 +1489,226 @@ mod tests {
         );
     }
 
+    // See the comment on `resync_instance_resolves_a_brand_new_nested_prefab_reference` just
+    // above for why this lives here rather than in `prefab_merge`'s own test module.
+    #[test]
+    fn resync_instance_re_resolves_a_nested_reference_whose_path_changed() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = ProjectDir(dir.path().to_string_lossy().to_string());
+        app.insert_resource(project_dir.clone());
+        let nested_a_path = write_prefab(
+            dir.path(),
+            "nested_a",
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "NestedARoot", primitive: Some(Cube)),
+            ])"#,
+        );
+        let nested_b_path = write_prefab(
+            dir.path(),
+            "nested_b",
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "NestedBRoot", primitive: Some(Sphere)),
+            ])"#,
+        );
+
+        let baseline: bsengine_scene::types::PrefabDescriptor = ron::from_str(&format!(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "NestedRef", parent: Some("Body"), prefab: Some("{nested_a_path}")),
+            ])"#
+        ))
+        .unwrap();
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let old_nested_root = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_core::PrefabInstance)>();
+            q.iter(app.world())
+                .find(|(_, i)| i.source_path == nested_a_path)
+                .map(|(e, _)| e)
+                .expect("baseline's nested reference must have resolved to a live PrefabInstance")
+        };
+
+        // Same raw name ("NestedRef"), but the `prefab:` path it points at
+        // changed -- the "despawn old subtree, resolve new one" branch of
+        // `nested_reference_changed`, distinct from the "unrelated fields
+        // changed, path same" case the existing "unchanged" tests exercise.
+        let new: bsengine_scene::types::PrefabDescriptor = ron::from_str(&format!(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "NestedRef", parent: Some("Body"), prefab: Some("{nested_b_path}")),
+            ])"#
+        ))
+        .unwrap();
+        let own_source_paths = std::collections::HashSet::from([
+            "assets/prefabs/turret.ron".to_string(),
+            nested_b_path.clone(),
+        ]);
+        crate::prefab_merge::resync_instance(
+            app.world_mut(),
+            root,
+            &baseline,
+            &new,
+            &own_source_paths,
+        )
+        .unwrap();
+
+        assert!(
+            app.world().get_entity(old_nested_root).is_none(),
+            "the old nested instance (pointing at nested_a.ron) must be despawned once its \
+             reference is repointed at a different file"
+        );
+        let old_instance_still_present = {
+            let mut q = app.world_mut().query::<&bsengine_core::PrefabInstance>();
+            q.iter(app.world()).any(|i| i.source_path == nested_a_path)
+        };
+        assert!(
+            !old_instance_still_present,
+            "no live PrefabInstance should still point at nested_a.ron after the reference \
+             moved to nested_b.ron"
+        );
+
+        let new_nested_root = {
+            let mut q = app
+                .world_mut()
+                .query::<(Entity, &bsengine_core::PrefabInstance)>();
+            q.iter(app.world())
+                .find(|(_, i)| i.source_path == nested_b_path)
+                .map(|(e, _)| e)
+        };
+        assert!(
+            new_nested_root.is_some(),
+            "a new nested instance pointing at nested_b.ron must be resolved in the old one's \
+             place"
+        );
+        // The resolved root is renamed to `spawned_name` ("NestedRef#<suffix>") per
+        // `spawn_or_resolve_entity`'s contract, so nested_b.ron's own entity name
+        // ("NestedBRoot") never appears verbatim -- confirm nested_b.ron's own content came
+        // through by checking the field it declared (Sphere, vs. nested_a.ron's Cube).
+        assert_eq!(
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(new_nested_root.unwrap())
+                .map(|p| p.0.clone()),
+            Some(bsengine_scene::Primitive::Sphere),
+            "the freshly-resolved nested instance must reflect nested_b.ron's own content"
+        );
+    }
+
+    // See the comment on `resync_instance_resolves_a_brand_new_nested_prefab_reference` just
+    // above for why this lives here rather than in `prefab_merge`'s own test module.
+    #[test]
+    fn resync_instance_converts_a_plain_entity_into_a_nested_prefab_reference() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = ProjectDir(dir.path().to_string_lossy().to_string());
+        app.insert_resource(project_dir.clone());
+        let nested_path = write_prefab(
+            dir.path(),
+            "nested",
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "NestedRoot", primitive: Some(Cube)),
+            ])"#,
+        );
+
+        let baseline: bsengine_scene::types::PrefabDescriptor = ron::from_str(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Widget", parent: Some("Body"), primitive: Some(Cube)),
+            ])"#,
+        )
+        .unwrap();
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/turret.ron",
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let old_widget = {
+            let mut q = app.world_mut().query::<(Entity, &Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Widget#"))
+                .map(|(e, _)| e)
+                .expect("baseline's plain Widget entity must have spawned")
+        };
+        assert!(
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(old_widget)
+                .is_some(),
+            "sanity check: Widget starts out as a plain entity with a PrimitiveMesh"
+        );
+
+        // Same raw name ("Widget"), but `new` turns it into a nested prefab
+        // reference instead of a plain entity -- the
+        // `b.prefab.is_some() || n.prefab.is_some()` match guard's other
+        // direction from the path-change test above.
+        let new: bsengine_scene::types::PrefabDescriptor = ron::from_str(&format!(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Body", primitive: Some(Cube)),
+                EntityDescriptor(name: "Widget", parent: Some("Body"), prefab: Some("{nested_path}")),
+            ])"#
+        ))
+        .unwrap();
+        let own_source_paths = std::collections::HashSet::from([
+            "assets/prefabs/turret.ron".to_string(),
+            nested_path.clone(),
+        ]);
+        crate::prefab_merge::resync_instance(
+            app.world_mut(),
+            root,
+            &baseline,
+            &new,
+            &own_source_paths,
+        )
+        .unwrap();
+
+        assert!(
+            app.world().get_entity(old_widget).is_none(),
+            "the old plain Widget entity must be despawned when it's converted to a nested \
+             reference, not left behind or field-merged in place"
+        );
+
+        let new_widget = {
+            let mut q = app.world_mut().query::<(Entity, &Name, &bsengine_core::PrefabInstance)>();
+            q.iter(app.world())
+                .find(|(_, n, _)| n.0.starts_with("Widget#"))
+                .map(|(e, _, i)| (e, i.source_path.clone()))
+        };
+        assert_eq!(
+            new_widget.as_ref().map(|(_, path)| path.clone()),
+            Some(nested_path.clone()),
+            "a fresh entity named Widget#<suffix> must exist, resolved as a real nested \
+             PrefabInstance pointing at nested.ron -- not confused with, or left in, its old \
+             plain-entity representation"
+        );
+        // The resolved nested root is renamed to `spawned_name` ("Widget#<suffix>") per
+        // `spawn_or_resolve_entity`'s contract, so nested.ron's own entity name
+        // ("NestedRoot") never appears verbatim -- instead, confirm the nested file's own
+        // content actually came through by checking the field it declared (Cube), which
+        // the old plain Widget entity in `baseline` never had set this way.
+        assert_eq!(
+            app.world()
+                .get::<bsengine_scene::PrimitiveMesh>(new_widget.unwrap().0)
+                .map(|p| p.0.clone()),
+            Some(bsengine_scene::Primitive::Cube),
+            "the newly-resolved nested subtree's own content (nested.ron's root primitive) \
+             must be present"
+        );
+    }
+
     #[test]
     fn resync_prefab_instances_preserves_an_override_end_to_end_through_the_real_baseline() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/bsengine-editor/src/prefab_watcher.rs
+++ b/crates/bsengine-editor/src/prefab_watcher.rs
@@ -19,9 +19,9 @@
 
 use bevy_app::{App, Plugin, Startup, Update};
 use bevy_ecs::prelude::{Commands, Entity, IntoSystemConfigs, Res, Resource, World};
-use bsengine_core::{Parent, PrefabInstance};
 #[cfg(test)]
 use bsengine_core::Transform;
+use bsengine_core::{Parent, PrefabInstance};
 #[cfg(test)]
 use bsengine_scene::{Name, TransformDescriptor};
 use notify_debouncer_full::{
@@ -1307,7 +1307,8 @@ mod tests {
 
         let resolved_a = bsengine_core::resolve_project_path(Some(&project_dir), &a_path);
         let content = std::fs::read_to_string(&resolved_a).unwrap();
-        let a_descriptor: bsengine_scene::types::PrefabDescriptor = ron::from_str(&content).unwrap();
+        let a_descriptor: bsengine_scene::types::PrefabDescriptor =
+            ron::from_str(&content).unwrap();
 
         let paths = nested_prefab_source_paths(&a_path, &a_descriptor, Some(&project_dir));
 
@@ -1468,8 +1469,14 @@ mod tests {
         .unwrap();
         let own_source_paths =
             std::collections::HashSet::from(["assets/prefabs/turret.ron".to_string()]);
-        crate::prefab_merge::resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths)
-            .unwrap();
+        crate::prefab_merge::resync_instance(
+            app.world_mut(),
+            root,
+            &baseline,
+            &new,
+            &own_source_paths,
+        )
+        .unwrap();
 
         let nested_instance_found = {
             let mut q = app.world_mut().query::<&bsengine_core::PrefabInstance>();

--- a/crates/bsengine-editor/src/prefab_watcher.rs
+++ b/crates/bsengine-editor/src/prefab_watcher.rs
@@ -1,23 +1,28 @@
-//! Despawn-and-reinstantiate resync for prefab instances whose source file
-//! changed on disk, plus the file watcher that detects those changes.
+//! Patch-in-place resync for prefab instances whose source file changed on
+//! disk, plus the file watcher that detects those changes.
 //!
 //! [`resync_prefab_instances`] is the resync itself: given a project-relative
 //! prefab path, it finds every live [`PrefabInstance`] root pointing at that
-//! path, despawns each one's full subtree, and re-instantiates fresh from the
-//! file's current content -- preserving the instance's original name,
-//! transform, and parent. It takes a plain path and `&mut World`, so it can be
-//! (and is, in this crate's tests) driven directly without any debouncer or
-//! timing involved.
-//!
-//! This is a **destructive** sync: without override tracking (explicitly out
-//! of scope -- see the design doc), any manual edit made directly to an
-//! instance (added children, tweaked child transforms, attached components)
-//! is lost the next time that instance's source prefab changes and gets
-//! synced.
+//! path and, for each one with a recorded [`bsengine_core::PrefabInstanceBaseline`],
+//! delegates to [`crate::prefab_merge::resync_instance`] -- which merges the
+//! instance in place field-by-field, preserving the instance's original name,
+//! transform, and parent, and preserving any manually-overridden field or
+//! manually-added child rather than clobbering it (see
+//! `docs/superpowers/specs/2026-08-19-prefab-override-tracking-design.md`).
+//! Structural removals in the source file still cascade away unconditionally,
+//! regardless of overrides underneath. A root with no recorded baseline (a
+//! scene saved before override tracking existed) is left untouched once while
+//! a fresh baseline is recorded, so tracking begins from the next change.
+//! This function takes a plain path and `&mut World`, so it can be (and is,
+//! in this crate's tests) driven directly without any debouncer or timing
+//! involved.
 
 use bevy_app::{App, Plugin, Startup, Update};
 use bevy_ecs::prelude::{Commands, Entity, IntoSystemConfigs, Res, Resource, World};
-use bsengine_core::{Parent, PrefabInstance, Transform};
+use bsengine_core::{Parent, PrefabInstance};
+#[cfg(test)]
+use bsengine_core::Transform;
+#[cfg(test)]
 use bsengine_scene::{Name, TransformDescriptor};
 use notify_debouncer_full::{
     new_debouncer,
@@ -182,15 +187,22 @@ pub(crate) fn despawn_subtree(
 
 /// Resyncs every live [`PrefabInstance`] root whose `source_path` matches
 /// `changed_source_path` (a project-relative path, e.g.
-/// `"assets/prefabs/turret.ron"`): despawns each instance's full subtree and
-/// re-instantiates it fresh from the file's current content, preserving each
-/// instance's original name, transform, and parent.
+/// `"assets/prefabs/turret.ron"`): patches each instance in place field by
+/// field via [`crate::prefab_merge::resync_instance`], preserving each
+/// instance's original name, transform, and parent, and preserving any
+/// manually-overridden field or manually-added child rather than clobbering
+/// it. Structural removals in the source file still cascade away
+/// unconditionally, regardless of overrides underneath.
 ///
 /// A missing, unparseable, or structurally invalid (wrong root count, a
 /// duplicate entity name) file leaves every matching instance untouched
 /// rather than despawning anything -- the existence/parse/structural-validity
 /// check happens before any entity is touched, precisely so a bad edit can't
-/// destroy a working instance on the way to failing.
+/// destroy a working instance on the way to failing. An instance with no
+/// recorded [`bsengine_core::PrefabInstanceBaseline`] (a scene saved before
+/// override tracking existed) is likewise left untouched this one time,
+/// while a fresh baseline is recorded so tracking begins from the next
+/// change.
 pub(crate) fn resync_prefab_instances(world: &mut World, changed_source_path: &str) {
     let roots: Vec<Entity> = {
         let mut q = world.query::<(Entity, &PrefabInstance)>();

--- a/crates/bsengine-scene/Cargo.toml
+++ b/crates/bsengine-scene/Cargo.toml
@@ -29,3 +29,4 @@ bsengine-app.workspace = true
 # probe directory, and assert on the warnings that come out — both of which
 # `bsengine-asset` already has helpers for.
 bsengine-asset = { workspace = true, features = ["test-support"] }
+tempfile = "3"

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -15,8 +15,8 @@ pub mod prefab;
 pub mod types;
 
 pub use plugin::{
-    instantiate_prefab_from_path, register_gameplay_reflect_types, spawn_scene_entities, Name,
-    ScenePlugin,
+    instantiate_prefab_from_path, instantiate_prefab_reference, register_gameplay_reflect_types,
+    spawn_scene_entities, spawn_single_entity, Name, ScenePlugin,
 };
 pub use prefab::{instantiate_prefab, next_instance_suffix, validate_prefab_descriptor};
 pub use types::{

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -775,8 +775,13 @@ pub fn spawn_single_entity(world: &mut World, descriptor: &EntityDescriptor) -> 
         builder.insert((
             Transform {
                 position: Vec3::from(t.position).into(),
-                rotation: Quat::from_xyzw(t.rotation[0], t.rotation[1], t.rotation[2], t.rotation[3])
-                    .into(),
+                rotation: Quat::from_xyzw(
+                    t.rotation[0],
+                    t.rotation[1],
+                    t.rotation[2],
+                    t.rotation[3],
+                )
+                .into(),
                 scale: Vec3::from(t.scale).into(),
             },
             GlobalTransform::default(),
@@ -787,7 +792,11 @@ pub fn spawn_single_entity(world: &mut World, descriptor: &EntityDescriptor) -> 
     }
     if descriptor.emissive.is_some() || descriptor.color.is_some() {
         builder.insert(Material {
-            emissive: descriptor.emissive.map(Vec3::from).unwrap_or(Vec3::ZERO).into(),
+            emissive: descriptor
+                .emissive
+                .map(Vec3::from)
+                .unwrap_or(Vec3::ZERO)
+                .into(),
             base_color: descriptor.color.map(Vec3::from).unwrap_or(Vec3::ONE).into(),
             opacity: descriptor.opacity.unwrap_or(1.0),
             ..Default::default()
@@ -934,7 +943,12 @@ mod tests {
 
         assert_eq!(app.world().get::<Name>(entity).unwrap().0, "Standalone");
         assert_eq!(
-            app.world().get::<Transform>(entity).unwrap().position.0.to_array(),
+            app.world()
+                .get::<Transform>(entity)
+                .unwrap()
+                .position
+                .0
+                .to_array(),
             [1.0, 2.0, 3.0]
         );
     }
@@ -960,7 +974,10 @@ mod tests {
             super::instantiate_prefab_reference(app.world_mut(), "NestedRef", &prefab_ref, None)
                 .expect("a project-relative bare-path reference must resolve against ProjectDir");
 
-        assert!(app.world().get::<bsengine_core::PrefabInstance>(root).is_some());
+        assert!(app
+            .world()
+            .get::<bsengine_core::PrefabInstance>(root)
+            .is_some());
     }
 
     #[test]

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -719,6 +719,83 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
     }
 }
 
+/// Resolves `prefab_ref` (an asset-identity-aware or bare-path prefab
+/// reference, exactly as `EntityDescriptor::prefab` stores it) against the
+/// current `AssetIndex`/`ProjectDir`, then instantiates it. This is the same
+/// two-step resolution `spawn_scene_entities`'s own `entity.prefab` branch
+/// performs (`resolve_asset_ref` then `resolve_project_path`) before calling
+/// `instantiate_prefab_from_path` -- both steps are required, not optional:
+/// skipping `resolve_asset_ref` breaks a GUID-identified reference surviving
+/// a rename, and skipping `resolve_project_path` means a project-relative
+/// path (the common case for every real `games/*` prefab) is opened relative
+/// to the process's CWD instead and fails to read at all (see
+/// `spawn_scene_entities`'s own comment on this exact failure mode). Exposed
+/// as a public function because `bsengine-editor`'s prefab-merge resync
+/// needs to resolve a single nested reference on demand, outside of spawning
+/// a whole entity list via `spawn_scene_entities`.
+pub fn instantiate_prefab_reference(
+    world: &mut World,
+    entity_name: &str,
+    prefab_ref: &AssetRef,
+    root_transform: Option<TransformDescriptor>,
+) -> Result<Entity, String> {
+    let project_dir = world.get_resource::<bsengine_core::ProjectDir>().cloned();
+    let prefab_path = resolve_asset_ref(
+        world.get_resource::<AssetIndex>(),
+        project_dir.as_ref(),
+        entity_name,
+        "prefab",
+        prefab_ref,
+    );
+    let prefab_path = bsengine_core::resolve_project_path(project_dir.as_ref(), &prefab_path);
+    instantiate_prefab_from_path(world, &prefab_path, Some(entity_name), root_transform, None)
+}
+
+/// Spawns exactly one entity from `descriptor`, with none of
+/// `spawn_scene_entities`'s batch machinery (multi-entity asset-ref
+/// pre-resolution, `parent:` name wiring across the batch) -- callers that
+/// already know the resolved parent `Entity` and only need one entity at a
+/// time (currently: `bsengine-editor`'s prefab-merge resync, spawning a
+/// single newly-added prefab entity mid-diff) call this directly instead.
+/// Does not handle `descriptor.prefab` (a nested prefab reference) --
+/// callers with a `prefab:`-bearing descriptor must call
+/// `instantiate_prefab_reference` instead, same as `spawn_scene_entities`
+/// itself branches before ever reaching this code path.
+///
+/// Covers the same representative field set `bsengine-editor`'s prefab
+/// merge algorithm covers: `transform`, `primitive`, `emissive`/`color`/
+/// `opacity`. Any other field on `descriptor` is silently ignored -- adding
+/// the remaining field groups (`gltf`, `camera`, lights, physics, `script`,
+/// `texture`) is a follow-up PR's job, exactly like the merge algorithm's
+/// own scope limit.
+pub fn spawn_single_entity(world: &mut World, descriptor: &EntityDescriptor) -> Entity {
+    let mut builder = world.spawn(Name(descriptor.name.clone()));
+
+    if let Some(t) = &descriptor.transform {
+        builder.insert((
+            Transform {
+                position: Vec3::from(t.position).into(),
+                rotation: Quat::from_xyzw(t.rotation[0], t.rotation[1], t.rotation[2], t.rotation[3])
+                    .into(),
+                scale: Vec3::from(t.scale).into(),
+            },
+            GlobalTransform::default(),
+        ));
+    }
+    if let Some(prim) = &descriptor.primitive {
+        builder.insert(PrimitiveMesh(prim.clone()));
+    }
+    if descriptor.emissive.is_some() || descriptor.color.is_some() {
+        builder.insert(Material {
+            emissive: descriptor.emissive.map(Vec3::from).unwrap_or(Vec3::ZERO).into(),
+            base_color: descriptor.color.map(Vec3::from).unwrap_or(Vec3::ONE).into(),
+            opacity: descriptor.opacity.unwrap_or(1.0),
+            ..Default::default()
+        });
+    }
+    builder.id()
+}
+
 /// Registers every `bsengine_core` component type an `EntityDescriptor`'s
 /// `components:` field (arbitrary reflected components, e.g. `Shield`,
 /// `SaveData`, `AnimationStateMachine`, `NavMeshAgent`, `Bloom`, `ToneMap`)
@@ -838,6 +915,52 @@ mod tests {
         let path = std::env::temp_dir().join(filename);
         std::fs::write(&path, content).unwrap();
         path.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn spawn_single_entity_creates_one_entity_with_transform_and_primitive() {
+        let mut app = bsengine_app::new_app();
+        let descriptor = crate::types::EntityDescriptor {
+            name: "Standalone".to_string(),
+            transform: Some(crate::types::TransformDescriptor {
+                position: [1.0, 2.0, 3.0],
+                ..Default::default()
+            }),
+            primitive: Some(crate::types::Primitive::Cube),
+            ..Default::default()
+        };
+
+        let entity = super::spawn_single_entity(app.world_mut(), &descriptor);
+
+        assert_eq!(app.world().get::<Name>(entity).unwrap().0, "Standalone");
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().position.0.to_array(),
+            [1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn instantiate_prefab_reference_resolves_a_project_relative_path_against_project_dir() {
+        let mut app = bsengine_app::new_app();
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = bsengine_core::ProjectDir(dir.path().to_string_lossy().to_string());
+        app.insert_resource(project_dir.clone());
+        let prefabs_dir = dir.path().join("assets").join("prefabs");
+        std::fs::create_dir_all(&prefabs_dir).unwrap();
+        std::fs::write(
+            prefabs_dir.join("nested.ron"),
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "NestedRoot", primitive: Some(Cube)),
+            ])"#,
+        )
+        .unwrap();
+
+        let prefab_ref = crate::types::AssetRef::Path("assets/prefabs/nested.ron".to_string());
+        let root =
+            super::instantiate_prefab_reference(app.world_mut(), "NestedRef", &prefab_ref, None)
+                .expect("a project-relative bare-path reference must resolve against ProjectDir");
+
+        assert!(app.world().get::<bsengine_core::PrefabInstance>(root).is_some());
     }
 
     #[test]

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -197,14 +197,20 @@ pub fn instantiate_prefab_from_path(
     // false positive rather than a one-off glitch.
     let _guard = ResolvingGuard(prefab_path.to_string());
     let source_path = project_relative_prefab_path(world, prefab_path);
-    crate::prefab::instantiate_prefab(
+    let root = crate::prefab::instantiate_prefab(
         world,
         &prefab,
         &source_path,
         root_name,
         root_transform,
         parent,
-    )
+    )?;
+    world
+        .entity_mut(root)
+        .insert(bsengine_core::PrefabInstanceBaseline {
+            synced_ron: content.clone(),
+        });
+    Ok(root)
 }
 
 /// Resolves one `entity.prefab` reference: instantiates the file in the
@@ -746,6 +752,7 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
     app.register_type::<bsengine_core::Lifetime>();
     app.register_type::<bsengine_core::NetworkId>();
     app.register_type::<bsengine_core::PrefabInstance>();
+    app.register_type::<bsengine_core::PrefabInstanceBaseline>();
     app.register_type::<bsengine_core::SaveData>();
     app.register_type::<bsengine_core::Shield>();
     app.register_type::<bsengine_core::Skybox>();
@@ -831,6 +838,35 @@ mod tests {
         let path = std::env::temp_dir().join(filename);
         std::fs::write(&path, content).unwrap();
         path.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn instantiate_prefab_from_path_attaches_a_baseline_with_the_exact_file_content() {
+        let mut app = bsengine_app::new_app();
+        let dir = tempfile::tempdir().unwrap();
+        let content = r#"PrefabDescriptor(entities: [
+            EntityDescriptor(name: "Body", primitive: Some(Cube)),
+        ])"#;
+        let path = dir.path().join("turret.ron");
+        std::fs::write(&path, content).unwrap();
+
+        let root = super::instantiate_prefab_from_path(
+            app.world_mut(),
+            path.to_str().unwrap(),
+            Some("MyTurret"),
+            None,
+            None,
+        )
+        .expect("a well-formed prefab should instantiate");
+
+        let baseline = app
+            .world()
+            .get::<bsengine_core::PrefabInstanceBaseline>(root)
+            .expect("the instantiated root must carry a PrefabInstanceBaseline");
+        assert_eq!(
+            baseline.synced_ron, content,
+            "the baseline must be the exact file text read at instantiation time"
+        );
     }
 
     #[test]

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -236,7 +236,7 @@ pub struct ScriptPath(pub String);
 ///
 /// All component fields are optional and default to absent; only `name` is
 /// required.  The legacy `components` field is kept for compatibility.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EntityDescriptor {
     /// Name assigned to the spawned entity's `Name` component.
     pub name: String,
@@ -333,7 +333,7 @@ pub struct EntityDescriptor {
 }
 
 /// Position, rotation, and scale for a scene entity, as written in a scene file.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransformDescriptor {
     /// World-space position as [x, y, z]. Defaults to the origin.
     #[serde(default)]
@@ -793,5 +793,31 @@ mod tests {
         assert_eq!(t.position, [0.0, 0.0, 0.0]);
         assert_eq!(t.rotation, [0.0, 0.0, 0.0, 1.0]);
         assert_eq!(t.scale, [1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn transform_descriptor_supports_equality_comparison() {
+        let a = TransformDescriptor {
+            position: [1.0, 2.0, 3.0],
+            ..Default::default()
+        };
+        let b = a.clone();
+        let c = TransformDescriptor {
+            position: [9.0, 9.0, 9.0],
+            ..Default::default()
+        };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn entity_descriptor_has_a_default_with_only_name_and_components_populated() {
+        let d = EntityDescriptor {
+            name: "X".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(d.name, "X");
+        assert_eq!(d.transform, None);
+        assert!(d.components.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Implements the first of the two sub-problems the prefab live-sync design deliberately deferred (`docs/superpowers/specs/2026-08-18-prefab-live-sync-design.md`): **override tracking**. Pull sync ("Apply to Prefab") remains separate future work.

- Push-sync (`resync_prefab_instances`) used to despawn and re-instantiate a prefab instance's *entire* subtree on every source-file change, silently discarding any manual edit (transform tweak, attached component, added child).
- It now patches the instance **in place**, field by field: a new `PrefabInstanceBaseline` component records the source file's content as of the last sync, and a resync adopts a field from the new file only if the live value still matches that baseline — otherwise the live (overridden) value wins.
- Structural presence/absence of an entity is the one deliberate exception: source removal always cascades away everything underneath, regardless of overrides (matches Unity/Unreal's actual behavior).
- Field-level merge covers four representative groups for this PR: `transform`, `primitive`, `emissive`/`color`/`opacity` (Material), and the reflected `components` catalog. The remaining field groups (`gltf`, `camera`, lights, physics, `script`, `texture`) follow the identical pattern in a follow-up PR.

Full design rationale: `docs/superpowers/specs/2026-08-19-prefab-override-tracking-design.md`
Implementation plan (11 tasks, executed via subagent-driven development): `docs/superpowers/plans/2026-08-19-prefab-override-tracking.md`

## Process note

Built via brainstorming → plan → subagent-driven implementation, one fresh subagent per task, each independently verified. A final whole-branch review (separate from the per-task reviews) caught one **critical, empirically-reproduced panic**: a stale `Entity` handle when a structurally-removed entity's despawn cascade also swept away a live descendant that was independently tracked by name — reachable via an ordinary 3+-level hierarchy edit, no overrides required. Fixed with a regression test, plus two additional nested-prefab-reference test scenarios the review flagged as uncovered.

## Test plan

- [x] `cargo test --workspace` — full workspace green, 0 failures
- [x] `cargo clippy -p bsengine-core -p bsengine-scene -p bsengine-editor --all-targets` — zero warnings in every file this PR touches (pre-existing warnings elsewhere in the workspace are unrelated and untouched)
- [x] `cargo fmt` — formatting-only pass applied (excluding `bsengine-editor/src/plugin.rs`, which crashes local rustfmt on this machine — a known pre-existing issue; CI's fmt-check covers it)
- [x] New/updated tests: field-override preservation, manually-added-child preservation, cascade-delete-with-overrides-underneath, user-deletion-not-resurrected, root-transform-never-diffed, new-entity-spawn, brand-new/changed/converted nested-prefab-reference resolution, no-baseline fallback + self-heal, end-to-end override preservation through the real `resync_prefab_instances` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)