### PR TITLE
feat(app): terrain editor brush tool (ENGINE_ROADMAP item 44, sub-step 3/3 — final)

### DIFF
--- a/crates/bsengine-app/Cargo.toml
+++ b/crates/bsengine-app/Cargo.toml
@@ -24,6 +24,11 @@ bsengine-scene.workspace = true
 bsengine-physics.workspace = true
 bsengine-asset.workspace = true
 glam.workspace = true
+# The terrain brush tool (terrain_brush.rs) decodes/encodes splatmap PNGs
+# directly at commit/preview time (the splatmap has no dedicated
+# `AssetLoader`-based decode helper the way the heightmap does), so this
+# needs to be a real dependency, not just a test-time one.
+image.workspace = true
 # The particle emitter logs when it hits its per-emitter cap; a silently
 # truncated effect looks exactly like a broken one.
 tracing.workspace = true
@@ -41,9 +46,6 @@ bsengine-scripting.workspace = true
 bsengine-plugin.workspace = true
 bsengine-mcp.workspace = true
 serde_json.workspace = true
-# Encodes the 16-bit grayscale PNG heightmap fixture terrain.rs's tests build
-# at test time, mirroring bsengine-asset's own test-time PNG fixtures.
-image.workspace = true
 # terrain.rs's tests build a real headless GpuMeshRegistry (mirroring
 # bsengine-gltf's insert_headless_gpu_registries), since WgpuRHIPlugin only
 # builds one once a window exists.

--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -29,6 +29,9 @@ pub mod terrain;
 /// Pure heightmap-to-chunk-geometry algorithm for the terrain system (no
 /// ECS/GPU/physics types); `terrain`'s ECS layer calls into this.
 pub mod terrain_chunking;
+/// `TerrainBrushPlugin`: picks the terrain surface point under the cursor
+/// while the editor's terrain brush tool is active.
+pub mod terrain_brush;
 /// `TimePlugin`: ticks the `Time` resource once per frame.
 pub mod time;
 /// `TimerPlugin`: ticks `Timer` components once per frame.
@@ -45,6 +48,7 @@ pub use nav_mesh::NavMeshPlugin;
 pub use particles::ParticlePlugin;
 pub use shield::ShieldPlugin;
 pub use terrain::TerrainPlugin;
+pub use terrain_brush::TerrainBrushPlugin;
 pub use time::TimePlugin;
 pub use timer::TimerPlugin;
 pub use tween::TweenPlugin;

--- a/crates/bsengine-app/src/lib.rs
+++ b/crates/bsengine-app/src/lib.rs
@@ -26,12 +26,12 @@ pub mod shield;
 /// `TerrainPlugin`: loads a `Terrain`'s heightmap and spawns its chunk
 /// entities (render mesh + Rapier heightfield collider).
 pub mod terrain;
-/// Pure heightmap-to-chunk-geometry algorithm for the terrain system (no
-/// ECS/GPU/physics types); `terrain`'s ECS layer calls into this.
-pub mod terrain_chunking;
 /// `TerrainBrushPlugin`: picks the terrain surface point under the cursor
 /// while the editor's terrain brush tool is active.
 pub mod terrain_brush;
+/// Pure heightmap-to-chunk-geometry algorithm for the terrain system (no
+/// ECS/GPU/physics types); `terrain`'s ECS layer calls into this.
+pub mod terrain_chunking;
 /// `TimePlugin`: ticks the `Time` resource once per frame.
 pub mod time;
 /// `TimerPlugin`: ticks `Timer` components once per frame.

--- a/crates/bsengine-app/src/terrain.rs
+++ b/crates/bsengine-app/src/terrain.rs
@@ -415,6 +415,7 @@ mod tests {
                     layer1_texture_path: write_test_texture("no-registry-l1", [120, 120, 120, 255]),
                     layer2_texture_path: write_test_texture("no-registry-l2", [110, 80, 40, 255]),
                     layer3_texture_path: write_test_texture("no-registry-l3", [240, 240, 250, 255]),
+                    splatmap_path: None,
                 },
                 Transform::default(),
             ))
@@ -459,6 +460,7 @@ mod tests {
                         "missing-heightmap-l3",
                         [240, 240, 250, 255],
                     ),
+                    splatmap_path: None,
                 },
                 Transform::default(),
             ))
@@ -515,6 +517,7 @@ mod tests {
                     layer1_texture_path: write_test_texture("chunks-l1", [120, 120, 120, 255]),
                     layer2_texture_path: write_test_texture("chunks-l2", [110, 80, 40, 255]),
                     layer3_texture_path: write_test_texture("chunks-l3", [240, 240, 250, 255]),
+                    splatmap_path: None,
                 },
                 Transform::from_position(Vec3::new(100.0, 0.0, -50.0)),
             ))
@@ -587,6 +590,7 @@ mod tests {
                     layer1_texture_path: write_test_texture("flat-drop-l1", [120, 120, 120, 255]),
                     layer2_texture_path: write_test_texture("flat-drop-l2", [110, 80, 40, 255]),
                     layer3_texture_path: write_test_texture("flat-drop-l3", [240, 240, 250, 255]),
+                    splatmap_path: None,
                 },
                 Transform::from_position(Vec3::ZERO),
             ))
@@ -651,6 +655,7 @@ mod tests {
                     layer1_texture_path: write_test_texture("splat-l1", [120, 120, 120, 255]),
                     layer2_texture_path: write_test_texture("splat-l2", [110, 80, 40, 255]),
                     layer3_texture_path: write_test_texture("splat-l3", [240, 240, 250, 255]),
+                    splatmap_path: None,
                 },
                 Transform::default(),
             ))

--- a/crates/bsengine-app/src/terrain.rs
+++ b/crates/bsengine-app/src/terrain.rs
@@ -55,10 +55,16 @@ pub use bsengine_scene::Terrain;
 /// `Terrain`'s chunks aren't spawned until its heightmap AND all 4 diffuse
 /// layers have arrived -- `generate_terrain_chunks` needs all 5 to build the
 /// `TerrainSplat` it attaches to each chunk.
+///
+/// `splatmap` additionally tracks the optional 6th asset named by
+/// `Terrain::splatmap_path`: `None` when the `Terrain` has no splatmap (the
+/// procedural-weights path, unchanged), `Some` with its own in-flight
+/// `AssetSlot` when it does.
 #[derive(Component)]
 struct PendingTerrain {
     heightmap: bsengine_asset::AssetSlot<HeightmapAsset>,
     layers: [bsengine_asset::AssetSlot<TextureAsset>; 4],
+    splatmap: Option<bsengine_asset::AssetSlot<TextureAsset>>,
 }
 
 /// Marks a `Terrain` entity whose chunks have already been spawned, so
@@ -71,6 +77,17 @@ struct PendingTerrain {
 #[reflect(Component)]
 pub struct TerrainChunksGenerated;
 
+/// Back-reference from a chunk entity to the `Terrain` entity it belongs
+/// to. Public and reflected for the same reason `TerrainChunksGenerated`
+/// is: the terrain brush tool's picking/apply systems need to query it
+/// directly, and nothing about it is meaningfully serializable scene state
+/// (it's derived, re-created every time chunks are generated), so it's
+/// still excluded from RON the same way `PendingTerrain` is -- being
+/// `Reflect`-registered for R1 compliance doesn't mean scenes author it.
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(Component)]
+pub struct TerrainChunkOf(pub Entity);
+
 /// Bevy plugin that loads each `Terrain`'s heightmap and spawns its chunk
 /// entities once both the heightmap and a `GpuMeshRegistry` are available.
 pub struct TerrainPlugin;
@@ -79,6 +96,7 @@ impl Plugin for TerrainPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Terrain>()
             .register_type::<TerrainChunksGenerated>()
+            .register_type::<TerrainChunkOf>()
             .add_systems(Update, generate_terrain_chunks);
     }
 }
@@ -115,9 +133,15 @@ fn generate_terrain_chunks(
             let layers = layer_paths.map(|p| {
                 bsengine_asset::AssetSlot::from_handle(asset_server.load::<TextureAsset>(p))
             });
+            let splatmap = terrain.splatmap_path.as_ref().map(|p| {
+                bsengine_asset::AssetSlot::from_handle(
+                    asset_server.load::<TextureAsset>(p.clone()),
+                )
+            });
             commands.entity(entity).insert(PendingTerrain {
                 heightmap: bsengine_asset::AssetSlot::from_handle(heightmap_handle),
                 layers,
+                splatmap,
             });
             continue;
         };
@@ -132,7 +156,12 @@ fn generate_terrain_chunks(
                 any_layer_failed = true;
             }
         }
-        if heightmap_failed || any_layer_failed {
+        let splatmap_failed = pending
+            .splatmap
+            .as_mut()
+            .map(|s| matches!(s.poll(&asset_server, &textures), Polled::Failed(_)))
+            .unwrap_or(false);
+        if heightmap_failed || any_layer_failed || splatmap_failed {
             // A failed load never resolves, so the path is dropped entirely --
             // otherwise a missing file retries silently forever.
             warn!(
@@ -185,7 +214,26 @@ fn generate_terrain_chunks(
             chunk_size: terrain.chunk_size,
             height_scale: terrain.height_scale,
         };
-        let chunks = crate::terrain_chunking::generate_chunks(heightmap, &params);
+
+        let splatmap_override = match &pending.splatmap {
+            None => None,
+            Some(slot) => {
+                let Some(tex) = textures.get(slot.handle()) else {
+                    continue;
+                };
+                Some(crate::terrain_chunking::SplatmapOverride {
+                    width: tex.width,
+                    height: tex.height,
+                    data: tex.data.clone(),
+                })
+            }
+        };
+
+        let chunks = crate::terrain_chunking::generate_chunks_with_splatmap(
+            heightmap,
+            &params,
+            splatmap_override.as_ref(),
+        );
 
         // Rapier's heightfield shape is centered on its own local origin
         // (confirmed against `bsengine-physics`'s
@@ -218,6 +266,7 @@ fn generate_terrain_chunks(
                     weight_texture_id: weight_id,
                     layer_texture_ids: layer_ids,
                 },
+                TerrainChunkOf(entity),
                 RigidBody::fixed(),
                 Collider {
                     shape: ColliderShape::Heightfield {
@@ -690,5 +739,41 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn every_chunk_carries_a_terrain_chunk_of_pointing_back_to_its_terrain() {
+        let mut app = test_app();
+        let path = write_test_heightmap("chunk-of", 5, 5, &[10_000u16; 25]);
+        let terrain_entity = app
+            .world_mut()
+            .spawn((
+                Terrain {
+                    heightmap_path: path,
+                    chunk_count: (2, 1),
+                    chunk_size: 8.0,
+                    height_scale: 5.0,
+                    layer0_texture_path: write_test_texture("chunk-of-l0", [50, 200, 50, 255]),
+                    layer1_texture_path: write_test_texture("chunk-of-l1", [120, 120, 120, 255]),
+                    layer2_texture_path: write_test_texture("chunk-of-l2", [110, 80, 40, 255]),
+                    layer3_texture_path: write_test_texture("chunk-of-l3", [240, 240, 250, 255]),
+                    splatmap_path: None,
+                },
+                Transform::default(),
+            ))
+            .id();
+        run_until_generated(&mut app, terrain_entity);
+
+        let mut query = app.world_mut().query::<&TerrainChunkOf>();
+        let backrefs: Vec<Entity> = query.iter(app.world()).map(|c| c.0).collect();
+        assert_eq!(
+            backrefs.len(),
+            2,
+            "one chunk per (chunk_count.0 * chunk_count.1)"
+        );
+        assert!(
+            backrefs.iter().all(|&e| e == terrain_entity),
+            "every chunk's TerrainChunkOf must point at the Terrain entity it came from"
+        );
     }
 }

--- a/crates/bsengine-app/src/terrain.rs
+++ b/crates/bsengine-app/src/terrain.rs
@@ -134,9 +134,7 @@ fn generate_terrain_chunks(
                 bsengine_asset::AssetSlot::from_handle(asset_server.load::<TextureAsset>(p))
             });
             let splatmap = terrain.splatmap_path.as_ref().map(|p| {
-                bsengine_asset::AssetSlot::from_handle(
-                    asset_server.load::<TextureAsset>(p.clone()),
-                )
+                bsengine_asset::AssetSlot::from_handle(asset_server.load::<TextureAsset>(p.clone()))
             });
             commands.entity(entity).insert(PendingTerrain {
                 heightmap: bsengine_asset::AssetSlot::from_handle(heightmap_handle),

--- a/crates/bsengine-app/src/terrain_brush.rs
+++ b/crates/bsengine-app/src/terrain_brush.rs
@@ -6,12 +6,18 @@
 //! `generate_terrain_chunks` lives in this crate rather than in
 //! `bsengine-editor` or `bsengine-rhi-wgpu`.
 
+use crate::terrain::{Terrain, TerrainChunkOf, TerrainChunksGenerated};
 use bevy_app::{App, Plugin, Update};
-use bsengine_core::InspectorState;
-use bsengine_ecs::{Query, Res, ResMut};
+use bevy_ecs::prelude::{Local, Resource};
+use bsengine_core::{InspectorState, TerrainBrushKind, TerrainBrushStroke, Transform};
+use bsengine_ecs::{Entity, IntoSystemConfigs, Query, Res, ResMut, With};
 use bsengine_input::MouseState;
-use bsengine_physics::PhysicsWorld;
+use bsengine_physics::{Collider, ColliderShape, PhysicsWorld};
+use bsengine_render::components::TerrainSplat;
+use bsengine_render::MeshRenderer;
+use bsengine_rhi_wgpu::{GpuMeshRegistry, GpuQueueResource, GpuTextureRegistry};
 use glam::{Mat4, Vec3};
+use tracing::warn;
 
 /// Unprojects a screen-space point into a world-space ray, given the
 /// camera's combined view-projection matrix and its world position.
@@ -66,10 +72,7 @@ fn pick_terrain_under_cursor(
         return;
     };
     let cam_pos = Vec3::from(insp.editor_cam_pos);
-    let cursor = (
-        mouse_state.position.0 as f32,
-        mouse_state.position.1 as f32,
-    );
+    let cursor = (mouse_state.position.0 as f32, mouse_state.position.1 as f32);
     let (origin, dir) = screen_to_world_ray(
         Mat4::from_cols_array_2d(&view_proj),
         cam_pos,
@@ -85,12 +88,623 @@ fn pick_terrain_under_cursor(
     });
 }
 
-/// Bevy plugin that runs the terrain brush's picking system each frame.
+/// In-memory, full-resolution copy of the heightmap/splatmap grid an
+/// in-progress brush stroke is editing, if any.
+///
+/// **Design decision (where does edited grid data live between "chunk
+/// spawned" and "brush stroke commits" -- see this task's own design
+/// question):** a `Resource`, populated fresh from disk the first preview
+/// frame that actually touches a `Terrain`, mutated in place by every later
+/// preview frame, and cleared back to `TerrainBrushEditState::default()`
+/// once `commit_terrain_brush_stroke` finishes committing (or gives up).
+///
+/// This was chosen over the alternative the task sketch also names -- a
+/// permanent full-resolution copy `generate_terrain_chunks` (terrain.rs)
+/// populates once at chunk-spawn time and keeps alive on the `Terrain`
+/// entity forever. That alternative would cost *every* `Terrain` entity,
+/// including every shipped game that never opens the editor, a second full
+/// copy of its heightmap/splatmap in memory, permanently, for a feature
+/// only the editor ever uses. A stroke-scoped resource only exists while
+/// someone is actively dragging the brush, and `commit_terrain_brush_stroke`
+/// already has to hit disk at the *end* of every stroke anyway -- re-reading
+/// from disk at the *start* of one costs nothing new in kind, only in
+/// frequency (once per stroke, not once ever).
+///
+/// A `Resource` rather than a per-`Terrain` `Component`, because
+/// `InspectorState::terrain_brush_stroke` is a single `Option`, not one per
+/// entity -- at most one stroke is ever in flight at a time, so there is
+/// nothing to key by entity. A resource also sidesteps a real problem a
+/// component would have: populating it via `Commands::insert` on first
+/// touch would not be readable until the *next* frame (`Commands` are
+/// deferred to the next sync point), so the very first preview frame of
+/// every drag would silently do nothing. A `ResMut<TerrainBrushEditState>`
+/// can be populated and read within the same system call, the same frame a
+/// drag starts.
+///
+/// Edits are kept at full heightmap/splatmap resolution, not per-chunk,
+/// because `terrain_chunking::generate_chunks_with_splatmap`'s boundary
+/// row/column is shared between neighboring chunks (see its own doc
+/// comment) -- a brush stroke spanning a chunk boundary must edit that one
+/// shared source of truth once, not two independent per-chunk copies that
+/// could disagree at the seam.
+#[derive(Resource, Default)]
+struct TerrainBrushEditState {
+    /// Which `Terrain` entity (by index, matching
+    /// `TerrainBrushStroke::terrain_entity_id`) this edit belongs to. Lets a
+    /// stroke that jumps to a different terrain (or a stale leftover from a
+    /// previous stroke that somehow wasn't cleared) be detected and reset
+    /// rather than silently misapplied to the wrong terrain.
+    terrain_entity_id: Option<u64>,
+    /// Full-resolution raw height samples (row-major, same shape as
+    /// `HeightmapAsset::data`/the PNG at `Terrain::heightmap_path`). `Some`
+    /// once a `Height` stroke has actually touched this terrain this drag.
+    heights: Option<Vec<u16>>,
+    /// Full-resolution RGBA8 splat weights (row-major, same shape as a
+    /// decoded splatmap PNG). `Some` once a `Paint` stroke has actually
+    /// touched this terrain this drag.
+    weights: Option<Vec<u8>>,
+    /// Heightmap/splatmap pixel width; both grids share this (see
+    /// `terrain_chunking::SplatmapOverride`'s doc comment: a splatmap's
+    /// dimensions are assumed to match the heightmap's).
+    width: u32,
+    /// Heightmap/splatmap pixel height; see `width`.
+    height: u32,
+}
+
+/// Raw heightmap units (out of `u16::MAX`) a height stroke shifts the texel
+/// exactly at the brush center by, per frame, at `strength == 1.0` --
+/// scaled down by the smoothstep falloff for texels away from center, and
+/// linearly by `strength` itself (see `TerrainBrushSettings::strength`).
+/// Not tied to any real-world unit; chosen so a held brush visibly
+/// raises/lowers terrain over a couple dozen frames rather than jumping to
+/// a plateau on frame one.
+const HEIGHT_BRUSH_RATE: f32 = 3000.0;
+
+/// Raises (`raise == true`) or lowers raw heightmap samples within `radius`
+/// world units of `(local_x, local_z)` -- both already `Terrain`-local
+/// (the world-space brush position minus the `Terrain`'s own `Transform`).
+/// Falloff is smoothstep, from full effect at the center to zero at
+/// `radius`, so a brush edge blends rather than hard-stepping.
+fn apply_height_brush(
+    heights: &mut [u16],
+    width: u32,
+    height: u32,
+    params: &crate::terrain_chunking::ChunkParams,
+    local_x: f32,
+    local_z: f32,
+    radius: f32,
+    strength: f32,
+    raise: bool,
+) {
+    if width == 0 || height == 0 || radius <= 0.0 {
+        return;
+    }
+    let (step_x, step_z) = crate::terrain_chunking::texel_world_step(width, height, params);
+    let (center_x, center_z) =
+        crate::terrain_chunking::world_to_texel(local_x, local_z, width, height, params);
+    let radius_texels_x = (radius / step_x).ceil() as i32;
+    let radius_texels_z = (radius / step_z).ceil() as i32;
+    let strength = strength.clamp(0.0, 1.0);
+    let sign = if raise { 1.0 } else { -1.0 };
+
+    for dz in -radius_texels_z..=radius_texels_z {
+        for dx in -radius_texels_x..=radius_texels_x {
+            let hx = center_x as i32 + dx;
+            let hz = center_z as i32 + dz;
+            if hx < 0 || hz < 0 || hx >= width as i32 || hz >= height as i32 {
+                continue;
+            }
+            let wx = hx as f32 * step_x;
+            let wz = hz as f32 * step_z;
+            let dist = ((wx - local_x).powi(2) + (wz - local_z).powi(2)).sqrt();
+            if dist > radius {
+                continue;
+            }
+            let t = 1.0 - (dist / radius);
+            let falloff = t * t * (3.0 - 2.0 * t); // smoothstep
+            let delta = HEIGHT_BRUSH_RATE * strength * falloff * sign;
+            let idx = (hz as u32 * width + hx as u32) as usize;
+            let new_val = (heights[idx] as f32 + delta).clamp(0.0, u16::MAX as f32);
+            heights[idx] = new_val as u16;
+        }
+    }
+}
+
+/// Blends RGBA8 splat weights within `radius` world units of `(local_x,
+/// local_z)` towards a one-hot target vector for `layer` (0-3, matching
+/// `TerrainBrushKind::Paint::layer` and `splat_weight_for`'s [grass, rock,
+/// dirt, snow] channel order). Falloff and `strength` scale the per-frame
+/// lerp factor towards the target -- the same smoothstep shape
+/// `apply_height_brush` uses, but blended rather than additive: a paint
+/// brush converges on a target color, it doesn't accumulate without bound.
+fn apply_paint_brush(
+    weights: &mut [u8],
+    width: u32,
+    height: u32,
+    params: &crate::terrain_chunking::ChunkParams,
+    local_x: f32,
+    local_z: f32,
+    radius: f32,
+    strength: f32,
+    layer: u8,
+) {
+    if width == 0 || height == 0 || radius <= 0.0 {
+        return;
+    }
+    let layer = layer.min(3) as usize;
+    let (step_x, step_z) = crate::terrain_chunking::texel_world_step(width, height, params);
+    let (center_x, center_z) =
+        crate::terrain_chunking::world_to_texel(local_x, local_z, width, height, params);
+    let radius_texels_x = (radius / step_x).ceil() as i32;
+    let radius_texels_z = (radius / step_z).ceil() as i32;
+    let strength = strength.clamp(0.0, 1.0);
+
+    for dz in -radius_texels_z..=radius_texels_z {
+        for dx in -radius_texels_x..=radius_texels_x {
+            let hx = center_x as i32 + dx;
+            let hz = center_z as i32 + dz;
+            if hx < 0 || hz < 0 || hx >= width as i32 || hz >= height as i32 {
+                continue;
+            }
+            let wx = hx as f32 * step_x;
+            let wz = hz as f32 * step_z;
+            let dist = ((wx - local_x).powi(2) + (wz - local_z).powi(2)).sqrt();
+            if dist > radius {
+                continue;
+            }
+            let t = 1.0 - (dist / radius);
+            let t = t * t * (3.0 - 2.0 * t) * strength; // smoothstep * strength
+            let idx = ((hz as u32 * width + hx as u32) * 4) as usize;
+            for c in 0..4 {
+                let target = if c == layer { 255.0 } else { 0.0 };
+                let old = weights[idx + c] as f32;
+                weights[idx + c] = (old + (target - old) * t).clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+}
+
+/// Recovers a chunk entity's (cx, cz) grid coordinate from its own
+/// `Transform` and its `Terrain`'s, inverting the placement
+/// `generate_terrain_chunks` (terrain.rs) uses when it spawns each chunk at
+/// `transform.position + (chunk.world_offset.0, 0, chunk.world_offset.1)`
+/// where `world_offset == (cx * chunk_size, cz * chunk_size)`. Used instead
+/// of relying on `Query` iteration order, which nothing guarantees to
+/// preserve.
+fn chunk_grid_coords(
+    chunk_transform: &Transform,
+    terrain_transform: &Transform,
+    chunk_size: f32,
+) -> (i32, i32) {
+    let offset = chunk_transform.position.0 - terrain_transform.position.0;
+    (
+        (offset.x / chunk_size).round() as i32,
+        (offset.z / chunk_size).round() as i32,
+    )
+}
+
+/// Whether chunk `(cx, cz)`'s world-space AABB (size `chunk_size` per side)
+/// falls within `radius` of the `Terrain`-local brush center `(local_x,
+/// local_z)` -- a circle-vs-AABB overlap test (closest point on the box to
+/// the circle's center). Used to skip re-uploading chunks the brush isn't
+/// anywhere near.
+fn chunk_touches_brush(
+    cx: i32,
+    cz: i32,
+    chunk_size: f32,
+    local_x: f32,
+    local_z: f32,
+    radius: f32,
+) -> bool {
+    if cx < 0 || cz < 0 {
+        return false;
+    }
+    let min_x = cx as f32 * chunk_size;
+    let min_z = cz as f32 * chunk_size;
+    let closest_x = local_x.clamp(min_x, min_x + chunk_size);
+    let closest_z = local_z.clamp(min_z, min_z + chunk_size);
+    let dx = local_x - closest_x;
+    let dz = local_z - closest_z;
+    (dx * dx + dz * dz).sqrt() <= radius
+}
+
+/// Row-major index into `generate_chunks`/`generate_chunks_with_splatmap`'s
+/// output for grid coordinate `(cx, cz)`, matching that function's own `for
+/// cz { for cx { chunks.push(..) } }` iteration/push order. `chunks_x` is
+/// `params.chunk_count.0`.
+fn chunk_index(cx: i32, cz: i32, chunks_x: u32, total: usize) -> Option<usize> {
+    if cx < 0 || cz < 0 {
+        return None;
+    }
+    let idx = (cz as u32 * chunks_x + cx as u32) as usize;
+    (idx < total).then_some(idx)
+}
+
+/// Derives a fresh splatmap path from `heightmap_path` the first time a
+/// paint stroke touches a `Terrain` with no `splatmap_path` yet --
+/// `"terrain/hills.png"` -> `"terrain/hills_splatmap.png"`, alongside the
+/// heightmap. Always forward-slash, matching this codebase's convention for
+/// authored asset paths.
+fn default_splatmap_path(heightmap_path: &str) -> String {
+    let path = std::path::Path::new(heightmap_path);
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("terrain");
+    let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("png");
+    let file_name = format!("{stem}_splatmap.{ext}");
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => {
+            parent.join(&file_name).to_string_lossy().replace('\\', "/")
+        }
+        _ => file_name,
+    }
+}
+
+/// Every frame `InspectorState::terrain_brush_stroke` is `Some`, mutates
+/// `TerrainBrushEditState`'s in-memory grid and re-uploads every touched
+/// chunk's full vertex buffer (`Height`) or weight texture (`Paint`) --
+/// live preview only, no physics or disk I/O (`commit_terrain_brush_stroke`
+/// below handles those once the drag ends).
+///
+/// Recomputes the whole terrain's chunk geometry/weights in CPU memory each
+/// call (the same work `generate_terrain_chunks` already does once at spawn
+/// time, so it's cheap) but only re-uploads chunks the brush actually
+/// overlaps (`chunk_touches_brush`) -- full per-chunk buffers, not a partial
+/// sub-region diff, matching every other GPU update path in this codebase
+/// (`GpuMeshRegistry::update_vertices`/`GpuTextureRegistry::replace` have no
+/// partial-update variant to call instead).
+fn preview_terrain_brush_stroke(
+    inspector: Option<Res<InspectorState>>,
+    terrain_query: Query<(Entity, &Terrain, &Transform), With<TerrainChunksGenerated>>,
+    chunk_query: Query<(&Transform, &MeshRenderer, &TerrainSplat, &TerrainChunkOf)>,
+    mut edit_state: ResMut<TerrainBrushEditState>,
+    mut mesh_registry: Option<ResMut<GpuMeshRegistry>>,
+    mut tex_registry: Option<ResMut<GpuTextureRegistry>>,
+    gpu_queue: Option<Res<GpuQueueResource>>,
+) {
+    let Some(insp) = inspector else {
+        return;
+    };
+    let Some(stroke) = insp.terrain_brush_stroke else {
+        return;
+    };
+    let Some((terrain_entity, terrain, terrain_transform)) = terrain_query
+        .iter()
+        .find(|(e, _, _)| e.index() as u64 == stroke.terrain_entity_id)
+    else {
+        return;
+    };
+
+    if edit_state.terrain_entity_id != Some(stroke.terrain_entity_id) {
+        *edit_state = TerrainBrushEditState {
+            terrain_entity_id: Some(stroke.terrain_entity_id),
+            ..Default::default()
+        };
+    }
+
+    let params = crate::terrain_chunking::ChunkParams {
+        chunk_count: terrain.chunk_count,
+        chunk_size: terrain.chunk_size,
+        height_scale: terrain.height_scale,
+    };
+    let local = Vec3::from(stroke.world_pos) - terrain_transform.position.0;
+    let radius = insp.terrain_brush_settings.radius;
+    let strength = insp.terrain_brush_settings.strength;
+
+    match insp.terrain_brush_settings.kind {
+        TerrainBrushKind::Height { raise } => {
+            if edit_state.heights.is_none() {
+                match std::fs::read(&terrain.heightmap_path)
+                    .map_err(|e| e.to_string())
+                    .and_then(|bytes| {
+                        bsengine_asset::heightmap_loader::decode_heightmap_png(&bytes)
+                    }) {
+                    Ok(hm) => {
+                        edit_state.width = hm.width;
+                        edit_state.height = hm.height;
+                        edit_state.heights = Some(hm.data);
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[terrain-brush] could not load heightmap '{}' for preview: {e}",
+                            terrain.heightmap_path
+                        );
+                        return;
+                    }
+                }
+            }
+            let width = edit_state.width;
+            let height = edit_state.height;
+            let Some(heights) = edit_state.heights.as_mut() else {
+                return;
+            };
+
+            apply_height_brush(
+                heights, width, height, &params, local.x, local.z, radius, strength, raise,
+            );
+
+            let Some(mesh_reg) = mesh_registry.as_mut() else {
+                return;
+            };
+            let Some(queue) = gpu_queue.as_deref() else {
+                return;
+            };
+            let hm = bsengine_asset::HeightmapAsset {
+                width,
+                height,
+                data: heights.clone(),
+            };
+            let chunks = crate::terrain_chunking::generate_chunks(&hm, &params);
+            let chunks_x = params.chunk_count.0;
+
+            for (chunk_transform, mesh_renderer, _splat, chunk_of) in chunk_query.iter() {
+                if chunk_of.0 != terrain_entity {
+                    continue;
+                }
+                let (cx, cz) =
+                    chunk_grid_coords(chunk_transform, terrain_transform, params.chunk_size);
+                if !chunk_touches_brush(cx, cz, params.chunk_size, local.x, local.z, radius) {
+                    continue;
+                }
+                let Some(idx) = chunk_index(cx, cz, chunks_x, chunks.len()) else {
+                    continue;
+                };
+                if !mesh_reg.update_vertices(&queue.0, mesh_renderer.mesh_id, &chunks[idx].vertices)
+                {
+                    warn!("[terrain-brush] failed to upload preview vertices for a touched chunk");
+                }
+            }
+        }
+        TerrainBrushKind::Paint { layer } => {
+            if edit_state.weights.is_none() {
+                let seeded = terrain.splatmap_path.as_ref().and_then(|path| {
+                    image::open(path).ok().map(|img| {
+                        let rgba = img.to_rgba8();
+                        (rgba.width(), rgba.height(), rgba.into_raw())
+                    })
+                });
+                let (width, height, data) = match seeded {
+                    Some(v) => v,
+                    None => {
+                        // No splatmap yet (or it failed to load): seed from
+                        // the same procedural formula the chunks are
+                        // already rendering, so painting doesn't
+                        // discontinuously reset the rest of the terrain.
+                        match std::fs::read(&terrain.heightmap_path)
+                            .map_err(|e| e.to_string())
+                            .and_then(|bytes| {
+                                bsengine_asset::heightmap_loader::decode_heightmap_png(&bytes)
+                            }) {
+                            Ok(hm) => {
+                                let grid =
+                                    crate::terrain_chunking::procedural_splat_grid(&hm, &params);
+                                (hm.width, hm.height, grid)
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "[terrain-brush] could not load heightmap '{}' to seed \
+                                     paint preview: {e}",
+                                    terrain.heightmap_path
+                                );
+                                return;
+                            }
+                        }
+                    }
+                };
+                edit_state.width = width;
+                edit_state.height = height;
+                edit_state.weights = Some(data);
+            }
+            let width = edit_state.width;
+            let height = edit_state.height;
+            let Some(weights) = edit_state.weights.as_mut() else {
+                return;
+            };
+
+            apply_paint_brush(
+                weights, width, height, &params, local.x, local.z, radius, strength, layer,
+            );
+
+            let Some(tex_reg) = tex_registry.as_mut() else {
+                return;
+            };
+            // `generate_chunks_with_splatmap` always computes real vertex
+            // heights/normals too, even though a splatmap override makes
+            // its splat-weight output ignore them entirely -- so any
+            // correctly-shaped heightmap works here; the actual values in
+            // `dummy_hm.data` are never read for anything this branch uses.
+            let dummy_hm = bsengine_asset::HeightmapAsset {
+                width,
+                height,
+                data: vec![0u16; (width as usize) * (height as usize)],
+            };
+            let overlay = crate::terrain_chunking::SplatmapOverride {
+                width,
+                height,
+                data: weights.clone(),
+            };
+            let chunks = crate::terrain_chunking::generate_chunks_with_splatmap(
+                &dummy_hm,
+                &params,
+                Some(&overlay),
+            );
+            let chunks_x = params.chunk_count.0;
+
+            for (chunk_transform, _mesh_renderer, splat, chunk_of) in chunk_query.iter() {
+                if chunk_of.0 != terrain_entity {
+                    continue;
+                }
+                let (cx, cz) =
+                    chunk_grid_coords(chunk_transform, terrain_transform, params.chunk_size);
+                if !chunk_touches_brush(cx, cz, params.chunk_size, local.x, local.z, radius) {
+                    continue;
+                }
+                let Some(idx) = chunk_index(cx, cz, chunks_x, chunks.len()) else {
+                    continue;
+                };
+                let chunk = &chunks[idx];
+                let weight_bytes: Vec<u8> = chunk.splat_weights.iter().flatten().copied().collect();
+                if !tex_reg.replace(
+                    splat.weight_texture_id,
+                    chunk.heightfield_cols as u32,
+                    chunk.heightfield_rows as u32,
+                    &weight_bytes,
+                ) {
+                    warn!("[terrain-brush] failed to upload preview weights for a touched chunk");
+                }
+            }
+        }
+    }
+}
+
+/// Runs every frame; on the frame `InspectorState::terrain_brush_stroke`
+/// transitions from `Some` (last frame) to `None` (this frame) -- i.e. the
+/// drag just ended -- rebuilds the affected chunks' Rapier heightfield
+/// colliders and persists the edited grid to disk.
+///
+/// Uses `Local<Option<TerrainBrushStroke>>` (a per-system, non-shared
+/// value) rather than a new `InspectorState` field to detect the
+/// transition: nothing else in the engine needs to observe "did a stroke
+/// just end," so it doesn't belong on the shared editor blackboard
+/// resource.
+fn commit_terrain_brush_stroke(
+    inspector: Option<Res<InspectorState>>,
+    mut prev_stroke: Local<Option<TerrainBrushStroke>>,
+    mut terrain_query: Query<(Entity, &mut Terrain, &Transform), With<TerrainChunksGenerated>>,
+    mut chunk_query: Query<(Entity, &Transform, &TerrainChunkOf, &mut Collider)>,
+    mut edit_state: ResMut<TerrainBrushEditState>,
+    mut physics: Option<ResMut<PhysicsWorld>>,
+) {
+    let current = inspector.as_deref().and_then(|i| i.terrain_brush_stroke);
+    let previous = std::mem::replace(&mut *prev_stroke, current);
+
+    let Some(ended) = previous else {
+        return;
+    };
+    if current.is_some() {
+        return; // still dragging -- not a Some -> None transition
+    }
+
+    // Take (not just read) so a mid-commit early return below still leaves
+    // a clean slate for the next stroke, rather than a half-applied one
+    // that the next drag's first-touch check would mistake for its own.
+    let state = std::mem::take(&mut *edit_state);
+    if state.terrain_entity_id != Some(ended.terrain_entity_id) {
+        // Nothing was ever previewed for this stroke (e.g. no
+        // GpuMeshRegistry was ever available) -- nothing to commit.
+        return;
+    }
+
+    let Some((terrain_entity, mut terrain, terrain_transform)) = terrain_query
+        .iter_mut()
+        .find(|(e, _, _)| e.index() as u64 == ended.terrain_entity_id)
+    else {
+        return;
+    };
+
+    let params = crate::terrain_chunking::ChunkParams {
+        chunk_count: terrain.chunk_count,
+        chunk_size: terrain.chunk_size,
+        height_scale: terrain.height_scale,
+    };
+
+    if let Some(heights) = &state.heights {
+        match bsengine_asset::heightmap_loader::encode_heightmap_png(
+            state.width,
+            state.height,
+            heights,
+        ) {
+            Ok(bytes) => {
+                if let Err(e) = std::fs::write(&terrain.heightmap_path, bytes) {
+                    warn!(
+                        "[terrain-brush] failed to write heightmap '{}': {e}",
+                        terrain.heightmap_path
+                    );
+                }
+            }
+            Err(e) => warn!("[terrain-brush] failed to encode edited heightmap: {e}"),
+        }
+
+        // Rebuild every chunk's collider from the edited heightmap. Rebuilds
+        // every chunk of this terrain rather than tracking exactly which
+        // ones the stroke touched over the drag -- simpler, and correct
+        // regardless of how many chunks a stroke spanned; it only runs once
+        // per commit, not per frame.
+        let hm = bsengine_asset::HeightmapAsset {
+            width: state.width,
+            height: state.height,
+            data: heights.clone(),
+        };
+        let chunks = crate::terrain_chunking::generate_chunks(&hm, &params);
+        let chunks_x = params.chunk_count.0;
+        if let Some(physics) = physics.as_mut() {
+            for (chunk_entity, chunk_transform, chunk_of, mut collider) in chunk_query.iter_mut() {
+                if chunk_of.0 != terrain_entity {
+                    continue;
+                }
+                let (cx, cz) =
+                    chunk_grid_coords(chunk_transform, terrain_transform, params.chunk_size);
+                let Some(idx) = chunk_index(cx, cz, chunks_x, chunks.len()) else {
+                    continue;
+                };
+                let chunk = &chunks[idx];
+                let shape = ColliderShape::Heightfield {
+                    heights: chunk.heightfield_heights.clone(),
+                    rows: chunk.heightfield_rows,
+                    cols: chunk.heightfield_cols,
+                    scale: Vec3::new(params.chunk_size, 1.0, params.chunk_size).into(),
+                };
+                if !physics.set_collider_shape(chunk_entity, &shape) {
+                    warn!("[terrain-brush] failed to rebuild collider for a terrain chunk");
+                }
+                // Keep the ECS-visible `Collider` component in step with the
+                // Rapier-side shape `set_collider_shape` just rebuilt --
+                // chunks aren't scene-serialized (they're regenerated from
+                // the heightmap on next load), so this is purely for
+                // anything else that inspects `Collider.shape` at runtime.
+                collider.shape = shape;
+            }
+        }
+    }
+
+    if let Some(weights) = &state.weights {
+        let path = terrain
+            .splatmap_path
+            .clone()
+            .unwrap_or_else(|| default_splatmap_path(&terrain.heightmap_path));
+        match image::RgbaImage::from_raw(state.width, state.height, weights.clone()) {
+            Some(img) => match img.save(&path) {
+                Ok(()) => {
+                    if terrain.splatmap_path.is_none() {
+                        terrain.splatmap_path = Some(path);
+                    }
+                }
+                Err(e) => warn!("[terrain-brush] failed to write splatmap '{path}': {e}"),
+            },
+            None => warn!(
+                "[terrain-brush] edited splat weights did not match {}x{}",
+                state.width, state.height
+            ),
+        }
+    }
+}
+
+/// Bevy plugin that runs the terrain brush's picking, live-preview, and
+/// commit systems each frame, in that order.
 pub struct TerrainBrushPlugin;
 
 impl Plugin for TerrainBrushPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, pick_terrain_under_cursor);
+        app.init_resource::<TerrainBrushEditState>().add_systems(
+            Update,
+            (
+                pick_terrain_under_cursor,
+                preview_terrain_brush_stroke,
+                commit_terrain_brush_stroke,
+            )
+                .chain(),
+        );
     }
 }
 
@@ -105,8 +719,13 @@ mod tests {
         let view = Mat4::look_at_rh(cam_pos, Vec3::ZERO, Vec3::Y);
         let view_proj = proj * view;
 
-        let (origin, dir) =
-            screen_to_world_ray(view_proj, cam_pos, (640.0, 360.0), (0.0, 0.0), (1280.0, 720.0));
+        let (origin, dir) = screen_to_world_ray(
+            view_proj,
+            cam_pos,
+            (640.0, 360.0),
+            (0.0, 0.0),
+            (1280.0, 720.0),
+        );
 
         assert!((origin - cam_pos).length() < 1e-4);
         let expected_dir = (Vec3::ZERO - cam_pos).normalize();
@@ -198,5 +817,529 @@ mod tests {
 
         let insp = app.world().resource::<InspectorState>();
         assert_eq!(insp.terrain_pick, None);
+    }
+
+    // ---- apply_height_brush / apply_paint_brush: pure-function coverage ----
+    //
+    // These are the tests that actually prove a brush stroke computes
+    // different values than before -- see this module's `preview_terrain_
+    // brush_stroke` test below for why an end-to-end GPU-level assertion
+    // can't do this (no read-back API exists; `mesh.rs`'s own
+    // `update_vertices_overwrites_existing_buffer_contents` test hits the
+    // exact same wall and settles for "didn't panic, still registered").
+    // What actually reaches `update_vertices`/`GpuTextureRegistry::replace`
+    // is exactly the array these pure functions computed, so testing them
+    // directly is testing the real content of the upload.
+
+    fn flat_params() -> crate::terrain_chunking::ChunkParams {
+        crate::terrain_chunking::ChunkParams {
+            chunk_count: (1, 1),
+            chunk_size: 10.0,
+            height_scale: 20.0,
+        }
+    }
+
+    #[test]
+    fn apply_height_brush_raises_more_at_the_center_than_the_edge_and_leaves_outside_radius_untouched(
+    ) {
+        let width = 5;
+        let height = 5;
+        let mut heights = vec![10_000u16; (width * height) as usize];
+        let original = heights.clone();
+        let params = flat_params(); // chunk_size=10, chunk_count=(1,1) -> texel step = 10/5 = 2.0
+
+        // world (4.0, 4.0) lands exactly on texel (2, 2) -- an exact
+        // multiple of the 2.0 step, not a half-step, so `world_to_texel`'s
+        // rounding is unambiguous.
+        apply_height_brush(
+            &mut heights,
+            width,
+            height,
+            &params,
+            4.0,
+            4.0,
+            3.0,
+            1.0,
+            true,
+        );
+
+        let idx_at = |x: u32, z: u32| (z * width + x) as usize;
+        let center = idx_at(2, 2); // world (4.0, 4.0) at step 2.0 -> texel (2,2)
+        let near_edge = idx_at(1, 2); // world (2.0, 4.0): distance 2.0 < radius 3.0
+        let far_corner = idx_at(0, 0); // world (0,0): distance ~5.66 > radius 3.0
+
+        assert!(
+            heights[center] > original[center],
+            "the brush center should have been raised"
+        );
+        assert!(
+            heights[near_edge] > original[near_edge],
+            "a nearby texel should also have been raised"
+        );
+        assert!(
+            heights[near_edge] - original[near_edge] < heights[center] - original[center],
+            "falloff should make a texel farther from the center rise less than the center: \
+             center delta={}, near-edge delta={}",
+            heights[center] - original[center],
+            heights[near_edge] - original[near_edge]
+        );
+        assert_eq!(
+            heights[far_corner], original[far_corner],
+            "a texel outside the brush radius must be left untouched"
+        );
+    }
+
+    #[test]
+    fn apply_height_brush_lowers_when_raise_is_false() {
+        let width = 5;
+        let height = 5;
+        let mut heights = vec![10_000u16; (width * height) as usize];
+        let original = heights.clone();
+        let params = flat_params();
+
+        apply_height_brush(
+            &mut heights,
+            width,
+            height,
+            &params,
+            4.0,
+            4.0,
+            3.0,
+            1.0,
+            false,
+        );
+
+        let center = (2 * width + 2) as usize; // world (4.0, 4.0) at step 2.0 -> texel (2,2)
+        assert!(
+            heights[center] < original[center],
+            "raise=false should lower the brushed texel, got {} (was {})",
+            heights[center],
+            original[center]
+        );
+    }
+
+    #[test]
+    fn apply_height_brush_clamps_at_u16_max_instead_of_wrapping() {
+        let width = 3;
+        let height = 3;
+        let mut heights = vec![u16::MAX; (width * height) as usize];
+        let params = flat_params();
+
+        // Already saturated; raising further must clamp, not wrap around to
+        // a small number (which would silently invert the terrain).
+        apply_height_brush(
+            &mut heights,
+            width,
+            height,
+            &params,
+            5.0,
+            5.0,
+            10.0,
+            1.0,
+            true,
+        );
+
+        assert!(
+            heights.iter().all(|&h| h == u16::MAX),
+            "raising an already-saturated grid must clamp at u16::MAX, got {heights:?}"
+        );
+    }
+
+    #[test]
+    fn apply_paint_brush_blends_the_center_toward_the_target_layer() {
+        let width = 5;
+        let height = 5;
+        // Start fully grass (channel 0) everywhere, matching what
+        // `splat_weight_for` would produce for a flat, low terrain.
+        let mut weights = vec![0u8; (width * height * 4) as usize];
+        for px in weights.chunks_mut(4) {
+            px[0] = 255;
+        }
+        let params = flat_params();
+
+        // Paint layer 1 (rock) at the center with full strength.
+        apply_paint_brush(&mut weights, width, height, &params, 4.0, 4.0, 3.0, 1.0, 1);
+
+        let center = ((2 * width + 2) * 4) as usize; // world (4.0, 4.0) at step 2.0 -> texel (2,2)
+        assert!(
+            weights[center + 1] > weights[center],
+            "rock (channel 1) should now outweigh grass (channel 0) at the brush center, \
+             got {:?}",
+            &weights[center..center + 4]
+        );
+
+        let far_corner = 0usize; // world (0,0), outside radius 3.0
+        assert_eq!(
+            &weights[far_corner..far_corner + 4],
+            &[255, 0, 0, 0],
+            "a texel outside the brush radius must be left untouched"
+        );
+    }
+
+    // ---- end-to-end preview/commit tests ----
+
+    fn write_test_heightmap(name: &str, width: u32, height: u32, values: &[u16]) -> String {
+        let img: image::ImageBuffer<image::Luma<u16>, Vec<u16>> =
+            image::ImageBuffer::from_raw(width, height, values.to_vec())
+                .expect("test fixture dimensions must match values.len()");
+        let mut bytes = Vec::new();
+        image::DynamicImage::ImageLuma16(img)
+            .write_to(
+                &mut std::io::Cursor::new(&mut bytes),
+                image::ImageFormat::Png,
+            )
+            .expect("encoding the test fixture PNG failed");
+        let path = std::env::temp_dir().join(format!(
+            "bsengine_terrain_brush_test_{name}_{}.png",
+            std::process::id()
+        ));
+        std::fs::write(&path, bytes).expect("write test heightmap fixture");
+        path.to_str().unwrap().to_owned()
+    }
+
+    fn write_test_texture(name: &str, rgba: [u8; 4]) -> String {
+        let img = image::RgbaImage::from_pixel(2, 2, image::Rgba(rgba));
+        let path = std::env::temp_dir().join(format!(
+            "bsengine_terrain_brush_test_tex_{name}_{}.png",
+            std::process::id()
+        ));
+        img.save(&path).expect("write test texture fixture");
+        path.to_str().unwrap().to_owned()
+    }
+
+    /// Inserts real, headless `GpuMeshRegistry`/`GpuTextureRegistry`/
+    /// `GpuQueueResource` -- not stand-ins, the same types the renderer
+    /// uses. Mirrors `bsengine-gltf`'s own
+    /// `insert_headless_gpu_registries` test helper exactly (including
+    /// inserting `GpuQueueResource`, which `WgpuRHIPlugin::windowed()`
+    /// alone never does without a real window/surface): this module's
+    /// `preview_terrain_brush_stroke` needs all three, the same way
+    /// `bsengine-gltf`'s `update_skinned_meshes` does, so a helper that
+    /// only supplied the two registries would silently exclude this
+    /// system from every test built on it.
+    fn insert_headless_gpu_registries(app: &mut bevy_app::App) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::None,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .expect("a headless adapter; the rest of this suite already requires one");
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("bsengine-app terrain-brush test device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::default(),
+            },
+            None,
+        ))
+        .expect("headless device request");
+        let device = std::sync::Arc::new(device);
+        let queue = std::sync::Arc::new(queue);
+        app.insert_resource(GpuMeshRegistry::new(device.clone()));
+        app.insert_resource(GpuTextureRegistry::new(device, queue.clone()));
+        app.insert_resource(GpuQueueResource(queue));
+    }
+
+    /// An app with everything the terrain brush needs end-to-end: a real
+    /// `AssetServer`, real headless GPU registries, `PhysicsPlugin`,
+    /// `TerrainPlugin` (to actually spawn chunks), and `TerrainBrushPlugin`
+    /// itself.
+    fn brush_test_app() -> bevy_app::App {
+        let mut app = crate::new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(bsengine_rhi_wgpu::WgpuRHIPlugin::windowed());
+        app.add_plugins(bsengine_physics::PhysicsPlugin);
+        app.add_plugins(bsengine_input::InputPlugin);
+        app.add_plugins(crate::terrain::TerrainPlugin);
+        insert_headless_gpu_registries(&mut app);
+        app.insert_resource(InspectorState::default());
+        app.add_plugins(TerrainBrushPlugin);
+        app
+    }
+
+    fn spawn_flat_terrain(
+        app: &mut bevy_app::App,
+        name: &str,
+        width: u32,
+        height: u32,
+        flat_raw: u16,
+        chunk_count: (u32, u32),
+        chunk_size: f32,
+        height_scale: f32,
+    ) -> Entity {
+        let path = write_test_heightmap(
+            name,
+            width,
+            height,
+            &vec![flat_raw; (width * height) as usize],
+        );
+        app.world_mut()
+            .spawn((
+                Terrain {
+                    heightmap_path: path,
+                    chunk_count,
+                    chunk_size,
+                    height_scale,
+                    layer0_texture_path: write_test_texture(
+                        &format!("{name}-l0"),
+                        [50, 200, 50, 255],
+                    ),
+                    layer1_texture_path: write_test_texture(
+                        &format!("{name}-l1"),
+                        [120, 120, 120, 255],
+                    ),
+                    layer2_texture_path: write_test_texture(
+                        &format!("{name}-l2"),
+                        [110, 80, 40, 255],
+                    ),
+                    layer3_texture_path: write_test_texture(
+                        &format!("{name}-l3"),
+                        [240, 240, 250, 255],
+                    ),
+                    splatmap_path: None,
+                },
+                Transform::from_position(Vec3::ZERO),
+            ))
+            .id()
+    }
+
+    fn run_until_generated(app: &mut bevy_app::App, entity: Entity) {
+        for _ in 0..200 {
+            app.update();
+            if app
+                .world()
+                .get::<crate::terrain::TerrainChunksGenerated>(entity)
+                .is_some()
+            {
+                return;
+            }
+        }
+        panic!("terrain chunks were not generated within 200 frames");
+    }
+
+    /// End-to-end smoke test mirroring `mesh.rs`'s own
+    /// `update_vertices_overwrites_existing_buffer_contents` idiom: no GPU
+    /// read-back API exists, so this proves the real system runs against a
+    /// real `GpuMeshRegistry`/`GpuQueueResource` without panicking and
+    /// leaves the touched chunk's mesh registered -- the numeric proof that
+    /// different Y values were actually computed lives in the
+    /// `apply_height_brush` pure-function tests above, which is exactly
+    /// what gets forwarded into `update_vertices` here.
+    #[test]
+    fn preview_terrain_brush_stroke_runs_end_to_end_without_panicking_and_leaves_the_chunk_mesh_registered(
+    ) {
+        let mut app = brush_test_app();
+        let terrain_entity =
+            spawn_flat_terrain(&mut app, "preview", 4, 4, 20_000, (1, 1), 10.0, 20.0);
+        run_until_generated(&mut app, terrain_entity);
+
+        let mesh_id = {
+            let mut q = app.world_mut().query::<&MeshRenderer>();
+            q.iter(app.world()).next().expect("one chunk").mesh_id
+        };
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.terrain_brush_settings.kind = TerrainBrushKind::Height { raise: true };
+            insp.terrain_brush_settings.radius = 20.0;
+            insp.terrain_brush_settings.strength = 1.0;
+            insp.terrain_brush_stroke = Some(TerrainBrushStroke {
+                terrain_entity_id: terrain_entity.index() as u64,
+                world_pos: [5.0, 0.0, 5.0],
+            });
+        }
+        for _ in 0..5 {
+            app.update();
+        }
+
+        let mesh_registry = app.world().resource::<GpuMeshRegistry>();
+        assert!(
+            mesh_registry.get(mesh_id).is_some(),
+            "the touched chunk's mesh must still be registered after preview updates"
+        );
+    }
+
+    /// The physics regression test: proves `set_collider_shape` is actually
+    /// wired end-to-end by this task's systems (Task 2 already unit-tested
+    /// the method itself in isolation). Mirrors terrain.rs's own
+    /// `a_dropped_body_lands_on_the_chunk_it_visually_sits_above` in shape,
+    /// but drives the new height through a real held brush stroke and
+    /// commit first, then confirms a dropped body lands at whatever height
+    /// the brush actually produced (read back from the committed heightmap
+    /// PNG) rather than the original flat height -- so this test isn't
+    /// coupled to `HEIGHT_BRUSH_RATE`'s exact tuning value.
+    #[test]
+    fn held_height_stroke_then_commit_raises_where_a_dropped_body_lands() {
+        let mut app = brush_test_app();
+
+        let flat_raw: u16 = 20_000;
+        let height_scale = 20.0f32;
+        let chunk_size = 10.0f32;
+        let original_height = (flat_raw as f32 / u16::MAX as f32) * height_scale;
+
+        let terrain_entity = spawn_flat_terrain(
+            &mut app,
+            "physics-regression",
+            4,
+            4,
+            flat_raw,
+            (1, 1),
+            chunk_size,
+            height_scale,
+        );
+        run_until_generated(&mut app, terrain_entity);
+        let heightmap_path = app
+            .world()
+            .get::<Terrain>(terrain_entity)
+            .unwrap()
+            .heightmap_path
+            .clone();
+
+        let drop_xz = chunk_size / 2.0;
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.terrain_brush_settings.kind = TerrainBrushKind::Height { raise: true };
+            insp.terrain_brush_settings.radius = 20.0;
+            insp.terrain_brush_settings.strength = 1.0;
+            insp.terrain_brush_stroke = Some(TerrainBrushStroke {
+                terrain_entity_id: terrain_entity.index() as u64,
+                world_pos: [drop_xz, 0.0, drop_xz],
+            });
+        }
+        // Hold the drag for a few frames -- each frame nudges the center
+        // texel up by HEIGHT_BRUSH_RATE at full strength/falloff.
+        for _ in 0..5 {
+            app.update();
+        }
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.terrain_brush_stroke = None;
+        }
+        app.update(); // the Some -> None transition frame: commits
+
+        // Read back the actual height the brush produced, rather than
+        // hardcoding an expected value derived from HEIGHT_BRUSH_RATE.
+        let bytes = std::fs::read(&heightmap_path).expect("heightmap PNG should still exist");
+        let decoded = bsengine_asset::heightmap_loader::decode_heightmap_png(&bytes)
+            .expect("decode the committed heightmap");
+        let params = crate::terrain_chunking::ChunkParams {
+            chunk_count: (1, 1),
+            chunk_size,
+            height_scale,
+        };
+        let (tx, tz) = crate::terrain_chunking::world_to_texel(
+            drop_xz,
+            drop_xz,
+            decoded.width,
+            decoded.height,
+            &params,
+        );
+        let raw = decoded.data[(tz * decoded.width + tx) as usize];
+        let new_height = (raw as f32 / u16::MAX as f32) * height_scale;
+        assert!(
+            new_height > original_height + 0.5,
+            "the committed heightmap should be measurably higher than the original: \
+             new={new_height}, original={original_height}"
+        );
+
+        let radius = 0.5;
+        let start = Vec3::new(drop_xz, new_height + 10.0, drop_xz);
+        let ball = app
+            .world_mut()
+            .spawn((
+                Transform::from_position(start),
+                bsengine_physics::RigidBody::dynamic(),
+                bsengine_physics::Collider::ball(radius),
+                bsengine_physics::PhysicsInput {
+                    position: start.into(),
+                    rotation: glam::Quat::IDENTITY.into(),
+                },
+            ))
+            .id();
+
+        for _ in 0..200 {
+            app.update();
+        }
+
+        let y = app.world().get::<Transform>(ball).unwrap().position.0.y;
+        let expected = new_height + radius;
+        assert!(
+            (y - expected).abs() < 0.3,
+            "expected the ball to rest at the BRUSHED height y~={expected} (new terrain \
+             height {new_height}, original was {original_height}), but it settled at y={y} \
+             -- the collider does not reflect the brushed heightmap"
+        );
+        assert!(
+            (y - (original_height + radius)).abs() > 0.5,
+            "the ball must land at the NEW height, not the original -- got y={y}, original \
+             resting height would have been {}",
+            original_height + radius
+        );
+    }
+
+    /// Proves the heightmap PNG on disk actually changed after a commit.
+    #[test]
+    fn committing_a_height_stroke_writes_the_edited_heightmap_to_disk() {
+        let mut app = brush_test_app();
+        let flat_raw: u16 = 15_000;
+        let chunk_size = 10.0;
+        let height_scale = 20.0;
+        let terrain_entity = spawn_flat_terrain(
+            &mut app,
+            "disk-persistence",
+            4,
+            4,
+            flat_raw,
+            (1, 1),
+            chunk_size,
+            height_scale,
+        );
+        run_until_generated(&mut app, terrain_entity);
+        let heightmap_path = app
+            .world()
+            .get::<Terrain>(terrain_entity)
+            .unwrap()
+            .heightmap_path
+            .clone();
+
+        let original_bytes = std::fs::read(&heightmap_path).unwrap();
+        let original =
+            bsengine_asset::heightmap_loader::decode_heightmap_png(&original_bytes).unwrap();
+
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.terrain_brush_settings.kind = TerrainBrushKind::Height { raise: true };
+            insp.terrain_brush_settings.radius = 20.0;
+            insp.terrain_brush_settings.strength = 1.0;
+            insp.terrain_brush_stroke = Some(TerrainBrushStroke {
+                terrain_entity_id: terrain_entity.index() as u64,
+                world_pos: [chunk_size / 2.0, 0.0, chunk_size / 2.0],
+            });
+        }
+        for _ in 0..5 {
+            app.update();
+        }
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.terrain_brush_stroke = None;
+        }
+        app.update(); // commit frame
+
+        let edited_bytes =
+            std::fs::read(&heightmap_path).expect("heightmap PNG should still exist");
+        let edited = bsengine_asset::heightmap_loader::decode_heightmap_png(&edited_bytes)
+            .expect("decode the committed heightmap");
+
+        assert_eq!(edited.width, original.width);
+        assert_eq!(edited.height, original.height);
+        assert_ne!(
+            edited.data, original.data,
+            "committing a height stroke must actually change the on-disk heightmap"
+        );
     }
 }

--- a/crates/bsengine-app/src/terrain_brush.rs
+++ b/crates/bsengine-app/src/terrain_brush.rs
@@ -1,0 +1,202 @@
+//! Terrain brush tool: picking (screen -> world ray -> terrain surface
+//! point) and applying height/paint edits. All the "real work" lives here
+//! rather than in the editor UI crate (`bsengine-rhi-wgpu`) because this is
+//! the only crate with `PhysicsWorld`, `GpuMeshRegistry`, `GpuTextureRegistry`,
+//! and `InspectorState` all in reach at once -- the same reason
+//! `generate_terrain_chunks` lives in this crate rather than in
+//! `bsengine-editor` or `bsengine-rhi-wgpu`.
+
+use bevy_app::{App, Plugin, Update};
+use bsengine_core::InspectorState;
+use bsengine_ecs::{Query, Res, ResMut};
+use bsengine_input::MouseState;
+use bsengine_physics::PhysicsWorld;
+use glam::{Mat4, Vec3};
+
+/// Unprojects a screen-space point into a world-space ray, given the
+/// camera's combined view-projection matrix and its world position.
+/// Standard technique: unproject the near and far NDC points through the
+/// inverse view-projection matrix, then the ray direction is far - near.
+pub fn screen_to_world_ray(
+    view_proj: Mat4,
+    cam_pos: Vec3,
+    screen_pos: (f32, f32),
+    viewport_pos: (f32, f32),
+    viewport_size: (f32, f32),
+) -> (Vec3, Vec3) {
+    let ndc_x = ((screen_pos.0 - viewport_pos.0) / viewport_size.0) * 2.0 - 1.0;
+    let ndc_y = 1.0 - ((screen_pos.1 - viewport_pos.1) / viewport_size.1) * 2.0;
+    let inv_vp = view_proj.inverse();
+    let near = inv_vp * glam::Vec4::new(ndc_x, ndc_y, 0.0, 1.0);
+    let far = inv_vp * glam::Vec4::new(ndc_x, ndc_y, 1.0, 1.0);
+    let near_world = near.truncate() / near.w;
+    let far_world = far.truncate() / far.w;
+    let dir = (far_world - near_world).normalize();
+    (cam_pos, dir)
+}
+
+/// Every frame, if the editor is in terrain-brush mode and the cursor is
+/// over the viewport, raycasts from the camera through the cursor and
+/// writes the hit (if any, and if it landed on a `TerrainChunkOf` entity)
+/// into `InspectorState::terrain_pick`.
+///
+/// The raw cursor position comes from `bsengine_input::MouseState` (the
+/// same resource `bsengine-render`'s `render_frame` reads for its own
+/// cursor position, via `ms.position`) rather than from any field on
+/// `InspectorState`, which does not track raw screen coordinates.
+fn pick_terrain_under_cursor(
+    physics: Res<PhysicsWorld>,
+    chunk_query: Query<&crate::terrain::TerrainChunkOf>,
+    mut inspector: Option<ResMut<InspectorState>>,
+    mouse_state: Option<Res<MouseState>>,
+) {
+    let Some(insp) = inspector.as_mut() else {
+        return;
+    };
+    if !insp.terrain_brush_active || !insp.viewport_contains_cursor {
+        insp.terrain_pick = None;
+        return;
+    }
+    let Some(view_proj) = insp.editor_view_proj else {
+        insp.terrain_pick = None;
+        return;
+    };
+    let Some(mouse_state) = mouse_state.as_deref() else {
+        insp.terrain_pick = None;
+        return;
+    };
+    let cam_pos = Vec3::from(insp.editor_cam_pos);
+    let cursor = (
+        mouse_state.position.0 as f32,
+        mouse_state.position.1 as f32,
+    );
+    let (origin, dir) = screen_to_world_ray(
+        Mat4::from_cols_array_2d(&view_proj),
+        cam_pos,
+        cursor,
+        (insp.viewport_pos[0], insp.viewport_pos[1]),
+        (insp.viewport_size[0], insp.viewport_size[1]),
+    );
+    let hit = physics.cast_ray(origin, dir, 10_000.0);
+    insp.terrain_pick = hit.and_then(|h| {
+        let chunk_entity = h.entity?;
+        let owner = chunk_query.get(chunk_entity).ok()?;
+        Some((owner.0.index() as u64, h.point.to_array()))
+    });
+}
+
+/// Bevy plugin that runs the terrain brush's picking system each frame.
+pub struct TerrainBrushPlugin;
+
+impl Plugin for TerrainBrushPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, pick_terrain_under_cursor);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn screen_center_unprojects_to_the_camera_forward_direction() {
+        let cam_pos = Vec3::new(0.0, 5.0, 10.0);
+        let proj = Mat4::perspective_rh(60f32.to_radians(), 16.0 / 9.0, 0.1, 1000.0);
+        let view = Mat4::look_at_rh(cam_pos, Vec3::ZERO, Vec3::Y);
+        let view_proj = proj * view;
+
+        let (origin, dir) =
+            screen_to_world_ray(view_proj, cam_pos, (640.0, 360.0), (0.0, 0.0), (1280.0, 720.0));
+
+        assert!((origin - cam_pos).length() < 1e-4);
+        let expected_dir = (Vec3::ZERO - cam_pos).normalize();
+        assert!(
+            dir.dot(expected_dir) > 0.999,
+            "screen center should unproject close to the camera-forward direction, \
+             got dir={dir:?}, expected~={expected_dir:?}"
+        );
+    }
+
+    #[test]
+    fn a_ray_through_a_known_point_passes_near_it() {
+        // Camera looking straight down at the origin from above; the world
+        // point (2, 0, 0) should unproject from wherever its own screen
+        // projection is.
+        let cam_pos = Vec3::new(0.0, 10.0, 0.0);
+        let proj = Mat4::perspective_rh(60f32.to_radians(), 1.0, 0.1, 1000.0);
+        let view = Mat4::look_at_rh(cam_pos, Vec3::ZERO, Vec3::NEG_Z);
+        let view_proj = proj * view;
+
+        let target = Vec3::new(2.0, 0.0, 0.0);
+        let clip = view_proj * target.extend(1.0);
+        let ndc = clip.truncate() / clip.w;
+        let screen_x = (ndc.x * 0.5 + 0.5) * 800.0;
+        let screen_y = (1.0 - (ndc.y * 0.5 + 0.5)) * 800.0;
+
+        let (origin, dir) = screen_to_world_ray(
+            view_proj,
+            cam_pos,
+            (screen_x, screen_y),
+            (0.0, 0.0),
+            (800.0, 800.0),
+        );
+
+        // Distance from `target` to the infinite ray (origin, dir).
+        let to_target = target - origin;
+        let t = to_target.dot(dir);
+        let closest = origin + dir * t;
+        let dist = (closest - target).length();
+        assert!(
+            dist < 0.05,
+            "ray through target's own screen projection should pass within 5cm of it, got {dist}"
+        );
+    }
+
+    #[test]
+    fn terrain_brush_plugin_can_be_added_to_app() {
+        let mut app = crate::new_app();
+        app.add_plugins(bsengine_physics::PhysicsPlugin);
+        app.add_plugins(bsengine_input::InputPlugin);
+        app.insert_resource(InspectorState::default());
+        app.add_plugins(TerrainBrushPlugin);
+        app.update();
+    }
+
+    #[test]
+    fn inactive_brush_leaves_terrain_pick_none() {
+        let mut app = crate::new_app();
+        app.add_plugins(bsengine_physics::PhysicsPlugin);
+        app.add_plugins(bsengine_input::InputPlugin);
+        // `terrain_brush_active` defaults to false; the picking system must
+        // leave `terrain_pick` untouched (still `None`) rather than raycast.
+        app.insert_resource(InspectorState::default());
+        app.add_plugins(TerrainBrushPlugin);
+        app.update();
+
+        let insp = app.world().resource::<InspectorState>();
+        assert_eq!(insp.terrain_pick, None);
+    }
+
+    #[test]
+    fn active_brush_without_a_view_proj_leaves_terrain_pick_none() {
+        let mut app = crate::new_app();
+        app.add_plugins(bsengine_physics::PhysicsPlugin);
+        app.add_plugins(bsengine_input::InputPlugin);
+        // Active and hovered, but no camera matrix yet (e.g. before the
+        // editor viewport has rendered a first frame) -- must not panic and
+        // must leave the pick cleared rather than raycasting with stale data.
+        // Built via mutation, not struct-literal update syntax: InspectorState
+        // has private fields (e.g. `prev_selected_id`), so only this crate's
+        // own `Default` impl can construct one at all.
+        let mut inspector = InspectorState::default();
+        inspector.terrain_brush_active = true;
+        inspector.viewport_contains_cursor = true;
+        inspector.editor_view_proj = None;
+        app.insert_resource(inspector);
+        app.add_plugins(TerrainBrushPlugin);
+        app.update();
+
+        let insp = app.world().resource::<InspectorState>();
+        assert_eq!(insp.terrain_pick, None);
+    }
+}

--- a/crates/bsengine-app/src/terrain_chunking.rs
+++ b/crates/bsengine-app/src/terrain_chunking.rs
@@ -77,7 +77,12 @@ impl SplatmapOverride {
         let x = x.min(self.width - 1);
         let z = z.min(self.height - 1);
         let i = ((z * self.width + x) * 4) as usize;
-        [self.data[i], self.data[i + 1], self.data[i + 2], self.data[i + 3]]
+        [
+            self.data[i],
+            self.data[i + 1],
+            self.data[i + 2],
+            self.data[i + 3],
+        ]
     }
 }
 
@@ -89,6 +94,118 @@ pub struct ChunkParams {
     pub chunk_size: f32,
     /// Multiplier applied to the normalized heightmap sample.
     pub height_scale: f32,
+}
+
+/// Samples `heightmap` at texel `(x, z)` (clamped to its bounds) and scales
+/// it into world-space height units. Factored out of
+/// `generate_chunks_with_splatmap`'s own per-vertex loop (a top-level `fn`
+/// rather than the closure it used to be) so `procedural_splat_grid` below
+/// can reuse the exact same sampling -- both need "the height at this texel"
+/// and must never disagree about it.
+fn height_at(heightmap: &HeightmapAsset, height_scale: f32, x: u32, z: u32) -> f32 {
+    let x = x.min(heightmap.width - 1);
+    let z = z.min(heightmap.height - 1);
+    let raw = heightmap.data[(z * heightmap.width + x) as usize];
+    (raw as f32 / u16::MAX as f32) * height_scale
+}
+
+/// Central-difference surface normal at texel `(x, z)`, from the four
+/// neighboring texels. `world_step` scales the normal's Y component to
+/// match the actual world-space texel spacing (see
+/// `generate_chunks_with_splatmap`'s own use of this same formula). Shared
+/// with `procedural_splat_grid` for the same reason `height_at` is.
+fn normal_at(
+    heightmap: &HeightmapAsset,
+    height_scale: f32,
+    world_step: f32,
+    x: u32,
+    z: u32,
+) -> glam::Vec3 {
+    let hl = height_at(heightmap, height_scale, x.saturating_sub(1), z);
+    let hr = height_at(heightmap, height_scale, x + 1, z);
+    let hd = height_at(heightmap, height_scale, x, z.saturating_sub(1));
+    let hu = height_at(heightmap, height_scale, x, z + 1);
+    glam::Vec3::new(hl - hr, 2.0 * world_step, hd - hu).normalize()
+}
+
+/// World-space size, in world units, of one heightmap texel along x and z
+/// respectively, given `params`. Assumes `heightmap_width`/`heightmap_height`
+/// divide evenly by `params.chunk_count` on each axis -- the common case,
+/// and the same case `generate_chunks_with_splatmap` itself favors (see its
+/// doc comment on remainder absorption). When they don't divide evenly, the
+/// real last chunk along that axis is very slightly denser than this
+/// returns (it absorbed the leftover texels), so callers that use this for
+/// world<->texel conversion (the terrain brush tool) are very slightly off
+/// only within that one edge chunk. Getting that edge case pixel-perfect is
+/// out of scope for the terrain brush's first working version -- see
+/// `world_to_texel`'s doc comment.
+pub(crate) fn texel_world_step(
+    heightmap_width: u32,
+    heightmap_height: u32,
+    params: &ChunkParams,
+) -> (f32, f32) {
+    let base_texels_x = (heightmap_width / params.chunk_count.0.max(1)).max(1);
+    let base_texels_z = (heightmap_height / params.chunk_count.1.max(1)).max(1);
+    (
+        params.chunk_size / base_texels_x as f32,
+        params.chunk_size / base_texels_z as f32,
+    )
+}
+
+/// Converts a world-space, `Terrain`-local (x, z) offset (i.e. already
+/// relative to the `Terrain` entity's own `Transform`) into the
+/// corresponding heightmap texel coordinate -- the inverse of the vertex
+/// placement math in `generate_chunks_with_splatmap`, which places a
+/// chunk-local vertex at `[lx as f32 * world_step, y, lz as f32 *
+/// world_step]` and then offsets the whole chunk by `chunk.world_offset`
+/// (itself `cx as f32 * chunk_size`). For a resolution that divides evenly
+/// by `chunk_count`, `world_step` is the same in every chunk, so that
+/// composition collapses to exactly `texel_index as f32 * world_step` --
+/// which is what this inverts. Used by the terrain brush tool to turn a
+/// raycast hit's world position into "which texel did the user click."
+pub(crate) fn world_to_texel(
+    local_x: f32,
+    local_z: f32,
+    heightmap_width: u32,
+    heightmap_height: u32,
+    params: &ChunkParams,
+) -> (u32, u32) {
+    let (step_x, step_z) = texel_world_step(heightmap_width, heightmap_height, params);
+    let hx = (local_x / step_x)
+        .round()
+        .clamp(0.0, (heightmap_width.max(1) - 1) as f32) as u32;
+    let hz = (local_z / step_z)
+        .round()
+        .clamp(0.0, (heightmap_height.max(1) - 1) as f32) as u32;
+    (hx, hz)
+}
+
+/// Computes the full-resolution procedural splat-weight grid for the whole
+/// `heightmap` (row-major RGBA8, `width * height * 4` bytes), using the
+/// exact same per-texel `splat_weight_for` formula
+/// `generate_chunks_with_splatmap` applies per vertex -- just evaluated once
+/// over the whole heightmap instead of once per chunk (with duplicated
+/// boundary texels).
+///
+/// Used by the terrain brush tool to seed a paint stroke's starting weights
+/// when a `Terrain` has no splatmap yet: without this, the first paint
+/// stroke would reset every already-rendered texel in a touched chunk to an
+/// arbitrary default the moment that chunk's weight texture is re-uploaded
+/// (the brush re-uploads a whole touched chunk's buffer at once, not a
+/// sub-region diff), which would look like the rest of that chunk
+/// spontaneously re-texturing itself.
+pub(crate) fn procedural_splat_grid(heightmap: &HeightmapAsset, params: &ChunkParams) -> Vec<u8> {
+    let (world_step, _) = texel_world_step(heightmap.width, heightmap.height, params);
+    let mut out = Vec::with_capacity((heightmap.width * heightmap.height * 4) as usize);
+    for z in 0..heightmap.height {
+        for x in 0..heightmap.width {
+            let y = height_at(heightmap, params.height_scale, x, z);
+            let normal = normal_at(heightmap, params.height_scale, world_step, x, z);
+            let height_ratio = y / params.height_scale.max(0.0001);
+            out.extend_from_slice(&splat_weight_for(height_ratio, normal.y));
+        }
+    }
+    out
 }
 
 /// One chunk's generated geometry -- both the render mesh and the physics
@@ -138,13 +255,6 @@ pub fn generate_chunks_with_splatmap(
     let base_texels_x = heightmap.width / chunks_x;
     let base_texels_z = heightmap.height / chunks_z;
 
-    let height_at = |x: u32, z: u32| -> f32 {
-        let x = x.min(heightmap.width - 1);
-        let z = z.min(heightmap.height - 1);
-        let raw = heightmap.data[(z * heightmap.width + x) as usize];
-        (raw as f32 / u16::MAX as f32) * params.height_scale
-    };
-
     let mut chunks = Vec::with_capacity((chunks_x * chunks_z) as usize);
     for cz in 0..chunks_z {
         for cx in 0..chunks_x {
@@ -175,15 +285,11 @@ pub fn generate_chunks_with_splatmap(
                 for lx in 0..verts_x {
                     let hx = origin_x + lx;
                     let hz = origin_z + lz;
-                    let y = height_at(hx, hz);
+                    let y = height_at(heightmap, params.height_scale, hx, hz);
                     heightfield_heights.push(y);
 
                     // Central-difference normal from the four neighboring texels.
-                    let hl = height_at(hx.saturating_sub(1), hz);
-                    let hr = height_at(hx + 1, hz);
-                    let hd = height_at(hx, hz.saturating_sub(1));
-                    let hu = height_at(hx, hz + 1);
-                    let normal = glam::Vec3::new(hl - hr, 2.0 * world_step, hd - hu).normalize();
+                    let normal = normal_at(heightmap, params.height_scale, world_step, hx, hz);
 
                     let height_ratio = y / params.height_scale.max(0.0001);
                     splat_weights.push(match splatmap {

--- a/crates/bsengine-app/src/terrain_chunking.rs
+++ b/crates/bsengine-app/src/terrain_chunking.rs
@@ -59,6 +59,28 @@ fn splat_weight_for(height_ratio: f32, normal_y: f32) -> [u8; 4] {
     [to_u8(grass_w), to_u8(rock_w), 0u8, to_u8(snow_w)]
 }
 
+/// A whole-terrain splatmap already decoded to RGBA8 pixels, provided by
+/// the caller instead of letting `generate_chunks` compute weights
+/// procedurally. `width`/`height` must match the heightmap's own
+/// dimensions -- both describe the same terrain, sampled at the same grid.
+pub struct SplatmapOverride {
+    /// Splatmap width in pixels; expected to match the heightmap's width.
+    pub width: u32,
+    /// Splatmap height in pixels; expected to match the heightmap's height.
+    pub height: u32,
+    /// Decoded RGBA8 pixel data, row-major, `width * height * 4` bytes long.
+    pub data: Vec<u8>,
+}
+
+impl SplatmapOverride {
+    fn sample(&self, x: u32, z: u32) -> [u8; 4] {
+        let x = x.min(self.width - 1);
+        let z = z.min(self.height - 1);
+        let i = ((z * self.width + x) * 4) as usize;
+        [self.data[i], self.data[i + 1], self.data[i + 2], self.data[i + 3]]
+    }
+}
+
 /// Chunking configuration for one `Terrain` entity.
 pub struct ChunkParams {
     /// Number of chunks along (x, z).
@@ -99,6 +121,19 @@ pub struct ChunkData {
 /// `heightmap`'s resolution doesn't evenly divide `chunk_count`, the
 /// remainder is absorbed into the last chunk along that axis.
 pub fn generate_chunks(heightmap: &HeightmapAsset, params: &ChunkParams) -> Vec<ChunkData> {
+    generate_chunks_with_splatmap(heightmap, params, None)
+}
+
+/// Same as `generate_chunks`, but when `splatmap` is `Some`, every vertex's
+/// splat weight is sampled from it instead of computed procedurally via
+/// `splat_weight_for`. `splatmap`'s dimensions are assumed to match
+/// `heightmap`'s (the terrain brush tool is responsible for keeping the two
+/// files the same size when it creates a splatmap).
+pub fn generate_chunks_with_splatmap(
+    heightmap: &HeightmapAsset,
+    params: &ChunkParams,
+    splatmap: Option<&SplatmapOverride>,
+) -> Vec<ChunkData> {
     let (chunks_x, chunks_z) = params.chunk_count;
     let base_texels_x = heightmap.width / chunks_x;
     let base_texels_z = heightmap.height / chunks_z;
@@ -151,7 +186,10 @@ pub fn generate_chunks(heightmap: &HeightmapAsset, params: &ChunkParams) -> Vec<
                     let normal = glam::Vec3::new(hl - hr, 2.0 * world_step, hd - hu).normalize();
 
                     let height_ratio = y / params.height_scale.max(0.0001);
-                    splat_weights.push(splat_weight_for(height_ratio, normal.y));
+                    splat_weights.push(match splatmap {
+                        Some(sm) => sm.sample(hx, hz),
+                        None => splat_weight_for(height_ratio, normal.y),
+                    });
 
                     vertices.push(Vertex {
                         position: [lx as f32 * world_step, y, lz as f32 * world_step],
@@ -338,6 +376,53 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn a_provided_splatmap_overrides_procedural_weights() {
+        let hm = test_heightmap(); // existing 5x5 helper already in this file
+        let params = ChunkParams {
+            chunk_count: (1, 1),
+            chunk_size: 10.0,
+            height_scale: 1.0,
+        };
+        // A splatmap that's 100% layer1 (rock) everywhere -- the opposite of
+        // what the flat, low, un-sloped test_heightmap() would generate
+        // procedurally (which would be grass-dominant).
+        let splatmap_rgba: Vec<u8> = std::iter::repeat([0u8, 255, 0, 0])
+            .take(5 * 5)
+            .flatten()
+            .collect();
+        let splatmap = SplatmapOverride {
+            width: 5,
+            height: 5,
+            data: splatmap_rgba,
+        };
+
+        let chunks = generate_chunks_with_splatmap(&hm, &params, Some(&splatmap));
+        let chunk = &chunks[0];
+        for w in &chunk.splat_weights {
+            assert_eq!(
+                *w,
+                [0, 255, 0, 0],
+                "every weight should come from the provided splatmap, not procedural generation"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_chunks_without_a_splatmap_is_unchanged() {
+        // Regression: the existing procedural path (no splatmap) must still
+        // produce exactly what generate_chunks always produced.
+        let hm = test_heightmap();
+        let params = ChunkParams {
+            chunk_count: (1, 1),
+            chunk_size: 10.0,
+            height_scale: 1.0,
+        };
+        let via_old_fn = generate_chunks(&hm, &params);
+        let via_new_fn = generate_chunks_with_splatmap(&hm, &params, None);
+        assert_eq!(via_old_fn[0].splat_weights, via_new_fn[0].splat_weights);
     }
 
     #[test]

--- a/crates/bsengine-asset/src/heightmap_loader.rs
+++ b/crates/bsengine-asset/src/heightmap_loader.rs
@@ -25,6 +25,28 @@ pub(crate) fn decode_heightmap_png(bytes: &[u8]) -> Result<HeightmapAsset, Strin
     })
 }
 
+/// Encodes `data` (row-major, `width * height` long) as a 16-bit grayscale
+/// PNG -- the inverse of `decode_heightmap_png`. Used by the terrain brush
+/// tool to persist an edited heightmap back to the same file
+/// `Terrain::heightmap_path` already points to.
+pub fn encode_heightmap_png(width: u32, height: u32, data: &[u16]) -> Result<Vec<u8>, String> {
+    if data.len() as u32 != width * height {
+        return Err(format!(
+            "encode: expected {} samples ({width}x{height}), got {}",
+            width * height,
+            data.len()
+        ));
+    }
+    let img: image::ImageBuffer<image::Luma<u16>, Vec<u16>> =
+        image::ImageBuffer::from_raw(width, height, data.to_vec())
+            .ok_or_else(|| "encode: failed to build image buffer".to_string())?;
+    let mut bytes = Vec::new();
+    image::DynamicImage::ImageLuma16(img)
+        .write_to(&mut std::io::Cursor::new(&mut bytes), image::ImageFormat::Png)
+        .map_err(|e| format!("encode: {e}"))?;
+    Ok(bytes)
+}
+
 /// Backs `LoadMode::Async` for heightmaps via `AssetServer::load` --
 /// see `load_mode.rs` for how `TextureAssetLoader` is wired the same way.
 #[derive(Default)]
@@ -83,5 +105,30 @@ mod tests {
     fn decode_fails_cleanly_on_non_image_bytes() {
         let err = decode_heightmap_png(b"not a png").unwrap_err();
         assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn encode_then_decode_round_trips_exactly() {
+        let width = 4;
+        let height = 3;
+        let values: Vec<u16> = (0..width * height).map(|i| (i as u16) * 1000).collect();
+
+        let png_bytes =
+            encode_heightmap_png(width, height, &values).expect("encode should succeed");
+        let decoded = decode_heightmap_png(&png_bytes).expect("decode should succeed");
+
+        assert_eq!(decoded.width, width);
+        assert_eq!(decoded.height, height);
+        assert_eq!(decoded.data, values);
+    }
+
+    #[test]
+    fn encode_rejects_a_length_mismatch() {
+        let err = encode_heightmap_png(4, 4, &[0u16; 3])
+            .expect_err("width*height must match data.len()");
+        assert!(
+            err.contains("16") && err.contains("3"),
+            "error should name both the expected and actual length: {err}"
+        );
     }
 }

--- a/crates/bsengine-asset/src/heightmap_loader.rs
+++ b/crates/bsengine-asset/src/heightmap_loader.rs
@@ -13,7 +13,14 @@ use crate::types::HeightmapAsset;
 /// decoded format (8-bit grayscale, RGB, etc.) into 16-bit grayscale, so a
 /// lower-precision source just loses precision it never had rather than
 /// failing to load.
-pub(crate) fn decode_heightmap_png(bytes: &[u8]) -> Result<HeightmapAsset, String> {
+///
+/// `pub`, not `pub(crate)`, for the same reason [`encode_heightmap_png`]
+/// already is: the terrain brush tool (`bsengine-app`'s `terrain_brush`
+/// module) needs to decode a `Terrain::heightmap_path` PNG straight from
+/// disk when a brush stroke first touches it (see that module's
+/// `TerrainBrushEditState` doc comment), and it lives in a different crate
+/// with no `AssetLoader` plumbing of its own to go through instead.
+pub fn decode_heightmap_png(bytes: &[u8]) -> Result<HeightmapAsset, String> {
     let img = image::load_from_memory(bytes)
         .map_err(|e| format!("decode: {e}"))?
         .to_luma16();
@@ -42,7 +49,10 @@ pub fn encode_heightmap_png(width: u32, height: u32, data: &[u16]) -> Result<Vec
             .ok_or_else(|| "encode: failed to build image buffer".to_string())?;
     let mut bytes = Vec::new();
     image::DynamicImage::ImageLuma16(img)
-        .write_to(&mut std::io::Cursor::new(&mut bytes), image::ImageFormat::Png)
+        .write_to(
+            &mut std::io::Cursor::new(&mut bytes),
+            image::ImageFormat::Png,
+        )
         .map_err(|e| format!("encode: {e}"))?;
     Ok(bytes)
 }
@@ -124,8 +134,8 @@ mod tests {
 
     #[test]
     fn encode_rejects_a_length_mismatch() {
-        let err = encode_heightmap_png(4, 4, &[0u16; 3])
-            .expect_err("width*height must match data.len()");
+        let err =
+            encode_heightmap_png(4, 4, &[0u16; 3]).expect_err("width*height must match data.len()");
         assert!(
             err.contains("16") && err.contains("3"),
             "error should name both the expected and actual length: {err}"

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -336,6 +336,9 @@ pub enum InspectorCmd {
         layer2_texture_path: String,
         /// Diffuse texture for the high-altitude splat layer (e.g. snow).
         layer3_texture_path: String,
+        /// Path to a splatmap image, or `None` to keep procedural splat
+        /// generation. Mirrors `Terrain::splatmap_path`.
+        splatmap_path: Option<String>,
     },
 }
 

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -1,4 +1,5 @@
 use bevy_ecs::prelude::Resource;
+use bevy_reflect::Reflect;
 
 /// Canonical set of recognized primitive-mesh kind strings, lowercase. This
 /// is the string format used by `InspectorEntityInfo.primitive` and
@@ -365,6 +366,64 @@ pub enum GizmoMode {
     Scale,
 }
 
+/// Which terrain-editing behavior a drag applies, and its parameters.
+/// Orthogonal to `GizmoMode` -- the terrain brush is a distinct tool, not
+/// a 4th gizmo mode, since it only makes sense while a `Terrain` entity is
+/// selected and mutates terrain data rather than a transform.
+#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
+pub enum TerrainBrushKind {
+    /// Raise (if `raise` is true) or lower the heightmap under the brush.
+    Height {
+        /// Whether the brush raises (`true`) or lowers (`false`) the terrain.
+        raise: bool,
+    },
+    /// Paint the given splat layer (0-3) under the brush.
+    Paint {
+        /// Splat layer index (0-3) to paint.
+        layer: u8,
+    },
+}
+
+/// Settings for the terrain brush tool, active whenever
+/// `InspectorState::terrain_brush_active` is true.
+#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
+pub struct TerrainBrushSettings {
+    /// Which terrain-editing behavior is active.
+    pub kind: TerrainBrushKind,
+    /// World-space radius of the brush.
+    pub radius: f32,
+    /// 0-1 strength applied per frame the brush is held over a point.
+    pub strength: f32,
+}
+
+impl Default for TerrainBrushSettings {
+    fn default() -> Self {
+        Self {
+            kind: TerrainBrushKind::Height { raise: true },
+            radius: 2.0,
+            strength: 0.5,
+        }
+    }
+}
+
+/// One frame's worth of "the brush is being applied here" intent, written
+/// by the viewport panel every frame a brush drag is active and read by
+/// `bsengine-app`'s terrain-brush-apply system (the only place with the
+/// `PhysicsWorld`/`GpuMeshRegistry`/`GpuTextureRegistry` access needed to
+/// actually mutate anything) -- the same "UI writes a blackboard field, a
+/// system elsewhere reads it" pattern `editor_view_proj` already uses.
+#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
+pub struct TerrainBrushStroke {
+    /// The `Terrain` entity being edited, by id (matches
+    /// `InspectorEntityInfo::id`/`InspectorCmd`'s existing `u64` entity-id
+    /// convention, not a raw `bevy_ecs::Entity`, since `InspectorState`
+    /// crosses the same crate boundary those already cross).
+    pub terrain_entity_id: u64,
+    /// World-space point the brush is centered on this frame (the picked
+    /// point on the terrain surface).
+    pub world_pos: [f32; 3],
+}
+
 /// Editor-side resource holding the current entity snapshot, selection,
 /// pending edit commands, and all viewport/gizmo/camera UI state.
 #[derive(Resource)]
@@ -448,6 +507,26 @@ pub struct InspectorState {
     /// Which viewport gizmo (translate/rotate) is currently active.
     pub gizmo_mode: GizmoMode,
 
+    // Terrain brush tool state. See `TerrainBrushKind`/`TerrainBrushSettings`/
+    // `TerrainBrushStroke` above for the full picture.
+    /// Whether the terrain brush tool is the active viewport tool. When
+    /// true, a drag over a selected `Terrain`'s surface paints instead of
+    /// manipulating the gizmo.
+    pub terrain_brush_active: bool,
+    /// Current brush parameters, editable via the brush settings popup.
+    pub terrain_brush_settings: TerrainBrushSettings,
+    /// This frame's picked point on a `Terrain`'s surface under the mouse,
+    /// written by `bsengine-app`'s picking system every frame, read by the
+    /// viewport panel to draw a brush cursor and to know where a drag
+    /// should paint. `None` when the mouse isn't over any terrain.
+    pub terrain_pick: Option<(u64, [f32; 3])>,
+    /// Set by the viewport panel every frame a brush drag is in progress;
+    /// cleared (`None`) the frame after a drag stops. `bsengine-app`'s
+    /// terrain-brush-apply system treats a stroke being present as "keep
+    /// live-previewing," and its *absence* immediately after having been
+    /// present as "commit: rebuild the collider and persist to disk."
+    pub terrain_brush_stroke: Option<TerrainBrushStroke>,
+
     // Translate-gizmo drag state (viewport panel). `gizmo_drag_axis` is
     // 0=X, 1=Y, 2=Z while a handle is being dragged.
     /// Axis (0=X, 1=Y, 2=Z) of the translate-gizmo handle currently being dragged, if any.
@@ -522,6 +601,10 @@ impl Default for InspectorState {
             editor_proj: [[0.0; 4]; 4],
             editor_cam_pos: [0.0; 3],
             gizmo_mode: GizmoMode::Translate,
+            terrain_brush_active: false,
+            terrain_brush_settings: TerrainBrushSettings::default(),
+            terrain_pick: None,
+            terrain_brush_stroke: None,
             gizmo_drag_axis: None,
             gizmo_drag_start_world: [0.0; 3],
             gizmo_drag_start_mouse: [0.0; 2],
@@ -631,5 +714,20 @@ mod tests {
     fn editor_cam_default_distance() {
         let s = InspectorState::default();
         assert!((s.cam_distance - 10.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn inspector_state_default_has_terrain_brush_inactive() {
+        let insp = InspectorState::default();
+        assert!(!insp.terrain_brush_active);
+        assert_eq!(insp.terrain_pick, None);
+        assert_eq!(insp.terrain_brush_stroke, None);
+    }
+
+    #[test]
+    fn terrain_brush_settings_default_is_a_raising_height_brush() {
+        let s = TerrainBrushSettings::default();
+        assert_eq!(s.kind, TerrainBrushKind::Height { raise: true });
+        assert!(s.radius > 0.0);
     }
 }

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -109,7 +109,8 @@ pub use follow::{Follow, LookAt};
 pub use global_transform::GlobalTransform;
 pub use hud_texts::HudTexts;
 pub use inspector::{
-    EditorPlayState, GizmoMode, InspectorCmd, InspectorEntityInfo, InspectorState, PRIMITIVE_KINDS,
+    EditorPlayState, GizmoMode, InspectorCmd, InspectorEntityInfo, InspectorState,
+    TerrainBrushKind, TerrainBrushSettings, TerrainBrushStroke, PRIMITIVE_KINDS,
 };
 pub use lifetime::Lifetime;
 pub use light::{DirectionalLight, PointLight, SpotLight};

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -162,6 +162,7 @@ fn process_editor_commands(
                 layer1_texture_path,
                 layer2_texture_path,
                 layer3_texture_path,
+                splatmap_path,
             } => {
                 let resolved =
                     bsengine_core::resolve_project_path(project_dir.as_deref(), &heightmap_path);
@@ -181,6 +182,8 @@ fn process_editor_commands(
                     project_dir.as_deref(),
                     &layer3_texture_path,
                 );
+                let splatmap_resolved = splatmap_path
+                    .map(|p| bsengine_core::resolve_project_path(project_dir.as_deref(), &p));
                 // `bsengine_scene::Terrain`, not `bsengine_app::terrain::Terrain`
                 // (though `bsengine-app`'s module re-exports the same type under
                 // that path): `bsengine-app` depends on `bsengine-editor`, so
@@ -196,6 +199,7 @@ fn process_editor_commands(
                         layer1_texture_path: layer1_resolved,
                         layer2_texture_path: layer2_resolved,
                         layer3_texture_path: layer3_resolved,
+                        splatmap_path: splatmap_resolved,
                     },
                     Transform::default(),
                     GlobalTransform::default(),
@@ -1971,6 +1975,7 @@ fn apply_inspector_cmds(
                 layer1_texture_path,
                 layer2_texture_path,
                 layer3_texture_path,
+                splatmap_path,
             } => {
                 queue.push(EditorCommand::SpawnTerrain {
                     heightmap_path,
@@ -1981,6 +1986,7 @@ fn apply_inspector_cmds(
                     layer1_texture_path,
                     layer2_texture_path,
                     layer3_texture_path,
+                    splatmap_path,
                 });
             }
             InspectorCmd::Despawn { id } => {
@@ -2485,7 +2491,8 @@ impl Plugin for EditorPlugin {
                         "layer0_texture_path": { "type": "string", "description": "Diffuse texture for the low/flat splat layer (e.g. grass)" },
                         "layer1_texture_path": { "type": "string", "description": "Diffuse texture for the steep-slope splat layer (e.g. rock)" },
                         "layer2_texture_path": { "type": "string", "description": "Diffuse texture for the paint-only splat layer (e.g. dirt)" },
-                        "layer3_texture_path": { "type": "string", "description": "Diffuse texture for the high-altitude splat layer (e.g. snow)" }
+                        "layer3_texture_path": { "type": "string", "description": "Diffuse texture for the high-altitude splat layer (e.g. snow)" },
+                        "splatmap_path": { "type": "string", "description": "Optional path to a whole-terrain RGBA8 splatmap image; omit to keep procedural splat generation" }
                     },
                     "required": ["heightmap_path", "chunk_count", "chunk_size", "height_scale", "layer0_texture_path", "layer1_texture_path", "layer2_texture_path", "layer3_texture_path"]
                 })),
@@ -2541,6 +2548,7 @@ impl Plugin for EditorPlugin {
                             return McpToolOutput::error("missing 'layer3_texture_path' field")
                         }
                     };
+                    let splatmap_path = input["splatmap_path"].as_str().map(|s| s.to_string());
                     queue_terrain.lock().unwrap().push(EditorCommand::SpawnTerrain {
                         heightmap_path,
                         chunk_count,
@@ -2550,6 +2558,7 @@ impl Plugin for EditorPlugin {
                         layer1_texture_path,
                         layer2_texture_path,
                         layer3_texture_path,
+                        splatmap_path,
                     });
                     McpToolOutput::success(json!({"status": "queued"}))
                 }),
@@ -31322,6 +31331,53 @@ mod tests {
         assert_eq!(terrain.layer1_texture_path, "assets/terrain/rock.png");
         assert_eq!(terrain.layer2_texture_path, "assets/terrain/dirt.png");
         assert_eq!(terrain.layer3_texture_path, "assets/terrain/snow.png");
+    }
+
+    /// `splatmap_path` is the one optional `terrain_write` arg (the other 6
+    /// are `required`); the test above proves omitting it still works, and
+    /// this proves the field round-trips onto the spawned `Terrain` when the
+    /// caller does provide it.
+    #[test]
+    fn mcp_terrain_write_threads_an_optional_splatmap_path_through_when_given() {
+        let mut app = new_app();
+        app.add_plugins(McpPlugin);
+        app.add_plugins(EditorPlugin);
+        app.update();
+
+        {
+            let mcp = app.world().resource::<bsengine_mcp::McpRegistryResource>();
+            let out = mcp
+                .0
+                .lock()
+                .unwrap()
+                .execute(
+                    "terrain_write",
+                    json!({
+                        "heightmap_path": "assets/terrain/test_heightmap.png",
+                        "chunk_count": [2, 2],
+                        "chunk_size": 32.0,
+                        "height_scale": 20.0,
+                        "layer0_texture_path": "assets/terrain/grass.png",
+                        "layer1_texture_path": "assets/terrain/rock.png",
+                        "layer2_texture_path": "assets/terrain/dirt.png",
+                        "layer3_texture_path": "assets/terrain/snow.png",
+                        "splatmap_path": "assets/terrain/splatmap.png",
+                    }),
+                )
+                .expect("terrain_write not registered");
+            assert!(out.is_ok(), "terrain_write failed: {:?}", out.error);
+        }
+        app.update();
+
+        let mut query = app.world_mut().query::<&bsengine_app::terrain::Terrain>();
+        let terrain = query
+            .iter(app.world())
+            .next()
+            .expect("expected one entity with a Terrain component");
+        assert_eq!(
+            terrain.splatmap_path.as_deref(),
+            Some("assets/terrain/splatmap.png")
+        );
     }
 
     #[test]

--- a/crates/bsengine-editor/src/snapshot.rs
+++ b/crates/bsengine-editor/src/snapshot.rs
@@ -417,6 +417,8 @@ pub enum EditorCommand {
         layer2_texture_path: String,
         /// Diffuse texture for the high-altitude splat layer (e.g. snow).
         layer3_texture_path: String,
+        /// Mirrors `Terrain::splatmap_path`.
+        splatmap_path: Option<String>,
     },
 }
 

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -302,7 +302,7 @@ fn sync_physics_input_from_transform_for_kinematic(
     }
 }
 
-fn make_shape(shape: &ColliderShape) -> SharedShape {
+pub(crate) fn make_shape(shape: &ColliderShape) -> SharedShape {
     match shape {
         ColliderShape::Box { half_extents } => {
             SharedShape::cuboid(half_extents.x, half_extents.y, half_extents.z)

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -472,6 +472,32 @@ impl PhysicsWorld {
         self.cast_ray_filtered(origin, dir, max_dist, QueryFilter::default())
     }
 
+    /// Rebuilds `entity`'s collider shape in place, keeping the same
+    /// `ColliderHandle` (so nothing referencing it, e.g. `PhysicsHandles`,
+    /// needs to change) -- the first place in this engine that mutates a
+    /// collider's shape after it was originally spawned. Returns whether
+    /// `entity` had a body with an attached collider to update.
+    pub fn set_collider_shape(
+        &mut self,
+        entity: Entity,
+        shape: &crate::components::ColliderShape,
+    ) -> bool {
+        let Some(&body_handle) = self.entity_body_map.get(&entity) else {
+            return false;
+        };
+        let Some(body) = self.rigid_body_set.get(body_handle) else {
+            return false;
+        };
+        let Some(&collider_handle) = body.colliders().first() else {
+            return false;
+        };
+        let Some(collider) = self.collider_set.get_mut(collider_handle) else {
+            return false;
+        };
+        collider.set_shape(crate::plugin::make_shape(shape));
+        true
+    }
+
     fn cast_ray_filtered(
         &self,
         origin: Vec3,
@@ -502,5 +528,74 @@ impl PhysicsWorld {
                     distance: t,
                 }
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_collider_shape_changes_where_a_raycast_hits() {
+        let mut world = PhysicsWorld::new(9.81);
+        // A flat box collider at the origin, top surface at y = 0.5.
+        let entity = bevy_ecs::prelude::Entity::from_raw(0);
+        let body = rapier3d::prelude::RigidBodyBuilder::fixed().build();
+        let body_handle = world.rigid_body_set.insert(body);
+        let shape = crate::plugin::make_shape(&crate::components::ColliderShape::Box {
+            half_extents: Vec3::new(1.0, 0.5, 1.0).into(),
+        });
+        let collider = rapier3d::prelude::ColliderBuilder::new(shape).build();
+        let collider_handle = world.add_collider(collider, body_handle);
+        world.collider_entity_map.insert(collider_handle, entity);
+        world.register_entity_body(entity, body_handle);
+
+        // The broad-phase BVH that `cast_ray` queries is only rebuilt inside
+        // `step()` (see `PhysicsPipeline::step`'s call to `broad_phase.update`
+        // in the vendored rapier3d source) -- inserting a collider directly
+        // via `add_collider` does not register it in the tree by itself. The
+        // body is fixed, so stepping does not move it; `&()` is rapier's
+        // built-in no-op `EventHandler`.
+        world.step(&());
+
+        let before = world.cast_ray(Vec3::new(0.0, 10.0, 0.0), Vec3::new(0.0, -1.0, 0.0), 100.0);
+        assert!(
+            (before.as_ref().unwrap().point.y - 0.5).abs() < 1e-4,
+            "sanity: ray should hit the original box's top face at y=0.5, got {:?}",
+            before
+        );
+
+        let changed = world.set_collider_shape(
+            entity,
+            &crate::components::ColliderShape::Box {
+                half_extents: Vec3::new(1.0, 2.0, 1.0).into(),
+            },
+        );
+        assert!(
+            changed,
+            "set_collider_shape must report success for a real entity"
+        );
+
+        // Same reason as above: the shape change needs a step to propagate
+        // into the broad-phase tree before a raycast will see it.
+        world.step(&());
+
+        let after = world.cast_ray(Vec3::new(0.0, 10.0, 0.0), Vec3::new(0.0, -1.0, 0.0), 100.0);
+        assert!(
+            (after.as_ref().unwrap().point.y - 2.0).abs() < 1e-4,
+            "after set_collider_shape, a raycast must hit the NEW shape's top face at y=2.0, \
+             got {:?} -- the collider was not actually rebuilt",
+            after
+        );
+    }
+
+    #[test]
+    fn set_collider_shape_reports_failure_for_an_unknown_entity() {
+        let mut world = PhysicsWorld::new(9.81);
+        let unknown = bevy_ecs::prelude::Entity::from_raw(999);
+        assert!(!world.set_collider_shape(
+            unknown,
+            &crate::components::ColliderShape::Sphere { radius: 1.0 }
+        ));
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/hierarchy.rs
@@ -360,6 +360,7 @@ impl EditorPanel for HierarchyPanel {
                 layer1_texture_path: String::new(),
                 layer2_texture_path: String::new(),
                 layer3_texture_path: String::new(),
+                splatmap_path: None,
             });
         }
     }

--- a/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/viewport.rs
@@ -356,10 +356,69 @@ impl EditorPanel for ViewportPanel {
             }
         }
 
+        // Terrain brush cursor + drag handling. Not nested inside
+        // `is_stopped` above -- `bsengine-app`'s picking system (the writer
+        // of `terrain_pick`) doesn't gate on play state either, so this
+        // stays consistent with the backend it drives rather than
+        // introducing a restriction Task 8 never imposed. All of the actual
+        // terrain mutation lives downstream (`bsengine-app`'s
+        // preview/commit systems reading `terrain_brush_stroke`); this
+        // block only turns a drag into that one shared field.
+        if insp.terrain_brush_active {
+            if let Some((terrain_id, world_pos)) = insp.terrain_pick {
+                if let Some(view_proj) = insp.editor_view_proj {
+                    // Ground-plane (Y=0 relative to the pick) ring of points
+                    // around the brush center, reusing the same
+                    // ring_points/world_to_screen helpers the rotate gizmo
+                    // already uses for its axis rings -- there's no
+                    // dedicated "draw a world-space circle" helper in
+                    // `gizmo` yet, so this reuses the two pieces of math it
+                    // does expose rather than duplicating the projection
+                    // logic here.
+                    let radius = insp.terrain_brush_settings.radius.max(0.01);
+                    let ring = crate::gizmo::ring_points(
+                        glam::Vec3::from(world_pos),
+                        crate::gizmo::AXIS_Y,
+                        radius,
+                    );
+                    let stroke = egui::Stroke::new(2.0, crate::theme::ACCENT);
+                    for i in 0..ring.len() {
+                        let j = (i + 1) % ring.len();
+                        if let (Some(a), Some(b)) = (
+                            crate::gizmo::world_to_screen(ring[i], &view_proj, panel_rect),
+                            crate::gizmo::world_to_screen(ring[j], &view_proj, panel_rect),
+                        ) {
+                            ui.painter().line_segment([a, b], stroke);
+                        }
+                    }
+                }
+
+                if response.dragged() {
+                    insp.terrain_brush_stroke = Some(bsengine_core::TerrainBrushStroke {
+                        terrain_entity_id: terrain_id,
+                        world_pos,
+                    });
+                } else if response.drag_stopped() {
+                    insp.terrain_brush_stroke = None;
+                }
+            } else {
+                insp.terrain_brush_stroke = None;
+            }
+        }
+
         egui::Area::new(egui::Id::new("viewport_mini_toolbar"))
             .fixed_pos(panel_rect.min + egui::vec2(8.0, 8.0))
             .show(ui.ctx(), |ui| {
                 egui::Frame::menu(ui.style()).show(ui, |ui| {
+                    // Toggling the tool and opening its settings popup share
+                    // the same click on purpose -- there's no separate gear
+                    // icon, so `toggle_popup` is called in lockstep with the
+                    // active flag: turning the brush on surfaces its
+                    // settings immediately, turning it off tucks them away
+                    // again rather than leaving a popup for an inactive tool.
+                    let terrain_brush_popup_id =
+                        ui.make_persistent_id("viewport_terrain_brush_settings_popup");
+                    let mut terrain_brush_button: Option<egui::Response> = None;
                     ui.horizontal(|ui| {
                         if ui
                             .selectable_label(
@@ -398,7 +457,101 @@ impl EditorPanel for ViewportPanel {
                         {
                             insp.show_grid = !insp.show_grid;
                         }
+
+                        // Explicit size, not a shrink-wrapped
+                        // `selectable_label` like its sibling buttons above --
+                        // this is the one button in the row paired with a
+                        // `popup_below_widget`, which derives the popup's
+                        // width from this response's rect and
+                        // `debug_assert!`s it non-negative, which a
+                        // near-zero shrink-wrapped width can violate under
+                        // the headless empty-font `Context` this panel is
+                        // tested with (same reasoning as `hierarchy.rs`'s
+                        // "Create Terrain" button).
+                        let brush_button_size = ui.spacing().interact_size;
+                        let response = ui
+                            .add_sized(
+                                brush_button_size,
+                                egui::SelectableLabel::new(
+                                    insp.terrain_brush_active,
+                                    egui_phosphor::regular::PAINT_BRUSH,
+                                ),
+                            )
+                            .on_hover_text("Terrain Brush");
+                        if response.clicked() {
+                            insp.terrain_brush_active = !insp.terrain_brush_active;
+                            ui.memory_mut(|m| m.toggle_popup(terrain_brush_popup_id));
+                        }
+                        terrain_brush_button = Some(response);
                     });
+
+                    if let Some(button_response) = &terrain_brush_button {
+                        egui::popup::popup_below_widget(
+                            ui,
+                            terrain_brush_popup_id,
+                            button_response,
+                            egui::popup::PopupCloseBehavior::CloseOnClickOutside,
+                            |ui| {
+                                ui.set_min_width(180.0);
+                                ui.label("Terrain Brush");
+                                ui.separator();
+
+                                let settings = &mut insp.terrain_brush_settings;
+                                let is_height = matches!(
+                                    settings.kind,
+                                    bsengine_core::TerrainBrushKind::Height { .. }
+                                );
+                                ui.horizontal(|ui| {
+                                    if ui.selectable_label(is_height, "Height").clicked()
+                                        && !is_height
+                                    {
+                                        settings.kind =
+                                            bsengine_core::TerrainBrushKind::Height { raise: true };
+                                    }
+                                    if ui.selectable_label(!is_height, "Paint").clicked()
+                                        && is_height
+                                    {
+                                        settings.kind =
+                                            bsengine_core::TerrainBrushKind::Paint { layer: 0 };
+                                    }
+                                });
+
+                                match &mut settings.kind {
+                                    bsengine_core::TerrainBrushKind::Height { raise } => {
+                                        ui.horizontal(|ui| {
+                                            if ui.selectable_label(*raise, "Raise").clicked() {
+                                                *raise = true;
+                                            }
+                                            if ui.selectable_label(!*raise, "Lower").clicked() {
+                                                *raise = false;
+                                            }
+                                        });
+                                    }
+                                    bsengine_core::TerrainBrushKind::Paint { layer } => {
+                                        ui.horizontal(|ui| {
+                                            for l in 0u8..4 {
+                                                if ui
+                                                    .selectable_label(*layer == l, l.to_string())
+                                                    .clicked()
+                                                {
+                                                    *layer = l;
+                                                }
+                                            }
+                                        });
+                                    }
+                                }
+
+                                ui.add(
+                                    egui::Slider::new(&mut settings.radius, 0.1..=50.0)
+                                        .text("Radius"),
+                                );
+                                ui.add(
+                                    egui::Slider::new(&mut settings.strength, 0.0..=1.0)
+                                        .text("Strength"),
+                                );
+                            },
+                        );
+                    }
                 });
             });
 
@@ -421,5 +574,271 @@ impl EditorPanel for ViewportPanel {
                     .extend(),
                 );
             });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_core::{InspectorEntityInfo, InspectorState};
+
+    /// Headless multi-frame harness for `ViewportPanel::ui`, following
+    /// `hierarchy.rs`'s `HierarchyHarness` exactly (same empty-font
+    /// `Context`, same `frame`/`click` shape) -- no equivalent harness
+    /// existed in this file before this task. `entities_snapshot` is always
+    /// empty: none of these tests exercise the camera-frustum overlay,
+    /// which is the only thing here that reads it.
+    struct ViewportHarness {
+        egui_ctx: egui::Context,
+        screen_rect: egui::Rect,
+        insp: InspectorState,
+        entities_snapshot: Vec<InspectorEntityInfo>,
+        panel: ViewportPanel,
+    }
+
+    impl ViewportHarness {
+        fn new() -> Self {
+            let egui_ctx = egui::Context::default();
+            egui_ctx.set_fonts(egui::FontDefinitions::empty());
+            Self {
+                egui_ctx,
+                screen_rect: egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(400.0, 400.0)),
+                insp: InspectorState::default(),
+                entities_snapshot: Vec::new(),
+                panel: ViewportPanel::default(),
+            }
+        }
+
+        /// Runs one frame with `events` delivered to it. Same "hit-tests
+        /// against the *previous* frame's widget rects" caveat as
+        /// `HierarchyHarness::frame` applies to any position read from this
+        /// call's own return value.
+        fn frame(&mut self, events: Vec<egui::Event>) -> egui::FullOutput {
+            self.egui_ctx.run(
+                egui::RawInput {
+                    screen_rect: Some(self.screen_rect),
+                    events,
+                    ..Default::default()
+                },
+                |egui_ctx| {
+                    egui::CentralPanel::default().show(egui_ctx, |ui| {
+                        let mut ctx = EditorPanelContext {
+                            insp: &mut self.insp,
+                            entities_snapshot: &self.entities_snapshot,
+                            cursor_pos: (0.0, 0.0),
+                            type_registry: None,
+                        };
+                        self.panel.ui(ui, &mut ctx);
+                    });
+                },
+            )
+        }
+
+        /// A frame that delivers a single press+release click at `pos`.
+        fn click(&mut self, pos: egui::Pos2) -> egui::FullOutput {
+            self.frame(vec![
+                egui::Event::PointerMoved(pos),
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ])
+        }
+
+        /// A frame that presses the primary button at `pos`, deliberately
+        /// *not* combined with any subsequent move in the same event list.
+        /// egui's own `InputState::is_decidedly_dragging` doc comment says
+        /// it "can return true on the same frame the drag is released, but
+        /// NOT on the first frame it was started", and its body explicitly
+        /// requires `!self.any_pressed()` -- so a press-and-move sent
+        /// together in one `RawInput` never reports `dragged() == true`,
+        /// confirmed empirically: the press must land on its own frame
+        /// first (its effect only visible to the *next* frame's snapshot,
+        /// which is itself computed from the *previous* frame's widget
+        /// rects per `interaction.rs`'s own `InteractionSnapshot` doc
+        /// comment -- "Calculated at the start of each frame based on:
+        /// Widget rects from previous frame").
+        fn press(&mut self, pos: egui::Pos2) -> egui::FullOutput {
+            self.frame(vec![
+                egui::Event::PointerMoved(pos),
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ])
+        }
+
+        /// A frame that moves the pointer to `pos` while the primary button
+        /// is still held down from an earlier `press()` call -- no new
+        /// `PointerButton` event, since egui's own button-down state
+        /// persists across frames until a release event arrives. This is
+        /// the frame on which `dragged()` actually first turns true (see
+        /// `press`'s doc comment).
+        fn drag_to(&mut self, pos: egui::Pos2) -> egui::FullOutput {
+            self.frame(vec![egui::Event::PointerMoved(pos)])
+        }
+
+        /// A frame that releases the primary button at `pos`, with no
+        /// preceding move -- for continuing an already-started drag from a
+        /// prior `drag()` call into a release.
+        fn release(&mut self, pos: egui::Pos2) -> egui::FullOutput {
+            self.frame(vec![egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::default(),
+            }])
+        }
+    }
+
+    /// Every literal string egui rendered as text in one frame, paired with
+    /// the position it was drawn at. Ported from `hierarchy.rs`'s identical
+    /// helper (itself ported from `inspector.rs`) -- see that copy's doc
+    /// comment for the full rationale. Toolbar icon buttons render their
+    /// `egui_phosphor` glyph as ordinary text (icon fonts are just unicode
+    /// characters), so this same helper locates them too: click the
+    /// returned `pos` as-is, with no "reach the centre" offset, since
+    /// `FontDefinitions::empty()` gives every galley zero size and a
+    /// top-down `Ui` centers a zero-sized widget's content on the padded
+    /// rect's own centre.
+    fn collect_rendered_texts_with_pos(
+        shapes: &[egui::epaint::ClippedShape],
+    ) -> Vec<(String, egui::Pos2)> {
+        fn walk(shape: &egui::Shape, out: &mut Vec<(String, egui::Pos2)>) {
+            match shape {
+                egui::Shape::Text(text_shape) => {
+                    out.push((text_shape.galley.text().to_string(), text_shape.pos))
+                }
+                egui::Shape::Vec(nested) => {
+                    for s in nested {
+                        walk(s, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut out = Vec::new();
+        for clipped in shapes {
+            walk(&clipped.shape, &mut out);
+        }
+        out
+    }
+
+    #[test]
+    fn clicking_the_brush_button_toggles_terrain_brush_active() {
+        let mut harness = ViewportHarness::new();
+        assert!(!harness.insp.terrain_brush_active);
+
+        // The toolbar lives inside an `egui::Area`, which -- unlike
+        // `HierarchyPanel`'s toolbar buttons, drawn directly on the panel's
+        // own `Ui` -- renders invisibly on the very first frame it's shown.
+        // That's egui's own "sizing pass" (see `Prepared::content_ui` in
+        // egui's `area.rs`: `if self.sizing_pass { ui_builder =
+        // ui_builder.sizing_pass().invisible(); }`), used to compute the
+        // Area's size before positioning it for real; it paints nothing
+        // that frame. One extra settle frame -- discarded here -- clears
+        // that before this test reads back a real button position.
+        harness.frame(vec![]);
+        let layout = harness.frame(vec![]);
+        let (_, brush_pos) = collect_rendered_texts_with_pos(&layout.shapes)
+            .into_iter()
+            .find(|(t, _)| t == egui_phosphor::regular::PAINT_BRUSH)
+            .expect("toolbar must render the terrain brush button's icon glyph");
+
+        harness.click(brush_pos);
+
+        assert!(
+            harness.insp.terrain_brush_active,
+            "clicking the brush button must activate it"
+        );
+
+        // Clicking again toggles it back off.
+        let layout2 = harness.frame(vec![]);
+        let (_, brush_pos2) = collect_rendered_texts_with_pos(&layout2.shapes)
+            .into_iter()
+            .find(|(t, _)| t == egui_phosphor::regular::PAINT_BRUSH)
+            .expect("brush button must still render after activation");
+        harness.click(brush_pos2);
+        assert!(
+            !harness.insp.terrain_brush_active,
+            "clicking the brush button again must deactivate it"
+        );
+    }
+
+    #[test]
+    fn dragging_while_a_terrain_pick_is_present_sets_a_brush_stroke() {
+        let mut harness = ViewportHarness::new();
+        harness.insp.terrain_brush_active = true;
+        harness.insp.terrain_pick = Some((42, [1.0, 0.0, 2.0]));
+
+        // Two settle frames, not one, are needed before the press -- the
+        // toolbar/stats-overlay `egui::Area`s each render their first-ever
+        // frame as an invisible "sizing pass" (see the comment in
+        // `clicking_the_brush_button_toggles_terrain_brush_active`), and
+        // during THAT pass their placeholder interact rect is egui's
+        // built-in `default_area_size`, which is large enough to cover
+        // most of this 400x400 test screen -- including (150,150)/
+        // (250,250) below. Since hit-testing a press always uses the
+        // *previous* frame's widget rects (see `HierarchyHarness::frame`'s
+        // doc comment in `hierarchy.rs`), pressing on settle frame 1's
+        // heels would hit-test against that oversized placeholder and
+        // misattribute the press to the toolbar Area instead of the
+        // viewport's own `response`. A second settle frame lets the Areas
+        // shrink to their real (small, corner-hugging) size first.
+        harness.frame(vec![]);
+        harness.frame(vec![]);
+
+        let from = egui::Pos2::new(150.0, 150.0);
+        let to = egui::Pos2::new(250.0, 250.0);
+        // The press and the move-while-held are deliberately two separate
+        // frames -- see `ViewportHarness::press`'s doc comment for why a
+        // single frame combining both never reports `dragged() == true`.
+        harness.press(from);
+        harness.drag_to(to);
+
+        let stroke = harness
+            .insp
+            .terrain_brush_stroke
+            .expect("dragging while a terrain pick is present must set a brush stroke");
+        assert_eq!(stroke.terrain_entity_id, 42);
+        assert_eq!(stroke.world_pos, [1.0, 0.0, 2.0]);
+    }
+
+    #[test]
+    fn releasing_the_drag_clears_the_brush_stroke() {
+        let mut harness = ViewportHarness::new();
+        harness.insp.terrain_brush_active = true;
+        harness.insp.terrain_pick = Some((42, [1.0, 0.0, 2.0]));
+
+        // See the equivalent two-settle-frame comment in
+        // `dragging_while_a_terrain_pick_is_present_sets_a_brush_stroke`.
+        harness.frame(vec![]);
+        harness.frame(vec![]);
+
+        let from = egui::Pos2::new(150.0, 150.0);
+        let to = egui::Pos2::new(250.0, 250.0);
+        harness.press(from);
+        harness.drag_to(to);
+        assert!(
+            harness.insp.terrain_brush_stroke.is_some(),
+            "precondition: the drag must have set a stroke before release can clear it"
+        );
+
+        harness.release(to);
+
+        assert_eq!(
+            harness.insp.terrain_brush_stroke, None,
+            "releasing the drag must clear the brush stroke"
+        );
     }
 }

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use bsengine_app::{
     new_app, AnimationPlugin, AnimationStateMachinePlugin, LifetimePlugin, NavMeshPlugin,
-    ParticlePlugin, TerrainPlugin, TimePlugin,
+    ParticlePlugin, TerrainBrushPlugin, TerrainPlugin, TimePlugin,
 };
 use bsengine_asset::{AssetIdentityPlugin, AssetPlugin, AssetStatusPlugin, AssetWatcherPlugin};
 use bsengine_audio::AudioPlugin;
@@ -208,6 +208,13 @@ fn run_windowed(project_dir: &str) {
         // so a `Terrain` entity in a real game would sit in the scene file
         // and never grow chunks -- the whole system was inert in production.
         .add_plugins(TerrainPlugin)
+        // Picks the terrain surface point under the cursor while the
+        // editor's terrain brush tool is active. Registered here, not just
+        // in bsengine-app's own test suite -- see TerrainPlugin's comment
+        // above for the exact gap (a plugin present in one host and absent
+        // in the other is a feature that works when you look at it and not
+        // when you test it) this follows the same precedent to avoid.
+        .add_plugins(TerrainBrushPlugin)
         .add_plugins(ScenePlugin::from_file(&scene_path))
         .add_plugins(ScriptingPlugin {
             project_dir: project_dir.to_string(),

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -7,7 +7,9 @@ use std::io::{self, BufRead, Write};
 
 use bevy_app::App;
 use bevy_ecs::event::Events;
-use bsengine_app::{LifetimePlugin, NavMeshPlugin, ParticlePlugin, TerrainPlugin, TimePlugin};
+use bsengine_app::{
+    LifetimePlugin, NavMeshPlugin, ParticlePlugin, TerrainBrushPlugin, TerrainPlugin, TimePlugin,
+};
 use bsengine_asset::{AssetIdentityPlugin, AssetPlugin, AssetStatusPlugin};
 use bsengine_audio::AudioPlugin;
 use bsengine_core::{EditorPlayState, InspectorState};
@@ -136,6 +138,10 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>, fast_rend
         // a headless E2E replay or `--test` session would never grow chunks
         // either -- the same silent-inert failure, just in the other host.
         .add_plugins(TerrainPlugin)
+        // Mirrors the windowed runtime (main.rs's run_windowed): the terrain
+        // brush's picking system, kept in both hosts for the same reason
+        // TerrainPlugin itself is -- see the comment there.
+        .add_plugins(TerrainBrushPlugin)
         .add_plugins(ScenePlugin::from_file(&scene_path))
         .add_plugins(ScriptingPlugin {
             project_dir: project_dir.to_string(),

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -1489,4 +1489,294 @@ mod tests {
             colors
         );
     }
+
+    /// Task 10 (roadmap item 44's final sub-step): proves a terrain brush
+    /// edit committed through the real `pick_terrain_under_cursor` ->
+    /// `preview_terrain_brush_stroke` -> `commit_terrain_brush_stroke` chain
+    /// (`TerrainBrushPlugin`, registered in `build_test_app` above the same
+    /// way `TerrainPlugin` is) actually survives a full scene reload -- not
+    /// just that the heightmap PNG on disk changed
+    /// (`bsengine-app::terrain_brush`'s own
+    /// `committing_a_height_stroke_writes_the_edited_heightmap_to_disk`
+    /// already proved that against a synthetic in-memory `Terrain`), but
+    /// that a *second*, independently-built `build_test_app` -- standing in
+    /// for "close and reopen the project" -- reads the edited PNG back off
+    /// disk and a dropped body actually lands at the new height, not the
+    /// original.
+    ///
+    /// Deliberately builds a small throwaway project under
+    /// `tempfile::tempdir()` (the same pattern
+    /// `moving_a_grandparent_moves_the_grandchild_on_screen` above uses)
+    /// rather than driving this against the committed `games/terrain-demo`
+    /// fixture: `heightmap.png` there is a shared, committed fixture two
+    /// other tests in this file
+    /// (`a_dynamic_body_dropped_above_terrain_demo_comes_to_rest_
+    /// supported_by_the_heightfield`,
+    /// `terrain_demo_renders_more_than_one_blended_color`) read as ground
+    /// truth, and `commit_terrain_brush_stroke` writes `std::fs::
+    /// write(&terrain.heightmap_path, ..)` for real. Mutating that shared
+    /// file here would need a guaranteed-restore mechanism (an RAII guard,
+    /// since a failed assertion must not skip the restore) that nothing
+    /// else in this codebase has needed before -- no existing test mutates
+    /// a committed fixture in place. A fresh temp project sidesteps that
+    /// entirely: nothing under `games/terrain-demo` is ever opened for
+    /// writing, so there is nothing to restore and no risk to `git status`
+    /// or to those other tests' fixture data.
+    ///
+    /// The temp project's scene authors `Terrain.heightmap_path`/
+    /// `layer*_texture_path` project-relative (`"assets/terrain/
+    /// heightmap.png"`, the same convention `games/terrain-demo`'s own
+    /// `main.ron` uses), *not* pre-built as absolute strings: `bsengine-
+    /// scene`'s scene deserializer (`plugin.rs`, the `Terrain`-specific
+    /// branch of its generic `components:` handling) already resolves
+    /// exactly those five fields through `bsengine_core::resolve_project_
+    /// path(project_dir, path)` -- i.e. `format!("{project_dir}/{path}")`
+    /// -- before the `Terrain` component is ever inserted. Since this
+    /// test's `project_dir` (passed to `build_test_app` below) is itself
+    /// absolute (`tempdir()`'s own path), the `Terrain` component that
+    /// actually lands on the `Ground` entity ends up with a fully absolute
+    /// `heightmap_path` regardless of the test binary's CWD -- which is
+    /// exactly what `commit_terrain_brush_stroke`'s verbatim `std::fs::
+    /// write(&terrain.heightmap_path, ..)` needs. (An earlier version of
+    /// this test pre-resolved the paths itself and embedded *those* in the
+    /// RON; `resolve_project_path` then prefixed `project_dir` onto an
+    /// already-absolute path a second time, producing a malformed
+    /// `<project_dir>/C:/Users/...` string and an OS "invalid filename"
+    /// error from `bevy_asset` -- project-relative paths in the RON, left
+    /// for the scene loader to resolve exactly once, are the correct
+    /// shape.)
+    #[test]
+    fn terrain_brush_edit_survives_a_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("assets/scenes")).unwrap();
+        std::fs::create_dir_all(root.join("assets/terrain")).unwrap();
+
+        // 4x4 texels, one 10x10-world-unit chunk, flat at raw=20_000 -- the
+        // exact fixture shape `bsengine-app::terrain_brush`'s own
+        // `held_height_stroke_then_commit_raises_where_a_dropped_body_lands`
+        // uses, since that combination is already proven to make a dropped
+        // ball's resting height track the brushed texel precisely.
+        let width = 4u32;
+        let height = 4u32;
+        let flat_raw: u16 = 20_000;
+        let height_scale = 20.0f32;
+        let chunk_size = 10.0f32;
+        let original_height = (flat_raw as f32 / u16::MAX as f32) * height_scale;
+
+        // Written directly under `root` (not through any path-resolution
+        // helper) since these are the real files the scene's
+        // project-relative `Terrain` paths, once resolved against
+        // `project_dir` (== `root`), must actually find on disk.
+        let heightmap_path = root.join("assets/terrain/heightmap.png");
+        let img: image::ImageBuffer<image::Luma<u16>, Vec<u16>> =
+            image::ImageBuffer::from_raw(width, height, vec![flat_raw; (width * height) as usize])
+                .unwrap();
+        image::DynamicImage::ImageLuma16(img)
+            .save(&heightmap_path)
+            .expect("write the temp project's fixture heightmap");
+
+        image::RgbaImage::from_pixel(2, 2, image::Rgba([80u8, 160, 80, 255]))
+            .save(root.join("assets/terrain/grass.png"))
+            .expect("write the temp project's fixture layer texture");
+        image::RgbaImage::from_pixel(2, 2, image::Rgba([120u8, 120, 120, 255]))
+            .save(root.join("assets/terrain/rock.png"))
+            .expect("write the temp project's fixture layer texture");
+        image::RgbaImage::from_pixel(2, 2, image::Rgba([110u8, 80, 40, 255]))
+            .save(root.join("assets/terrain/dirt.png"))
+            .expect("write the temp project's fixture layer texture");
+        image::RgbaImage::from_pixel(2, 2, image::Rgba([240u8, 240, 250, 255]))
+            .save(root.join("assets/terrain/snow.png"))
+            .expect("write the temp project's fixture layer texture");
+
+        std::fs::write(
+            root.join("project.toml"),
+            "[project]\nname = \"Terrain Brush E2E\"\nentry_scene = \"assets/scenes/main.ron\"\n",
+        )
+        .unwrap();
+
+        std::fs::write(
+            root.join("assets/scenes/main.ron"),
+            format!(
+                r#"SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Camera",
+        camera: true,
+        transform: Some((position: (5.0, 15.0, 25.0))),
+        look_at: Some((5.0, 0.0, 5.0)),
+    ),
+    EntityDescriptor(
+        name: "Ground",
+        transform: Some((position: (0.0, 0.0, 0.0))),
+        components: [
+            ("bsengine_scene::types::Terrain", "(heightmap_path: \"assets/terrain/heightmap.png\", chunk_count: (1, 1), chunk_size: {chunk_size:.1}, height_scale: {height_scale:.1}, layer0_texture_path: \"assets/terrain/grass.png\", layer1_texture_path: \"assets/terrain/rock.png\", layer2_texture_path: \"assets/terrain/dirt.png\", layer3_texture_path: \"assets/terrain/snow.png\", splatmap_path: None)"),
+        ],
+    ),
+])"#
+            ),
+        )
+        .unwrap();
+
+        let project_dir = root.to_str().unwrap().to_string();
+
+        // --- Phase 1: edit, through the real app stack ---
+        let mut app = build_test_app(&project_dir, None, false);
+
+        let mut terrain_ready = false;
+        for _ in 0..200 {
+            app.update();
+            let mut q = app.world_mut().query::<(
+                &bsengine_scene::Name,
+                Option<&bsengine_app::terrain::TerrainChunksGenerated>,
+            )>();
+            if q.iter(app.world())
+                .any(|(name, generated)| name.0 == "Ground" && generated.is_some())
+            {
+                terrain_ready = true;
+                break;
+            }
+        }
+        assert!(
+            terrain_ready,
+            "the temp project's Ground entity never finished generating chunks within \
+             200 frames"
+        );
+
+        let terrain_entity = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0 == "Ground")
+                .map(|(e, _)| e)
+                .expect("Ground should have spawned from the scene file")
+        };
+
+        // Hold a raising height stroke centered on the chunk for a few
+        // frames (mirrors `held_height_stroke_then_commit_raises_where_a_
+        // dropped_body_lands`'s exact pattern), then release it -- the
+        // Some -> None transition on the next `app.update()` is what
+        // `commit_terrain_brush_stroke` watches for.
+        let drop_xz = chunk_size / 2.0;
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.terrain_brush_settings.kind =
+                bsengine_core::TerrainBrushKind::Height { raise: true };
+            insp.terrain_brush_settings.radius = 20.0;
+            insp.terrain_brush_settings.strength = 1.0;
+            insp.terrain_brush_stroke = Some(bsengine_core::TerrainBrushStroke {
+                terrain_entity_id: terrain_entity.index() as u64,
+                world_pos: [drop_xz, 0.0, drop_xz],
+            });
+        }
+        for _ in 0..5 {
+            app.update();
+        }
+        {
+            let mut insp = app.world_mut().resource_mut::<InspectorState>();
+            insp.terrain_brush_stroke = None;
+        }
+        app.update(); // the Some -> None transition frame: commits to disk
+
+        // Confirm the heightmap PNG on disk actually changed -- re-decoded
+        // independently, not read back through any in-memory cache.
+        let edited_bytes = std::fs::read(&heightmap_path)
+            .expect("heightmap PNG should still exist after commit");
+        let edited = bsengine_asset::heightmap_loader::decode_heightmap_png(&edited_bytes)
+            .expect("decode the committed heightmap");
+        assert_eq!(edited.width, width);
+        assert_eq!(edited.height, height);
+        assert_ne!(
+            edited.data,
+            vec![flat_raw; (width * height) as usize],
+            "committing a height stroke must actually change the on-disk heightmap"
+        );
+
+        // `terrain_chunking::world_to_texel` (the real conversion
+        // `preview_terrain_brush_stroke`/`commit_terrain_brush_stroke` use)
+        // is `pub(crate)` to `bsengine-app`, unreachable from this crate --
+        // but with a single 1x1 chunk its formula collapses to
+        // `world / (chunk_size / texel_count)`, reproduced here directly.
+        let step = chunk_size / width as f32;
+        let tx = (drop_xz / step).round().clamp(0.0, (width - 1) as f32) as u32;
+        let tz = (drop_xz / step).round().clamp(0.0, (height - 1) as f32) as u32;
+        let raw = edited.data[(tz * edited.width + tx) as usize];
+        let new_height = (raw as f32 / u16::MAX as f32) * height_scale;
+        assert!(
+            new_height > original_height + 0.5,
+            "the committed heightmap should read measurably higher at the brushed texel: \
+             new={new_height}, original={original_height}"
+        );
+
+        // Release phase 1's app (and its GPU device/window-less surface)
+        // before building a second one below. This is deliberately two
+        // separate `App`s, not one continuing app: the property this test
+        // exists to prove is specifically that the edit survives a
+        // *reload* (a second app reading the same project fresh), not just
+        // that it survives while the first app stays resident in memory.
+        drop(app);
+
+        // --- Phase 2: reload, through a brand-new app pointed at the same
+        // project directory ---
+        let mut app = build_test_app(&project_dir, None, false);
+
+        let mut terrain_ready = false;
+        for _ in 0..200 {
+            app.update();
+            let mut q = app.world_mut().query::<(
+                &bsengine_scene::Name,
+                Option<&bsengine_app::terrain::TerrainChunksGenerated>,
+            )>();
+            if q.iter(app.world())
+                .any(|(name, generated)| name.0 == "Ground" && generated.is_some())
+            {
+                terrain_ready = true;
+                break;
+            }
+        }
+        assert!(
+            terrain_ready,
+            "the reloaded temp project's Ground entity never finished generating chunks \
+             within 200 frames"
+        );
+
+        let radius = 0.5f32;
+        let start = glam::Vec3::new(drop_xz, new_height + 10.0, drop_xz);
+        let ball = app
+            .world_mut()
+            .spawn((
+                bsengine_core::Transform::from_position(start),
+                bsengine_physics::RigidBody::dynamic(),
+                bsengine_physics::Collider::ball(radius),
+                bsengine_physics::PhysicsInput {
+                    position: start.into(),
+                    rotation: glam::Quat::IDENTITY.into(),
+                },
+            ))
+            .id();
+
+        for _ in 0..200 {
+            app.update();
+        }
+
+        let y = app
+            .world()
+            .get::<bsengine_core::Transform>(ball)
+            .unwrap()
+            .position
+            .0
+            .y;
+        let expected = new_height + radius;
+        assert!(
+            (y - expected).abs() < 0.3,
+            "expected the ball to rest at the BRUSHED height y~={expected} (reloaded \
+             terrain height {new_height} at the drop point, original was \
+             {original_height}), but it settled at y={y} -- the reloaded terrain does not \
+             reflect the committed edit"
+        );
+        assert!(
+            (y - (original_height + radius)).abs() > 0.5,
+            "the ball must land at the NEW height after reload, not the original -- got \
+             y={y}, original resting height would have been {}",
+            original_height + radius
+        );
+    }
 }

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -1678,8 +1678,8 @@ mod tests {
 
         // Confirm the heightmap PNG on disk actually changed -- re-decoded
         // independently, not read back through any in-memory cache.
-        let edited_bytes = std::fs::read(&heightmap_path)
-            .expect("heightmap PNG should still exist after commit");
+        let edited_bytes =
+            std::fs::read(&heightmap_path).expect("heightmap PNG should still exist after commit");
         let edited = bsengine_asset::heightmap_loader::decode_heightmap_png(&edited_bytes)
             .expect("decode the committed heightmap");
         assert_eq!(edited.width, width);

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -1866,7 +1866,7 @@ mod tests {
     fn scene_plugin_terrain_heightmap_path_resolves_against_project_dir() {
         let ron = r#"SceneDescriptor(entities: [
             EntityDescriptor(name: "Ground", components: [
-                ("bsengine_scene::types::Terrain", "(heightmap_path: \"terrain/hills.png\", chunk_count: (1, 1), chunk_size: 10.0, height_scale: 1.0, layer0_texture_path: \"terrain/grass.png\", layer1_texture_path: \"terrain/rock.png\", layer2_texture_path: \"terrain/dirt.png\", layer3_texture_path: \"terrain/snow.png\")"),
+                ("bsengine_scene::types::Terrain", "(heightmap_path: \"terrain/hills.png\", chunk_count: (1, 1), chunk_size: 10.0, height_scale: 1.0, layer0_texture_path: \"terrain/grass.png\", layer1_texture_path: \"terrain/rock.png\", layer2_texture_path: \"terrain/dirt.png\", layer3_texture_path: \"terrain/snow.png\", splatmap_path: None)"),
             ]),
         ])"#;
         let path = write_temp_scene("test_terrain_project_dir.ron", ron);
@@ -1893,7 +1893,7 @@ mod tests {
     fn scene_plugin_terrain_heightmap_path_unchanged_without_project_dir() {
         let ron = r#"SceneDescriptor(entities: [
             EntityDescriptor(name: "Ground", components: [
-                ("bsengine_scene::types::Terrain", "(heightmap_path: \"terrain/hills.png\", chunk_count: (1, 1), chunk_size: 10.0, height_scale: 1.0, layer0_texture_path: \"terrain/grass.png\", layer1_texture_path: \"terrain/rock.png\", layer2_texture_path: \"terrain/dirt.png\", layer3_texture_path: \"terrain/snow.png\")"),
+                ("bsengine_scene::types::Terrain", "(heightmap_path: \"terrain/hills.png\", chunk_count: (1, 1), chunk_size: 10.0, height_scale: 1.0, layer0_texture_path: \"terrain/grass.png\", layer1_texture_path: \"terrain/rock.png\", layer2_texture_path: \"terrain/dirt.png\", layer3_texture_path: \"terrain/snow.png\", splatmap_path: None)"),
             ]),
         ])"#;
         let path = write_temp_scene("test_terrain_no_project_dir.ron", ron);
@@ -1913,7 +1913,7 @@ mod tests {
     fn scene_plugin_terrain_layer_texture_paths_resolve_against_project_dir() {
         let ron = r#"SceneDescriptor(entities: [
             EntityDescriptor(name: "Ground", components: [
-                ("bsengine_scene::types::Terrain", "(heightmap_path: \"terrain/hills.png\", chunk_count: (1, 1), chunk_size: 10.0, height_scale: 1.0, layer0_texture_path: \"terrain/grass.png\", layer1_texture_path: \"terrain/rock.png\", layer2_texture_path: \"terrain/dirt.png\", layer3_texture_path: \"terrain/snow.png\")"),
+                ("bsengine_scene::types::Terrain", "(heightmap_path: \"terrain/hills.png\", chunk_count: (1, 1), chunk_size: 10.0, height_scale: 1.0, layer0_texture_path: \"terrain/grass.png\", layer1_texture_path: \"terrain/rock.png\", layer2_texture_path: \"terrain/dirt.png\", layer3_texture_path: \"terrain/snow.png\", splatmap_path: None)"),
             ]),
         ])"#;
         let path = write_temp_scene("test_terrain_layer_paths.ron", ron);

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -516,6 +516,14 @@ pub struct Terrain {
     pub layer2_texture_path: String,
     /// Diffuse texture for the high-altitude splat layer (e.g. snow).
     pub layer3_texture_path: String,
+    /// Path to a whole-terrain RGBA8 splatmap image, one channel per layer
+    /// (same [grass, rock, dirt, snow] order `splat_weight_for` packs).
+    /// `None` means every chunk's splat weights are still generated
+    /// procedurally from height/slope, exactly as before this field existed
+    /// -- every scene authored before it keeps working unchanged. The
+    /// terrain brush tool creates this file and sets this field the first
+    /// time a user paints texture weights.
+    pub splatmap_path: Option<String>,
 }
 
 fn default_rotation() -> [f32; 4] {

--- a/games/terrain-demo/assets/scenes/main.ron
+++ b/games/terrain-demo/assets/scenes/main.ron
@@ -26,7 +26,7 @@ SceneDescriptor(entities: [
         name: "Ground",
         transform: Some((position: (0.0, 0.0, 0.0))),
         components: [
-            ("bsengine_scene::types::Terrain", "(heightmap_path: \"assets/terrain/heightmap.png\", chunk_count: (2, 2), chunk_size: 20.0, height_scale: 6.0, layer0_texture_path: \"assets/terrain/grass.png\", layer1_texture_path: \"assets/terrain/rock.png\", layer2_texture_path: \"assets/terrain/dirt.png\", layer3_texture_path: \"assets/terrain/snow.png\")"),
+            ("bsengine_scene::types::Terrain", "(heightmap_path: \"assets/terrain/heightmap.png\", chunk_count: (2, 2), chunk_size: 20.0, height_scale: 6.0, layer0_texture_path: \"assets/terrain/grass.png\", layer1_texture_path: \"assets/terrain/rock.png\", layer2_texture_path: \"assets/terrain/dirt.png\", layer3_texture_path: \"assets/terrain/snow.png\", splatmap_path: None)"),
         ],
     ),
     EntityDescriptor(

--- a/games/terrain-demo/assets/scenes/main.ron.meta
+++ b/games/terrain-demo/assets/scenes/main.ron.meta
@@ -1,6 +1,6 @@
 (
     guid: "a997879a-f710-4fbd-a697-d0f09925a770",
-    hash: "blake3:04a8121f0f4cbb6884ca66808614d0e093b223e9af51f3ba3420ba0aeb48d1c1",
-    size: Some(2192),
+    hash: "blake3:01fb3b8d310aead401cfcbdb466e816901da11c93759b3f9f43e10dca8804812",
+    size: Some(2213),
     former_paths: [],
 )


### PR DESCRIPTION
## Summary

- Adds an editor brush tool for sculpting terrain height and painting texture-splat layer weights, completing ENGINE_ROADMAP item 44's final sub-step (1/3 core, 2/3 texture splatting, this PR: 3/3 editor brush).
- Picking: a new screen-to-world-ray unprojection helper + the existing `PhysicsWorld::cast_ray` (Rapier `QueryPipeline`), raycasting against terrain chunks' existing heightfield colliders — no new ray-mesh intersection math needed.
- `PhysicsWorld::set_collider_shape` — the first post-spawn collider rebuild in this engine, confirmed safe via Rapier's own `Collider::set_shape` (keeps the same `ColliderHandle`, no remove/reinsert).
- Live preview (every frame during a drag): height strokes update render-mesh vertices via `GpuMeshRegistry::update_vertices`; paint strokes update the chunk's weight texture via `GpuTextureRegistry::replace`. Neither touches physics or disk.
- Commit (on drag-release): rebuilds the affected chunk's Rapier collider and persists — height edits overwrite the same heightmap PNG in place; paint edits create/update a new whole-terrain splatmap PNG (`Terrain.splatmap_path: Option<String>`, backward-compatible — every existing scene keeps working unchanged).
- New `TerrainChunkOf` back-reference component closes a real gap: chunk entities previously had no way to resolve back to their owning `Terrain` (never needed by sub-steps 1/2, since everything happened atomically at spawn time).
- Viewport UI: a 5th toolbar tool (alongside Translate/Rotate/Scale/Grid) with a Height/Paint settings popup, reusing the existing gizmo drag pattern.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --exclude bsengine-editor` — 0 failures across every crate
- [x] `cargo test -p bsengine-editor --lib` — 937/937 passing (isolated per this repo's V8/reflection stack-overflow constraint)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` — 0 violations (55 components tracked)
- [x] `cargo clippy --workspace --all-targets` — 0 errors; new warnings are 3 `too_many_arguments` on well-tested internal brush-math functions and 1 more instance of an already-19-times-pre-existing `f32` literal-fallback pattern in `bsengine-rhi-wgpu` — noting these for a maintainer call rather than unilaterally refactoring already-verified code
- [x] `cargo +nightly fmt --all` applied
- [x] New physics regression test proves the collider rebuild is wired end-to-end (a dropped body lands at the *edited* height, not the original)
- [x] New E2E test (`terrain_brush_edit_survives_a_reload`) proves a brush edit persists across a full scene reload, driven against a throwaway temp project (not the shared `games/terrain-demo` fixture, to avoid any risk of corrupting it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)