### PR TITLE
feat: LOD (Level of Detail) system for meshes and terrain chunks

### DIFF
--- a/crates/bsengine-app/src/terrain.rs
+++ b/crates/bsengine-app/src/terrain.rs
@@ -15,11 +15,33 @@ use bsengine_asset::{AssetServer, Assets, HeightmapAsset, Polled, TextureAsset};
 use bsengine_core::{GlobalTransform, Transform};
 use bsengine_ecs::{Commands, Component, Entity, Query, Res, ResMut, Without};
 use bsengine_physics::{Collider, ColliderShape, PhysicsInput, RigidBody};
-use bsengine_render::components::TerrainSplat;
+use bsengine_render::components::{LodLevels, TerrainSplat};
 use bsengine_render::MeshRenderer;
 use bsengine_rhi_wgpu::{GpuMeshRegistry, GpuTextureRegistry};
 use glam::{Quat, Vec3};
 use tracing::warn;
+
+/// `texel_stride` (see `terrain_chunking::generate_chunks_with_splatmap`)
+/// for the two lower-resolution LOD mesh variants generated per terrain
+/// chunk at chunk-creation time: LOD 1 samples every 2nd texel, LOD 2 every
+/// 4th. Never used to build a `Collider` -- see `generate_terrain_chunks`'s
+/// per-chunk loop, which builds the heightfield only from the `texel_stride:
+/// 1` chunk.
+const CHUNK_LOD_1_TEXEL_STRIDE: u32 = 2;
+const CHUNK_LOD_2_TEXEL_STRIDE: u32 = 4;
+
+/// Camera-distance ratios, relative to a `Terrain`'s own `chunk_size`, at
+/// which a chunk switches to a lower-detail LOD mesh, and the hysteresis
+/// band around each switch (see `select_lod_level`'s doc comment in
+/// `bsengine-render` for why a band prevents popping). Ratios rather than
+/// fixed absolute distances so they scale sensibly across differently-sized
+/// terrains -- multiplied by `params.chunk_size` at the point of use in
+/// `generate_terrain_chunks`. Simple module-level tuning-knob constants,
+/// matching this codebase's existing precedent for such values
+/// (`SNOW_HEIGHT_RATIO` etc. in `terrain_chunking.rs`).
+const CHUNK_LOD_DISTANCE_1_RATIO: f32 = 2.0;
+const CHUNK_LOD_DISTANCE_2_RATIO: f32 = 5.0;
+const CHUNK_LOD_HYSTERESIS_BAND_RATIO: f32 = 0.2;
 
 /// Re-exported from `bsengine-scene` rather than defined here: `Terrain`'s
 /// fields are plain, RON-serializable data with no runtime-only handles (the
@@ -231,6 +253,24 @@ fn generate_terrain_chunks(
             heightmap,
             &params,
             splatmap_override.as_ref(),
+            1,
+        );
+        // Two extra, lower-resolution mesh variants of the SAME chunks above,
+        // from the same heightmap/params -- used ONLY to populate each
+        // chunk's `LodLevels.mesh_ids` below. Their `heightfield_*` fields
+        // are never read: the `Collider` a few lines down is built
+        // exclusively from `chunks` (texel_stride 1), never from these.
+        let lod1_chunks = crate::terrain_chunking::generate_chunks_with_splatmap(
+            heightmap,
+            &params,
+            splatmap_override.as_ref(),
+            CHUNK_LOD_1_TEXEL_STRIDE,
+        );
+        let lod2_chunks = crate::terrain_chunking::generate_chunks_with_splatmap(
+            heightmap,
+            &params,
+            splatmap_override.as_ref(),
+            CHUNK_LOD_2_TEXEL_STRIDE,
         );
 
         // Rapier's heightfield shape is centered on its own local origin
@@ -245,8 +285,12 @@ fn generate_terrain_chunks(
         // collision would happen `chunk_size / 2` away from what is drawn.
         let half_chunk = Vec3::new(params.chunk_size / 2.0, 0.0, params.chunk_size / 2.0);
 
-        for chunk in chunks {
+        for ((chunk, lod1_chunk), lod2_chunk) in
+            chunks.into_iter().zip(lod1_chunks).zip(lod2_chunks)
+        {
             let mesh_id = mesh_reg.register(&chunk.vertices, &chunk.indices);
+            let lod1_mesh_id = mesh_reg.register(&lod1_chunk.vertices, &lod1_chunk.indices);
+            let lod2_mesh_id = mesh_reg.register(&lod2_chunk.vertices, &lod2_chunk.indices);
             let weight_bytes: Vec<u8> = chunk.splat_weights.iter().flatten().copied().collect();
             let weight_id = tex_reg.load_from_rgba(
                 chunk.heightfield_cols as u32,
@@ -264,8 +308,22 @@ fn generate_terrain_chunks(
                     weight_texture_id: weight_id,
                     layer_texture_ids: layer_ids,
                 },
+                LodLevels {
+                    mesh_ids: vec![lod1_mesh_id, lod2_mesh_id],
+                    switch_distances: vec![
+                        params.chunk_size * CHUNK_LOD_DISTANCE_1_RATIO,
+                        params.chunk_size * CHUNK_LOD_DISTANCE_2_RATIO,
+                    ],
+                    hysteresis_band: params.chunk_size * CHUNK_LOD_HYSTERESIS_BAND_RATIO,
+                    current_index: None,
+                },
                 TerrainChunkOf(entity),
                 RigidBody::fixed(),
+                // The heightfield below is built ONLY from `chunk`
+                // (texel_stride 1, full resolution) -- never from
+                // `lod1_chunk`/`lod2_chunk`. LOD is a rendering-only
+                // concept (see `LodLevels` above); it must never be
+                // reachable from anything that determines collision.
                 Collider {
                     shape: ColliderShape::Heightfield {
                         heights: chunk.heightfield_heights,
@@ -772,6 +830,179 @@ mod tests {
         assert!(
             backrefs.iter().all(|&e| e == terrain_entity),
             "every chunk's TerrainChunkOf must point at the Terrain entity it came from"
+        );
+    }
+
+    /// Mirrors `terrain_chunks_carry_a_terrain_splat_with_real_texture_ids`'s
+    /// shape, but for `LodLevels`: every chunk must carry two extra, real,
+    /// distinct registered mesh ids (not the zero-valued default a forgotten
+    /// registration would leave behind -- `GpuMeshRegistry` ids start at 1,
+    /// see `terrain_chunks_carry_a_terrain_splat_with_real_texture_ids`'s own
+    /// reasoning for its texture-id counterpart), and neither may collide
+    /// with each other or with the chunk's own full-resolution
+    /// `MeshRenderer.mesh_id`.
+    #[test]
+    fn terrain_chunks_carry_lod_levels_with_real_distinct_mesh_ids() {
+        let mut app = test_app();
+
+        let mut values = vec![0u16; 9 * 9];
+        for (i, v) in values.iter_mut().enumerate() {
+            *v = (i as u16 * 100) % u16::MAX;
+        }
+        let path = write_test_heightmap("lod", 9, 9, &values);
+
+        let chunk_count = (2u32, 2u32);
+        let terrain_entity = app
+            .world_mut()
+            .spawn((
+                Terrain {
+                    heightmap_path: path,
+                    chunk_count,
+                    chunk_size: 8.0,
+                    height_scale: 5.0,
+                    layer0_texture_path: write_test_texture("lod-l0", [50, 200, 50, 255]),
+                    layer1_texture_path: write_test_texture("lod-l1", [120, 120, 120, 255]),
+                    layer2_texture_path: write_test_texture("lod-l2", [110, 80, 40, 255]),
+                    layer3_texture_path: write_test_texture("lod-l3", [240, 240, 250, 255]),
+                    splatmap_path: None,
+                },
+                Transform::default(),
+            ))
+            .id();
+
+        run_until_generated(&mut app, terrain_entity);
+
+        let mut query = app.world_mut().query::<(&MeshRenderer, &LodLevels)>();
+        let chunks: Vec<(MeshRenderer, LodLevels)> = query
+            .iter(app.world())
+            .map(|(mr, lod)| (mr.clone(), lod.clone()))
+            .collect();
+        assert_eq!(
+            chunks.len(),
+            (chunk_count.0 * chunk_count.1) as usize,
+            "expected one chunk entity per (chunk_count.0 * chunk_count.1)"
+        );
+
+        for (mesh_renderer, lod) in &chunks {
+            assert_eq!(
+                lod.mesh_ids.len(),
+                2,
+                "expected exactly 2 extra LOD mesh ids, got {:?}",
+                lod.mesh_ids
+            );
+            for (i, id) in lod.mesh_ids.iter().enumerate() {
+                assert!(
+                    *id > 0,
+                    "lod.mesh_ids[{i}] must be a real registered id, got {id}"
+                );
+            }
+            assert_ne!(
+                lod.mesh_ids[0], lod.mesh_ids[1],
+                "the two LOD mesh ids must be distinct registrations"
+            );
+            assert_ne!(
+                lod.mesh_ids[0], mesh_renderer.mesh_id,
+                "LOD 1's mesh id must not collide with the full-res mesh id"
+            );
+            assert_ne!(
+                lod.mesh_ids[1], mesh_renderer.mesh_id,
+                "LOD 2's mesh id must not collide with the full-res mesh id"
+            );
+        }
+    }
+
+    /// The non-negotiable physics invariant this whole task exists to prove:
+    /// a terrain chunk's `Collider` is built exclusively from full-resolution
+    /// height data, completely independent of which LOD level is (or would
+    /// be) selected for rendering. Mirrors
+    /// `a_dropped_body_lands_on_the_chunk_it_visually_sits_above`'s setup,
+    /// but additionally forces `LodLevels.current_index` to `Some(1)`
+    /// (simulating "far away, lowest detail selected") before dropping the
+    /// body -- if that render-only selection ever became reachable from
+    /// collision, the ball would land at the wrong height (or not on the
+    /// terrain at all, since a lower-res mesh's height samples don't
+    /// necessarily coincide with the ball's drop point).
+    #[test]
+    fn a_dropped_body_lands_at_the_same_height_regardless_of_terrain_lod() {
+        let mut app = test_app();
+        app.add_plugins(bsengine_physics::PhysicsPlugin);
+
+        let flat_height_raw: u16 = 32768; // -> (32768 / 65535) * height_scale
+        let height_scale = 20.0f32;
+        let expected_height = (flat_height_raw as f32 / u16::MAX as f32) * height_scale;
+
+        let values = vec![flat_height_raw; 4 * 4];
+        let path = write_test_heightmap("flat-drop-lod", 4, 4, &values);
+
+        let chunk_size = 10.0;
+        let terrain_entity = app
+            .world_mut()
+            .spawn((
+                Terrain {
+                    heightmap_path: path,
+                    chunk_count: (1, 1),
+                    chunk_size,
+                    height_scale,
+                    layer0_texture_path: write_test_texture("flat-drop-lod-l0", [50, 200, 50, 255]),
+                    layer1_texture_path: write_test_texture(
+                        "flat-drop-lod-l1",
+                        [120, 120, 120, 255],
+                    ),
+                    layer2_texture_path: write_test_texture("flat-drop-lod-l2", [110, 80, 40, 255]),
+                    layer3_texture_path: write_test_texture(
+                        "flat-drop-lod-l3",
+                        [240, 240, 250, 255],
+                    ),
+                    splatmap_path: None,
+                },
+                Transform::from_position(Vec3::ZERO),
+            ))
+            .id();
+        run_until_generated(&mut app, terrain_entity);
+
+        // Force the render-only LOD selection to the lowest-detail level, as
+        // if the camera were far away. This must have zero bearing on where
+        // the collider is or how the body settles.
+        let mut lod_query = app.world_mut().query::<(&TerrainChunkOf, &mut LodLevels)>();
+        let mut forced_any = false;
+        for (chunk_of, mut lod) in lod_query.iter_mut(app.world_mut()) {
+            if chunk_of.0 == terrain_entity {
+                lod.current_index = Some(1);
+                forced_any = true;
+            }
+        }
+        assert!(
+            forced_any,
+            "expected at least one chunk entity to force LodLevels.current_index on"
+        );
+
+        let radius = 0.5;
+        let drop_xz = chunk_size / 2.0;
+        let start = Vec3::new(drop_xz, expected_height + 10.0, drop_xz);
+        let ball = app
+            .world_mut()
+            .spawn((
+                Transform::from_position(start),
+                bsengine_physics::RigidBody::dynamic(),
+                bsengine_physics::Collider::ball(radius),
+                bsengine_physics::PhysicsInput {
+                    position: start.into(),
+                    rotation: Quat::IDENTITY.into(),
+                },
+            ))
+            .id();
+
+        for _ in 0..200 {
+            app.update();
+        }
+
+        let y = app.world().get::<Transform>(ball).unwrap().position.0.y;
+        let expected = expected_height + radius;
+        assert!(
+            (y - expected).abs() < 0.1,
+            "expected the ball to rest at y ~= {expected} (terrain height {expected_height} \
+             + radius {radius}) regardless of the forced LOD selection, but it settled at \
+             y={y} -- LOD must never be reachable from collision"
         );
     }
 }

--- a/crates/bsengine-app/src/terrain_brush.rs
+++ b/crates/bsengine-app/src/terrain_brush.rs
@@ -528,6 +528,7 @@ fn preview_terrain_brush_stroke(
                 &dummy_hm,
                 &params,
                 Some(&overlay),
+                1,
             );
             let chunks_x = params.chunk_count.0;
 

--- a/crates/bsengine-app/src/terrain_chunking.rs
+++ b/crates/bsengine-app/src/terrain_chunking.rs
@@ -238,7 +238,7 @@ pub struct ChunkData {
 /// `heightmap`'s resolution doesn't evenly divide `chunk_count`, the
 /// remainder is absorbed into the last chunk along that axis.
 pub fn generate_chunks(heightmap: &HeightmapAsset, params: &ChunkParams) -> Vec<ChunkData> {
-    generate_chunks_with_splatmap(heightmap, params, None)
+    generate_chunks_with_splatmap(heightmap, params, None, 1)
 }
 
 /// Same as `generate_chunks`, but when `splatmap` is `Some`, every vertex's
@@ -246,11 +246,28 @@ pub fn generate_chunks(heightmap: &HeightmapAsset, params: &ChunkParams) -> Vec<
 /// `splat_weight_for`. `splatmap`'s dimensions are assumed to match
 /// `heightmap`'s (the terrain brush tool is responsible for keeping the two
 /// files the same size when it creates a splatmap).
+///
+/// `texel_stride` selects a lower-resolution variant of the same chunk span
+/// for use as an LOD mesh: at `1` (the only value every pre-LOD call site
+/// used, and still every call site except terrain LOD generation), every
+/// texel is sampled and this function's output is byte-identical to its
+/// pre-`texel_stride` behavior. At `N > 1`, only every Nth texel is sampled
+/// (`hx = origin_x + lx * texel_stride`), producing roughly `1/N` the vertex
+/// resolution along each axis while `world_offset`/the chunk's world-space
+/// footprint (`params.chunk_size`) are unchanged -- fewer samples over the
+/// same physical area, not a smaller chunk. `heightfield_heights` /
+/// `heightfield_rows` / `heightfield_cols` on a strided `ChunkData` describe
+/// that same lower-resolution grid too; callers building a `Collider` MUST
+/// use a `texel_stride: 1` chunk's fields for that, never a strided one's --
+/// LOD is a rendering-only concept, so this function makes no attempt to
+/// keep a strided chunk's heightfield collision-worthy.
 pub fn generate_chunks_with_splatmap(
     heightmap: &HeightmapAsset,
     params: &ChunkParams,
     splatmap: Option<&SplatmapOverride>,
+    texel_stride: u32,
 ) -> Vec<ChunkData> {
+    let stride = texel_stride.max(1);
     let (chunks_x, chunks_z) = params.chunk_count;
     let base_texels_x = heightmap.width / chunks_x;
     let base_texels_z = heightmap.height / chunks_z;
@@ -272,19 +289,24 @@ pub fn generate_chunks_with_splatmap(
 
             let origin_x = cx * base_texels_x;
             let origin_z = cz * base_texels_z;
-            // +1 on both axes: the shared boundary row/column with the next chunk.
-            let verts_x = texels_x + 1;
-            let verts_z = texels_z + 1;
+            // Number of strided steps spanning this chunk's texel extent --
+            // equals `texels_x`/`texels_z` exactly when `stride == 1`. +1 on
+            // both axes: the shared boundary row/column with the next chunk
+            // (same convention as full resolution).
+            let lod_texels_x = texels_x.div_ceil(stride).max(1);
+            let lod_texels_z = texels_z.div_ceil(stride).max(1);
+            let verts_x = lod_texels_x + 1;
+            let verts_z = lod_texels_z + 1;
 
             let mut vertices = Vec::with_capacity((verts_x * verts_z) as usize);
             let mut heightfield_heights = Vec::with_capacity((verts_x * verts_z) as usize);
             let mut splat_weights = Vec::with_capacity((verts_x * verts_z) as usize);
-            let world_step = params.chunk_size / texels_x.max(1) as f32; // square chunks; x and z share one step
+            let world_step = params.chunk_size / lod_texels_x.max(1) as f32; // square chunks; x and z share one step
 
             for lz in 0..verts_z {
                 for lx in 0..verts_x {
-                    let hx = origin_x + lx;
-                    let hz = origin_z + lz;
+                    let hx = origin_x + lx * stride;
+                    let hz = origin_z + lz * stride;
                     let y = height_at(heightmap, params.height_scale, hx, hz);
                     heightfield_heights.push(y);
 
@@ -301,14 +323,17 @@ pub fn generate_chunks_with_splatmap(
                         position: [lx as f32 * world_step, y, lz as f32 * world_step],
                         color: [1.0, 1.0, 1.0],
                         normal: normal.to_array(),
-                        uv: [lx as f32 / texels_x as f32, lz as f32 / texels_z as f32],
+                        uv: [
+                            lx as f32 / lod_texels_x as f32,
+                            lz as f32 / lod_texels_z as f32,
+                        ],
                     });
                 }
             }
 
-            let mut indices = Vec::with_capacity((texels_x * texels_z * 6) as usize);
-            for lz in 0..texels_z {
-                for lx in 0..texels_x {
+            let mut indices = Vec::with_capacity((lod_texels_x * lod_texels_z * 6) as usize);
+            for lz in 0..lod_texels_z {
+                for lx in 0..lod_texels_x {
                     let i0 = lz * verts_x + lx;
                     let i1 = lz * verts_x + lx + 1;
                     let i2 = (lz + 1) * verts_x + lx + 1;
@@ -505,7 +530,7 @@ mod tests {
             data: splatmap_rgba,
         };
 
-        let chunks = generate_chunks_with_splatmap(&hm, &params, Some(&splatmap));
+        let chunks = generate_chunks_with_splatmap(&hm, &params, Some(&splatmap), 1);
         let chunk = &chunks[0];
         for w in &chunk.splat_weights {
             assert_eq!(
@@ -527,8 +552,102 @@ mod tests {
             height_scale: 1.0,
         };
         let via_old_fn = generate_chunks(&hm, &params);
-        let via_new_fn = generate_chunks_with_splatmap(&hm, &params, None);
+        let via_new_fn = generate_chunks_with_splatmap(&hm, &params, None, 1);
         assert_eq!(via_old_fn[0].splat_weights, via_new_fn[0].splat_weights);
+    }
+
+    #[test]
+    fn texel_stride_of_one_is_byte_identical_to_the_pre_stride_behavior() {
+        let hm = test_heightmap();
+        let params = ChunkParams {
+            chunk_count: (2, 2),
+            chunk_size: 10.0,
+            height_scale: 1.0,
+        };
+        let via_generate_chunks = generate_chunks(&hm, &params);
+        let via_explicit_stride_1 = generate_chunks_with_splatmap(&hm, &params, None, 1);
+        assert_eq!(via_generate_chunks.len(), via_explicit_stride_1.len());
+        for (a, b) in via_generate_chunks.iter().zip(via_explicit_stride_1.iter()) {
+            assert_eq!(a.vertices.len(), b.vertices.len());
+            for (va, vb) in a.vertices.iter().zip(b.vertices.iter()) {
+                assert_eq!(va.position, vb.position);
+                assert_eq!(va.normal, vb.normal);
+                assert_eq!(va.uv, vb.uv);
+                assert_eq!(va.color, vb.color);
+            }
+            assert_eq!(a.indices, b.indices);
+            assert_eq!(a.world_offset, b.world_offset);
+            assert_eq!(a.heightfield_heights, b.heightfield_heights);
+            assert_eq!(a.heightfield_rows, b.heightfield_rows);
+            assert_eq!(a.heightfield_cols, b.heightfield_cols);
+            assert_eq!(a.splat_weights, b.splat_weights);
+        }
+    }
+
+    #[test]
+    fn texel_stride_of_two_roughly_halves_vertex_resolution_but_keeps_the_same_footprint() {
+        // An 8x8 heightmap in a single chunk: with chunk_count (1, 1),
+        // texels_x/texels_z equal the heightmap's own width/height exactly
+        // (there's no other chunk to absorb a remainder against), so a
+        // stride of 2 divides the texel span evenly (no remainder-absorption
+        // noise to account for), making "roughly half" an exact half here.
+        let mut data = vec![0u16; 8 * 8];
+        for (i, v) in data.iter_mut().enumerate() {
+            *v = (i as u16 * 100) % u16::MAX;
+        }
+        let hm = HeightmapAsset {
+            width: 8,
+            height: 8,
+            data,
+        };
+        let params = ChunkParams {
+            chunk_count: (1, 1),
+            chunk_size: 16.0,
+            height_scale: 5.0,
+        };
+
+        let full_res = generate_chunks_with_splatmap(&hm, &params, None, 1);
+        let half_res = generate_chunks_with_splatmap(&hm, &params, None, 2);
+        assert_eq!(full_res.len(), 1);
+        assert_eq!(half_res.len(), 1);
+
+        let full = &full_res[0];
+        let half = &half_res[0];
+
+        // Full res: 8 texels -> 9x9 verts. Half res (stride 2): 4 texels -> 5x5 verts.
+        assert_eq!(full.heightfield_cols, 9);
+        assert_eq!(full.heightfield_rows, 9);
+        assert_eq!(half.heightfield_cols, 5);
+        assert_eq!(half.heightfield_rows, 5);
+        assert!(
+            half.vertices.len() < full.vertices.len(),
+            "a texel_stride of 2 must produce fewer vertices than full resolution"
+        );
+
+        // Same physical footprint: both chunks describe the same world_offset
+        // and were generated from the same chunk_size, and both meshes' far
+        // corner vertex should land at (approximately) the same world position.
+        assert_eq!(full.world_offset, half.world_offset);
+        let full_far_corner = full.vertices.last().unwrap().position;
+        let half_far_corner = half.vertices.last().unwrap().position;
+        assert!(
+            (full_far_corner[0] - half_far_corner[0]).abs() < 0.001,
+            "full-res and half-res far corners should be at the same world x, \
+             got {} vs {}",
+            full_far_corner[0],
+            half_far_corner[0]
+        );
+        assert!(
+            (full_far_corner[2] - half_far_corner[2]).abs() < 0.001,
+            "full-res and half-res far corners should be at the same world z, \
+             got {} vs {}",
+            full_far_corner[2],
+            half_far_corner[2]
+        );
+        assert_eq!(
+            full_far_corner[0], params.chunk_size,
+            "the far corner should sit exactly at chunk_size along x"
+        );
     }
 
     #[test]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1194,6 +1194,10 @@ fn build_entity_descriptors(entities: &[EntityInfo]) -> Vec<EntityDescriptor> {
                     // feature that doesn't exist yet, not to any task in
                     // this plan.
                     prefab: None,
+                    // Always None: no live ECS component carries LOD data
+                    // yet (that wiring is a later task in this plan), so
+                    // there is nothing here to round-trip on save.
+                    lod: None,
                 }
             })
         })

--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -25,5 +25,5 @@ pub use asset_loader::GltfSourceLoader;
 pub use loader::{
     GltfImageData, GltfLoader, LoadedGltf, MeshData, NodeTransform, SkinData, VertexSkin,
 };
-pub use plugin::{GltfAsset, GltfPlugin};
+pub use plugin::{GltfAsset, GltfPlugin, LodRequest};
 pub use skinned_mesh::{AnimationClipLibrary, SkinnedMesh, SkinnedMeshPlugin};

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -312,9 +312,9 @@ fn load_lod_assets(
                         GltfLoader::load_full,
                     ) {
                         Ok(handle) => bsengine_asset::AssetSlot::from_handle(handle),
-                        Err(_) => unreachable!(
-                            "LoadMode::Async is infallible, see load_gltf_assets"
-                        ),
+                        Err(_) => {
+                            unreachable!("LoadMode::Async is infallible, see load_gltf_assets")
+                        }
                     }
                 })
                 .collect();

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -31,6 +31,32 @@ impl GltfAsset {
     }
 }
 
+/// Marker component requesting extra, lower-detail glTF files be loaded
+/// for an entity that already has (or is about to have) a `MeshRenderer`
+/// from its own `GltfAsset`/base mesh. Consumed by `load_lod_assets`,
+/// which attaches `bsengine_render::components::LodLevels` once every
+/// requested file has loaded.
+///
+/// Registered for reflection (R1: every public `#[derive(Component)]` type
+/// must be registered), but not from here: `GltfPlugin::build` is the wrong
+/// place for the exact reason `GltfAsset`'s own doc comment gives -- the
+/// plugin is absent from the headless `bsengine-runtime --test` app (it
+/// needs the GPU registries), so a registration made in this crate would be
+/// missing from exactly the host the E2E replays run in.
+/// `bsengine_scene::register_gameplay_reflect_types` -- which both hosts
+/// call, and which already depends on this crate -- registers it instead,
+/// right alongside `GltfAsset`.
+#[derive(Component, Clone, Debug, bevy_reflect::Reflect)]
+#[reflect(Component)]
+pub struct LodRequest {
+    /// Filesystem paths to the extra glTF/GLB files, LOD 1 first.
+    pub paths: Vec<String>,
+    /// See `LodLevels::switch_distances`. Same length as `paths`.
+    pub switch_distances: Vec<f32>,
+    /// See `LodLevels::hysteresis_band`.
+    pub hysteresis_band: f32,
+}
+
 /// Bevy plugin that loads `GltfAsset` entities into renderable meshes each frame.
 pub struct GltfPlugin;
 

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -65,7 +65,10 @@ impl Plugin for GltfPlugin {
         use bevy_asset::AssetApp;
         app.init_asset::<LoadedGltf>()
             .register_asset_loader(crate::asset_loader::GltfSourceLoader)
-            .add_systems(Update, (load_gltf_assets, rebuild_modified_gltf).chain());
+            .add_systems(
+                Update,
+                (load_gltf_assets, load_lod_assets, rebuild_modified_gltf).chain(),
+            );
     }
 }
 
@@ -260,6 +263,122 @@ fn load_gltf_assets(
                 texture_ids: tex_ids.iter().flatten().copied().collect(),
             });
         }
+    }
+}
+
+/// The in-flight loads for a [`LodRequest`], one [`bsengine_asset::AssetSlot`]
+/// per extra glTF file, mirroring [`PendingGltf`]'s single-slot version (see
+/// its own doc comment) but for a variable-length list.
+#[derive(Component)]
+struct PendingLod {
+    slots: Vec<bsengine_asset::AssetSlot<LoadedGltf>>,
+}
+
+/// Loads every path in a [`LodRequest`], registers each as a GPU mesh (using
+/// only the FIRST mesh in each loaded glTF -- a LOD level file is expected
+/// to contain exactly one mesh; if it contains more, the rest are silently
+/// ignored, matching the simplest reasonable interpretation of "this file
+/// is one LOD level" rather than treating extra meshes as more sub-parts),
+/// and attaches `bsengine_render::components::LodLevels` once every
+/// requested file has arrived.
+///
+/// Gated on `With<MeshRenderer>` -- the opposite of [`load_gltf_assets`],
+/// which gates on `Without<MeshRenderer>` -- because a `LodRequest` only
+/// makes sense once the entity's own base mesh has finished loading. `GltfPlugin`
+/// therefore chains this strictly after `load_gltf_assets` in the same
+/// `Update` schedule, so an entity whose base glTF and LOD files both start
+/// loading in the same frame cannot have its `LodRequest` processed before
+/// `MeshRenderer` exists.
+fn load_lod_assets(
+    mut commands: Commands,
+    mut query: Query<(Entity, &LodRequest, Option<&mut PendingLod>), With<MeshRenderer>>,
+    mut mesh_registry: Option<ResMut<GpuMeshRegistry>>,
+    mut gltf_assets: ResMut<bevy_asset::Assets<LoadedGltf>>,
+    asset_server: Res<bevy_asset::AssetServer>,
+) {
+    for (entity, request, pending) in query.iter_mut() {
+        // Request every path exactly once, then retain the handles. See
+        // `PendingLod`/`PendingGltf`.
+        let Some(mut pending) = pending else {
+            let slots = request
+                .paths
+                .iter()
+                .map(|path| {
+                    match bsengine_asset::load(
+                        bsengine_asset::LoadMode::Async,
+                        &asset_server,
+                        &mut gltf_assets,
+                        path,
+                        GltfLoader::load_full,
+                    ) {
+                        Ok(handle) => bsengine_asset::AssetSlot::from_handle(handle),
+                        Err(_) => unreachable!(
+                            "LoadMode::Async is infallible, see load_gltf_assets"
+                        ),
+                    }
+                })
+                .collect();
+            commands.entity(entity).insert(PendingLod { slots });
+            continue;
+        };
+
+        let mut any_failed = false;
+        for slot in pending.slots.iter_mut() {
+            if matches!(
+                slot.poll(&asset_server, &gltf_assets),
+                bsengine_asset::Polled::Failed(_)
+            ) {
+                any_failed = true;
+            }
+        }
+        if any_failed {
+            warn!("[lod] one or more LOD levels failed to load; dropping LodRequest");
+            commands.entity(entity).remove::<(LodRequest, PendingLod)>();
+            continue;
+        }
+
+        let mut loaded_meshes = Vec::with_capacity(pending.slots.len());
+        let mut all_arrived = true;
+        for slot in pending.slots.iter() {
+            match gltf_assets.get(slot.handle()) {
+                Some(loaded) => loaded_meshes.push(loaded),
+                None => {
+                    all_arrived = false;
+                    break;
+                }
+            }
+        }
+        if !all_arrived {
+            continue;
+        }
+
+        let Some(mesh_reg) = mesh_registry.as_mut() else {
+            continue;
+        };
+
+        let mesh_ids: Vec<u64> = loaded_meshes
+            .iter()
+            .filter_map(|loaded| loaded.meshes.first())
+            .map(|mesh_data| mesh_reg.register(&mesh_data.vertices, &mesh_data.indices))
+            .collect();
+
+        if mesh_ids.len() != request.paths.len() {
+            warn!(
+                "[lod] expected {} LOD mesh(es), got {} (one or more LOD files had no meshes)",
+                request.paths.len(),
+                mesh_ids.len()
+            );
+        }
+
+        commands
+            .entity(entity)
+            .insert(bsengine_render::components::LodLevels {
+                mesh_ids,
+                switch_distances: request.switch_distances.clone(),
+                hysteresis_band: request.hysteresis_band,
+                current_index: None,
+            })
+            .remove::<(LodRequest, PendingLod)>();
     }
 }
 
@@ -1338,6 +1457,108 @@ mod tests {
             gave_up,
             "a GltfAsset with an unloadable path must be given up on, not \
              retried on every frame forever"
+        );
+    }
+
+    /// Drives `load_lod_assets` end to end: a `LodRequest` naming two files
+    /// becomes `LodLevels` once both have loaded, chained strictly after
+    /// `load_gltf_assets` resolves the base `MeshRenderer`.
+    ///
+    /// Reuses `fox.glb` -- the one committed `.glb`/`.gltf` fixture anywhere
+    /// in this repository (outside `target/`), already the fixture every
+    /// other loading test in this file resolves via `CARGO_MANIFEST_DIR` --
+    /// for the base mesh *and* both LOD levels, rather than hand-authoring a
+    /// new binary glTF fixture. `load_lod_assets` doesn't care whether a LOD
+    /// level is literally lower-poly than LOD 0; it only needs a real,
+    /// independently loadable glTF per path, and `GpuMeshRegistry::register`
+    /// hands out a fresh id on every call regardless of whether the source
+    /// data is identical, so reusing one file still exercises "N requested
+    /// paths become N distinct registered mesh ids."
+    #[test]
+    fn lod_request_becomes_lod_levels_once_every_file_loads() {
+        use bsengine_render::components::LodLevels;
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../games/mini-arena/assets/models/fox.glb");
+        let path = fixture.to_str().unwrap().to_owned();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
+        app.add_plugins(GltfPlugin);
+        insert_headless_gpu_registries(&mut app);
+
+        let e = app
+            .world_mut()
+            .spawn((
+                GltfAsset::new(path.clone()),
+                LodRequest {
+                    paths: vec![path.clone(), path.clone()],
+                    switch_distances: vec![10.0, 30.0],
+                    hysteresis_band: 2.0,
+                },
+            ))
+            .id();
+
+        let mut ready = false;
+        for _ in 0..200 {
+            app.update();
+            if app.world().get::<MeshRenderer>(e).is_some()
+                && app.world().get::<LodLevels>(e).is_some()
+            {
+                ready = true;
+                break;
+            }
+        }
+        assert!(
+            ready,
+            "MeshRenderer (from GltfAsset) and LodLevels (from LodRequest) must \
+             both appear within 200 frames"
+        );
+
+        let mesh_id = app
+            .world()
+            .get::<MeshRenderer>(e)
+            .expect("checked above")
+            .mesh_id;
+        let lod_levels = app
+            .world()
+            .get::<LodLevels>(e)
+            .expect("checked above")
+            .clone();
+
+        assert_eq!(
+            lod_levels.mesh_ids.len(),
+            2,
+            "one registered mesh id per requested LOD path, got {:?}",
+            lod_levels.mesh_ids
+        );
+        assert!(
+            lod_levels.mesh_ids.iter().all(|id| *id > 0),
+            "GpuMeshRegistry ids start at 1 and are never 0: {:?}",
+            lod_levels.mesh_ids
+        );
+        assert_ne!(
+            lod_levels.mesh_ids[0], lod_levels.mesh_ids[1],
+            "each requested LOD level must register as its own mesh, even when \
+             both paths name the same source file"
+        );
+        assert!(
+            !lod_levels.mesh_ids.contains(&mesh_id),
+            "LOD mesh ids ({:?}) must be distinct from the base MeshRenderer's \
+             mesh id ({mesh_id}) -- LOD 0 is that id already and must not be \
+             duplicated into mesh_ids",
+            lod_levels.mesh_ids
+        );
+
+        assert!(
+            app.world().get::<LodRequest>(e).is_none(),
+            "LodRequest must be removed once LodLevels attaches, or the request \
+             would be reprocessed forever"
+        );
+        assert!(
+            app.world().get::<PendingLod>(e).is_none(),
+            "PendingLod must be removed alongside LodRequest"
         );
     }
 }

--- a/crates/bsengine-render/src/components.rs
+++ b/crates/bsengine-render/src/components.rs
@@ -29,6 +29,33 @@ pub struct TerrainSplat {
     pub layer_texture_ids: [u64; 4],
 }
 
+/// Extra, lower-detail mesh alternatives for an entity, switched by camera
+/// distance. LOD 0 (highest detail) is never duplicated here -- it's
+/// whatever `MeshRenderer.mesh_id` already is; this component only adds
+/// the alternatives and the switching state. An entity with no
+/// `LodLevels` renders exactly as it always has.
+///
+/// Public and reflected (R1: every public `#[derive(Component)]` type
+/// must be registered) because it is genuinely cross-crate: `bsengine-gltf`
+/// and `bsengine-app` both construct it, `bsengine-render`'s `render_frame`
+/// queries and mutates it directly every frame.
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component)]
+pub struct LodLevels {
+    /// GPU mesh ids for LOD 1, LOD 2, ... in nearest-to-farthest order.
+    pub mesh_ids: Vec<u64>,
+    /// Camera distance at which each transition occurs:
+    /// `switch_distances[0]` is LOD0->LOD1, `switch_distances[1]` is
+    /// LOD1->LOD2, etc. Same length as `mesh_ids`.
+    pub switch_distances: Vec<f32>,
+    /// Width of the dead zone around each `switch_distances` entry -- see
+    /// `select_lod_level`'s doc comment for why this prevents popping.
+    pub hysteresis_band: f32,
+    /// Currently selected level: `None` = LOD 0 (`MeshRenderer.mesh_id`),
+    /// `Some(i)` = `mesh_ids[i]`. Updated once per frame by `render_frame`.
+    pub current_index: Option<usize>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -47,5 +74,17 @@ mod tests {
         };
         assert_eq!(ts.weight_texture_id, 7);
         assert_eq!(ts.layer_texture_ids, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn lod_levels_stores_its_fields() {
+        let lod = LodLevels {
+            mesh_ids: vec![7, 8],
+            switch_distances: vec![10.0, 30.0],
+            hysteresis_band: 2.0,
+            current_index: Some(1),
+        };
+        assert_eq!(lod.mesh_ids, vec![7, 8]);
+        assert_eq!(lod.current_index, Some(1));
     }
 }

--- a/crates/bsengine-render/src/lib.rs
+++ b/crates/bsengine-render/src/lib.rs
@@ -13,6 +13,8 @@
 
 /// ECS components describing renderable entities (currently `MeshRenderer`).
 pub mod components;
+/// Pure hysteresis LOD-level selection.
+pub mod lod;
 /// The Bevy `Plugin` wiring transform propagation and frame rendering into the app schedule.
 pub mod plugin;
 /// Custom WGSL shader source asset and its loader.
@@ -21,5 +23,6 @@ pub mod shader_asset;
 pub mod texture_cache;
 
 pub use components::MeshRenderer;
+pub use lod::select_lod_level;
 pub use plugin::RenderPlugin;
 pub use shader_asset::{load_shader_source, ShaderSource, ShaderSourceLoader};

--- a/crates/bsengine-render/src/lod.rs
+++ b/crates/bsengine-render/src/lod.rs
@@ -1,0 +1,98 @@
+//! Pure hysteresis LOD (level-of-detail) level selection.
+//!
+//! Picking a LOD level from a raw distance-vs-threshold comparison alone
+//! flickers whenever the camera sits almost exactly at a threshold —
+//! jitter, orbiting, or a slowly approaching camera all cross a single
+//! boundary many times per second. [`select_lod_level`] avoids that by
+//! taking the *current* level as an input and only switching once the
+//! distance has clearly crossed into the next level's territory, not
+//! merely touched the boundary.
+
+/// Picks which LOD level should be active given the entity's current level
+/// (`None` = LOD 0, `Some(i)` = `mesh_ids[i]`, matching `LodLevels`'
+/// own field), the current camera distance, the per-transition switch
+/// distances, and a hysteresis band width.
+///
+/// A raw distance-vs-threshold check alone would flicker whenever the
+/// entity sits almost exactly at a threshold (camera jitter, orbiting,
+/// etc.) -- moving `hysteresis_band` around each threshold makes the
+/// entity only switch once it has clearly crossed into the next level's
+/// territory, not merely touched the boundary. This is why the *current*
+/// level is an input, not just distance: the function needs to know which
+/// side of the (now-widened) boundary it's already committed to.
+pub fn select_lod_level(
+    current: Option<usize>,
+    distance: f32,
+    switch_distances: &[f32],
+    hysteresis_band: f32,
+) -> Option<usize> {
+    if switch_distances.is_empty() {
+        return None;
+    }
+    let half_band = hysteresis_band / 2.0;
+    let current_level = current.map(|i| i + 1).unwrap_or(0); // 0 = LOD0, 1 = LOD1 (mesh_ids[0]), ...
+
+    // Consider moving up a level (farther away) first, then down.
+    let mut level = current_level;
+    while level < switch_distances.len() && distance > switch_distances[level] + half_band {
+        level += 1;
+    }
+    while level > 0 && distance < switch_distances[level - 1] - half_band {
+        level -= 1;
+    }
+
+    if level == 0 {
+        None
+    } else {
+        Some(level - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stays_at_lod_zero_within_the_first_switch_distance() {
+        let distances = [10.0, 30.0];
+        assert_eq!(select_lod_level(None, 5.0, &distances, 2.0), None);
+    }
+
+    #[test]
+    fn switches_to_lod_one_once_past_the_first_threshold() {
+        let distances = [10.0, 30.0];
+        assert_eq!(select_lod_level(None, 12.0, &distances, 2.0), Some(0));
+    }
+
+    #[test]
+    fn switches_to_lod_two_once_past_the_second_threshold() {
+        let distances = [10.0, 30.0];
+        assert_eq!(select_lod_level(Some(0), 32.0, &distances, 2.0), Some(1));
+    }
+
+    #[test]
+    fn switches_back_down_once_distance_drops_well_below_a_threshold() {
+        let distances = [10.0, 30.0];
+        // Currently at LOD 1 (index 0), moving back inside the hysteresis
+        // band's lower edge (10.0 - 2.0/2 = 9.0) should drop to LOD 0 (None).
+        assert_eq!(select_lod_level(Some(0), 8.0, &distances, 2.0), None);
+    }
+
+    #[test]
+    fn jitter_within_the_hysteresis_band_does_not_flip_the_level() {
+        let distances = [10.0, 30.0];
+        // At LOD 0 (None), a distance of 10.5 is past the raw 10.0 threshold
+        // but still within the 2.0-wide band around it (9.0..=11.0) -- must
+        // NOT switch, since jitter right at a boundary is exactly what
+        // hysteresis exists to suppress.
+        assert_eq!(select_lod_level(None, 10.5, &distances, 2.0), None);
+        // Symmetrically, already at LOD 1 (index 0) and drifting to 9.5
+        // (still within the band) must stay at LOD 1, not drop back.
+        assert_eq!(select_lod_level(Some(0), 9.5, &distances, 2.0), Some(0));
+    }
+
+    #[test]
+    fn empty_switch_distances_always_selects_lod_zero() {
+        assert_eq!(select_lod_level(None, 1000.0, &[], 2.0), None);
+    }
+}

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -15,6 +15,7 @@ use bsengine_window::WindowResized;
 use glam::{Mat4, Vec3, Vec4};
 
 use crate::components::{LodLevels, MeshRenderer, TerrainSplat};
+use crate::lod::select_lod_level;
 
 /// Returns false if the sphere is completely outside the view frustum.
 /// Uses Gribb-Hartmann plane extraction from the view-projection matrix
@@ -534,6 +535,7 @@ fn render_frame(
             Option<&Material>,
             Option<&Visible>,
             Option<&CustomShader>,
+            Option<&mut LodLevels>,
         )>,
         Query<(&DirectionalLight, Option<&GlobalTransform>, &Transform)>,
         Query<(&PointLight, Option<&GlobalTransform>, &Transform)>,
@@ -634,14 +636,16 @@ fn render_frame(
 
     let draw_calls: Vec<(u64, Mat4, Option<u64>, MaterialParams, Option<String>)> = render_queries
         .p1()
-        .iter()
-        .filter_map(|(mr, t, gt, mat, vis, cs)| {
+        .iter_mut()
+        .filter_map(|(mr, t, gt, mat, vis, cs, mut lod)| {
             if !vis.map(|v| v.is_visible).unwrap_or(true) {
                 return None;
             }
             let model = gt.map(|g| g.to_matrix()).unwrap_or_else(|| t.to_matrix());
+            let mut world_center: Option<Vec3> = None;
             if let Some((local_center, local_radius)) = registry.get_bounds(mr.mesh_id) {
-                let world_center = (model * local_center.extend(1.0)).truncate();
+                let center = (model * local_center.extend(1.0)).truncate();
+                world_center = Some(center);
                 let max_scale = model
                     .x_axis
                     .truncate()
@@ -649,10 +653,26 @@ fn render_frame(
                     .max(model.y_axis.truncate().length())
                     .max(model.z_axis.truncate().length());
                 let world_radius = local_radius * max_scale.max(1.0);
-                if !sphere_visible_in_frustum(view_proj, world_center, world_radius) {
+                if !sphere_visible_in_frustum(view_proj, center, world_radius) {
                     return None;
                 }
             }
+            let effective_mesh_id = if let Some(lod) = lod.as_deref_mut() {
+                let distance = world_center
+                    .map(|wc| (wc - cam_pos).length())
+                    .unwrap_or(f32::MAX);
+                lod.current_index = select_lod_level(
+                    lod.current_index,
+                    distance,
+                    &lod.switch_distances,
+                    lod.hysteresis_band,
+                );
+                lod.current_index
+                    .and_then(|i| lod.mesh_ids.get(i).copied())
+                    .unwrap_or(mr.mesh_id)
+            } else {
+                mr.mesh_id
+            };
             let tex_id = mat.and_then(|m| m.texture_id);
             let mat_params = mat
                 .map(|m| MaterialParams {
@@ -664,7 +684,7 @@ fn render_frame(
                 })
                 .unwrap_or_default();
             Some((
-                mr.mesh_id,
+                effective_mesh_id,
                 model,
                 tex_id,
                 mat_params,
@@ -860,10 +880,10 @@ impl Plugin for RenderPlugin {
 #[cfg(test)]
 mod tests {
     use super::{CompileStatus, PendingShader, PendingShaders, PendingSkybox, RenderPlugin};
-    use crate::components::MeshRenderer;
+    use crate::components::{LodLevels, MeshRenderer};
     use bsengine_app::new_app;
     use bsengine_core::{Camera, GlobalTransform, Material, Parent, PointLight, Transform};
-    use bsengine_rhi_wgpu::WgpuRHIPlugin;
+    use bsengine_rhi_wgpu::{GpuMeshRegistry, Vertex, WgpuRHIPlugin};
     use bsengine_window::WindowResized;
     use glam::Vec3;
 
@@ -1934,5 +1954,93 @@ mod tests {
             Vec3::new(0.0, 0.0, -150.0),
             0.5
         ));
+    }
+
+    // Proves `render_frame` actually drives LOD selection end to end: a real
+    // (offscreen, no window needed) GPU registry gives the entity's mesh a
+    // real bounding sphere, so `world_center` -- and therefore the distance
+    // fed to `select_lod_level` -- comes from the genuine camera-to-object
+    // distance, not the `f32::MAX` fallback an unregistered mesh id would
+    // produce. `WgpuRHIPlugin::offscreen` is the same helper
+    // `bsengine-runtime`'s headless test/replay runtime uses to get a real
+    // renderer without a window (see `test_mode.rs`); `render_plugin_uses_pbr_material`
+    // and friends above use `WgpuRHIPlugin::windowed()` instead, but windowed
+    // mode never gets a `WindowHandle` in a test, so its `WgpuSurfaceResource`
+    // -- and therefore `GpuMeshRegistry` -- never comes into existence, and
+    // `render_frame` takes its early return before ever reaching the LOD
+    // selection this test needs to exercise.
+    #[test]
+    fn lod_current_index_updates_based_on_camera_distance() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin::offscreen(64, 64, true));
+        app.add_plugins(RenderPlugin);
+        // Startup (which builds the offscreen surface and GpuMeshRegistry)
+        // only runs on the first update.
+        app.update();
+
+        let mesh_id = {
+            let mut registry = app.world_mut().resource_mut::<GpuMeshRegistry>();
+            registry.register(
+                &[
+                    Vertex {
+                        position: [0.0, 0.0, 0.0],
+                        color: [1.0, 1.0, 1.0],
+                        normal: [0.0, 1.0, 0.0],
+                        uv: [0.0, 0.0],
+                    },
+                    Vertex {
+                        position: [1.0, 0.0, 0.0],
+                        color: [1.0, 1.0, 1.0],
+                        normal: [0.0, 1.0, 0.0],
+                        uv: [1.0, 0.0],
+                    },
+                    Vertex {
+                        position: [0.0, 1.0, 0.0],
+                        color: [1.0, 1.0, 1.0],
+                        normal: [0.0, 1.0, 0.0],
+                        uv: [0.0, 1.0],
+                    },
+                ],
+                &[0, 1, 2],
+            )
+        };
+
+        // Camera far from the origin -- comfortably past both switch
+        // thresholds (plus their hysteresis half-bands), so this must cross
+        // at least the first one.
+        app.world_mut().spawn((
+            Camera::default(),
+            Transform::from_position(Vec3::new(0.0, 0.0, 200.0)),
+        ));
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                MeshRenderer { mesh_id },
+                Transform::from_position(Vec3::ZERO),
+                LodLevels {
+                    // These don't need to be registered meshes -- this test
+                    // only asserts on `current_index`, never draws them.
+                    mesh_ids: vec![mesh_id + 100, mesh_id + 200],
+                    switch_distances: vec![10.0, 50.0],
+                    hysteresis_band: 2.0,
+                    current_index: None,
+                },
+            ))
+            .id();
+
+        app.update();
+
+        let lod = app
+            .world()
+            .get::<LodLevels>(entity)
+            .expect("entity still carries its LodLevels component");
+        assert!(
+            lod.current_index.is_some(),
+            "an entity 200 units from the camera, with switch_distances \
+             [10.0, 50.0], must have selected a LOD level beyond LOD0 -- got \
+             current_index = None"
+        );
     }
 }

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -14,7 +14,7 @@ use bsengine_rhi_wgpu::{
 use bsengine_window::WindowResized;
 use glam::{Mat4, Vec3, Vec4};
 
-use crate::components::{MeshRenderer, TerrainSplat};
+use crate::components::{LodLevels, MeshRenderer, TerrainSplat};
 
 /// Returns false if the sphere is completely outside the view frustum.
 /// Uses Gribb-Hartmann plane extraction from the view-projection matrix
@@ -826,6 +826,7 @@ impl Plugin for RenderPlugin {
         // there is nothing for a headless app to inspect or attach.
         app.register_type::<MeshRenderer>();
         app.register_type::<TerrainSplat>();
+        app.register_type::<LodLevels>();
         app.init_asset::<crate::shader_asset::ShaderSource>()
             .register_asset_loader(crate::shader_asset::ShaderSourceLoader)
             .init_resource::<UiState>()

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -1779,4 +1779,256 @@ mod tests {
             original_height + radius
         );
     }
+
+    /// Builds a minimal, valid binary glTF (`.glb`) file containing exactly
+    /// one triangle: a 12-byte header, a `JSON` chunk (scene/node/mesh/
+    /// accessor structure, no external files -- the vertex/index data lives
+    /// in the `BIN` chunk right below it), and a `BIN` chunk (3 `f32x3`
+    /// positions + 3 `u16` indices). Every length/offset here follows the
+    /// glTF 2.0 binary container spec directly (4-byte-aligned chunks, JSON
+    /// padded with ASCII spaces, BIN padded with zero bytes).
+    ///
+    /// Exists only for
+    /// `lod_reduces_triangle_count_when_far_from_camera` below, which needs
+    /// two real, independently loadable glTF fixtures with a genuinely
+    /// different triangle count -- searched this repository first (outside
+    /// `target/`, the only committed `.glb`/`.gltf` fixture anywhere is
+    /// `games/mini-arena/assets/models/fox.glb`, reused below as the
+    /// high-poly LOD 0 mesh) and found no second fixture and no existing
+    /// glTF-*writing* helper to reuse, so this constructs the low-poly LOD
+    /// 1 fixture by hand instead. Verified during this test's development
+    /// (not merely assumed) to actually round-trip through
+    /// `GltfLoader::load_full` -- the exact function `GltfSourceLoader`
+    /// (and therefore `load_lod_assets`) calls -- reporting `indices.len()
+    /// == 3`, i.e. exactly one triangle.
+    fn build_single_triangle_glb() -> Vec<u8> {
+        let positions: [[f32; 3]; 3] = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let mut bin: Vec<u8> = Vec::new();
+        for v in positions {
+            for c in v {
+                bin.extend_from_slice(&c.to_le_bytes());
+            }
+        }
+        let pos_bytes = bin.len() as u32; // 36: 3 vertices * 3 floats * 4 bytes
+        for idx in [0u16, 1, 2] {
+            bin.extend_from_slice(&idx.to_le_bytes());
+        }
+        let idx_bytes = bin.len() as u32 - pos_bytes; // 6: 3 indices * 2 bytes
+        let total_bin_len = bin.len() as u32; // 42, before BIN-chunk padding
+        while bin.len() % 4 != 0 {
+            bin.push(0); // BIN chunk padding must be zero bytes, per spec
+        }
+
+        let json = format!(
+            r#"{{"asset":{{"version":"2.0"}},"scene":0,"scenes":[{{"nodes":[0]}}],"nodes":[{{"mesh":0}}],"meshes":[{{"primitives":[{{"attributes":{{"POSITION":0}},"indices":1,"mode":4}}]}}],"buffers":[{{"byteLength":{total_bin_len}}}],"bufferViews":[{{"buffer":0,"byteOffset":0,"byteLength":{pos_bytes},"target":34962}},{{"buffer":0,"byteOffset":{pos_bytes},"byteLength":{idx_bytes},"target":34963}}],"accessors":[{{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3","min":[0.0,0.0,0.0],"max":[1.0,1.0,0.0]}},{{"bufferView":1,"componentType":5123,"count":3,"type":"SCALAR"}}]}}"#
+        );
+        let mut json_bytes = json.into_bytes();
+        while json_bytes.len() % 4 != 0 {
+            json_bytes.push(0x20); // JSON chunk padding must be ASCII spaces, per spec
+        }
+
+        let mut glb = Vec::new();
+        glb.extend_from_slice(b"glTF");
+        glb.extend_from_slice(&2u32.to_le_bytes());
+        let total_len_pos = glb.len();
+        glb.extend_from_slice(&0u32.to_le_bytes()); // total length, patched below
+
+        glb.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+        glb.extend_from_slice(b"JSON");
+        glb.extend_from_slice(&json_bytes);
+
+        glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+        glb.extend_from_slice(b"BIN\0");
+        glb.extend_from_slice(&bin);
+
+        let total_len = glb.len() as u32;
+        glb[total_len_pos..total_len_pos + 4].copy_from_slice(&total_len.to_le_bytes());
+        glb
+    }
+
+    /// Task 8, and the roadmap item 43 condition it exists to satisfy
+    /// directly ("프로파일러로 LOD 켬/끔 시 프레임 비용 차이를 실측해 효과
+    /// 입증" -- prove the effect via the profiler with a measured before/
+    /// after, not just "LOD doesn't crash"). `bsengine-render`'s own
+    /// `lod_current_index_updates_based_on_camera_distance` already proves
+    /// `current_index` responds to distance, and `bsengine-gltf`'s
+    /// `lod_request_becomes_lod_levels_once_every_file_loads` already
+    /// proves a `LodRequest` resolves into distinct registered mesh ids --
+    /// neither proves the thing actually rendered fewer triangles. This
+    /// test drives the real headless app (`build_test_app`, the same stack
+    /// `--test`/E2E replays and the windowed runtime use) end to end and
+    /// reads `get_frame_stats` (the real frame profiler, item 43/PR #1805 --
+    /// `crate::test_query::get_frame_stats`, dispatched by exactly the
+    /// string `"get_frame_stats"` with empty `{}` args, confirmed by
+    /// reading `test_query.rs` and its own
+    /// `run_query_dispatches_get_frame_stats` test before writing this one)
+    /// with the far LOD active, then again with LOD 0 active, and asserts
+    /// the near frame's triangle count is strictly greater.
+    ///
+    /// Fixtures: LOD 0 is `games/mini-arena`'s real `fox.glb` (576
+    /// triangles), copied into this test's own temp project so the scene's
+    /// `gltf:`/`lod:` fields can stay project-relative -- exactly the
+    /// pattern `terrain_brush_edit_survives_a_reload` above already
+    /// established for copying fixtures into a throwaway `tempfile::
+    /// tempdir()` project rather than mutating or pointing absolutely at a
+    /// shared `games/*` fixture. LOD 1 is `build_single_triangle_glb`'s
+    /// hand-built one-triangle `.glb` above -- see that function's own doc
+    /// comment for why a hand-built fixture was necessary here.
+    ///
+    /// The `Tree` entity sits on the camera's forward axis (camera at the
+    /// origin with the default identity rotation looks down -Z, the same
+    /// convention `moving_a_grandparent_moves_the_grandchild_on_screen` and
+    /// `prefab_referenced_from_a_scene_file_renders_at_the_instantiation_
+    /// points_position` above both rely on), so its exact camera distance
+    /// is just the absolute value of its own z position -- 300 units away
+    /// (well past `switch_distances: [50.0]` plus the 2.0 hysteresis band's
+    /// half-width) for the far phase, then moved to 5 units away (well
+    /// inside the same band's floor) for the near phase.
+    #[test]
+    fn lod_reduces_triangle_count_when_far_from_camera() {
+        use bsengine_render::components::LodLevels;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("assets/scenes")).unwrap();
+        std::fs::create_dir_all(root.join("assets/models")).unwrap();
+
+        let fox_bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../games/mini-arena/assets/models/fox.glb"),
+        )
+        .expect("games/mini-arena's fox.glb fixture should exist");
+        std::fs::write(root.join("assets/models/fox.glb"), &fox_bytes)
+            .expect("write the temp project's copy of fox.glb");
+        std::fs::write(
+            root.join("assets/models/lowpoly.glb"),
+            build_single_triangle_glb(),
+        )
+        .expect("write the temp project's hand-built single-triangle LOD fixture");
+
+        std::fs::write(
+            root.join("project.toml"),
+            "[project]\nname = \"LOD E2E\"\nentry_scene = \"assets/scenes/main.ron\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("assets/scenes/main.ron"),
+            r#"SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Camera",
+        camera: true,
+        transform: Some((position: (0.0, 0.0, 0.0))),
+    ),
+    EntityDescriptor(
+        name: "Tree",
+        gltf: Some("assets/models/fox.glb"),
+        lod: Some((
+            levels: ["assets/models/lowpoly.glb"],
+            distances: [50.0],
+            hysteresis_band: 2.0,
+        )),
+        transform: Some((position: (0.0, 0.0, -300.0))),
+    ),
+])"#,
+        )
+        .unwrap();
+
+        let project_dir = root.to_str().unwrap().to_string();
+        let mut app = build_test_app(&project_dir, None, false);
+
+        // --- Phase 1: far -- the low-poly LOD level should be selected ---
+        let mut far_selected = false;
+        for _ in 0..300 {
+            app.update();
+            let mut q = app
+                .world_mut()
+                .query::<(&bsengine_scene::Name, &LodLevels)>();
+            if let Some((_, lod)) = q.iter(app.world()).find(|(n, _)| n.0 == "Tree") {
+                if lod.current_index.is_some() {
+                    far_selected = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            far_selected,
+            "Tree's LodLevels never selected a level beyond LOD0 within 300 frames -- \
+             either the base mesh or the LOD level failed to load (check the fixtures \
+             above), or something is wrong with LOD selection itself: at 300 units \
+             away with switch_distances=[50.0], it must have selected the far level"
+        );
+
+        let far_stats =
+            crate::test_query::run_query(app.world_mut(), "get_frame_stats", &json!({}))
+                .expect("get_frame_stats should succeed once RenderPlugin has drawn a frame");
+        let far_triangles = far_stats["triangles"]
+            .as_u64()
+            .expect("get_frame_stats should report triangles as a number");
+
+        // --- Phase 2: near -- move Tree close, LOD0 should be reselected ---
+        let tree = {
+            let mut q = app.world_mut().query::<(Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0 == "Tree")
+                .map(|(e, _)| e)
+                .expect("Tree should have spawned from the scene file")
+        };
+        app.world_mut()
+            .get_mut::<bsengine_core::Transform>(tree)
+            .unwrap()
+            .position = glam::Vec3::new(0.0, 0.0, -5.0).into();
+
+        let mut near_selected = false;
+        for _ in 0..20 {
+            app.update();
+            let lod = app
+                .world()
+                .get::<LodLevels>(tree)
+                .expect("LodLevels should still be attached once selected");
+            if lod.current_index.is_none() {
+                near_selected = true;
+                break;
+            }
+        }
+        assert!(
+            near_selected,
+            "Tree's LodLevels never dropped back to LOD0 (current_index=None) within 20 \
+             frames after moving to 5 units from the camera -- well inside the \
+             49.0-unit hysteresis floor (switch_distances=[50.0], hysteresis_band=2.0)"
+        );
+
+        let near_stats =
+            crate::test_query::run_query(app.world_mut(), "get_frame_stats", &json!({}))
+                .expect("get_frame_stats should succeed once RenderPlugin has drawn a frame");
+        let near_triangles = near_stats["triangles"]
+            .as_u64()
+            .expect("get_frame_stats should report triangles as a number");
+
+        // The real proof: not "both ran without error", but a measured
+        // triangle-count drop. `render_frame` builds one draw-call list from
+        // `current_index`'s selected mesh id and every consumer of it (main
+        // opaque pass, shadow pass -- both unconditional here since this
+        // test does not request `fast_render`) draws that same id, so the
+        // near frame (LOD0 = fox.glb, 576 triangles) should report on the
+        // order of 2*(576-1) = 1150 more triangles than the far frame
+        // (LOD1 = the 1-triangle fixture) -- any constant per-frame
+        // contribution from post-processing is identical between the two
+        // frames and cancels out of this comparison.
+        assert!(
+            near_triangles > far_triangles,
+            "LOD must measurably reduce triangle count: near (LOD0, fox.glb, 576 \
+             triangles) frame reported {near_triangles} triangles, far (LOD1, the \
+             1-triangle fixture) frame reported {far_triangles} triangles -- equal or \
+             reversed counts mean either the LOD fixtures don't actually differ or LOD \
+             selection isn't taking effect (current_index was already checked above)"
+        );
+        assert!(
+            near_triangles > far_triangles + 500,
+            "the near/far triangle-count gap ({near_triangles} vs {far_triangles}) is \
+             far smaller than the ~1150 this specific fixture pair (576 vs 1 triangles, \
+             drawn in both the main and shadow passes) should produce -- a small but \
+             nonzero gap would suggest the wrong mesh is being measured somewhere, not \
+             a genuinely working LOD reduction"
+        );
+    }
 }

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -1815,7 +1815,7 @@ mod tests {
         }
         let idx_bytes = bin.len() as u32 - pos_bytes; // 6: 3 indices * 2 bytes
         let total_bin_len = bin.len() as u32; // 42, before BIN-chunk padding
-        while bin.len() % 4 != 0 {
+        while !bin.len().is_multiple_of(4) {
             bin.push(0); // BIN chunk padding must be zero bytes, per spec
         }
 
@@ -1823,7 +1823,7 @@ mod tests {
             r#"{{"asset":{{"version":"2.0"}},"scene":0,"scenes":[{{"nodes":[0]}}],"nodes":[{{"mesh":0}}],"meshes":[{{"primitives":[{{"attributes":{{"POSITION":0}},"indices":1,"mode":4}}]}}],"buffers":[{{"byteLength":{total_bin_len}}}],"bufferViews":[{{"buffer":0,"byteOffset":0,"byteLength":{pos_bytes},"target":34962}},{{"buffer":0,"byteOffset":{pos_bytes},"byteLength":{idx_bytes},"target":34963}}],"accessors":[{{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3","min":[0.0,0.0,0.0],"max":[1.0,1.0,0.0]}},{{"bufferView":1,"componentType":5123,"count":3,"type":"SCALAR"}}]}}"#
         );
         let mut json_bytes = json.into_bytes();
-        while json_bytes.len() % 4 != 0 {
+        while !json_bytes.len().is_multiple_of(4) {
             json_bytes.push(0x20); // JSON chunk padding must be ASCII spaces, per spec
         }
 

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -575,6 +575,21 @@ pub fn spawn_scene_entities(world: &mut World, entities: &[EntityDescriptor]) {
             )));
         }
 
+        if let Some(lod_desc) = &entity.lod {
+            let paths: Vec<String> = lod_desc
+                .levels
+                .iter()
+                .map(|asset_ref| {
+                    bsengine_core::resolve_project_path(project_dir.as_ref(), asset_ref.path())
+                })
+                .collect();
+            builder.insert(bsengine_gltf::LodRequest {
+                paths,
+                switch_distances: lod_desc.distances.clone(),
+                hysteresis_band: lod_desc.hysteresis_band,
+            });
+        }
+
         if entity.camera {
             match entity.camera_fov {
                 Some(fov) => {
@@ -933,6 +948,7 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
     app.register_type::<crate::types::ColliderDesc>();
     app.register_type::<crate::types::ColliderShapeDesc>();
     app.register_type::<bsengine_gltf::GltfAsset>();
+    app.register_type::<bsengine_gltf::LodRequest>();
     app.register_type::<bsengine_gltf::SkinnedMesh>();
     app.register_type::<bsengine_gltf::AnimationClipLibrary>();
 
@@ -1846,6 +1862,38 @@ mod tests {
         let results: Vec<_> = q.iter(app.world()).collect();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].1.path, "models/hero.glb");
+    }
+
+    #[test]
+    fn scene_plugin_lod_paths_resolve_against_project_dir() {
+        let ron = r#"SceneDescriptor(entities: [
+            EntityDescriptor(
+                name: "Tree",
+                gltf: Some("models/tree_lod0.glb"),
+                lod: Some((
+                    levels: ["models/tree_lod1.glb", "models/tree_lod2.glb"],
+                    distances: [20.0, 60.0],
+                )),
+            ),
+        ])"#;
+        let path = write_temp_scene("test_lod_project_dir.ron", ron);
+
+        let mut app = new_app();
+        app.insert_resource(bsengine_core::ProjectDir("games/demo".to_string()));
+        app.add_plugins(ScenePlugin::from_file(&path));
+        app.update();
+
+        let mut q = app.world_mut().query::<(&Name, &bsengine_gltf::LodRequest)>();
+        let (name, request) = q.iter(app.world()).next().expect("Tree should have a LodRequest");
+        assert_eq!(name.0, "Tree");
+        assert_eq!(
+            request.paths,
+            vec![
+                "games/demo/models/tree_lod1.glb".to_string(),
+                "games/demo/models/tree_lod2.glb".to_string(),
+            ]
+        );
+        assert_eq!(request.switch_distances, vec![20.0, 60.0]);
     }
 
     /// `Terrain.heightmap_path` is authored through the generic `components:`

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -1883,8 +1883,13 @@ mod tests {
         app.add_plugins(ScenePlugin::from_file(&path));
         app.update();
 
-        let mut q = app.world_mut().query::<(&Name, &bsengine_gltf::LodRequest)>();
-        let (name, request) = q.iter(app.world()).next().expect("Tree should have a LodRequest");
+        let mut q = app
+            .world_mut()
+            .query::<(&Name, &bsengine_gltf::LodRequest)>();
+        let (name, request) = q
+            .iter(app.world())
+            .next()
+            .expect("Tree should have a LodRequest");
         assert_eq!(name.0, "Tree");
         assert_eq!(
             request.paths,

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -330,6 +330,30 @@ pub struct EntityDescriptor {
     /// logs a warning and is skipped, not a hard load failure.
     #[serde(default)]
     pub components: Vec<(String, String)>,
+    /// Extra, lower-detail mesh levels for this entity, switched by camera
+    /// distance. Absent means no LOD levels -- this entity always renders
+    /// its `gltf` mesh, exactly as every scene written before this field
+    /// existed.
+    #[serde(default)]
+    pub lod: Option<LodDescriptor>,
+}
+
+/// Extra, lower-detail glTF meshes for a scene entity and the camera
+/// distances at which to switch to them. The entity's own `gltf` field
+/// remains LOD 0 (highest detail).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LodDescriptor {
+    /// Additional meshes, index 0 = LOD 1 (first drop from full detail).
+    pub levels: Vec<AssetRef>,
+    /// One distance per entry in `levels` -- see `levels`' own ordering.
+    pub distances: Vec<f32>,
+    /// See `bsengine_render::components::LodLevels::hysteresis_band`.
+    #[serde(default = "default_lod_hysteresis_band")]
+    pub hysteresis_band: f32,
+}
+
+fn default_lod_hysteresis_band() -> f32 {
+    2.0
 }
 
 /// Position, rotation, and scale for a scene entity, as written in a scene file.
@@ -884,6 +908,46 @@ mod tests {
         assert_eq!(d.name, "X");
         assert_eq!(d.transform, None);
         assert!(d.components.is_empty());
+    }
+
+    #[test]
+    fn lod_field_parses_and_defaults_to_absent() {
+        let none: EntityDescriptor = ron::from_str(r#"EntityDescriptor(name: "A")"#)
+            .expect("scenes written before this field must still parse");
+        assert_eq!(none.lod, None);
+
+        let with_lod: EntityDescriptor = ron::from_str(
+            r#"EntityDescriptor(
+                name: "Tree",
+                gltf: Some("models/tree_lod0.glb"),
+                lod: Some((
+                    levels: ["models/tree_lod1.glb", "models/tree_lod2.glb"],
+                    distances: [20.0, 60.0],
+                )),
+            )"#,
+        )
+        .expect("a scene entity should be able to declare LOD levels");
+        let lod = with_lod.lod.expect("lod should be Some");
+        assert_eq!(lod.levels.len(), 2);
+        assert_eq!(lod.levels[0].path(), "models/tree_lod1.glb");
+        assert_eq!(lod.distances, [20.0, 60.0]);
+        assert_eq!(lod.hysteresis_band, 2.0, "should default when not specified");
+    }
+
+    #[test]
+    fn lod_hysteresis_band_can_be_overridden() {
+        let with_band: EntityDescriptor = ron::from_str(
+            r#"EntityDescriptor(
+                name: "Tree",
+                lod: Some((
+                    levels: ["models/tree_lod1.glb"],
+                    distances: [20.0],
+                    hysteresis_band: 5.0,
+                )),
+            )"#,
+        )
+        .expect("hysteresis_band should be overridable");
+        assert_eq!(with_band.lod.unwrap().hysteresis_band, 5.0);
     }
 
     #[test]

--- a/crates/bsengine-scene/src/types.rs
+++ b/crates/bsengine-scene/src/types.rs
@@ -931,7 +931,10 @@ mod tests {
         assert_eq!(lod.levels.len(), 2);
         assert_eq!(lod.levels[0].path(), "models/tree_lod1.glb");
         assert_eq!(lod.distances, [20.0, 60.0]);
-        assert_eq!(lod.hysteresis_band, 2.0, "should default when not specified");
+        assert_eq!(
+            lod.hysteresis_band, 2.0,
+            "should default when not specified"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Implements ENGINE_ROADMAP item 45 (LOD/Level of Detail): manual, distance-based LOD with hysteresis, applied uniformly to regular glTF meshes and terrain chunks.
- New `LodLevels` component (bsengine-render) + `select_lod_level` hysteresis state machine; wired into `render_frame`'s draw-call construction alongside the existing frustum-culling data (no new per-frame distance computation needed).
- Scene authoring: `EntityDescriptor.lod: Option<LodDescriptor>` (bsengine-scene), mirroring the existing `gltf`/`texture` typed-field pattern; async multi-file loading via `PendingLod`/`load_lod_assets` (bsengine-gltf), chained strictly after `load_gltf_assets`.
- Terrain chunks generate 2 extra lower-resolution mesh variants at chunk-creation time via a new `texel_stride` parameter on `generate_chunks_with_splatmap` (default 1, byte-identical to prior behavior), reusing the same `LodLevels` mechanism with no special-casing.
- **Hard invariant, enforced by a dedicated regression test:** LOD selection never touches physics. A terrain chunk's `Collider` is built exclusively from full-resolution (`texel_stride: 1`) data; forcing `LodLevels.current_index` to a lower level does not change where a dropped body lands.
- Profiler-based proof (item 43's frame profiler): a new E2E test drives the real headless app end-to-end and asserts `get_frame_stats` reports a measurably lower triangle count once the far LOD level is selected vs. near (LOD 0).

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test -p bsengine-render --lib` — 42/42 passing (incl. hysteresis unit tests + draw-call LOD selection test)
- [x] `cargo test -p bsengine-scene --lib` — 75/75 passing
- [x] `cargo test -p bsengine-gltf --lib` — 50/50 passing
- [x] `cargo test -p bsengine-app --lib` — 91/91 passing (incl. terrain LOD mesh-id test + the physics-untouched regression test)
- [x] `cargo test -p bsengine-runtime --bins` — 56/56 passing (incl. the profiler-based proof E2E test)
- [x] `cargo test --workspace --exclude bsengine-editor` — all green
- [x] `cargo test -p bsengine-editor --lib` — 937/937 passing (isolated, per this repo's CI split)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` — 0 violations (`LodLevels` registered; `LodRequest`/`PendingLod` correctly unregistered, private)
- [x] `cargo clippy --workspace --all-targets` — 0 new warnings vs. pre-existing baseline
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)