### PR TITLE
perf(runtime): fast-path shadow/SSAO/bloom in headless E2E replays

### DIFF
--- a/crates/bsengine-render/src/texture_cache.rs
+++ b/crates/bsengine-render/src/texture_cache.rs
@@ -130,7 +130,7 @@ mod tests {
     /// early return and every test here would pass by doing nothing.
     fn with_gpu(app: &mut bevy_app::App) {
         let surface = pollster::block_on(bsengine_rhi_wgpu::surface::WgpuSurface::new_offscreen(
-            16, 16,
+            16, 16, false,
         ))
         .expect("these tests need an adapter; a skip here would look like a pass");
         app.insert_resource(GpuTextureRegistry::new(

--- a/crates/bsengine-rhi-wgpu/src/plugin.rs
+++ b/crates/bsengine-rhi-wgpu/src/plugin.rs
@@ -37,6 +37,8 @@ pub enum SurfaceMode {
         width: u32,
         /// Render target height, in pixels.
         height: u32,
+        /// See `WgpuSurface::is_fast_render`.
+        fast_render: bool,
     },
 }
 
@@ -54,8 +56,12 @@ impl WgpuRHIPlugin {
     /// A surface built immediately from an offscreen texture of `width` x
     /// `height` pixels, no window required. Panics at `Startup` if no
     /// adapter can rasterise -- see `SurfaceMode::Offscreen`.
-    pub fn offscreen(width: u32, height: u32) -> Self {
-        Self(SurfaceMode::Offscreen { width, height })
+    pub fn offscreen(width: u32, height: u32, fast_render: bool) -> Self {
+        Self(SurfaceMode::Offscreen {
+            width,
+            height,
+            fast_render,
+        })
     }
 }
 
@@ -88,19 +94,21 @@ fn create_surface_system(world: &mut World, mode: SurfaceMode) {
                 None => None,
             }
         }
-        SurfaceMode::Offscreen { width, height } => {
-            match pollster::block_on(WgpuSurface::new_offscreen(width, height)) {
-                Ok(surface) => Some(surface),
-                Err(e) => panic!(
-                    "could not create an offscreen wgpu renderer: {e}\n\
+        SurfaceMode::Offscreen {
+            width,
+            height,
+            fast_render,
+        } => match pollster::block_on(WgpuSurface::new_offscreen(width, height, fast_render)) {
+            Ok(surface) => Some(surface),
+            Err(e) => panic!(
+                "could not create an offscreen wgpu renderer: {e}\n\
                      The headless test runtime needs an adapter that can actually \
                      rasterise. On Linux CI that is mesa-vulkan-drivers (lavapipe); on \
                      Windows it is normally the D3D12 WARP adapter. If this environment \
                      has neither, that is the finding worth reporting -- do not silence \
                      it by skipping."
-                ),
-            }
-        }
+            ),
+        },
     };
 
     let Some(surface) = surface else {
@@ -163,7 +171,7 @@ mod tests {
     #[test]
     fn offscreen_mode_creates_a_surface_with_no_window_handle() {
         let mut app = new_app();
-        app.add_plugins(WgpuRHIPlugin::offscreen(64, 64));
+        app.add_plugins(WgpuRHIPlugin::offscreen(64, 64, false));
         app.update();
         assert!(
             app.world().get_resource::<WgpuSurfaceResource>().is_some(),

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -707,7 +707,19 @@ impl PostProcessState {
 
     /// Runs the bloom, SSAO, and composite passes in sequence, writing the
     /// final tonemapped result into `surface_view`.
-    pub fn apply(&self, encoder: &mut wgpu::CommandEncoder, surface_view: &wgpu::TextureView) {
+    ///
+    /// `fast_render` skips the bloom/SSAO shading work but still clears both
+    /// targets to their neutral values (black = "no bloom contribution",
+    /// white = "fully visible") -- see `WgpuSurface::is_fast_render`. Never
+    /// skip the clear itself: the composite pass below always samples both
+    /// textures, and an un-cleared AO texture reads as 0.0 ("fully
+    /// occluded") instead of 1.0, which would render every pixel black.
+    pub fn apply(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        surface_view: &wgpu::TextureView,
+        fast_render: bool,
+    ) {
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("bloom pass"),
@@ -722,10 +734,12 @@ impl PostProcessState {
                 depth_stencil_attachment: None,
                 ..Default::default()
             });
-            pass.set_pipeline(&self.bloom_pipeline);
-            pass.set_bind_group(0, &self.hdr_bg, &[]);
-            pass.set_bind_group(1, &self.config_bg, &[]);
-            pass.draw(0..3, 0..1);
+            if !fast_render {
+                pass.set_pipeline(&self.bloom_pipeline);
+                pass.set_bind_group(0, &self.hdr_bg, &[]);
+                pass.set_bind_group(1, &self.config_bg, &[]);
+                pass.draw(0..3, 0..1);
+            }
         }
 
         {
@@ -742,11 +756,13 @@ impl PostProcessState {
                 depth_stencil_attachment: None,
                 ..Default::default()
             });
-            pass.set_pipeline(&self.ssao_pipeline);
-            pass.set_bind_group(0, &self.depth_bg, &[]);
-            pass.set_bind_group(1, &self.config_bg, &[]);
-            pass.set_bind_group(2, &self.ssao_cam_bg, &[]);
-            pass.draw(0..3, 0..1);
+            if !fast_render {
+                pass.set_pipeline(&self.ssao_pipeline);
+                pass.set_bind_group(0, &self.depth_bg, &[]);
+                pass.set_bind_group(1, &self.config_bg, &[]);
+                pass.set_bind_group(2, &self.ssao_cam_bg, &[]);
+                pass.draw(0..3, 0..1);
+            }
         }
 
         {

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -701,6 +701,13 @@ pub struct WgpuSurface {
     start_time: std::time::Instant,
     dock_state: Option<egui_dock::DockState<String>>,
     last_saved_layout_json: Option<String>,
+    /// When true, `render_frame` and `PostProcessState::apply` still clear
+    /// the shadow map / bloom / SSAO render targets to their neutral values
+    /// every frame, but skip the expensive shading work that writes anything
+    /// else into them — CI's headless E2E replays are the one caller that
+    /// needs this; see the design doc for why it must be clear-only, not a
+    /// bare skip.
+    fast_render: bool,
 }
 
 impl WgpuSurface {
@@ -747,6 +754,7 @@ impl WgpuSurface {
                 config,
                 _window: window,
             },
+            false,
         )
     }
 
@@ -756,7 +764,7 @@ impl WgpuSurface {
     /// [`Self::read_pixels`]. Pipelines come from the same [`Self::build`] the
     /// windowed path uses, so pixels observed here are the output of the
     /// pipelines that draw to a window.
-    pub async fn new_offscreen(width: u32, height: u32) -> Result<Self, String> {
+    pub async fn new_offscreen(width: u32, height: u32, fast_render: bool) -> Result<Self, String> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             ..Default::default()
@@ -771,6 +779,7 @@ impl WgpuSurface {
                 width,
                 height,
             },
+            fast_render,
         )
     }
 
@@ -810,6 +819,13 @@ impl WgpuSurface {
     /// The height of the render target, in pixels.
     pub fn height(&self) -> u32 {
         self.output.height()
+    }
+
+    /// Whether this renderer skips the shadow/bloom/SSAO shading work in
+    /// favour of clearing those targets to their neutral values. Only ever
+    /// true for `bsengine-runtime`'s CI replay path.
+    pub fn is_fast_render(&self) -> bool {
+        self.fast_render
     }
 
     /// This renderer's GPU device, for callers that must put resources on the
@@ -865,6 +881,7 @@ impl WgpuSurface {
         device: Arc<wgpu::Device>,
         queue: Arc<wgpu::Queue>,
         output: crate::output::Output,
+        fast_render: bool,
     ) -> Result<Self, String> {
         let format = output.format();
         let width = output.width();
@@ -1396,6 +1413,7 @@ impl WgpuSurface {
             start_time: std::time::Instant::now(),
             dock_state: None,
             last_saved_layout_json: None,
+            fast_render,
         })
     }
 
@@ -1886,6 +1904,11 @@ impl WgpuSurface {
         }
 
         // --- shadow pass ---
+        // In fast_render mode this still clears the shadow map to depth=1.0
+        // (max distance -- "nothing occludes anything"), which reads as
+        // fully lit, but skips redrawing every object into it. See the
+        // design doc for why clearing (not skipping the pass outright) is
+        // required for correctness.
         {
             let mut shadow_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("shadow pass"),
@@ -1901,21 +1924,23 @@ impl WgpuSurface {
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });
-            shadow_pass.set_pipeline(&self.shadow_pipeline);
-            shadow_pass.set_bind_group(0, &self.camera_bind_group, &[]);
-            for (i, (mesh_id, _, _, _, _)) in draw_calls.iter().enumerate() {
-                if i >= MAX_OBJECTS {
-                    break;
+            if !self.fast_render {
+                shadow_pass.set_pipeline(&self.shadow_pipeline);
+                shadow_pass.set_bind_group(0, &self.camera_bind_group, &[]);
+                for (i, (mesh_id, _, _, _, _)) in draw_calls.iter().enumerate() {
+                    if i >= MAX_OBJECTS {
+                        break;
+                    }
+                    let Some(mesh) = registry.get(*mesh_id) else {
+                        continue;
+                    };
+                    let offset = (i as u64 * MODEL_STRIDE) as u32;
+                    shadow_pass.set_bind_group(1, &self.model_bind_group, &[offset]);
+                    shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                    shadow_pass
+                        .set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+                    shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
                 }
-                let Some(mesh) = registry.get(*mesh_id) else {
-                    continue;
-                };
-                let offset = (i as u64 * MODEL_STRIDE) as u32;
-                shadow_pass.set_bind_group(1, &self.model_bind_group, &[offset]);
-                shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
-                shadow_pass
-                    .set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
-                shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
             }
         }
 

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2220,7 +2220,8 @@ impl WgpuSurface {
             .filter(|i| i.editor_mode)
             .map(|i| (i.viewport_pos[0] + 8.0, i.viewport_pos[1] + 8.0))
             .unwrap_or((8.0, 8.0));
-        self.post_process.apply(&mut encoder, &view);
+        self.post_process
+            .apply(&mut encoder, &view, self.fast_render);
 
         // UI + HUD overlay via egui (always on in editor mode)
         let has_ui = is_editor

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -251,8 +251,18 @@ impl Harness {
     /// test reads exactly like a passing one, and a suite that goes quiet on
     /// the machines that matter is not a suite.
     pub fn new() -> Self {
-        let surface =
-            pollster::block_on(WgpuSurface::new_offscreen(WIDTH, HEIGHT)).unwrap_or_else(|e| {
+        Self::build(false)
+    }
+
+    /// Same as [`Self::new`], but with `fast_render` set — see
+    /// `WgpuSurface::is_fast_render`.
+    pub fn new_fast() -> Self {
+        Self::build(true)
+    }
+
+    fn build(fast_render: bool) -> Self {
+        let surface = pollster::block_on(WgpuSurface::new_offscreen(WIDTH, HEIGHT, fast_render))
+            .unwrap_or_else(|e| {
                 panic!(
                     "could not create an offscreen renderer: {e}\n\
                      These tests need an adapter that can actually rasterise. On Linux CI \

--- a/crates/bsengine-rhi-wgpu/tests/pixels_fast_render.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_fast_render.rs
@@ -1,0 +1,51 @@
+//! Fast render mode (used only by CI's headless E2E replays): shadow, bloom
+//! and SSAO shading must be skipped, but every render target they'd
+//! otherwise write must still be cleared to its correct neutral value.
+
+mod common;
+
+use common::{Draw, Harness, Light, Scene};
+use glam::Vec3;
+
+#[test]
+fn fast_render_mode_skips_the_shadow_pass() {
+    // Light straight down, so a cube directly above the origin casts its
+    // shadow directly onto the origin -- avoids needing to hand-compute an
+    // angled shadow offset. Camera sits off-axis so its view direction is
+    // never anti-parallel with the harness's fixed Vec3::Y up vector.
+    let scene_with = |plane: u64, cube: u64| Scene {
+        draws: vec![
+            Draw::new(plane, Vec3::ZERO).scaled(Vec3::new(20.0, 1.0, 20.0), Vec3::ZERO),
+            Draw::new(cube, Vec3::new(0.0, 3.0, 0.0))
+                .scaled(Vec3::splat(3.0), Vec3::new(0.0, 3.0, 0.0)),
+        ],
+        light: Light {
+            direction: Vec3::new(0.0, -1.0, 0.0),
+            ambient: Vec3::splat(0.05),
+            ..Light::default()
+        },
+        camera_pos: Vec3::new(0.0, 5.0, 5.0),
+        look_at: Vec3::ZERO,
+        ..Scene::default()
+    };
+
+    let mut full = Harness::new();
+    let full_plane = full.plane();
+    let full_cube = full.cube();
+    let shadowed = full.render(&scene_with(full_plane, full_cube));
+
+    let mut fast = Harness::new_fast();
+    let fast_plane = fast.plane();
+    let fast_cube = fast.cube();
+    let unshadowed = fast.render(&scene_with(fast_plane, fast_cube));
+
+    assert!(
+        unshadowed.centre_luma() > shadowed.centre_luma() + 5.0,
+        "fast_render mode must skip the directional shadow pass (clearing the shadow map to \
+         \"fully lit\" instead of drawing the occluding cube into it): the ground directly \
+         under the cube should be brighter in fast mode ({:.1}) than in full mode, where the \
+         cube casts a real shadow onto it ({:.1})",
+        unshadowed.centre_luma(),
+        shadowed.centre_luma()
+    );
+}

--- a/crates/bsengine-rhi-wgpu/tests/pixels_fast_render.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_fast_render.rs
@@ -49,3 +49,46 @@ fn fast_render_mode_skips_the_shadow_pass() {
         shadowed.centre_luma()
     );
 }
+
+#[test]
+fn fast_render_mode_still_draws_a_lit_object_not_a_black_frame() {
+    // Bloom and SSAO both explicitly enabled, so this test would catch the
+    // black-frame bug a naive "skip the pass entirely" fix would cause: an
+    // un-cleared AO texture reads as 0.0 (fully occluded) instead of the
+    // correct neutral 1.0 (fully visible), and `combined = hdr * ao + bloom`
+    // would then evaluate to black everywhere.
+    let scene = |draws: Vec<Draw>| Scene {
+        draws,
+        bloom: Some(bsengine_core::Bloom {
+            enabled: true,
+            ..Default::default()
+        }),
+        ssao: Some(bsengine_core::AmbientOcclusion {
+            enabled: true,
+            ..Default::default()
+        }),
+        ..Scene::default()
+    };
+
+    let mut h = Harness::new_fast();
+    let cube = h.cube();
+    let empty = h.render(&scene(vec![]));
+    let lit = h.render(&scene(vec![
+        Draw::new(cube, Vec3::ZERO).colour(Vec3::new(1.0, 0.2, 0.2))
+    ]));
+
+    assert!(
+        lit.centre() != empty.centre(),
+        "fast_render mode must still draw the cube through the geometry+composite pass; \
+         centre pixel with the cube present ({:?}) should differ from the empty-scene \
+         background ({:?})",
+        lit.centre(),
+        empty.centre()
+    );
+    assert!(
+        lit.centre_luma() > 1.0,
+        "fast_render mode's centre pixel should not be pure black (a black frame means the \
+         composite pass read an un-cleared/zero AO texture as \"fully occluded\"); got {:?}",
+        lit.centre()
+    );
+}

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn a_script_loaded_scene_gets_its_own_scripts_running() {
         let dir = chained_scene_project();
-        let mut app = crate::test_mode::build_test_app(dir.path().to_str().unwrap(), None);
+        let mut app = crate::test_mode::build_test_app(dir.path().to_str().unwrap(), None, false);
 
         let mut swapped_at = None;
         let mut b_ran_at = None;

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -111,9 +111,13 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>) -> App {
         // `main.rs`'s windowed chain -- a headless GPU stack built in a
         // different order than the real runtime is a regression that would
         // pass every test here while behaving differently windowed.
+        // `fast_render: false` here, not `true` -- wiring this to actually
+        // skip shadow/bloom/SSAO shading for CI replays is a later task;
+        // this crate does not observe `fast_render` yet.
         .add_plugins(WgpuRHIPlugin::offscreen(
             manifest.window.width,
             manifest.window.height,
+            false,
         ))
         .add_plugins(InputPlugin)
         .add_plugins(AudioPlugin)

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -31,7 +31,7 @@ use crate::test_query::{eval_op, eval_path, run_query};
 /// replay log pin its own starting scene instead of always depending on
 /// whatever the project's entry scene currently is (which changes as a
 /// multi-level game's "real" entry point evolves during development).
-pub fn build_test_app(project_dir: &str, scene_override: Option<&str>) -> App {
+pub fn build_test_app(project_dir: &str, scene_override: Option<&str>, fast_render: bool) -> App {
     let manifest_path = format!("{project_dir}/project.toml");
     let manifest_str = std::fs::read_to_string(&manifest_path)
         .unwrap_or_else(|e| panic!("Cannot read {manifest_path}: {e}"));
@@ -111,13 +111,10 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>) -> App {
         // `main.rs`'s windowed chain -- a headless GPU stack built in a
         // different order than the real runtime is a regression that would
         // pass every test here while behaving differently windowed.
-        // `fast_render: false` here, not `true` -- wiring this to actually
-        // skip shadow/bloom/SSAO shading for CI replays is a later task;
-        // this crate does not observe `fast_render` yet.
         .add_plugins(WgpuRHIPlugin::offscreen(
             manifest.window.width,
             manifest.window.height,
-            false,
+            fast_render,
         ))
         .add_plugins(InputPlugin)
         .add_plugins(AudioPlugin)
@@ -207,7 +204,7 @@ fn mouse_button_from_u8(button: u8) -> Option<MouseButton> {
 }
 
 pub fn run_test_mode(project_dir: &str) {
-    let mut app = build_test_app(project_dir, None);
+    let mut app = build_test_app(project_dir, None, false);
     let mut frame: u64 = 0;
 
     let stdin = io::stdin();
@@ -472,7 +469,7 @@ pub fn run_replay_mode(project_dir: &str, log_path: &str) -> bool {
     let log: RecordedLog = serde_json::from_str(&log_str)
         .unwrap_or_else(|e| panic!("cannot parse replay log {log_path}: {e}"));
 
-    let mut app = build_test_app(project_dir, log.scene.as_deref());
+    let mut app = build_test_app(project_dir, log.scene.as_deref(), true);
     let mut frame: u64 = 0;
 
     for command in log.actions {
@@ -562,7 +559,7 @@ mod tests {
     #[test]
     fn build_test_app_with_no_override_loads_entry_scene() {
         let dir = write_two_scene_project();
-        let mut app = build_test_app(dir.path().to_str().unwrap(), None);
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None, false);
         app.update();
 
         let names = crate::test_query::get_entity_names(app.world_mut());
@@ -579,7 +576,7 @@ mod tests {
         // that -- there was no list entry to check. Asserting the behaviour
         // would have.
         let dir = write_two_scene_project();
-        let mut app = build_test_app(dir.path().to_str().unwrap(), None);
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None, false);
         let doomed = app
             .world_mut()
             .spawn(bsengine_core::Lifetime::from_seconds(0.05))
@@ -602,7 +599,7 @@ mod tests {
         // absent in the other is a feature that works when you look at it and
         // not when you test it.
         let dir = write_two_scene_project();
-        let mut app = build_test_app(dir.path().to_str().unwrap(), None);
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None, false);
         let e = app
             .world_mut()
             .spawn((
@@ -636,13 +633,37 @@ mod tests {
     #[test]
     fn build_test_app_with_override_loads_that_scene_instead() {
         let dir = write_two_scene_project();
-        let mut app = build_test_app(dir.path().to_str().unwrap(), Some("assets/scenes/b.ron"));
+        let mut app = build_test_app(
+            dir.path().to_str().unwrap(),
+            Some("assets/scenes/b.ron"),
+            false,
+        );
         app.update();
 
         let names = crate::test_query::get_entity_names(app.world_mut());
         let names: Vec<String> = serde_json::from_value(names).unwrap();
         assert!(names.contains(&"SceneB".to_string()), "names: {names:?}");
         assert!(!names.contains(&"SceneA".to_string()), "names: {names:?}");
+    }
+
+    #[test]
+    fn build_test_app_with_fast_render_true_produces_a_fast_render_surface() {
+        let dir = write_two_scene_project();
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None, true);
+        // `WgpuSurfaceResource` is inserted by a `Startup` system, which only
+        // runs on the first `app.update()` -- not during `build_test_app`
+        // itself. See `get_pixel_reads_the_last_rendered_frame` and
+        // `screenshot_returns_a_decodable_png` below for the same pattern.
+        app.update();
+        let surface = app
+            .world()
+            .resource::<bsengine_rhi_wgpu::surface::WgpuSurfaceResource>();
+        assert!(
+            surface.0.is_fast_render(),
+            "build_test_app(.., fast_render: true) must produce a WgpuSurface with \
+             is_fast_render() true -- this is what run_replay_mode relies on for CI E2E \
+             replay speed"
+        );
     }
 
     // Roadmap item 30. This app builds its own plugin list, so the windowed
@@ -686,7 +707,7 @@ mod tests {
         .unwrap();
 
         let project_dir = root.to_str().unwrap().to_string();
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         app.update();
 
         let mut q = app.world_mut().query::<&bsengine_gltf::GltfAsset>();
@@ -714,7 +735,7 @@ mod tests {
     #[test]
     fn editor_plugin_reload_scene_does_not_corrupt_scripting() {
         let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         let scene_path = app
             .world()
             .resource::<InspectorState>()
@@ -761,7 +782,7 @@ mod tests {
     #[test]
     fn wait_until_returns_immediately_when_already_satisfied() {
         let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         let mut frame: u64 = 0;
         app.update();
         frame += 1;
@@ -799,7 +820,7 @@ mod tests {
     #[test]
     fn wait_until_times_out_with_last_actual_value() {
         let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         let mut frame: u64 = 0;
 
         let (response, _) = execute_command(
@@ -840,7 +861,7 @@ mod tests {
     #[test]
     fn wait_until_waits_through_a_not_yet_evaluable_predicate() {
         let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         let mut frame: u64 = 0;
 
         let (response, _) = execute_command(
@@ -883,7 +904,7 @@ mod tests {
     #[test]
     fn wait_until_errors_when_predicate_is_still_not_evaluable_at_timeout() {
         let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         let mut frame: u64 = 0;
 
         let (response, _) = execute_command(
@@ -932,7 +953,7 @@ mod tests {
     #[test]
     fn mini_arenas_fox_mesh_loads_now_that_rendering_is_on() {
         let project_dir = format!("{}/../../games/mini-arena", env!("CARGO_MANIFEST_DIR"));
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         let mut status = Value::Null;
         for _ in 0..200 {
             app.update();
@@ -951,7 +972,7 @@ mod tests {
     #[test]
     fn get_pixel_reads_the_last_rendered_frame() {
         let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         app.update();
 
         let result =
@@ -966,7 +987,7 @@ mod tests {
     #[test]
     fn screenshot_returns_a_decodable_png() {
         let project_dir = format!("{}/../../games/cube-evader", env!("CARGO_MANIFEST_DIR"));
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         app.update();
 
         let result = crate::test_query::run_query(app.world_mut(), "screenshot", &json!({}))
@@ -1048,7 +1069,7 @@ mod tests {
         .unwrap();
 
         let project_dir = root.to_str().unwrap().to_string();
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         app.update();
 
         // Window defaults to 1280x720 (no [window] table -- see
@@ -1149,7 +1170,7 @@ mod tests {
         .unwrap();
 
         let project_dir = root.to_str().unwrap().to_string();
-        let mut app = build_test_app(&project_dir, None);
+        let mut app = build_test_app(&project_dir, None, false);
         app.update();
 
         // Window defaults to 1280x720 (no [window] table), so the exact
@@ -1202,7 +1223,7 @@ mod tests {
     #[test]
     fn press_key_is_observable_as_pressed_and_just_pressed_after_one_step() {
         let dir = write_two_scene_project();
-        let mut app = build_test_app(dir.path().to_str().unwrap(), None);
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None, false);
         let mut frame: u64 = 0;
 
         let (resp, _) = execute_command(


### PR DESCRIPTION
## Summary
- CI's Windows E2E replay step spends the overwhelming majority of its ~2h50m on shadow/SSAO/bloom
  shading that runs unconditionally every frame on the software (DX12/WARP) adapter, even though none of
  the 8 recordings read a pixel. Confirmed locally: forcing WARP and skipping those three passes dropped
  a 245-frame replay from 140.35s to 4.48s (~31x).
- This PR fast-paths those three passes (clear-only: targets still get cleared to their correct neutral
  value every frame, only the expensive shading is skipped) for `run_replay_mode` only. MCP interactive
  sessions, windowed play, and every existing test keep full-fidelity rendering, unchanged.
- See `docs/superpowers/specs/2026-08-26-headless-fast-render-path-design.md` for the full design.

## Test plan
- [x] New `pixels_fast_render.rs` tests: shadow pass is actually skipped; fast mode does not collapse to a
      black frame (guards the specific correctness bug a naive "skip entirely" approach would cause)
- [x] New `bsengine-runtime` test proving `run_replay_mode`'s app is actually `is_fast_render() == true`
- [x] Full workspace `cargo test` (935 bsengine-editor + all other crates) green
- [x] Scoped `cargo clippy` on touched crates: zero new warnings vs. base
- [x] All 8 `games/*/assets/tests/*.testlog.json` recordings replay locally with PASS
- [ ] CI's `Test (windows-latest)` E2E replays step duration compared against the ~2h49-50m baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)