### PR TITLE
feat(editor): Scale gizmo in the viewport

### DIFF
--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -332,6 +332,9 @@ pub enum GizmoMode {
     Translate,
     /// Drag rings rotate the entity about an axis.
     Rotate,
+    /// Drag handles scale the entity along an axis, or drag the center
+    /// handle to scale all three axes proportionally.
+    Scale,
 }
 
 /// Editor-side resource holding the current entity snapshot, selection,
@@ -361,6 +364,11 @@ pub struct InspectorState {
     /// selection change and read/written by the viewport's rotate-gizmo
     /// drag handling (see `gizmo_rotate_axis` below).
     pub edit_rot: [f32; 3],
+    /// Scale of the selected entity, synced from it on selection change and
+    /// read/written by the viewport's scale-gizmo drag handling (see
+    /// `gizmo_scale_axis` below). Defaults to `[1.0; 3]`, not `[0.0; 3]` --
+    /// zero scale is a degenerate transform.
+    pub edit_scale: [f32; 3],
     /// Live text in the Hierarchy panel's search box. Empty means "show the
     /// full tree"; non-empty switches Hierarchy to a flat, name-filtered
     /// list (see `HierarchyPanel::matches_search`).
@@ -431,6 +439,21 @@ pub struct InspectorState {
     /// Mouse angle, in radians, around the gizmo's screen-space center when the current rotate drag began.
     pub gizmo_rotate_start_angle: f32,
 
+    // Scale-gizmo drag state. Exactly one of `gizmo_scale_axis`/
+    // `gizmo_scale_uniform` is active at a time: a per-axis handle drag
+    // adds a delta to just that axis of `gizmo_scale_start_world`; the
+    // center uniform handle multiplies all three axes by the same factor
+    // (see `panels/viewport.rs` for why axis drags are additive but the
+    // uniform drag is multiplicative).
+    /// Axis (0=X, 1=Y, 2=Z) of the scale-gizmo handle currently being dragged, if any.
+    pub gizmo_scale_axis: Option<u8>,
+    /// Whether the center uniform-scale handle is currently being dragged.
+    pub gizmo_scale_uniform: bool,
+    /// Entity's scale when the current scale drag began.
+    pub gizmo_scale_start_world: [f32; 3],
+    /// Screen-space mouse position when the current scale drag began.
+    pub gizmo_scale_start_mouse: [f32; 2],
+
     // Set by the toolbar/keyboard to request an undo/redo; consumed and
     // cleared by EditorPlugin's history system the same frame.
     /// Set to request an undo of the last edit; cleared once processed.
@@ -453,6 +476,7 @@ impl Default for InspectorState {
             reflected_components: Vec::new(),
             edit_pos: [0.0; 3],
             edit_rot: [0.0; 3],
+            edit_scale: [1.0; 3],
             hierarchy_search: String::new(),
             show_grid: true,
             edit_visible: true,
@@ -476,6 +500,10 @@ impl Default for InspectorState {
             gizmo_rotate_axis: None,
             gizmo_rotate_start_deg: [0.0; 3],
             gizmo_rotate_start_angle: 0.0,
+            gizmo_scale_axis: None,
+            gizmo_scale_uniform: false,
+            gizmo_scale_start_world: [1.0; 3],
+            gizmo_scale_start_mouse: [0.0; 2],
             request_undo: false,
             request_redo: false,
             current_scene_path: None,
@@ -500,6 +528,7 @@ impl InspectorState {
                 if let Some(info) = self.entities.iter().find(|e| e.id == id) {
                     self.edit_pos = info.position.unwrap_or([0.0; 3]);
                     self.edit_rot = info.rotation.unwrap_or([0.0; 3]);
+                    self.edit_scale = info.scale.unwrap_or([1.0; 3]);
                     self.edit_visible = info.visible;
                 }
             }
@@ -536,6 +565,7 @@ mod tests {
         s.sync_selection();
         assert_eq!(s.edit_pos, [1.0, 2.0, 3.0]);
         assert_eq!(s.edit_rot, [10.0, 20.0, 30.0]);
+        assert_eq!(s.edit_scale, [2.0, 2.0, 2.0]);
     }
 
     #[test]
@@ -566,6 +596,7 @@ mod tests {
         s.sync_selection();
         assert_eq!(s.edit_pos, [0.0; 3]);
         assert_eq!(s.edit_rot, [0.0; 3]);
+        assert_eq!(s.edit_scale, [1.0; 3]);
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/gizmo.rs
+++ b/crates/bsengine-rhi-wgpu/src/gizmo.rs
@@ -2,7 +2,7 @@
 //! painter routine. Kept separate from `surface.rs` so the math is
 //! unit-testable without a live wgpu/winit context.
 
-use egui::{Color32, Painter, Pos2, Rect, Stroke, Vec2};
+use egui::{Color32, Painter, Pos2, Rect, Rounding, Stroke, Vec2};
 use glam::{Mat4, Quat, Vec3};
 
 /// Gizmo axis id for the X axis.
@@ -14,6 +14,7 @@ pub const AXIS_Z: u8 = 2;
 
 const HANDLE_HIT_RADIUS: f32 = 8.0;
 const HANDLE_LENGTH_FRACTION: f32 = 0.15;
+const SCALE_HANDLE_HALF_SIZE: f32 = 4.0;
 
 // Camera entities don't carry their real aspect ratio in EntityInfo (only
 // fov_y is tracked), so the frustum gizmo uses a fixed 16:9 stand-in — this
@@ -114,6 +115,37 @@ pub fn hit_test(
         .map(|(axis, _)| axis)
 }
 
+/// Which scale-gizmo handle is under the cursor: a per-axis handle, or the
+/// center handle that scales all three axes proportionally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScaleHandle {
+    /// A per-axis handle (0=X, 1=Y, 2=Z).
+    Axis(u8),
+    /// The center handle that scales all three axes proportionally.
+    Uniform,
+}
+
+/// Finds which scale handle (if any) is under `mouse_pos`. The uniform
+/// center handle is checked first: it sits at the same screen point the
+/// three axis handles' line segments all originate from, so checking axes
+/// first would make a click right at the origin ambiguously resolve to
+/// whichever axis segment the distance comparison happens to favor, rather
+/// than to the uniform handle a user clicking at dead-center almost
+/// certainly means.
+pub fn hit_test_scale(
+    pos: Vec3,
+    handle_len: f32,
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+    mouse_pos: Pos2,
+) -> Option<ScaleHandle> {
+    let origin = world_to_screen(pos, view_proj, rect)?;
+    if (mouse_pos - origin).length() <= HANDLE_HIT_RADIUS {
+        return Some(ScaleHandle::Uniform);
+    }
+    hit_test(pos, handle_len, view_proj, rect, mouse_pos).map(ScaleHandle::Axis)
+}
+
 /// Draws the three translate handles, highlighting `hovered`/`dragging`.
 pub fn draw(
     painter: &Painter,
@@ -141,6 +173,55 @@ pub fn draw(
         painter.line_segment([origin, tip], Stroke::new(width, color));
         painter.circle_filled(tip, 4.0, color);
     }
+}
+
+fn draw_scale_handle(painter: &Painter, center: Pos2, color: Color32) {
+    let side = SCALE_HANDLE_HALF_SIZE * 2.0;
+    let size = Vec2::new(side, side);
+    painter.rect_filled(
+        Rect::from_center_size(center, size),
+        Rounding::same(0.0),
+        color,
+    );
+}
+
+/// Draws the three per-axis scale handles plus the center uniform-scale
+/// handle, highlighting `hovered`/`dragging`.
+pub fn draw_scale_gizmo(
+    painter: &Painter,
+    pos: Vec3,
+    handle_len: f32,
+    view_proj: &[[f32; 4]; 4],
+    rect: Rect,
+    hovered: Option<ScaleHandle>,
+    dragging: Option<ScaleHandle>,
+) {
+    let Some(origin) = world_to_screen(pos, view_proj, rect) else {
+        return;
+    };
+    for axis in [AXIS_X, AXIS_Y, AXIS_Z] {
+        let Some(tip) = world_to_screen(pos + axis_dir(axis) * handle_len, view_proj, rect) else {
+            continue;
+        };
+        let handle = ScaleHandle::Axis(axis);
+        let active = dragging == Some(handle) || (dragging.is_none() && hovered == Some(handle));
+        let color = if active {
+            Color32::WHITE
+        } else {
+            axis_color(axis)
+        };
+        let width = if active { 4.0 } else { 2.5 };
+        painter.line_segment([origin, tip], Stroke::new(width, color));
+        draw_scale_handle(painter, tip, color);
+    }
+    let uniform_active = dragging == Some(ScaleHandle::Uniform)
+        || (dragging.is_none() && hovered == Some(ScaleHandle::Uniform));
+    let uniform_color = if uniform_active {
+        Color32::WHITE
+    } else {
+        Color32::from_rgb(200, 200, 200)
+    };
+    draw_scale_handle(painter, origin, uniform_color);
 }
 
 /// The 4 far-plane corners of a camera's frustum wireframe, in world space,
@@ -527,6 +608,43 @@ mod tests {
         let rect = test_rect();
         assert_eq!(
             hit_test_rotate(Vec3::ZERO, 1.0, &vp, rect, Pos2::new(-500.0, -500.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn hit_test_scale_finds_correct_axis_handle() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        let handle_len = 2.0;
+        let x_tip = world_to_screen(Vec3::new(handle_len, 0.0, 0.0), &vp, rect).unwrap();
+        assert_eq!(
+            hit_test_scale(Vec3::ZERO, handle_len, &vp, rect, x_tip),
+            Some(ScaleHandle::Axis(AXIS_X))
+        );
+    }
+
+    #[test]
+    fn hit_test_scale_prioritizes_uniform_handle_at_origin() {
+        // A click exactly at the gizmo origin is also within dist_to_segment's
+        // hit radius of all three axis segments (each one starts at the
+        // origin) -- the uniform handle must win, not whichever axis segment
+        // the distance comparison happens to favor.
+        let vp = test_view_proj();
+        let rect = test_rect();
+        let origin = world_to_screen(Vec3::ZERO, &vp, rect).unwrap();
+        assert_eq!(
+            hit_test_scale(Vec3::ZERO, 2.0, &vp, rect, origin),
+            Some(ScaleHandle::Uniform)
+        );
+    }
+
+    #[test]
+    fn hit_test_scale_misses_far_away_point() {
+        let vp = test_view_proj();
+        let rect = test_rect();
+        assert_eq!(
+            hit_test_scale(Vec3::ZERO, 2.0, &vp, rect, Pos2::new(10.0, 10.0)),
             None
         );
     }

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -247,6 +247,110 @@ impl EditorPanel for ViewportPanel {
                                 insp.gizmo_rotate_axis,
                             );
                         }
+                        bsengine_core::GizmoMode::Scale => {
+                            if response.drag_started() {
+                                if let Some(mp) = response.interact_pointer_pos() {
+                                    if let Some(handle) = crate::gizmo::hit_test_scale(
+                                        pos, handle_len, &view_proj, panel_rect, mp,
+                                    ) {
+                                        match handle {
+                                            crate::gizmo::ScaleHandle::Axis(axis) => {
+                                                insp.gizmo_scale_axis = Some(axis);
+                                                insp.gizmo_scale_uniform = false;
+                                            }
+                                            crate::gizmo::ScaleHandle::Uniform => {
+                                                insp.gizmo_scale_axis = None;
+                                                insp.gizmo_scale_uniform = true;
+                                            }
+                                        }
+                                        insp.gizmo_scale_start_world = insp.edit_scale;
+                                        insp.gizmo_scale_start_mouse = [mp.x, mp.y];
+                                    }
+                                }
+                            }
+
+                            let mut scale_changed = false;
+                            if let Some(axis) = insp.gizmo_scale_axis {
+                                if response.dragged() {
+                                    if let (Some((dir2d, px_per_unit)), Some(mp)) = (
+                                        crate::gizmo::axis_screen_dir_and_scale(
+                                            pos,
+                                            axis,
+                                            handle_len.max(0.01),
+                                            &view_proj,
+                                            panel_rect,
+                                        ),
+                                        response.interact_pointer_pos(),
+                                    ) {
+                                        let start = egui::Pos2::new(
+                                            insp.gizmo_scale_start_mouse[0],
+                                            insp.gizmo_scale_start_mouse[1],
+                                        );
+                                        let screen_delta = mp - start;
+                                        let world_delta = screen_delta.dot(dir2d) / px_per_unit;
+                                        let delta_frac = world_delta / handle_len.max(0.01);
+                                        let mut new_scale = insp.gizmo_scale_start_world;
+                                        new_scale[axis as usize] =
+                                            (new_scale[axis as usize] + delta_frac).max(0.01);
+                                        insp.edit_scale = new_scale;
+                                        scale_changed = true;
+                                    }
+                                } else if response.drag_stopped() {
+                                    insp.gizmo_scale_axis = None;
+                                }
+                            } else if insp.gizmo_scale_uniform {
+                                if response.dragged() {
+                                    if let (Some(origin), Some(mp)) = (
+                                        crate::gizmo::world_to_screen(pos, &view_proj, panel_rect),
+                                        response.interact_pointer_pos(),
+                                    ) {
+                                        let start_mouse = egui::Pos2::new(
+                                            insp.gizmo_scale_start_mouse[0],
+                                            insp.gizmo_scale_start_mouse[1],
+                                        );
+                                        let radial_start = (start_mouse - origin).length();
+                                        let radial_now = (mp - origin).length();
+                                        let delta_frac =
+                                            (radial_now - radial_start) / handle_len.max(0.01);
+                                        let scale_factor = (1.0 + delta_frac).max(0.01);
+                                        insp.edit_scale = insp
+                                            .gizmo_scale_start_world
+                                            .map(|s| (s * scale_factor).max(0.01));
+                                        scale_changed = true;
+                                    }
+                                } else if response.drag_stopped() {
+                                    insp.gizmo_scale_uniform = false;
+                                }
+                            }
+                            if scale_changed {
+                                insp.cmd_queue.push(InspectorCmd::SetScale {
+                                    id: sel_id,
+                                    sx: insp.edit_scale[0],
+                                    sy: insp.edit_scale[1],
+                                    sz: insp.edit_scale[2],
+                                });
+                            }
+
+                            let hovered = response.hover_pos().and_then(|mp| {
+                                crate::gizmo::hit_test_scale(
+                                    pos, handle_len, &view_proj, panel_rect, mp,
+                                )
+                            });
+                            let dragging = if insp.gizmo_scale_uniform {
+                                Some(crate::gizmo::ScaleHandle::Uniform)
+                            } else {
+                                insp.gizmo_scale_axis.map(crate::gizmo::ScaleHandle::Axis)
+                            };
+                            crate::gizmo::draw_scale_gizmo(
+                                ui.painter(),
+                                pos,
+                                handle_len,
+                                &view_proj,
+                                panel_rect,
+                                hovered,
+                                dragging,
+                            );
+                        }
                     }
                 }
             }
@@ -276,6 +380,16 @@ impl EditorPanel for ViewportPanel {
                             .clicked()
                         {
                             insp.gizmo_mode = bsengine_core::GizmoMode::Rotate;
+                        }
+                        if ui
+                            .selectable_label(
+                                insp.gizmo_mode == bsengine_core::GizmoMode::Scale,
+                                egui_phosphor::regular::CORNERS_OUT,
+                            )
+                            .on_hover_text("Scale (R)")
+                            .clicked()
+                        {
+                            insp.gizmo_mode = bsengine_core::GizmoMode::Scale;
                         }
                         if ui
                             .selectable_label(insp.show_grid, egui_phosphor::regular::GRID_FOUR)

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2404,7 +2404,7 @@ impl WgpuSurface {
                         let mut despawn_entity = false;
                         let mut duplicate_selected = false;
                         if ctx.memory(|m| m.focused()).is_none() {
-                            let (del, dup, undo, redo, save, move_mode, rotate_mode) =
+                            let (del, dup, undo, redo, save, move_mode, rotate_mode, scale_mode) =
                                 ctx.input(|i| {
                                     (
                                         i.key_pressed(egui::Key::Delete),
@@ -2419,6 +2419,7 @@ impl WgpuSurface {
                                         i.modifiers.ctrl && i.key_pressed(egui::Key::S),
                                         i.key_pressed(egui::Key::W),
                                         i.key_pressed(egui::Key::E),
+                                        i.key_pressed(egui::Key::R),
                                     )
                                 });
                             if del {
@@ -2441,6 +2442,9 @@ impl WgpuSurface {
                             }
                             if rotate_mode {
                                 insp.gizmo_mode = bsengine_core::GizmoMode::Rotate;
+                            }
+                            if scale_mode {
+                                insp.gizmo_mode = bsengine_core::GizmoMode::Scale;
                             }
                         }
                         if despawn_entity {
@@ -2562,6 +2566,19 @@ impl WgpuSurface {
                                             .clicked()
                                         {
                                             insp.gizmo_mode = bsengine_core::GizmoMode::Rotate;
+                                        }
+                                        if ui
+                                            .selectable_label(
+                                                insp.gizmo_mode == bsengine_core::GizmoMode::Scale,
+                                                format!(
+                                                    "{} Scale",
+                                                    egui_phosphor::regular::CORNERS_OUT
+                                                ),
+                                            )
+                                            .on_hover_text("Scale (R)")
+                                            .clicked()
+                                        {
+                                            insp.gizmo_mode = bsengine_core::GizmoMode::Scale;
                                         }
                                     });
                                     ui.separator();


### PR DESCRIPTION
## Summary
- Adds a Scale gizmo to the editor viewport, matching the existing Translate (`W`)/Rotate (`E`) gizmos' interaction model: three per-axis handles plus a center uniform-scale handle, keyboard shortcut `R`, and matching buttons on both the main toolbar and the floating viewport mini-toolbar.
- The backend (`InspectorCmd::SetScale` → `EditorCommand::SetScale` → `Transform.scale`) already existed and is unchanged — this PR adds only the missing gizmo-drag UI layer.
- Per-axis drags are additive (mirrors Translate's convention); the center uniform handle is multiplicative, so a non-uniform starting scale keeps its axis ratios instead of drifting toward uniform under an additive delta.
- `crates/bsengine-rhi-wgpu/src/gizmo.rs`: new `ScaleHandle` enum, `hit_test_scale` (prioritizes the center handle over axis segments at the origin), `draw_scale_gizmo` (square handle tips, visually distinct from Translate's circles).
- `crates/bsengine-core/src/inspector.rs`: new `GizmoMode::Scale` variant + `edit_scale`/`gizmo_scale_*` drag-state fields on `InspectorState`, synced on selection change.
- `crates/bsengine-rhi-wgpu/src/panels/viewport.rs` + `surface.rs`: the `GizmoMode::Scale` match arm, keyboard shortcut, and both toolbar buttons.

## Test plan
- [x] `cargo test --workspace` — all green (935/935 bsengine-editor, 132/132 bsengine-rhi-wgpu, no failures anywhere else; the two "REPLAY FAILED" log lines are expected output from meta-tests verifying the replay-failure-detection mechanism itself, both report `ok`)
- [x] `cargo clippy -p bsengine-core -p bsengine-rhi-wgpu --all-targets` — clean, only pre-existing unrelated warnings
- [x] `rustfmt --check --edition 2021` on all 4 touched files — clean
- [x] Each of the 3 tasks independently diff-reviewed and test-reverified (not just trusting subagent chat summaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)