### PR TITLE
Prefab resync: full field coverage for brand-new entities

### DIFF
--- a/ENGINE_ROADMAP.md
+++ b/ENGINE_ROADMAP.md
@@ -1945,13 +1945,6 @@ C는 합치지 않고 방향을 명시, 그리고 **축별 op 45개 축소는 it
   필요해지면 재검토.
 - **프레임 프로파일러/GPU 디버거** — 성능 병목이 실제로 보고된 적 없음.
 - **빌드/패키징/배포 파이프라인(콘솔/모바일 export)** — 현재 배포 대상이 없음.
-- ~~**프리팹 시스템**~~ — 2026-08-14~19 사이 별도 브레인스토밍/설계 트랙으로 진행되어
-  이 로드맵 밖에서 완료됨: 씬파일/스크립트/에디터 인스턴스화(#1787), 생성 경로(MCP
-  `prefab_write` + 에디터 Create Prefab, #1788), live-sync(`PrefabInstance` provenance +
-  파일 워처 기반 push-sync, 2026-08-19 master 직접 병합)까지. **남은 것:** override
-  tracking(인스턴스별 수동 수정이 push-sync에 덮어써지지 않게 보존)과 pull sync("Apply to
-  Prefab") — override tracking 없이는 pull sync가 의미가 없어 이 순서로만 가능. 설계 문서에서
-  의도적으로 범위 밖으로 남긴 것.
 - **타임라인/시퀀서** — 컷신 요구가 있는 콘텐츠가 아직 없음.
 - **LOD / 오클루전 컬링** — 프러스텀 컬링만으로 현재 씬 규모(수십~수백 엔티티)는 충분.
 
@@ -2020,3 +2013,5 @@ C는 합치지 않고 방향을 명시, 그리고 **축별 op 45개 축소는 it
 | 프리팹 시스템 — 씬파일(`prefab:` 필드)/스크립트(`Bsengine.instantiatePrefab`)/에디터(드래그앤드롭) 인스턴스화, 중첩 prefab 참조, 사이클 감지 | 2026-08-14 | [#1787](https://github.com/blas1n/BSEngine/pull/1787) |
 | 프리팹 생성 경로 — 라이브 엔티티 서브트리를 `assets/prefabs/*.ron`으로 저장 (MCP `prefab_write` + 에디터 Create Prefab 버튼); path-traversal/cycle-guard 버그 수정 포함 | 2026-08-18 | [#1788](https://github.com/blas1n/BSEngine/pull/1788) |
 | 프리팹 live-sync (push-sync 방향만) — `PrefabInstance` provenance 컴포넌트 + `PrefabWatcherPlugin`(파일 워처, `bsengine-asset::AssetWatcherPlugin` 패턴 재사용)이 `assets/prefabs/*.ron` 변경 시 배치된 인스턴스를 despawn+재인스턴스화; 리뷰 라운드에서 발견된 실제 버그 3개 수정(구조 검증 없이 despawn하는 문제, 무관한 인스턴스가 재부모화 시 콜래터럴 despawn되는 문제, 다단계 중첩에서 좀비 인스턴스가 새는 문제); PR 없이 로컬 병합 후 직접 push (개인 프로젝트, 사용자 승인) | 2026-08-19 | 직접 병합 (PR 없음), 커밋 `f29a2798`..`1cd08bf6` |
+| 프리팹 override tracking — 필드 단위(Unity 스타일) diff 기반 push-sync 보존: `PrefabInstanceBaseline` + `merge_entity_descriptor` 계열 병합 알고리즘. 4개 필드 그룹 클러스터로 순차 진행: 핵심 메커니즘+transform/Material/컴포넌트 카탈로그(#1789), physics(#1790), light(#1791), camera(#1792), AssetRef 필드(#1793, guid 기반 self-healing + ProjectDir 접두사 문제로 가장 난이도 높음) | 2026-08-22 | [#1789](https://github.com/blas1n/BSEngine/pull/1789)–[#1793](https://github.com/blas1n/BSEngine/pull/1793) |
+| 프리팹 pull sync ("Apply to Prefab") — MCP `apply_to_prefab` 툴이 인스턴스의 필드 단위 override를 소스 `.ron` 파일에 반영; `merge_entity_descriptor`를 파일-쓰기 방향으로 재사용(핵심 아이디어), 전파는 기존 `PrefabWatcherPlugin` 파일 워처가 그대로 처리(신규 전파 코드 없음); v1 범위: 필드값만(구조 변경 제외), MCP 툴만(에디터 UI 버튼은 후속) | 2026-08-24 | [#1794](https://github.com/blas1n/BSEngine/pull/1794) |

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -964,6 +964,7 @@ fn suffixed_name(raw_name: &str, suffix: &mut Option<String>) -> String {
 /// outer file) `entity.name` straight through.
 fn spawn_or_resolve_entity(
     world: &mut World,
+    registry: &TypeRegistry,
     spawned_name: &str,
     descriptor: &bsengine_scene::EntityDescriptor,
 ) -> Option<Entity> {
@@ -984,9 +985,83 @@ fn spawn_or_resolve_entity(
             }
         },
         None => {
-            let mut renamed = descriptor.clone();
-            renamed.name = spawned_name.to_string();
-            Some(bsengine_scene::spawn_single_entity(world, &renamed))
+            let mut resolved = descriptor.clone();
+            resolved.name = spawned_name.to_string();
+
+            // `apply_merged_descriptor` expects gltf/script/texture to already
+            // carry a fully-resolved path (it never re-resolves, to avoid
+            // double-prefixing ProjectDir on gltf -- see PR #1793/#1794's
+            // design). A brand-new entity has no live/baseline to diff
+            // against, so resolution here is unconditional: always adopt the
+            // file's value, resolved.
+            if let Some(r) = &resolved.gltf {
+                resolved.gltf = Some(bsengine_scene::AssetRef::Path(
+                    bsengine_scene::resolve_asset_ref_for_field(world, &resolved.name, "gltf", r),
+                ));
+            }
+            if let Some(r) = &resolved.script {
+                resolved.script = Some(bsengine_scene::AssetRef::Path(
+                    bsengine_scene::resolve_asset_ref_for_field(
+                        world,
+                        &resolved.name,
+                        "script",
+                        r,
+                    ),
+                ));
+            }
+            if let Some(r) = &resolved.texture {
+                resolved.texture = Some(bsengine_scene::AssetRef::Path(
+                    bsengine_scene::resolve_asset_ref_for_field(
+                        world,
+                        &resolved.name,
+                        "texture",
+                        r,
+                    ),
+                ));
+            }
+
+            let entity = world.spawn(bsengine_scene::Name(resolved.name.clone())).id();
+            // An empty "live" default is exactly correct for a brand-new
+            // entity: there's no existing Material to preserve out-of-scope
+            // fields from, no existing Camera to preserve aspect_ratio from,
+            // nothing to diff against at all. This reuses the exact same
+            // insert logic push-sync/pull-sync already use for every field
+            // group, instead of a second, narrower, independently-maintained
+            // set of inserts (`spawn_single_entity`, now unused) that had
+            // drifted behind it.
+            apply_merged_descriptor(
+                world,
+                entity,
+                registry,
+                &bsengine_scene::EntityDescriptor::default(),
+                &resolved,
+            );
+
+            // `apply_merged_descriptor` never touches `look_at` (deliberately,
+            // for the *matched*-entity case -- re-deriving Transform.rotation
+            // from it at resync would risk clobbering a user's manual
+            // rotation override). That rationale doesn't apply to a brand-new
+            // entity: there's no live rotation state to protect. Reproduce
+            // `spawn_scene_entities`'s own one-time look_at computation here,
+            // so a brand-new camera entity behaves identically whether it
+            // arrived via a fresh full instantiation or a mid-resync addition.
+            if resolved.camera {
+                if let Some(target) = resolved.look_at {
+                    if let Some(mut transform) =
+                        world.get_mut::<bsengine_core::Transform>(entity)
+                    {
+                        let pos = transform.position.0;
+                        let dir = glam::Vec3::from(target) - pos;
+                        if dir.length_squared() > 1e-10 {
+                            transform.rotation =
+                                glam::Quat::from_rotation_arc(glam::Vec3::NEG_Z, dir.normalize())
+                                    .into();
+                        }
+                    }
+                }
+            }
+
+            Some(entity)
         }
     }
 }
@@ -1116,7 +1191,9 @@ pub(crate) fn resync_instance(
                     // `n.prefab.is_some()` just because the *match guard*
                     // above required *either* side to have it.
                     let spawned_name = suffixed_name(raw_name, &mut suffix);
-                    if let Some(fresh) = spawn_or_resolve_entity(world, &spawned_name, n) {
+                    if let Some(fresh) =
+                        spawn_or_resolve_entity(world, &registry, &spawned_name, n)
+                    {
                         resolved_by_raw_name.insert(raw_name.to_string(), fresh);
                         spawned_needing_parent.push((fresh, n.parent.clone()));
                     }
@@ -1131,7 +1208,7 @@ pub(crate) fn resync_instance(
             }
             (None, Some(n), _) => {
                 let spawned_name = suffixed_name(raw_name, &mut suffix);
-                if let Some(fresh) = spawn_or_resolve_entity(world, &spawned_name, n) {
+                if let Some(fresh) = spawn_or_resolve_entity(world, &registry, &spawned_name, n) {
                     resolved_by_raw_name.insert(raw_name.to_string(), fresh);
                     spawned_needing_parent.push((fresh, n.parent.clone()));
                 }
@@ -4024,6 +4101,190 @@ mod tests {
         assert!(
             result.is_err(),
             "an entity with no PrefabInstance must be refused"
+        );
+    }
+
+    #[test]
+    fn resync_instance_gives_a_brand_new_entity_full_field_coverage_not_just_transform_primitive_color()
+    {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Root", primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/gains_a_child.ron",
+            Some("MyGainsAChild"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Root", primitive: Some(Cube)),
+                EntityDescriptor(
+                    name: "Lamp",
+                    parent: Some("Root"),
+                    point_light: Some((color: (1.0, 1.0, 1.0), intensity: 2.0, range: 15.0)),
+                    rigidbody: Some(Dynamic),
+                    collider: Some((shape: Sphere(radius: 0.5), restitution: 0.0, friction: 0.5, sensor: false)),
+                ),
+            ])"#,
+        );
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/gains_a_child.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        let lamp = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Lamp#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        let pl = app.world().get::<bsengine_core::PointLight>(lamp).unwrap();
+        assert_eq!(
+            pl.intensity, 2.0,
+            "a brand-new entity must get its light, not just transform/primitive/color"
+        );
+        let body = app
+            .world()
+            .get::<bsengine_scene::PhysicsBodyDesc>(lamp)
+            .unwrap();
+        assert_eq!(body.linear_damping, None);
+        let _ = body; // presence alone proves the physics group was attached
+    }
+
+    #[test]
+    fn resync_instance_resolves_gltf_script_texture_for_a_brand_new_entity_under_a_real_project_dir()
+    {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+        app.world_mut()
+            .insert_resource(bsengine_core::ProjectDir("games/demo".to_string()));
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Root", primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/gains_asset_refs.ron",
+            Some("MyGainsAssetRefs"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Root", primitive: Some(Cube)),
+                EntityDescriptor(
+                    name: "Prop",
+                    parent: Some("Root"),
+                    gltf: Some("assets/models/prop.glb"),
+                    script: Some("assets/scripts/prop.js"),
+                    texture: Some("assets/textures/prop.png"),
+                ),
+            ])"#,
+        );
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/gains_asset_refs.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        let prop = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Prop#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        assert_eq!(
+            app.world().get::<bsengine_gltf::GltfAsset>(prop).unwrap().path,
+            "games/demo/assets/models/prop.glb",
+            "gltf must get the ProjectDir prefix for a brand-new entity, same as spawn_scene_entities"
+        );
+        assert_eq!(
+            app.world()
+                .get::<bsengine_scene::ScriptPath>(prop)
+                .unwrap()
+                .0,
+            "assets/scripts/prop.js",
+            "script must NOT get the ProjectDir prefix"
+        );
+        assert_eq!(
+            app.world()
+                .get::<bsengine_core::TexturePath>(prop)
+                .unwrap()
+                .0,
+            "assets/textures/prop.png",
+            "texture must NOT get the ProjectDir prefix"
+        );
+    }
+
+    #[test]
+    fn resync_instance_computes_look_at_rotation_for_a_brand_new_camera_entity() {
+        let mut app = new_app();
+        bsengine_scene::register_gameplay_reflect_types(&mut app);
+
+        let baseline = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Root", primitive: Some(Cube)),
+            ])"#,
+        );
+        let root = bsengine_scene::instantiate_prefab(
+            app.world_mut(),
+            &baseline,
+            "assets/prefabs/gains_a_camera.ron",
+            Some("MyGainsACamera"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let new = parse(
+            r#"PrefabDescriptor(entities: [
+                EntityDescriptor(name: "Root", primitive: Some(Cube)),
+                EntityDescriptor(
+                    name: "Cam",
+                    parent: Some("Root"),
+                    camera: true,
+                    transform: Some((position: (0.0, 0.0, 5.0), rotation: (0.0, 0.0, 0.0, 1.0), scale: (1.0, 1.0, 1.0))),
+                    look_at: Some((0.0, 0.0, 0.0)),
+                ),
+            ])"#,
+        );
+        let own_source_paths =
+            std::collections::HashSet::from(["assets/prefabs/gains_a_camera.ron".to_string()]);
+        resync_instance(app.world_mut(), root, &baseline, &new, &own_source_paths).unwrap();
+
+        let cam = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0.starts_with("Cam#"))
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        let rotation = app
+            .world()
+            .get::<bsengine_core::Transform>(cam)
+            .unwrap()
+            .rotation
+            .0;
+        // Camera at (0,0,5) looking at (0,0,0): direction is -Z, so this should be
+        // (very close to) the identity rotation -- Quat::from_rotation_arc(NEG_Z, NEG_Z) = IDENTITY.
+        assert!(
+            rotation.abs_diff_eq(glam::Quat::IDENTITY, 1e-5),
+            "a brand-new camera entity's look_at must compute a rotation, matching what \
+             spawn_scene_entities would produce for the same descriptor -- got {rotation:?}"
         );
     }
 }

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -1001,12 +1001,7 @@ fn spawn_or_resolve_entity(
             }
             if let Some(r) = &resolved.script {
                 resolved.script = Some(bsengine_scene::AssetRef::Path(
-                    bsengine_scene::resolve_asset_ref_for_field(
-                        world,
-                        &resolved.name,
-                        "script",
-                        r,
-                    ),
+                    bsengine_scene::resolve_asset_ref_for_field(world, &resolved.name, "script", r),
                 ));
             }
             if let Some(r) = &resolved.texture {
@@ -1020,7 +1015,9 @@ fn spawn_or_resolve_entity(
                 ));
             }
 
-            let entity = world.spawn(bsengine_scene::Name(resolved.name.clone())).id();
+            let entity = world
+                .spawn(bsengine_scene::Name(resolved.name.clone()))
+                .id();
             // An empty "live" default is exactly correct for a brand-new
             // entity: there's no existing Material to preserve out-of-scope
             // fields from, no existing Camera to preserve aspect_ratio from,
@@ -1047,9 +1044,7 @@ fn spawn_or_resolve_entity(
             // arrived via a fresh full instantiation or a mid-resync addition.
             if resolved.camera {
                 if let Some(target) = resolved.look_at {
-                    if let Some(mut transform) =
-                        world.get_mut::<bsengine_core::Transform>(entity)
-                    {
+                    if let Some(mut transform) = world.get_mut::<bsengine_core::Transform>(entity) {
                         let pos = transform.position.0;
                         let dir = glam::Vec3::from(target) - pos;
                         if dir.length_squared() > 1e-10 {
@@ -1191,8 +1186,7 @@ pub(crate) fn resync_instance(
                     // `n.prefab.is_some()` just because the *match guard*
                     // above required *either* side to have it.
                     let spawned_name = suffixed_name(raw_name, &mut suffix);
-                    if let Some(fresh) =
-                        spawn_or_resolve_entity(world, &registry, &spawned_name, n)
+                    if let Some(fresh) = spawn_or_resolve_entity(world, &registry, &spawned_name, n)
                     {
                         resolved_by_raw_name.insert(raw_name.to_string(), fresh);
                         spawned_needing_parent.push((fresh, n.parent.clone()));
@@ -4105,8 +4099,8 @@ mod tests {
     }
 
     #[test]
-    fn resync_instance_gives_a_brand_new_entity_full_field_coverage_not_just_transform_primitive_color()
-    {
+    fn resync_instance_gives_a_brand_new_entity_full_field_coverage_not_just_transform_primitive_color(
+    ) {
         let mut app = new_app();
         bsengine_scene::register_gameplay_reflect_types(&mut app);
 
@@ -4162,8 +4156,8 @@ mod tests {
     }
 
     #[test]
-    fn resync_instance_resolves_gltf_script_texture_for_a_brand_new_entity_under_a_real_project_dir()
-    {
+    fn resync_instance_resolves_gltf_script_texture_for_a_brand_new_entity_under_a_real_project_dir(
+    ) {
         let mut app = new_app();
         bsengine_scene::register_gameplay_reflect_types(&mut app);
         app.world_mut()

--- a/crates/bsengine-editor/src/prefab_merge.rs
+++ b/crates/bsengine-editor/src/prefab_merge.rs
@@ -4250,6 +4250,14 @@ mod tests {
         )
         .unwrap();
 
+        // Position/target chosen so the look_at-computed rotation is
+        // provably NOT the literal `rotation:` given below (identity) --
+        // camera at (5,0,0) looking at (0,0,0) faces -X, not -Z, so
+        // reproducing spawn_scene_entities's look_at computation must
+        // rotate away from identity. A position/target pair whose computed
+        // rotation happens to equal the literal fixture value would let
+        // this test pass even if the look_at block were silently deleted
+        // (this exact mistake was caught during this task's own review).
         let new = parse(
             r#"PrefabDescriptor(entities: [
                 EntityDescriptor(name: "Root", primitive: Some(Cube)),
@@ -4257,7 +4265,7 @@ mod tests {
                     name: "Cam",
                     parent: Some("Root"),
                     camera: true,
-                    transform: Some((position: (0.0, 0.0, 5.0), rotation: (0.0, 0.0, 0.0, 1.0), scale: (1.0, 1.0, 1.0))),
+                    transform: Some((position: (5.0, 0.0, 0.0), rotation: (0.0, 0.0, 0.0, 1.0), scale: (1.0, 1.0, 1.0))),
                     look_at: Some((0.0, 0.0, 0.0)),
                 ),
             ])"#,
@@ -4279,12 +4287,22 @@ mod tests {
             .unwrap()
             .rotation
             .0;
-        // Camera at (0,0,5) looking at (0,0,0): direction is -Z, so this should be
-        // (very close to) the identity rotation -- Quat::from_rotation_arc(NEG_Z, NEG_Z) = IDENTITY.
+
+        let expected = glam::Quat::from_rotation_arc(
+            glam::Vec3::NEG_Z,
+            (glam::Vec3::ZERO - glam::Vec3::new(5.0, 0.0, 0.0)).normalize(),
+        );
         assert!(
-            rotation.abs_diff_eq(glam::Quat::IDENTITY, 1e-5),
+            rotation.abs_diff_eq(expected, 1e-5),
             "a brand-new camera entity's look_at must compute a rotation, matching what \
-             spawn_scene_entities would produce for the same descriptor -- got {rotation:?}"
+             spawn_scene_entities would produce for the same descriptor -- got {rotation:?}, \
+             expected {expected:?}"
+        );
+        assert!(
+            !rotation.abs_diff_eq(glam::Quat::IDENTITY, 1e-5),
+            "sanity check: the literal fixture rotation is identity, so a passing test above \
+             that also failed this assertion would mean look_at was never actually applied -- \
+             got {rotation:?}"
         );
     }
 }

--- a/crates/bsengine-scene/src/lib.rs
+++ b/crates/bsengine-scene/src/lib.rs
@@ -16,7 +16,7 @@ pub mod types;
 
 pub use plugin::{
     instantiate_prefab_from_path, instantiate_prefab_reference, register_gameplay_reflect_types,
-    resolve_asset_ref_for_field, spawn_scene_entities, spawn_single_entity, Name, ScenePlugin,
+    resolve_asset_ref_for_field, spawn_scene_entities, Name, ScenePlugin,
 };
 pub use prefab::{instantiate_prefab, next_instance_suffix, validate_prefab_descriptor};
 pub use types::{

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -782,60 +782,6 @@ pub fn instantiate_prefab_reference(
     instantiate_prefab_from_path(world, &prefab_path, Some(entity_name), root_transform, None)
 }
 
-/// Spawns exactly one entity from `descriptor`, with none of
-/// `spawn_scene_entities`'s batch machinery (multi-entity asset-ref
-/// pre-resolution, `parent:` name wiring across the batch) -- callers that
-/// already know the resolved parent `Entity` and only need one entity at a
-/// time (currently: `bsengine-editor`'s prefab-merge resync, spawning a
-/// single newly-added prefab entity mid-diff) call this directly instead.
-/// Does not handle `descriptor.prefab` (a nested prefab reference) --
-/// callers with a `prefab:`-bearing descriptor must call
-/// `instantiate_prefab_reference` instead, same as `spawn_scene_entities`
-/// itself branches before ever reaching this code path.
-///
-/// Covers the same representative field set `bsengine-editor`'s prefab
-/// merge algorithm covers: `transform`, `primitive`, `emissive`/`color`/
-/// `opacity`. Any other field on `descriptor` is silently ignored -- adding
-/// the remaining field groups (`gltf`, `camera`, lights, physics, `script`,
-/// `texture`) is a follow-up PR's job, exactly like the merge algorithm's
-/// own scope limit.
-pub fn spawn_single_entity(world: &mut World, descriptor: &EntityDescriptor) -> Entity {
-    let mut builder = world.spawn(Name(descriptor.name.clone()));
-
-    if let Some(t) = &descriptor.transform {
-        builder.insert((
-            Transform {
-                position: Vec3::from(t.position).into(),
-                rotation: Quat::from_xyzw(
-                    t.rotation[0],
-                    t.rotation[1],
-                    t.rotation[2],
-                    t.rotation[3],
-                )
-                .into(),
-                scale: Vec3::from(t.scale).into(),
-            },
-            GlobalTransform::default(),
-        ));
-    }
-    if let Some(prim) = &descriptor.primitive {
-        builder.insert(PrimitiveMesh(prim.clone()));
-    }
-    if descriptor.emissive.is_some() || descriptor.color.is_some() {
-        builder.insert(Material {
-            emissive: descriptor
-                .emissive
-                .map(Vec3::from)
-                .unwrap_or(Vec3::ZERO)
-                .into(),
-            base_color: descriptor.color.map(Vec3::from).unwrap_or(Vec3::ONE).into(),
-            opacity: descriptor.opacity.unwrap_or(1.0),
-            ..Default::default()
-        });
-    }
-    builder.id()
-}
-
 /// Registers every `bsengine_core` component type an `EntityDescriptor`'s
 /// `components:` field (arbitrary reflected components, e.g. `Shield`,
 /// `SaveData`, `AnimationStateMachine`, `NavMeshAgent`, `Bloom`, `ToneMap`)
@@ -991,33 +937,6 @@ mod tests {
             super::resolve_asset_ref_for_field(app.world(), "Thing", "gltf", &gltf_ref),
             "assets/models/a.glb",
             "with no ProjectDir resource, the path must pass through unchanged"
-        );
-    }
-
-    #[test]
-    fn spawn_single_entity_creates_one_entity_with_transform_and_primitive() {
-        let mut app = bsengine_app::new_app();
-        let descriptor = crate::types::EntityDescriptor {
-            name: "Standalone".to_string(),
-            transform: Some(crate::types::TransformDescriptor {
-                position: [1.0, 2.0, 3.0],
-                ..Default::default()
-            }),
-            primitive: Some(crate::types::Primitive::Cube),
-            ..Default::default()
-        };
-
-        let entity = super::spawn_single_entity(app.world_mut(), &descriptor);
-
-        assert_eq!(app.world().get::<Name>(entity).unwrap().0, "Standalone");
-        assert_eq!(
-            app.world()
-                .get::<Transform>(entity)
-                .unwrap()
-                .position
-                .0
-                .to_array(),
-            [1.0, 2.0, 3.0]
         );
     }
 


### PR DESCRIPTION
## Summary
- Fixes a gap found by a post-release audit of the prefab live-sync design (PR #1789-#1794, fully shipped): when a prefab source file gains a brand-new child entity and a live instance resyncs, `spawn_or_resolve_entity` spawned it via an older, narrower function (`spawn_single_entity`) that only covered `transform`/`primitive`/`emissive`/`color`/`opacity` — predating the physics/light/camera/`AssetRef` field groups later built out for *matched* entities. A new entity with a physics body, light, camera, script, mesh reference, or custom component got silently dropped down to just transform/primitive/color, no warning.
- Fix reuses `apply_merged_descriptor` (already tested across 5 PRs, the same function push-sync/pull-sync use for matched entities) with `live = EntityDescriptor::default()` — an empty default is exactly correct for a brand-new entity, since there's nothing existing to diff against. This closes the gap without duplicating insert logic a second time, avoiding the exact kind of drift that caused the original bug.
- `gltf`/`script`/`texture` are resolved unconditionally before that call (no live/baseline to diff against, so always adopt the file's value, resolved — mirrors PR #1793's resolution pipeline).
- `look_at` on a brand-new camera entity is handled too: `apply_merged_descriptor` deliberately never touches it (correct for matched entities, to avoid clobbering a user's manual rotation override), but that rationale doesn't apply to an entity with no live state to protect — this reproduces `spawn_scene_entities`'s own one-time look_at computation here.
- `bsengine_scene::spawn_single_entity` is now fully unused (its only real caller was the code above) and is deleted, along with its test and re-export, rather than left as orphaned dead code.
- Along the way, caught and fixed a real weakness in my own first draft of the look_at test: the original position/target/rotation fixture happened to make the correct answer equal the pre-fix (buggy) answer, so it would have passed even with the look_at fix silently deleted. Verified the strengthened version by temporarily disabling the fix and confirming the test actually fails.

## Test plan
- [x] `cargo test -p bsengine-editor prefab_merge::` — 69/69 passing (new-entity full field coverage, gltf/script/texture resolution under a real `ProjectDir`, look_at rotation — verified to genuinely discriminate, not just pass)
- [x] `cargo test -p bsengine-editor prefab_watcher::` — 18/18 passing, no regressions
- [x] `cargo test -p bsengine-scene` — 70/70 passing (one fewer than before: `spawn_single_entity`'s own test deleted along with the function)
- [x] `cargo test --workspace` — full suite green, zero failures
- [x] `cargo clippy -p bsengine-scene -p bsengine-editor --all-targets` — no new warnings
- [x] `cargo fmt` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)