### PR TITLE
feat(editor): Apply to Prefab button in the Hierarchy panel

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -302,6 +302,16 @@ pub enum InspectorCmd {
         /// Prefab file name, no extension or directory.
         name: String,
     },
+    /// Push this prefab instance's field-level overrides back into its
+    /// source file. Routed through `PrefabApplyCommandQueueResource` /
+    /// `process_prefab_apply_commands` (`bsengine-editor`), the same queue
+    /// the `apply_to_prefab` MCP tool already uses -- see
+    /// `bsengine_editor::prefab_merge::apply_instance_to_prefab`'s doc
+    /// comment for the actual logic.
+    ApplyToPrefab {
+        /// The prefab instance root entity id (must have a `PrefabInstance`).
+        entity_id: u64,
+    },
 }
 
 /// Whether the editor is showing the static scene or running gameplay.

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -71,6 +71,9 @@ pub struct InspectorEntityInfo {
     pub visible: bool,
     /// Whether the entity is currently selected in the editor.
     pub selected: bool,
+    /// Whether this entity is a prefab instance root (has `PrefabInstance`).
+    /// Drives the Hierarchy panel's "Apply to Prefab" context-menu entry.
+    pub is_prefab_instance: bool,
 }
 
 /// One queued edit request from the editor UI, drained and applied to the

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -41,6 +41,7 @@ fn update_editor_snapshot(
             Option<&bsengine_scene::ScriptPath>,
             Option<&bsengine_core::TexturePath>,
             Option<&bsengine_scene::PhysicsBodyDesc>,
+            Option<&bsengine_core::PrefabInstance>,
         ),
     )>,
 ) {
@@ -49,7 +50,7 @@ fn update_editor_snapshot(
     snapshot.entities = query
         .iter()
         .map(
-            |(e, name, transform, mesh, pt, dir, spot, cam, parent, tags, vis, mat, (prim, script, texture, physics_body))| {
+            |(e, name, transform, mesh, pt, dir, spot, cam, parent, tags, vis, mat, (prim, script, texture, physics_body, prefab_instance))| {
                 let light_type = if pt.is_some() {
                     Some("point".to_string())
                 } else if dir.is_some() {
@@ -99,6 +100,7 @@ fn update_editor_snapshot(
                     selected: selection.contains(&(e.index() as u64)),
                     extra_components: Vec::new(),
                     physics_body: physics_body.cloned(),
+                    is_prefab_instance: prefab_instance.is_some(),
                 }
             },
         )
@@ -1837,6 +1839,7 @@ fn populate_inspector(
             primitive: e.primitive.as_ref().map(primitive_to_str),
             visible: e.visible,
             selected: e.selected,
+            is_prefab_instance: e.is_prefab_instance,
         })
         .collect();
 }
@@ -90786,6 +90789,48 @@ mod tests {
             let pos = copy["position"].as_array().unwrap();
             assert!((pos[0].as_f64().unwrap() - 2.0).abs() < 1e-4);
         }
+    }
+
+    #[test]
+    fn update_editor_snapshot_and_populate_inspector_report_is_prefab_instance() {
+        let mut app = new_app();
+        app.add_plugins(EditorPlugin);
+
+        let with_instance = app
+            .world_mut()
+            .spawn((
+                Name("HasInstance".to_string()),
+                bsengine_core::PrefabInstance {
+                    source_path: "assets/prefabs/x.ron".to_string(),
+                },
+            ))
+            .id();
+        let without_instance = app
+            .world_mut()
+            .spawn(Name("NoInstance".to_string()))
+            .id();
+
+        app.update(); // update_editor_snapshot + populate_inspector capture both
+
+        let inspector = app.world().resource::<InspectorState>();
+        let with_info = inspector
+            .entities
+            .iter()
+            .find(|e| e.id == with_instance.index() as u64)
+            .unwrap();
+        let without_info = inspector
+            .entities
+            .iter()
+            .find(|e| e.id == without_instance.index() as u64)
+            .unwrap();
+        assert!(
+            with_info.is_prefab_instance,
+            "entity with PrefabInstance must report true"
+        );
+        assert!(
+            !without_info.is_prefab_instance,
+            "entity without PrefabInstance must report false"
+        );
     }
 
     #[test]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1877,6 +1877,7 @@ fn apply_inspector_cmds(
     queue_res: Res<EditorCommandQueueResource>,
     reflect_queue_res: Res<ReflectCommandQueueResource>,
     prefab_queue_res: Res<PrefabCommandQueueResource>,
+    prefab_apply_queue_res: Res<crate::snapshot::PrefabApplyCommandQueueResource>,
     selection_res: Res<EditorSelectionResource>,
     snapshot_res: Res<EditorSnapshotResource>,
     project_dir: Option<Res<bsengine_core::ProjectDir>>,
@@ -2033,6 +2034,13 @@ fn apply_inspector_cmds(
                     tracing::warn!("create_prefab: entity {entity_id} -> '{name}' failed: {e}");
                 }
             }
+            InspectorCmd::ApplyToPrefab { entity_id } => {
+                prefab_apply_queue_res
+                    .0
+                    .lock()
+                    .unwrap()
+                    .push(crate::snapshot::PrefabApplyCommand { entity_id });
+            }
         }
     }
 }
@@ -2098,7 +2106,22 @@ impl Plugin for EditorPlugin {
         app.add_systems(Update, process_editor_commands);
         app.add_systems(Update, process_reflect_commands.after(process_editor_commands));
         app.add_systems(Update, process_prefab_commands.after(process_editor_commands));
-        app.add_systems(Update, process_prefab_apply_commands);
+        // Explicit `.before(apply_inspector_cmds)`, not left unordered: both
+        // this system and `apply_inspector_cmds` only take `Res<...>` handles
+        // to their shared `Mutex`-wrapped queue, so Bevy sees no ECS access
+        // conflict between them and is free to run them in either order each
+        // frame. Without this constraint, a same-frame
+        // `InspectorCmd::ApplyToPrefab` (queued via `apply_inspector_cmds`
+        // during this exact `Update`) could be drained by this system before
+        // it was ever pushed, or after -- nondeterministically, varying
+        // update-to-update. Ordering this system first guarantees a command
+        // bridged from the Inspector this frame sits in the queue,
+        // unprocessed, until the *next* frame -- consistent with this
+        // function's own doc comment above (downstream effects already
+        // happen "on a later frame", not synchronously) and with the
+        // `apply_to_prefab` MCP tool's description ("Queued for processing;
+        // check ... on a subsequent call").
+        app.add_systems(Update, process_prefab_apply_commands.before(apply_inspector_cmds));
         app.add_systems(Update, apply_history_action.after(process_editor_commands));
         // Registration position matters here, and is not incidental: this has
         // to come after every `add_systems` call above, not next to the other
@@ -93291,5 +93314,25 @@ mod tests {
         }
         .expect("apply_to_prefab not registered");
         assert!(!out.is_ok());
+    }
+
+    #[test]
+    fn apply_inspector_cmds_bridges_apply_to_prefab_into_the_prefab_apply_queue() {
+        let mut app = new_app();
+        app.add_plugins(EditorPlugin);
+
+        {
+            let mut inspector = app.world_mut().resource_mut::<InspectorState>();
+            inspector.cmd_queue.push(InspectorCmd::ApplyToPrefab { entity_id: 42 });
+        }
+
+        app.update();
+
+        let queue = app
+            .world()
+            .resource::<crate::snapshot::PrefabApplyCommandQueueResource>();
+        let queued = queue.0.lock().unwrap();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].entity_id, 42);
     }
 }

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -84,6 +84,9 @@ pub struct EntityInfo {
     pub extra_components: Vec<(String, String)>,
     /// Physics body (rigidbody + collider), if the entity has one.
     pub physics_body: Option<bsengine_scene::PhysicsBodyDesc>,
+    /// Whether this entity is a prefab instance root (has `PrefabInstance`).
+    /// Used by the Hierarchy panel to conditionally show "Apply to Prefab".
+    pub is_prefab_instance: bool,
 }
 
 /// Full flattened capture of every tracked entity in the world, taken once

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -62,6 +62,7 @@ impl EditorPanel for HierarchyPanel {
         let mut duplicate: Option<u64> = None;
         let mut rename_commit: Option<(u64, String)> = None;
         let mut despawn_ids: Vec<u64> = Vec::new();
+        let mut apply_to_prefab_ids: Vec<u64> = Vec::new();
         let mut attach_script: Option<(u64, String)> = None;
 
         ui.horizontal(|ui| {
@@ -122,6 +123,7 @@ impl EditorPanel for HierarchyPanel {
                         &mut remove_parent,
                         &mut duplicate,
                         &mut despawn_ids,
+                        &mut apply_to_prefab_ids,
                         &mut rename_state,
                         &mut rename_commit,
                         &mut attach_script,
@@ -245,6 +247,10 @@ impl EditorPanel for HierarchyPanel {
                 insp.sync_selection();
             }
         }
+        for &id in &apply_to_prefab_ids {
+            insp.cmd_queue
+                .push(InspectorCmd::ApplyToPrefab { entity_id: id });
+        }
         if let Some((id, name)) = rename_commit {
             if !name.is_empty() {
                 insp.cmd_queue.push(InspectorCmd::RenameEntity { id, name });
@@ -365,6 +371,7 @@ impl HierarchyPanel {
         remove_parent: &mut Option<u64>,
         duplicate: &mut Option<u64>,
         despawn_ids: &mut Vec<u64>,
+        apply_to_prefab_ids: &mut Vec<u64>,
         rename_state: &mut Option<RenameState>,
         rename_commit: &mut Option<(u64, String)>,
         attach_script: &mut Option<(u64, String)>,
@@ -435,6 +442,7 @@ impl HierarchyPanel {
                                 remove_parent,
                                 duplicate,
                                 despawn_ids,
+                                apply_to_prefab_ids,
                                 rename_state,
                                 rename_commit,
                                 attach_script,
@@ -566,6 +574,10 @@ impl HierarchyPanel {
                         entity_id: info.id,
                         buffer: info.name.clone().unwrap_or_default(),
                     });
+                    ui.close_menu();
+                }
+                if info.is_prefab_instance && ui.button("Apply to Prefab").clicked() {
+                    apply_to_prefab_ids.push(info.id);
                     ui.close_menu();
                 }
             });


### PR DESCRIPTION
## Summary
- Adds an "Apply to Prefab" entry to the Hierarchy panel's per-entity right-click context menu, shown only for prefab instance roots.
- Threads a new `is_prefab_instance: bool` field through the entity-snapshot pipeline (`EntityInfo` → `InspectorEntityInfo`) so the UI can gate the button correctly.
- Wires clicks through a new `InspectorCmd::ApplyToPrefab` variant into the existing `PrefabApplyCommandQueueResource`/`process_prefab_apply_commands` machinery shipped in PR #1794 (pull sync) — no changes needed to the draining system's logic itself.
- Fixes a real, reproducible Bevy system-ordering bug found via TDD while wiring the bridge: `process_prefab_apply_commands` had no ordering constraint relative to `apply_inspector_cmds`, so same-frame interleaving was nondeterministic (confirmed flaky: pass/fail on alternating runs). Fixed with `.before(apply_inspector_cmds)`.

## Test plan
- [x] `cargo test --workspace` — all green (935/935 for bsengine-editor, 129/129 for bsengine-rhi-wgpu, no failures anywhere else)
- [x] `cargo clippy -p bsengine-core -p bsengine-editor -p bsengine-rhi-wgpu --all-targets` — clean, only pre-existing unrelated warnings
- [x] `rustfmt --check` on all touched files outside `plugin.rs` (which cannot run rustfmt locally on Windows due to a stack-overflow limitation) — clean
- [x] New ordering-fix test re-run 5x in a loop to confirm no flakiness
- [x] Full `bsengine-editor` suite re-run 4x after the ordering fix to confirm no new flakiness elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)