### PR TITLE
feat: occlusion culling via CPU software occluder rasterization

### DIFF
--- a/crates/bsengine-app/src/terrain.rs
+++ b/crates/bsengine-app/src/terrain.rs
@@ -15,7 +15,7 @@ use bsengine_asset::{AssetServer, Assets, HeightmapAsset, Polled, TextureAsset};
 use bsengine_core::{GlobalTransform, Transform};
 use bsengine_ecs::{Commands, Component, Entity, Query, Res, ResMut, Without};
 use bsengine_physics::{Collider, ColliderShape, PhysicsInput, RigidBody};
-use bsengine_render::components::{LodLevels, TerrainSplat};
+use bsengine_render::components::{LodLevels, Occluder, TerrainSplat};
 use bsengine_render::MeshRenderer;
 use bsengine_rhi_wgpu::{GpuMeshRegistry, GpuTextureRegistry};
 use glam::{Quat, Vec3};
@@ -300,6 +300,22 @@ fn generate_terrain_chunks(
             let world_min_corner =
                 transform.position.0 + Vec3::new(chunk.world_offset.0, 0.0, chunk.world_offset.1);
 
+            // Read before `chunk.heightfield_heights` is moved into the
+            // `Collider` below. The occluder box rises from local y=0 to the
+            // chunk's LOWEST height, so it stays under the real surface at
+            // every point -- the conservative rule `Occluder` documents. An
+            // all-zero chunk yields a zero-height box, which occludes
+            // nothing: correct, and safe. `.max(0.0)` keeps the box's
+            // half-extent non-negative even for a terrain authored with a
+            // negative `height_scale`.
+            let min_height = chunk
+                .heightfield_heights
+                .iter()
+                .copied()
+                .fold(f32::INFINITY, f32::min)
+                .max(0.0);
+            let half_chunk_extent = params.chunk_size / 2.0;
+
             commands.spawn((
                 Transform::from_position(world_min_corner),
                 GlobalTransform::default(),
@@ -316,6 +332,15 @@ fn generate_terrain_chunks(
                     ],
                     hysteresis_band: params.chunk_size * CHUNK_LOD_HYSTERESIS_BAND_RATIO,
                     current_index: None,
+                },
+                // Local space: the chunk's mesh spans `(0,0)..(chunk_size,
+                // chunk_size)` while its `Transform` sits at the min corner,
+                // so the box's center x/z are `chunk_size / 2`, not zero.
+                Occluder {
+                    center: Vec3::new(half_chunk_extent, min_height / 2.0, half_chunk_extent)
+                        .into(),
+                    half_extents: Vec3::new(half_chunk_extent, min_height / 2.0, half_chunk_extent)
+                        .into(),
                 },
                 TerrainChunkOf(entity),
                 RigidBody::fixed(),
@@ -1003,6 +1028,119 @@ mod tests {
             "expected the ball to rest at y ~= {expected} (terrain height {expected_height} \
              + radius {radius}) regardless of the forced LOD selection, but it settled at \
              y={y} -- LOD must never be reachable from collision"
+        );
+    }
+
+    /// Every terrain chunk must carry an `Occluder` whose box stays under the
+    /// real surface: its top (`center.y + half_extents.y`) may never exceed
+    /// the chunk's own minimum height. A box poking above the surface would
+    /// claim coverage the terrain does not have, which is exactly the
+    /// false-culling failure `Occluder`'s doc comment forbids. Horizontally
+    /// the box spans the full chunk footprint, which is safe: the chunk mesh
+    /// covers that whole footprint.
+    ///
+    /// The minimum is read back out of the chunk's own `Collider`
+    /// heightfield rather than recomputed from the source heightmap, so the
+    /// assertion proves the occluder and the collider agree about the same
+    /// chunk's geometry.
+    #[test]
+    fn terrain_chunks_carry_a_conservative_occluder_under_the_surface() {
+        let mut app = test_app();
+
+        // Varied heights, all comfortably above zero, so every chunk's
+        // minimum is a real non-degenerate value. A flat-at-zero heightmap
+        // would pass trivially even for a box built from the maximum; this
+        // one only passes if the minimum is genuinely used.
+        let mut values = vec![0u16; 9 * 9];
+        for (i, v) in values.iter_mut().enumerate() {
+            *v = 8000 + (i as u16 * 700) % 50000;
+        }
+        let path = write_test_heightmap("occluder", 9, 9, &values);
+
+        let chunk_size = 8.0f32;
+        let chunk_count = (2u32, 2u32);
+        let terrain_entity = app
+            .world_mut()
+            .spawn((
+                Terrain {
+                    heightmap_path: path,
+                    chunk_count,
+                    chunk_size,
+                    height_scale: 5.0,
+                    layer0_texture_path: write_test_texture("occluder-l0", [50, 200, 50, 255]),
+                    layer1_texture_path: write_test_texture("occluder-l1", [120, 120, 120, 255]),
+                    layer2_texture_path: write_test_texture("occluder-l2", [110, 80, 40, 255]),
+                    layer3_texture_path: write_test_texture("occluder-l3", [240, 240, 250, 255]),
+                    splatmap_path: None,
+                },
+                Transform::default(),
+            ))
+            .id();
+
+        run_until_generated(&mut app, terrain_entity);
+
+        let mut query = app.world_mut().query::<(&Occluder, &Collider)>();
+        let chunks: Vec<(Occluder, Vec<f32>)> = query
+            .iter(app.world())
+            .map(|(occluder, collider)| {
+                let ColliderShape::Heightfield { heights, .. } = &collider.shape else {
+                    panic!(
+                        "a terrain chunk's collider must be a Heightfield, got {:?}",
+                        collider.shape
+                    );
+                };
+                (*occluder, heights.clone())
+            })
+            .collect();
+        assert_eq!(
+            chunks.len(),
+            (chunk_count.0 * chunk_count.1) as usize,
+            "every chunk entity must carry an Occluder alongside its Collider"
+        );
+
+        let mut any_real_height = false;
+        for (occluder, heights) in &chunks {
+            assert!(
+                !heights.is_empty(),
+                "a chunk's heightfield must have samples to compare against"
+            );
+            let min_height = heights.iter().copied().fold(f32::INFINITY, f32::min);
+
+            assert_eq!(
+                occluder.half_extents.x,
+                chunk_size / 2.0,
+                "the occluder must span the chunk's full footprint in x"
+            );
+            assert_eq!(
+                occluder.half_extents.z,
+                chunk_size / 2.0,
+                "the occluder must span the chunk's full footprint in z"
+            );
+            assert!(
+                occluder.half_extents.x >= 0.0
+                    && occluder.half_extents.y >= 0.0
+                    && occluder.half_extents.z >= 0.0,
+                "half_extents must be non-negative on every axis, got {:?}",
+                occluder.half_extents
+            );
+
+            let box_top = occluder.center.y + occluder.half_extents.y;
+            assert!(
+                box_top <= min_height + 1e-4,
+                "the occluder box's top ({box_top}) must stay under the chunk's lowest \
+                 height ({min_height}) -- a box above the surface would occlude geometry \
+                 the terrain does not actually cover (center {:?}, half_extents {:?})",
+                occluder.center,
+                occluder.half_extents
+            );
+
+            any_real_height |= occluder.half_extents.y > 0.0;
+        }
+        assert!(
+            any_real_height,
+            "at least one chunk of this above-zero heightmap must get a box with real \
+             height -- an always-zero-height occluder would satisfy the conservative rule \
+             by occluding nothing at all"
         );
     }
 }

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -51,6 +51,8 @@ pub mod nav_mesh_agent;
 pub mod nav_poly;
 /// Networked entity identity and authority components.
 pub mod network_id;
+/// Runtime switch for occlusion culling, set from `project.toml`.
+pub mod occlusion_config;
 /// Parent-entity reference for building transform hierarchies.
 pub mod parent;
 /// Short-lived billboarded particles and the emitter that owns them.
@@ -119,6 +121,7 @@ pub use material::{Material, TexturePath};
 pub use nav_mesh::NavMesh;
 pub use nav_mesh_agent::{NavAgentState, NavMeshAgent};
 pub use network_id::{NetworkAuthority, NetworkId};
+pub use occlusion_config::OcclusionCullingEnabled;
 pub use parent::Parent;
 pub use particles::{Particle, ParticleEmitter, Rng};
 pub use pause_state::PauseState;

--- a/crates/bsengine-core/src/occlusion_config.rs
+++ b/crates/bsengine-core/src/occlusion_config.rs
@@ -1,0 +1,32 @@
+//! Runtime switch for occlusion culling, set from `project.toml`.
+
+use bevy_ecs::prelude::Resource;
+
+/// Whether `render_frame` should perform occlusion culling this run.
+///
+/// Inserted by the runtime from `project.toml`'s `[render]` section. When
+/// the resource is **absent** -- the editor, and every test that builds an
+/// app directly -- occlusion culling is enabled, matching the frustum
+/// culling that has always run unconditionally. Only an explicit
+/// `occlusion_culling = false` turns it off.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct OcclusionCullingEnabled(pub bool);
+
+impl Default for OcclusionCullingEnabled {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_enabled() {
+        assert!(
+            OcclusionCullingEnabled::default().0,
+            "absent config must mean enabled, like frustum culling"
+        );
+    }
+}

--- a/crates/bsengine-render/src/components.rs
+++ b/crates/bsengine-render/src/components.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::Reflect;
+use bsengine_core::ReflectVec3;
 
 /// Marks an entity as drawable and identifies which mesh asset to render it with.
 #[derive(Component, Debug, Clone, Reflect)]
@@ -56,6 +57,37 @@ pub struct LodLevels {
     pub current_index: Option<usize>,
 }
 
+/// Marks an entity as able to hide other entities behind it, by giving a
+/// box that occlusion culling may rasterize as an opaque blocker.
+///
+/// **The box must fit INSIDE the entity's real geometry.** It is a
+/// conservative under-estimate, never a bounding box. This is the one
+/// input that can make occlusion culling hide something genuinely
+/// visible: rasterizing a blocker larger than the real geometry claims
+/// coverage the geometry does not have. Everything else in
+/// `crate::occlusion` is built to under-cull; this component is where that
+/// guarantee is either kept or broken.
+///
+/// An entity without an `Occluder` hides nothing. It can still *be*
+/// hidden -- being an occluder and being a culling candidate are
+/// independent.
+///
+/// Public and reflected (R1: every public `#[derive(Component)]` type must
+/// be registered) because it is genuinely cross-crate: `bsengine-app`
+/// constructs it for terrain chunks, scenes author it by reflection, and
+/// `bsengine-render`'s `render_frame` queries it every frame.
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(Component)]
+pub struct Occluder {
+    /// Center of the box in the entity's LOCAL space. Not always the local
+    /// origin: a terrain chunk's mesh spans local `(0,0)..(chunk_size,
+    /// chunk_size)`, so its box has to be offset to sit under the geometry
+    /// it stands in for.
+    pub center: ReflectVec3,
+    /// Half-extents of the box in the entity's LOCAL space.
+    pub half_extents: ReflectVec3,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -86,5 +118,15 @@ mod tests {
         };
         assert_eq!(lod.mesh_ids, vec![7, 8]);
         assert_eq!(lod.current_index, Some(1));
+    }
+
+    #[test]
+    fn occluder_stores_its_box() {
+        let o = Occluder {
+            center: glam::Vec3::new(1.0, 2.0, 3.0).into(),
+            half_extents: glam::Vec3::new(4.0, 5.0, 6.0).into(),
+        };
+        assert_eq!(*o.center, glam::Vec3::new(1.0, 2.0, 3.0));
+        assert_eq!(*o.half_extents, glam::Vec3::new(4.0, 5.0, 6.0));
     }
 }

--- a/crates/bsengine-render/src/lib.rs
+++ b/crates/bsengine-render/src/lib.rs
@@ -15,6 +15,8 @@
 pub mod components;
 /// Pure hysteresis LOD-level selection.
 pub mod lod;
+/// GPU-free software occlusion culling: conservative occluder rasterization.
+pub mod occlusion;
 /// The Bevy `Plugin` wiring transform propagation and frame rendering into the app schedule.
 pub mod plugin;
 /// Custom WGSL shader source asset and its loader.

--- a/crates/bsengine-render/src/occlusion.rs
+++ b/crates/bsengine-render/src/occlusion.rs
@@ -57,10 +57,8 @@ impl OcclusionBuffer {
         self.depths.iter().all(|d| d.is_infinite())
     }
 
-    // Only read by this module's own tests until `box_occluded` lands
-    // alongside it; the allow keeps the intermediate state warning-free
-    // without weakening the method's visibility.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// The nearest occluder depth known to cover this pixel, or
+    /// `f32::INFINITY` when nothing covers it.
     fn depth_at(&self, x: usize, y: usize) -> f32 {
         self.depths[y * OCCLUSION_BUFFER_SIZE + x]
     }
@@ -209,6 +207,69 @@ pub fn rasterize_occluder_box(
     }
 }
 
+/// True only when the candidate is definitely hidden.
+///
+/// The candidate is described by a world-space center and half-extents --
+/// an *over*-estimate of the object (its bounding box), which is the safe
+/// direction: testing something larger than the object makes it harder to
+/// declare occluded, never easier.
+///
+/// Returns `false` (not occluded, the safe answer) when: the buffer is
+/// empty, any of the candidate's corners is unprojectable, its screen rect
+/// falls outside the buffer, any pixel of that rect is uncovered, or any
+/// covered pixel's stored occluder depth is not strictly nearer than the
+/// candidate's own nearest depth.
+pub fn box_occluded(
+    buf: &OcclusionBuffer,
+    view_proj: Mat4,
+    world_center: Vec3,
+    world_half_extents: Vec3,
+) -> bool {
+    if buf.is_empty() {
+        return false;
+    }
+
+    let corners = box_corners(Mat4::IDENTITY, world_center, world_half_extents);
+    let mut min_x = f32::MAX;
+    let mut max_x = f32::MIN;
+    let mut min_y = f32::MAX;
+    let mut max_y = f32::MIN;
+    // The candidate's NEAREST depth: if even its closest point is behind
+    // the occluder, all of it is.
+    let mut nearest_depth = f32::MAX;
+    for c in corners {
+        let Some(p) = project(view_proj, c) else {
+            return false;
+        };
+        min_x = min_x.min(p.x);
+        max_x = max_x.max(p.x);
+        min_y = min_y.min(p.y);
+        max_y = max_y.max(p.y);
+        nearest_depth = nearest_depth.min(p.depth);
+    }
+
+    let size = OCCLUSION_BUFFER_SIZE as f32;
+    // Any part of the candidate outside the buffer is unknown territory,
+    // and unknown must never mean occluded.
+    if min_x < 0.0 || min_y < 0.0 || max_x >= size || max_y >= size {
+        return false;
+    }
+
+    let x0 = min_x.floor() as usize;
+    let x1 = (max_x.ceil() as usize).min(OCCLUSION_BUFFER_SIZE - 1);
+    let y0 = min_y.floor() as usize;
+    let y1 = (max_y.ceil() as usize).min(OCCLUSION_BUFFER_SIZE - 1);
+
+    for py in y0..=y1 {
+        for px in x0..=x1 {
+            if buf.depth_at(px, py) >= nearest_depth {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,5 +335,123 @@ mod tests {
         assert!(!buf.is_empty());
         buf.clear();
         assert!(buf.is_empty(), "clear must restore the empty state");
+    }
+
+    /// The candidate sits at x = 2 rather than dead centre, and that offset
+    /// is load-bearing. Each box face is drawn as two triangles, and
+    /// inner-conservative rasterization leaves a one-pixel unwritten seam
+    /// along their shared diagonal -- measured as exactly the 104 interior
+    /// pixels where `px + py == 127`, i.e. straight through the buffer
+    /// centre. A candidate centred on the view axis has its screen rect
+    /// straddling that seam, so it reads as partly uncovered and stays
+    /// visible. That is the module's bias behaving as designed (a hole
+    /// under-culls, which is safe), and it does not depend on the
+    /// occluder's size: widening the wall to half-extent 20 or 100 leaves
+    /// the seam in the same place. Offsetting the candidate clear of the
+    /// seam is what makes this test measure the depth comparison it is
+    /// actually about.
+    #[test]
+    fn a_small_box_directly_behind_a_big_occluder_is_occluded() {
+        let vp = test_view_proj();
+        let mut buf = OcclusionBuffer::default();
+        rasterize_occluder_box(
+            &mut buf,
+            vp,
+            Mat4::IDENTITY,
+            Vec3::ZERO,
+            Vec3::new(5.0, 5.0, 0.5),
+        );
+        assert!(
+            box_occluded(&buf, vp, Vec3::new(2.0, 0.0, -20.0), Vec3::splat(0.5)),
+            "a small box far behind a large wall must be reported occluded"
+        );
+    }
+
+    /// The regression test this whole module exists to keep passing: an
+    /// object *beside* the wall, not behind it, must never be culled. This
+    /// is the failure mode that produces a visible rendering bug rather
+    /// than a missed optimization.
+    #[test]
+    fn a_box_beside_the_occluder_is_never_occluded() {
+        let vp = test_view_proj();
+        let mut buf = OcclusionBuffer::default();
+        rasterize_occluder_box(
+            &mut buf,
+            vp,
+            Mat4::IDENTITY,
+            Vec3::ZERO,
+            Vec3::new(1.0, 1.0, 0.5),
+        );
+        assert!(
+            !box_occluded(&buf, vp, Vec3::new(6.0, 0.0, -20.0), Vec3::splat(0.5)),
+            "an object beside the occluder must stay visible"
+        );
+    }
+
+    #[test]
+    fn a_box_in_front_of_the_occluder_is_not_occluded() {
+        let vp = test_view_proj();
+        let mut buf = OcclusionBuffer::default();
+        rasterize_occluder_box(
+            &mut buf,
+            vp,
+            Mat4::IDENTITY,
+            Vec3::ZERO,
+            Vec3::new(5.0, 5.0, 0.5),
+        );
+        assert!(
+            !box_occluded(&buf, vp, Vec3::new(0.0, 0.0, 5.0), Vec3::splat(0.5)),
+            "an object between the camera and the wall must stay visible"
+        );
+    }
+
+    #[test]
+    fn an_empty_buffer_occludes_nothing() {
+        let vp = test_view_proj();
+        let buf = OcclusionBuffer::default();
+        assert!(
+            !box_occluded(&buf, vp, Vec3::new(0.0, 0.0, -20.0), Vec3::splat(0.5)),
+            "with no occluders rasterized, nothing may be culled"
+        );
+    }
+
+    #[test]
+    fn a_box_only_partly_behind_the_occluder_is_not_occluded() {
+        let vp = test_view_proj();
+        let mut buf = OcclusionBuffer::default();
+        rasterize_occluder_box(
+            &mut buf,
+            vp,
+            Mat4::IDENTITY,
+            Vec3::ZERO,
+            Vec3::new(2.0, 2.0, 0.5),
+        );
+        // Wide enough that its screen rect spills past the occluder's edge.
+        assert!(
+            !box_occluded(
+                &buf,
+                vp,
+                Vec3::new(0.0, 0.0, -20.0),
+                Vec3::new(8.0, 8.0, 0.5)
+            ),
+            "a candidate whose screen rect extends past the occluder must stay visible"
+        );
+    }
+
+    #[test]
+    fn a_candidate_crossing_the_near_plane_is_not_occluded() {
+        let vp = test_view_proj();
+        let mut buf = OcclusionBuffer::default();
+        rasterize_occluder_box(
+            &mut buf,
+            vp,
+            Mat4::IDENTITY,
+            Vec3::ZERO,
+            Vec3::new(5.0, 5.0, 0.5),
+        );
+        assert!(
+            !box_occluded(&buf, vp, Vec3::new(0.0, 0.0, 10.0), Vec3::splat(50.0)),
+            "an unprojectable candidate must get the safe answer, not a guess"
+        );
     }
 }

--- a/crates/bsengine-render/src/occlusion.rs
+++ b/crates/bsengine-render/src/occlusion.rs
@@ -1,0 +1,278 @@
+//! CPU software occlusion culling: rasterize conservative occluder boxes
+//! into a small depth buffer, then test candidate bounding boxes against
+//! it. Deliberately GPU-free -- everything here is a pure function over
+//! plain math types, so it is unit-testable without an adapter, and it
+//! resolves within the same frame instead of a frame late the way a GPU
+//! occlusion query would.
+//!
+//! # The correctness rule
+//!
+//! There is exactly one failure mode that matters: culling something that
+//! was actually visible. A missed culling opportunity costs a little
+//! performance; a false cull is a visible rendering bug. Everything in
+//! this module is therefore biased toward under-culling, via two
+//! mechanisms that compose:
+//!
+//! 1. The occluder box the caller supplies must fit *inside* the real
+//!    geometry (enforced by whoever builds an `Occluder`, not here).
+//! 2. Rasterization is inner-conservative: a pixel is written only when
+//!    all four of its corners fall inside the projected triangle. Pixels
+//!    straddling a triangle edge, and thin seams between two triangles of
+//!    the same box, are left unwritten. Both leave *holes*, and a hole
+//!    reads as "not known to be covered", which can only under-cull.
+
+use glam::{Mat4, Vec3, Vec4Swizzles};
+
+/// Edge length of the square software depth buffer. Small on purpose: the
+/// cost is per-pixel per-occluder-triangle every frame, and occlusion only
+/// needs to answer a coarse "is this whole object behind that wall".
+pub const OCCLUSION_BUFFER_SIZE: usize = 128;
+
+/// A square software depth buffer holding, per pixel, the nearest occluder
+/// depth known to cover that pixel. `f32::INFINITY` means "nothing covers
+/// this pixel" -- the value that makes an empty buffer occlude nothing.
+#[derive(Clone)]
+pub struct OcclusionBuffer {
+    depths: Vec<f32>,
+}
+
+impl Default for OcclusionBuffer {
+    fn default() -> Self {
+        Self {
+            depths: vec![f32::INFINITY; OCCLUSION_BUFFER_SIZE * OCCLUSION_BUFFER_SIZE],
+        }
+    }
+}
+
+impl OcclusionBuffer {
+    /// Resets every pixel to "uncovered". Called once per frame before
+    /// rasterizing that frame's occluders; the allocation is reused.
+    pub fn clear(&mut self) {
+        self.depths.fill(f32::INFINITY);
+    }
+
+    /// True when no pixel has been written since the last `clear` -- i.e.
+    /// this frame had no usable occluders, so nothing can be culled.
+    pub fn is_empty(&self) -> bool {
+        self.depths.iter().all(|d| d.is_infinite())
+    }
+
+    // Only read by this module's own tests until `box_occluded` lands
+    // alongside it; the allow keeps the intermediate state warning-free
+    // without weakening the method's visibility.
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn depth_at(&self, x: usize, y: usize) -> f32 {
+        self.depths[y * OCCLUSION_BUFFER_SIZE + x]
+    }
+
+    fn write_nearer(&mut self, x: usize, y: usize, depth: f32) {
+        let slot = &mut self.depths[y * OCCLUSION_BUFFER_SIZE + x];
+        if depth < *slot {
+            *slot = depth;
+        }
+    }
+}
+
+/// One projected vertex: buffer-space x/y in pixels, plus NDC depth.
+#[derive(Clone, Copy)]
+struct Projected {
+    x: f32,
+    y: f32,
+    depth: f32,
+}
+
+/// Projects a world-space point into buffer space. Returns `None` when the
+/// point is at or behind the eye (`w <= 0`), which is the case a
+/// perspective divide cannot represent -- callers must treat any box with
+/// such a corner as unusable rather than guessing.
+fn project(view_proj: Mat4, world: Vec3) -> Option<Projected> {
+    let clip = view_proj * world.extend(1.0);
+    if clip.w <= 1e-6 {
+        return None;
+    }
+    let ndc = clip.xyz() / clip.w;
+    let size = OCCLUSION_BUFFER_SIZE as f32;
+    Some(Projected {
+        x: (ndc.x * 0.5 + 0.5) * size,
+        y: (0.5 - ndc.y * 0.5) * size,
+        depth: ndc.z,
+    })
+}
+
+/// The 8 corners of a local-space box, in world space.
+fn box_corners(model: Mat4, center: Vec3, half_extents: Vec3) -> [Vec3; 8] {
+    let mut out = [Vec3::ZERO; 8];
+    let mut i = 0;
+    for sx in [-1.0f32, 1.0] {
+        for sy in [-1.0f32, 1.0] {
+            for sz in [-1.0f32, 1.0] {
+                let local = center + half_extents * Vec3::new(sx, sy, sz);
+                out[i] = (model * local.extend(1.0)).truncate();
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Signed area of the triangle (a, b, c) in 2D; sign tells winding.
+fn edge(ax: f32, ay: f32, bx: f32, by: f32, px: f32, py: f32) -> f32 {
+    (bx - ax) * (py - ay) - (by - ay) * (px - ax)
+}
+
+/// Rasterizes one triangle inner-conservatively: a pixel is written only
+/// when all four of its corners are inside the triangle. Depth is taken as
+/// the triangle's maximum vertex depth, which is the farthest the triangle
+/// could be at any covered pixel -- using the farthest rather than an
+/// interpolated value keeps the stored depth from ever claiming the
+/// occluder is nearer than it really is at that pixel.
+fn rasterize_triangle(buf: &mut OcclusionBuffer, a: Projected, b: Projected, c: Projected) {
+    let size = OCCLUSION_BUFFER_SIZE as f32;
+    let min_x = a.x.min(b.x).min(c.x).floor().max(0.0) as usize;
+    let max_x = (a.x.max(b.x).max(c.x).ceil().min(size - 1.0)).max(0.0) as usize;
+    let min_y = a.y.min(b.y).min(c.y).floor().max(0.0) as usize;
+    let max_y = (a.y.max(b.y).max(c.y).ceil().min(size - 1.0)).max(0.0) as usize;
+    if min_x > max_x || min_y > max_y {
+        return;
+    }
+
+    // Normalize winding so "inside" is consistently non-negative.
+    let area = edge(a.x, a.y, b.x, b.y, c.x, c.y);
+    if area.abs() < 1e-6 {
+        return; // degenerate
+    }
+    let flip = if area < 0.0 { -1.0 } else { 1.0 };
+
+    let depth = a.depth.max(b.depth).max(c.depth);
+
+    for py in min_y..=max_y {
+        for px in min_x..=max_x {
+            let inside_all_corners = [
+                (px as f32, py as f32),
+                (px as f32 + 1.0, py as f32),
+                (px as f32, py as f32 + 1.0),
+                (px as f32 + 1.0, py as f32 + 1.0),
+            ]
+            .iter()
+            .all(|&(cx, cy)| {
+                edge(a.x, a.y, b.x, b.y, cx, cy) * flip >= 0.0
+                    && edge(b.x, b.y, c.x, c.y, cx, cy) * flip >= 0.0
+                    && edge(c.x, c.y, a.x, a.y, cx, cy) * flip >= 0.0
+            });
+            if inside_all_corners {
+                buf.write_nearer(px, py, depth);
+            }
+        }
+    }
+}
+
+/// Rasterizes one occluder box's 12 triangles into `buf`.
+///
+/// `center`/`half_extents` are in the entity's local space; `model` places
+/// it in the world. If any of the box's 8 corners fails to project (it is
+/// at or behind the eye), the whole box is skipped: a partially-projectable
+/// box cannot be rasterized correctly, and skipping it only under-culls.
+pub fn rasterize_occluder_box(
+    buf: &mut OcclusionBuffer,
+    view_proj: Mat4,
+    model: Mat4,
+    center: Vec3,
+    half_extents: Vec3,
+) {
+    let corners = box_corners(model, center, half_extents);
+    let mut projected = [Projected {
+        x: 0.0,
+        y: 0.0,
+        depth: 0.0,
+    }; 8];
+    for (i, c) in corners.iter().enumerate() {
+        match project(view_proj, *c) {
+            Some(p) => projected[i] = p,
+            None => return,
+        }
+    }
+
+    // Corner index bit layout from `box_corners`: bit2 = x sign, bit1 = y
+    // sign, bit0 = z sign (0 = -1, 1 = +1). These 12 triangles are the 6
+    // faces, two each.
+    const FACES: [[usize; 4]; 6] = [
+        [0, 1, 3, 2], // x = -1
+        [4, 6, 7, 5], // x = +1
+        [0, 4, 5, 1], // y = -1
+        [2, 3, 7, 6], // y = +1
+        [0, 2, 6, 4], // z = -1
+        [1, 5, 7, 3], // z = +1
+    ];
+    for f in FACES {
+        rasterize_triangle(buf, projected[f[0]], projected[f[1]], projected[f[2]]);
+        rasterize_triangle(buf, projected[f[0]], projected[f[2]], projected[f[3]]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A camera at +Z looking down -Z, the convention the engine's own
+    /// `Transform::view_matrix` produces for an unrotated camera.
+    fn test_view_proj() -> Mat4 {
+        let proj = Mat4::perspective_rh(60.0f32.to_radians(), 1.0, 0.1, 1000.0);
+        let view = Mat4::look_at_rh(Vec3::new(0.0, 0.0, 10.0), Vec3::ZERO, Vec3::Y);
+        proj * view
+    }
+
+    #[test]
+    fn a_fresh_buffer_is_empty_and_covers_nothing() {
+        let buf = OcclusionBuffer::default();
+        assert!(buf.is_empty());
+        assert!(buf.depth_at(64, 64).is_infinite());
+    }
+
+    #[test]
+    fn rasterizing_a_big_box_covers_the_center_of_the_buffer() {
+        let mut buf = OcclusionBuffer::default();
+        rasterize_occluder_box(
+            &mut buf,
+            test_view_proj(),
+            Mat4::IDENTITY,
+            Vec3::ZERO,
+            Vec3::new(5.0, 5.0, 0.5),
+        );
+        assert!(!buf.is_empty(), "a box filling the view must write pixels");
+        assert!(
+            buf.depth_at(64, 64).is_finite(),
+            "the center pixel must be covered by a box centered in view"
+        );
+    }
+
+    #[test]
+    fn a_box_entirely_behind_the_camera_writes_nothing() {
+        let mut buf = OcclusionBuffer::default();
+        rasterize_occluder_box(
+            &mut buf,
+            test_view_proj(),
+            Mat4::from_translation(Vec3::new(0.0, 0.0, 500.0)),
+            Vec3::ZERO,
+            Vec3::new(5.0, 5.0, 0.5),
+        );
+        assert!(
+            buf.is_empty(),
+            "a box behind the eye has unprojectable corners and must be skipped entirely"
+        );
+    }
+
+    #[test]
+    fn clear_resets_every_pixel() {
+        let mut buf = OcclusionBuffer::default();
+        rasterize_occluder_box(
+            &mut buf,
+            test_view_proj(),
+            Mat4::IDENTITY,
+            Vec3::ZERO,
+            Vec3::new(5.0, 5.0, 0.5),
+        );
+        assert!(!buf.is_empty());
+        buf.clear();
+        assert!(buf.is_empty(), "clear must restore the empty state");
+    }
+}

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -766,7 +766,9 @@ fn render_frame(
         .collect();
 
     // The count is the only externally visible evidence that occlusion
-    // culling did anything; the profiler picks it up in a later step.
+    // culling did anything; it is handed to `render_frame` below, which
+    // records it in `FrameStats::occluded_count` for the profiler panel and
+    // the `get_frame_stats` query tool.
     if occluded_count > 0 {
         tracing::trace!(occluded_count, "occlusion culling skipped entities");
     }
@@ -868,6 +870,7 @@ fn render_frame(
         sky_vp_inv,
         &draw_calls,
         &terrain_draw_calls,
+        occluded_count,
         &registry,
         light,
         tex_reg_ref,

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -14,7 +14,7 @@ use bsengine_rhi_wgpu::{
 use bsengine_window::WindowResized;
 use glam::{Mat4, Vec3, Vec4};
 
-use crate::components::{LodLevels, MeshRenderer, TerrainSplat};
+use crate::components::{LodLevels, MeshRenderer, Occluder, TerrainSplat};
 use crate::lod::select_lod_level;
 
 /// Returns false if the sphere is completely outside the view frustum.
@@ -847,6 +847,7 @@ impl Plugin for RenderPlugin {
         app.register_type::<MeshRenderer>();
         app.register_type::<TerrainSplat>();
         app.register_type::<LodLevels>();
+        app.register_type::<Occluder>();
         app.init_asset::<crate::shader_asset::ShaderSource>()
             .register_asset_loader(crate::shader_asset::ShaderSourceLoader)
             .init_resource::<UiState>()

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -1,5 +1,5 @@
 use bevy_app::{App, Plugin, PostUpdate, Update};
-use bevy_ecs::prelude::{EventReader, IntoSystemConfigs, ParamSet, Query, ResMut};
+use bevy_ecs::prelude::{EventReader, IntoSystemConfigs, Local, ParamSet, Query, ResMut};
 use bsengine_core::{
     AmbientOcclusion, Bloom, Camera, CustomShader, DirectionalLight, EditorPanelRegistry,
     EditorPlayState, GlobalTransform, HudTexts, InspectorState, Material, PointLight, SkyboxPath,
@@ -519,7 +519,12 @@ fn render_frame(
     // go up to 16 top-level params, and adding editor_panels as a 17th
     // plain parameter broke `IntoSystem` resolution for this function
     // (surfaced as a `.chain()` trait-bound error in RenderPlugin::build).
-    // Folding these five Querys into one param keeps the total at 13.
+    // Folding these Querys into one param keeps the total within that limit.
+    //
+    // This ParamSet is now FULL: Bevy 0.14's `impl_param_set!` macro is
+    // generated with `max_params = 8`, so there is no `p8()`. A ninth
+    // sub-query needs the same treatment applied one level down (a tuple,
+    // or a `#[derive(SystemParam)]` struct), not another entry here.
     mut render_queries: ParamSet<(
         Query<(
             &Camera,
@@ -550,6 +555,7 @@ fn render_frame(
             Option<&GlobalTransform>,
             &TerrainSplat,
         )>,
+        Query<(&Occluder, &Transform, Option<&GlobalTransform>)>,
     )>,
     editor_panels: Option<Res<EditorPanelRegistry>>,
     type_registry: Option<Res<bevy_ecs::reflect::AppTypeRegistry>>,
@@ -557,6 +563,24 @@ fn render_frame(
     // path becomes the id the GPU knows. Absent until item 38's cache exists,
     // in which case particles draw against the default white texture.
     texture_cache: Option<Res<crate::texture_cache::TextureCache>>,
+    // ONE tuple parameter, deliberately, rather than two plain ones: this
+    // function already stood at 15 top-level params and Bevy 0.14 stops
+    // implementing `SystemParamFunction` at 16, while the `ParamSet` above
+    // is now at its own hard maximum of 8 sub-params. Two more plain
+    // parameters would overflow the first limit and a ninth ParamSet entry
+    // the second. A tuple of `SystemParam`s is itself a `SystemParam`, so
+    // this pays one slot for both. (Overflowing either limit does not say
+    // so: it surfaces as a `.chain()` trait-bound error in
+    // `RenderPlugin::build`, exactly as the ParamSet comment above records.)
+    //
+    // The buffer is a `Local`, not a `Resource`, because nothing outside
+    // this system reads it -- so it does not belong in the ECS world -- but
+    // its 64 KB backing allocation should persist across frames rather than
+    // be rebuilt every one.
+    (occlusion_enabled, mut occlusion_buf): (
+        Option<Res<bsengine_core::OcclusionCullingEnabled>>,
+        Local<crate::occlusion::OcclusionBuffer>,
+    ),
 ) {
     let (Some(mut surface), Some(registry)) = (surface, registry) else {
         return;
@@ -634,6 +658,34 @@ fn render_frame(
         None
     };
 
+    // Occlusion pre-pass. It has to finish before the draw-call loop below
+    // borrows `p1()`: a ParamSet lends exactly one sub-query at a time, so
+    // this block's `p7()` borrow must end first -- hence a self-contained
+    // block here rather than anything interleaved with the loop.
+    //
+    // An absent `OcclusionCullingEnabled` means enabled, matching frustum
+    // culling, which has always run unconditionally.
+    let occlusion_on = occlusion_enabled.as_deref().map(|o| o.0).unwrap_or(true);
+    occlusion_buf.clear();
+    if occlusion_on {
+        for (occ, t, gt) in render_queries.p7().iter() {
+            let model = gt.map(|g| g.to_matrix()).unwrap_or_else(|| t.to_matrix());
+            crate::occlusion::rasterize_occluder_box(
+                &mut occlusion_buf,
+                view_proj,
+                model,
+                *occ.center,
+                *occ.half_extents,
+            );
+        }
+    }
+    // Shared immutably by the closure below, which also captures
+    // `occluded_count` mutably; without this reborrow the closure would try
+    // to take `occlusion_buf` (a `Local`, i.e. a smart pointer held by
+    // value) by unique borrow.
+    let occlusion_buf = &*occlusion_buf;
+    let mut occluded_count: u32 = 0;
+
     let draw_calls: Vec<(u64, Mat4, Option<u64>, MaterialParams, Option<String>)> = render_queries
         .p1()
         .iter_mut()
@@ -654,6 +706,26 @@ fn render_frame(
                     .max(model.z_axis.truncate().length());
                 let world_radius = local_radius * max_scale.max(1.0);
                 if !sphere_visible_in_frustum(view_proj, center, world_radius) {
+                    return None;
+                }
+                // Only entities that survived the frustum test get here, so
+                // the two culling stages compose instead of duplicating
+                // work. The candidate is tested as a cube of side
+                // `2 * world_radius` around its bounding sphere -- an
+                // over-estimate of the object, deliberately: testing
+                // something larger than the object makes it harder to
+                // declare occluded, never easier, and a false cull is a
+                // visible rendering bug while a missed one only costs a
+                // draw call.
+                if occlusion_on
+                    && crate::occlusion::box_occluded(
+                        occlusion_buf,
+                        view_proj,
+                        center,
+                        Vec3::splat(world_radius),
+                    )
+                {
+                    occluded_count += 1;
                     return None;
                 }
             }
@@ -692,6 +764,12 @@ fn render_frame(
             ))
         })
         .collect();
+
+    // The count is the only externally visible evidence that occlusion
+    // culling did anything; the profiler picks it up in a later step.
+    if occluded_count > 0 {
+        tracing::trace!(occluded_count, "occlusion culling skipped entities");
+    }
 
     let terrain_draw_calls: Vec<(u64, Mat4, [u64; 4], u64)> = render_queries
         .p6()
@@ -881,7 +959,7 @@ impl Plugin for RenderPlugin {
 #[cfg(test)]
 mod tests {
     use super::{CompileStatus, PendingShader, PendingShaders, PendingSkybox, RenderPlugin};
-    use crate::components::{LodLevels, MeshRenderer};
+    use crate::components::{LodLevels, MeshRenderer, Occluder};
     use bsengine_app::new_app;
     use bsengine_core::{Camera, GlobalTransform, Material, Parent, PointLight, Transform};
     use bsengine_rhi_wgpu::{GpuMeshRegistry, Vertex, WgpuRHIPlugin};
@@ -2043,5 +2121,179 @@ mod tests {
              [10.0, 50.0], must have selected a LOD level beyond LOD0 -- got \
              current_index = None"
         );
+    }
+
+    /// The regression test that matters: an entity beside a large occluder
+    /// must survive into the draw-call list while one directly behind it
+    /// does not. A false cull is a visible rendering bug, so this asserts
+    /// the safe direction explicitly rather than only testing that culling
+    /// happens at all.
+    ///
+    /// **How it observes a cull.** `render_frame` builds `draw_calls` in a
+    /// local `Vec` and hands it straight to the GPU, so draw-call
+    /// membership is not readable from the world afterwards -- but LOD
+    /// selection *is*. `LodLevels::current_index` is written inside the
+    /// same `filter_map` closure, strictly *after* the frustum and
+    /// occlusion `return None`s, and nothing else in the engine writes it.
+    /// So a `LodLevels` whose `current_index` is still `None` after a frame
+    /// in which its distance demands a level change is proof the closure
+    /// bailed out before reaching the LOD block -- i.e. that this entity
+    /// contributed no draw call. This is the same mechanism
+    /// `lod_current_index_updates_based_on_camera_distance` above relies
+    /// on, read in the other direction.
+    ///
+    /// The first frame runs with `OcclusionCullingEnabled(false)` as a
+    /// control: it proves both entities are otherwise perfectly drawable
+    /// (registered bounds, inside the frustum, visible), so the `None` seen
+    /// in the second frame can only come from the occlusion test. Without
+    /// that control a frustum-culled or bounds-less entity would produce
+    /// the same `None` and the test would pass for the wrong reason.
+    #[test]
+    fn an_entity_beside_an_occluder_is_not_culled_while_one_behind_it_is() {
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        // Offscreen, not windowed: a windowed plugin never acquires a
+        // `WindowHandle` in a test, so `GpuMeshRegistry` never exists,
+        // `render_frame` takes its early return, and this test would prove
+        // nothing at all.
+        app.add_plugins(WgpuRHIPlugin::offscreen(64, 64, true));
+        app.add_plugins(RenderPlugin);
+        app.update();
+
+        // A real registered mesh, so `registry.get_bounds` returns a real
+        // bounding sphere -- the occlusion test lives inside the `if let`
+        // that unwraps it, so an unregistered mesh id would skip culling
+        // entirely.
+        let mesh_id = {
+            let mut registry = app.world_mut().resource_mut::<GpuMeshRegistry>();
+            registry.register(
+                &[
+                    Vertex {
+                        position: [0.0, 0.0, 0.0],
+                        color: [1.0, 1.0, 1.0],
+                        normal: [0.0, 1.0, 0.0],
+                        uv: [0.0, 0.0],
+                    },
+                    Vertex {
+                        position: [1.0, 0.0, 0.0],
+                        color: [1.0, 1.0, 1.0],
+                        normal: [0.0, 1.0, 0.0],
+                        uv: [1.0, 0.0],
+                    },
+                    Vertex {
+                        position: [0.0, 1.0, 0.0],
+                        color: [1.0, 1.0, 1.0],
+                        normal: [0.0, 1.0, 0.0],
+                        uv: [0.0, 1.0],
+                    },
+                ],
+                &[0, 1, 2],
+            )
+        };
+
+        // Camera at +Z looking down -Z (the identity-rotation convention of
+        // `Transform::view_matrix`), default 60 degree vertical FOV.
+        app.world_mut().spawn((
+            Camera::default(),
+            Transform::from_position(Vec3::new(0.0, 0.0, 20.0)),
+        ));
+
+        // A 16x16 wall standing at z = 0, half a unit thick: from the
+        // camera it covers roughly the middle 40% of the screen width and
+        // 71% of its height.
+        app.world_mut().spawn((
+            Transform::from_position(Vec3::ZERO),
+            Occluder {
+                center: Vec3::ZERO.into(),
+                half_extents: Vec3::new(8.0, 8.0, 0.5).into(),
+            },
+        ));
+
+        // Twenty units behind the wall, and offset off the wall's
+        // screen-space diagonal: the box rasterizer splits each face into
+        // two triangles and leaves the seam between them unwritten (it is
+        // inner-conservative), so an object sitting exactly on the
+        // projected diagonal would find an uncovered pixel and correctly
+        // report itself un-occluded.
+        let hidden = spawn_lod_candidate(&mut app, mesh_id, Vec3::new(-3.0, 3.0, -20.0));
+        // Same depth, far enough sideways that the camera ray to it misses
+        // the wall entirely -- still comfortably inside the frustum and
+        // inside the occlusion buffer, so it is genuinely tested against
+        // the buffer and genuinely found visible.
+        let beside = spawn_lod_candidate(&mut app, mesh_id, Vec3::new(25.0, 0.0, -20.0));
+
+        // --- Control frame: culling off, so both must be drawn. ---
+        app.world_mut()
+            .insert_resource(bsengine_core::OcclusionCullingEnabled(false));
+        app.update();
+        assert_eq!(
+            lod_index(&app, hidden),
+            Some(0),
+            "control frame with occlusion culling disabled: the hidden \
+             entity must still be drawn, so any later cull is attributable \
+             to occlusion alone"
+        );
+        assert_eq!(
+            lod_index(&app, beside),
+            Some(0),
+            "control frame with occlusion culling disabled: the beside \
+             entity must be drawn"
+        );
+
+        // --- Real frame: culling on. ---
+        for e in [hidden, beside] {
+            app.world_mut()
+                .get_mut::<LodLevels>(e)
+                .expect("candidate still carries its LodLevels")
+                .current_index = None;
+        }
+        app.world_mut()
+            .insert_resource(bsengine_core::OcclusionCullingEnabled(true));
+        app.update();
+
+        assert_eq!(
+            lod_index(&app, hidden),
+            None,
+            "an entity directly behind a 16x16 occluder wall must be culled \
+             -- its LOD level was updated, so it reached the draw-call body"
+        );
+        assert_eq!(
+            lod_index(&app, beside),
+            Some(0),
+            "an entity beside the occluder is visible and must NOT be \
+             culled -- a false cull is a visible rendering bug"
+        );
+    }
+
+    /// Spawns a culling candidate whose `LodLevels` doubles as a
+    /// draw-call-membership probe: at any distance past 11 units the LOD
+    /// selector must move it off LOD0, so `current_index == Some(0)` means
+    /// "this entity reached the draw-call body" and `None` means "it was
+    /// culled before that".
+    fn spawn_lod_candidate(
+        app: &mut bevy_app::App,
+        mesh_id: u64,
+        position: Vec3,
+    ) -> bevy_ecs::entity::Entity {
+        app.world_mut()
+            .spawn((
+                MeshRenderer { mesh_id },
+                Transform::from_position(position),
+                LodLevels {
+                    // Never drawn -- this test only reads `current_index`.
+                    mesh_ids: vec![mesh_id + 100],
+                    switch_distances: vec![10.0],
+                    hysteresis_band: 2.0,
+                    current_index: None,
+                },
+            ))
+            .id()
+    }
+
+    fn lod_index(app: &bevy_app::App, entity: bevy_ecs::entity::Entity) -> Option<usize> {
+        app.world()
+            .get::<LodLevels>(entity)
+            .expect("candidate still carries its LodLevels")
+            .current_index
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/profiler.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/profiler.rs
@@ -72,8 +72,8 @@ impl EditorPanel for ProfilerPanel {
             latest.cpu_frame_time_ms
         ));
         ui.label(format!(
-            "Draw calls: {}   Triangles: {}",
-            latest.draw_calls, latest.triangles
+            "Draw calls: {}   Triangles: {}   Occluded: {}",
+            latest.draw_calls, latest.triangles, latest.occluded_count
         ));
         ui.label(format!(
             "Texture memory: {:.1} MB ({} textures)",

--- a/crates/bsengine-rhi-wgpu/src/profiler.rs
+++ b/crates/bsengine-rhi-wgpu/src/profiler.rs
@@ -149,6 +149,11 @@ pub struct FrameStats {
     pub draw_calls: u32,
     /// Number of triangles submitted this frame.
     pub triangles: u64,
+    /// Number of entities dropped this frame by occlusion culling --
+    /// entities that passed frustum culling but were found completely
+    /// hidden behind an `Occluder`. Zero when occlusion culling is off or
+    /// no occluders exist.
+    pub occluded_count: u32,
     /// Snapshot of [`texture_memory_bytes`] at the time this frame's stats were collected.
     pub texture_memory_bytes: u64,
     /// Snapshot of [`texture_count`] at the time this frame's stats were collected.

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2371,6 +2371,7 @@ impl WgpuSurface {
         sky_vp_inv: Option<Mat4>,
         draw_calls: &[(u64, Mat4, Option<u64>, MaterialParams, Option<String>)],
         terrain_draw_calls: &[(u64, Mat4, [u64; 4], u64)],
+        occluded_count: u32,
         registry: &GpuMeshRegistry,
         light: LightData,
         tex_registry: Option<&crate::texture::GpuTextureRegistry>,
@@ -3666,6 +3667,7 @@ impl WgpuSurface {
             gpu_timestamps_supported: self.timestamp_supported,
             draw_calls: frame_draw_calls,
             triangles: frame_triangles,
+            occluded_count,
             texture_memory_bytes: crate::profiler::texture_memory_bytes(),
             texture_count: crate::profiler::texture_count(),
         };

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -399,6 +399,7 @@ struct VertOut {{
                 sky_vp_inv,
                 &draw_calls,
                 &[],
+                0,
                 &self.registry,
                 scene.light.to_engine(),
                 Some(&self.textures),

--- a/crates/bsengine-rhi-wgpu/tests/terrain_draw.rs
+++ b/crates/bsengine-rhi-wgpu/tests/terrain_draw.rs
@@ -47,6 +47,7 @@ fn a_terrain_draw_call_does_not_panic_alongside_regular_draw_calls() {
         None,
         &[],
         &terrain_draw_calls,
+        0,
         &registry,
         LightData::default(),
         Some(&textures),

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -136,6 +136,9 @@ fn run_windowed(project_dir: &str) {
         .unwrap_or_else(|| manifest.project.name.clone());
 
     let mut app = new_app();
+    app.insert_resource(bsengine_core::OcclusionCullingEnabled(
+        manifest.render.occlusion_culling,
+    ));
     app.add_plugins(TimePlugin)
         .add_plugins(AssetPlugin)
         // Windowed only, deliberately. `--test` builds its own app

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -22,6 +22,8 @@ pub struct ProjectManifest {
     pub project: ProjectSection,
     #[serde(default)]
     pub window: WindowSection,
+    #[serde(default)]
+    pub render: RenderSection,
 }
 
 #[derive(Deserialize)]
@@ -57,6 +59,27 @@ impl Default for WindowSection {
             width: default_width(),
             height: default_height(),
             resizable: default_true(),
+        }
+    }
+}
+
+/// Rendering switches from `project.toml`'s `[render]` table.
+#[derive(Deserialize)]
+pub struct RenderSection {
+    /// Whether to cull entities hidden behind `Occluder`s. On by default,
+    /// matching frustum culling, which has always run unconditionally.
+    #[serde(default = "default_true")]
+    pub occlusion_culling: bool,
+}
+
+// Same rule as `WindowSection` above, and for the same reason: because
+// `ProjectManifest.render` is itself `#[serde(default)]`, this impl and
+// the field-level `#[serde(default = "...")]` must call the same function,
+// or an absent `[render]` table and an empty one would disagree.
+impl Default for RenderSection {
+    fn default() -> Self {
+        Self {
+            occlusion_culling: default_true(),
         }
     }
 }
@@ -415,5 +438,33 @@ mod tests {
              no collision or input dispatch — and it used to be zero",
             b_ran_at - swapped_at
         );
+    }
+
+    /// The `[render]` table being absent, present-but-empty, and explicit
+    /// must all agree -- the same three-way consistency `WindowSection`'s
+    /// Default impl comment above exists to protect.
+    #[test]
+    fn render_section_defaults_agree_whether_the_table_is_absent_or_empty() {
+        let absent: super::ProjectManifest =
+            toml::from_str("[project]\nname = \"t\"\nentry_scene = \"s.ron\"\n").unwrap();
+        let empty: super::ProjectManifest =
+            toml::from_str("[project]\nname = \"t\"\nentry_scene = \"s.ron\"\n[render]\n").unwrap();
+        assert_eq!(
+            absent.render.occlusion_culling, empty.render.occlusion_culling,
+            "an absent [render] table and an empty one must mean the same thing"
+        );
+        assert!(
+            absent.render.occlusion_culling,
+            "occlusion culling defaults to on"
+        );
+    }
+
+    #[test]
+    fn render_section_can_disable_occlusion_culling() {
+        let m: super::ProjectManifest = toml::from_str(
+            "[project]\nname = \"t\"\nentry_scene = \"s.ron\"\n[render]\nocclusion_culling = false\n",
+        )
+        .unwrap();
+        assert!(!m.render.occlusion_culling);
     }
 }

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -43,6 +43,9 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>, fast_rend
     let scene_path = format!("{project_dir}/{relative_scene}");
 
     let mut app = bsengine_app::new_app();
+    app.insert_resource(bsengine_core::OcclusionCullingEnabled(
+        manifest.render.occlusion_culling,
+    ));
     app.add_plugins(TimePlugin)
         .add_plugins(AssetPlugin)
         // Included here, unlike `AssetWatcherPlugin` (see main.rs's

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -2034,4 +2034,338 @@ mod tests {
              a genuinely working LOD reduction"
         );
     }
+
+    /// World-space (x, y) of the 30 small cubes parked 40 units behind the
+    /// wall, all of them well inside its screen-space silhouette.
+    ///
+    /// Two blocks (upper-left and lower-right) rather than one grid
+    /// straddling the view axis, and that is load-bearing rather than
+    /// decorative. `rasterize_occluder_box` splits each box face into two
+    /// triangles and is inner-conservative, so it leaves the seam along
+    /// their shared diagonal unwritten -- for a wall centred on the camera
+    /// axis that diagonal runs corner-to-corner through the middle of the
+    /// silhouette, exactly where `ndc.x == ndc.y`. Anything sitting on it
+    /// finds an uncovered pixel and correctly reports itself un-occluded
+    /// (a hole under-culls, which is the safe direction, and
+    /// `an_entity_beside_an_occluder_is_not_culled_while_one_behind_it_is`
+    /// in `bsengine-render` documents the same thing). Keeping every
+    /// candidate in a quadrant where `x` and `y` have opposite signs puts
+    /// `ndc.x` and `ndc.y` on opposite sides of zero, so none of them can
+    /// land on that seam no matter what the exact projection works out to.
+    ///
+    /// The bounds themselves: at z = -60 with a 60-degree vertical FOV and
+    /// a 16:9 aspect the visible half-extents are 61.6 x 34.6 world units,
+    /// and the wall's occluder box covers |ndc.x| < 0.59, |ndc.y| < 0.70 --
+    /// i.e. |x| < 36 and |y| < 24 at this depth. Every entry below is
+    /// inside that with at least five buffer pixels to spare, which also
+    /// keeps them far from the 128x128 buffer's own edge (`box_occluded`
+    /// refuses to cull anything whose screen rect leaves the buffer).
+    const OCCLUSION_HIDDEN_XY: [(f32, f32); 30] = [
+        (-30.0, 5.0),
+        (-30.0, 12.0),
+        (-30.0, 19.0),
+        (-24.0, 5.0),
+        (-24.0, 12.0),
+        (-24.0, 19.0),
+        (-18.0, 5.0),
+        (-18.0, 12.0),
+        (-18.0, 19.0),
+        (-12.0, 5.0),
+        (-12.0, 12.0),
+        (-12.0, 19.0),
+        (-6.0, 5.0),
+        (-6.0, 12.0),
+        (-6.0, 19.0),
+        (6.0, -5.0),
+        (6.0, -12.0),
+        (6.0, -19.0),
+        (12.0, -5.0),
+        (12.0, -12.0),
+        (12.0, -19.0),
+        (18.0, -5.0),
+        (18.0, -12.0),
+        (18.0, -19.0),
+        (24.0, -5.0),
+        (24.0, -12.0),
+        (24.0, -19.0),
+        (30.0, -5.0),
+        (30.0, -12.0),
+        (30.0, -19.0),
+    ];
+
+    /// World-space (x, y) of the three cubes at the same depth as the
+    /// hidden ones but off to the right of the wall entirely: at x = 48 the
+    /// camera ray to them misses the occluder (its silhouette ends at
+    /// x = 36 at this depth) while staying inside both the view frustum and
+    /// the occlusion buffer, so they are genuinely *tested* against the
+    /// buffer and genuinely found visible -- not skipped for being off
+    /// screen, which would prove nothing.
+    const OCCLUSION_BESIDE_XY: [(f32, f32); 3] = [(48.0, 0.0), (48.0, 10.0), (48.0, -10.0)];
+
+    /// Writes the temp project this test drives, with `occlusion_culling`
+    /// set either way. Called twice against the same directory: the second
+    /// call rewrites only `project.toml`, so the scene the two runs render
+    /// is byte-identical and the toggle is the single variable.
+    fn write_occlusion_project(root: &std::path::Path, occlusion_culling: bool) {
+        use std::fmt::Write as _;
+
+        std::fs::create_dir_all(root.join("assets/scenes")).unwrap();
+        std::fs::write(
+            root.join("project.toml"),
+            format!(
+                "[project]\nname = \"Occlusion E2E\"\n\
+                 entry_scene = \"assets/scenes/main.ron\"\n\
+                 [render]\nocclusion_culling = {occlusion_culling}\n"
+            ),
+        )
+        .unwrap();
+
+        // The camera sits at the origin unrotated, which looks down -Z --
+        // the same convention `lod_reduces_triangle_count_when_far_from_
+        // camera` above and the prefab/hierarchy tests before it rely on.
+        //
+        // The wall is a unit `Cube` primitive scaled to 24 x 16 x 1, so its
+        // real geometry spans +-12 x +-8 x +-0.5 world units at z = -20.
+        // Its `Occluder` box is authored in LOCAL space (the model matrix
+        // supplies the scale) at half-extent 0.49 rather than the mesh's
+        // own 0.5: an occluder must fit *inside* the geometry it stands in
+        // for, because rasterizing a blocker larger than the real thing is
+        // the one way this feature can hide something that was visible.
+        //
+        // `Occluder` has no typed `EntityDescriptor` field (unlike
+        // `gltf:`/`lod:`), so it is authored through the generic reflected
+        // `components:` list as a (type path, RON value) pair -- the same
+        // mechanism `games/terrain-demo`'s `Terrain` and `games/mini-arena`'s
+        // `Bloom`/`ToneMap`/`AudioListener` entries use. Both `center` and
+        // `half_extents` are `ReflectVec3`, which serialises as a plain
+        // three-float sequence, hence the `(x, y, z)` tuple syntax.
+        let mut scene = String::from(
+            r#"SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Camera",
+        camera: true,
+        transform: Some((position: (0.0, 0.0, 0.0))),
+    ),
+    EntityDescriptor(
+        name: "Wall",
+        primitive: Some(Cube),
+        transform: Some((position: (0.0, 0.0, -20.0), scale: (24.0, 16.0, 1.0))),
+        components: [
+            ("bsengine_render::components::Occluder", "(center: (0.0, 0.0, 0.0), half_extents: (0.49, 0.49, 0.49))"),
+        ],
+    ),
+"#,
+        );
+        for (i, (x, y)) in OCCLUSION_HIDDEN_XY.iter().enumerate() {
+            writeln!(
+                scene,
+                "    EntityDescriptor(name: \"Hidden{i}\", primitive: Some(Cube), \
+                 transform: Some((position: ({x:.1}, {y:.1}, -60.0)))),"
+            )
+            .unwrap();
+        }
+        for (i, (x, y)) in OCCLUSION_BESIDE_XY.iter().enumerate() {
+            writeln!(
+                scene,
+                "    EntityDescriptor(name: \"Beside{i}\", primitive: Some(Cube), \
+                 transform: Some((position: ({x:.1}, {y:.1}, -60.0)))),"
+            )
+            .unwrap();
+        }
+        scene.push_str("])\n");
+        std::fs::write(root.join("assets/scenes/main.ron"), scene).unwrap();
+    }
+
+    /// Steps `app` until every one of its `expected` primitive entities has
+    /// had its `PrimitiveMesh` resolved into a real `MeshRenderer` (that is
+    /// what makes an entity a culling candidate at all -- `render_frame`
+    /// only tests entities whose mesh id has registered bounds), then a few
+    /// frames more so the stats read back belong to a fully populated
+    /// scene rather than a half-loaded one.
+    fn step_until_meshes_ready(app: &mut App, expected: usize) {
+        let mut ready = false;
+        for _ in 0..300 {
+            app.update();
+            let mut q = app
+                .world_mut()
+                .query::<&bsengine_render::components::MeshRenderer>();
+            if q.iter(app.world()).count() >= expected {
+                ready = true;
+                break;
+            }
+        }
+        assert!(
+            ready,
+            "the occlusion temp project never resolved all {expected} primitive meshes \
+             within 300 frames -- without a MeshRenderer (and the registered bounds that \
+             come with it) an entity is never a culling candidate, so nothing below would \
+             be measuring occlusion"
+        );
+        for _ in 0..3 {
+            app.update();
+        }
+    }
+
+    /// Task 9, and the measured proof the whole occlusion feature exists to
+    /// produce: the profiler must show draw calls actually dropping, and it
+    /// must show the objects that were never hidden still being drawn.
+    ///
+    /// `bsengine-render`'s own unit tests already prove the pure functions
+    /// (`box_occluded` says yes behind a wall and no beside it) and its
+    /// `an_entity_beside_an_occluder_is_not_culled_while_one_behind_it_is`
+    /// already proves `render_frame` wires them up. Neither proves the
+    /// feature reaches the real runtime: the scene format has to be able to
+    /// author an `Occluder`, `project.toml`'s `[render] occlusion_culling`
+    /// has to reach the render path, and the saving has to be visible in
+    /// `FrameStats`. That is what this test drives, through the same
+    /// headless app (`build_test_app`) the E2E replays use, reading the
+    /// real frame profiler via `get_frame_stats`.
+    ///
+    /// **The assertion that matters is the third one.** `occluded_count > 0`
+    /// on its own would pass just as happily if every entity in the scene
+    /// were wrongly culled -- which is precisely the failure mode occlusion
+    /// culling must never have, because an over-cull is a visible rendering
+    /// bug while an under-cull only costs a draw call. So the beside-wall
+    /// entities are checked to still be drawn, by a floor on `draw_calls`.
+    ///
+    /// **Reading `draw_calls`.** It is a GPU-side count, not an entity
+    /// count: with `fast_render` off, each surviving mesh entity is drawn
+    /// once into the directional shadow map and once in the opaque pass, so
+    /// the figure is roughly `2 * survivors` plus a fixed post-processing
+    /// contribution that is identical between the two runs and cancels out
+    /// of any comparison between them. The assertions below are written in
+    /// those terms rather than against a hardcoded total.
+    ///
+    /// Measured when this test was written: culling on reports
+    /// `occluded_count = 30`, `draw_calls = 11` (the wall plus the three
+    /// beside entities drawn twice each, plus 3 post-processing draws);
+    /// culling off reports `occluded_count = 0`, `draw_calls = 71`
+    /// (34 x 2 + the same 3). Each of the three properties below was
+    /// mutation-verified rather than assumed: making `box_occluded` return
+    /// `true` unconditionally trips both the `<= hidden_count` bound and
+    /// the `visible_floor` over-cull assertion (draw_calls collapses to 3,
+    /// the post-processing floor), and ignoring `OcclusionCullingEnabled`
+    /// in `render_frame` trips the phase-2 `occluded_count == 0` check.
+    #[test]
+    fn occlusion_culling_reduces_draw_calls_without_hiding_visible_objects() {
+        let hidden_count = OCCLUSION_HIDDEN_XY.len();
+        let beside_count = OCCLUSION_BESIDE_XY.len();
+        // Wall + hidden + beside; the camera carries no mesh.
+        let mesh_entity_count = 1 + hidden_count + beside_count;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_occlusion_project(root, true);
+        let project_dir = root.to_str().unwrap().to_string();
+
+        // --- Phase 1: occlusion_culling = true ---
+        let mut app = build_test_app(&project_dir, None, false);
+        step_until_meshes_ready(&mut app, mesh_entity_count);
+
+        // A reflected component whose RON does not match its type's shape
+        // is skipped with a `tracing::warn!`, not a load failure -- so a
+        // typo in the `components:` entry above would leave the wall with
+        // no `Occluder` at all and this test would then be measuring an
+        // occluder-free scene. Check it directly rather than inferring it
+        // from the numbers.
+        {
+            let mut q = app.world_mut().query::<(
+                &bsengine_scene::Name,
+                &bsengine_render::components::Occluder,
+            )>();
+            let wall_occluder = q
+                .iter(app.world())
+                .find(|(n, _)| n.0 == "Wall")
+                .map(|(_, o)| *o);
+            let occ = wall_occluder.expect(
+                "the Wall entity must carry the Occluder authored in its scene `components:` \
+                 list -- an unparseable reflected component is only warned about, so its \
+                 absence here means the scene's type path or RON value is wrong",
+            );
+            assert_eq!(*occ.half_extents, glam::Vec3::splat(0.49));
+        }
+
+        let on_stats = crate::test_query::run_query(app.world_mut(), "get_frame_stats", &json!({}))
+            .expect("get_frame_stats should succeed once RenderPlugin has drawn a frame");
+        let on_occluded = on_stats["occluded_count"]
+            .as_u64()
+            .expect("get_frame_stats should report occluded_count as a number");
+        let on_draws = on_stats["draw_calls"]
+            .as_u64()
+            .expect("get_frame_stats should report draw_calls as a number");
+        println!("occlusion ON : occluded_count={on_occluded} draw_calls={on_draws}");
+
+        assert!(
+            on_occluded > 0,
+            "with a 24x16 wall standing between the camera and {hidden_count} cubes, the \
+             frame profiler reported occluded_count=0 -- nothing was culled at all"
+        );
+        assert!(
+            on_occluded <= hidden_count as u64,
+            "occluded_count={on_occluded} exceeds the {hidden_count} entities that are \
+             actually hidden, so something visible was culled"
+        );
+        assert!(
+            on_draws < mesh_entity_count as u64,
+            "occlusion culling must measurably cut the frame's work: draw_calls={on_draws} \
+             is not even below the {mesh_entity_count} mesh entities in the scene, and each \
+             drawn entity costs two draw calls (shadow + opaque) before post-processing is \
+             counted at all"
+        );
+        // THE regression assertion. Each surviving entity contributes two
+        // draw calls, so the {beside} entities beside the wall plus the
+        // wall itself put a floor under `draw_calls` that an
+        // over-culling implementation would fall straight through.
+        let visible_floor = 2 * (beside_count as u64 + 1);
+        assert!(
+            on_draws >= visible_floor,
+            "over-cull: draw_calls={on_draws} is below the {visible_floor} that the wall \
+             and the {beside_count} entities standing clear of it must produce on their \
+             own (two draw calls each: shadow pass + opaque pass). Something that was \
+             plainly visible got culled, which is a rendering bug, not an optimization"
+        );
+
+        // Release phase 1's app and its GPU device before building the
+        // second one, the same way `terrain_brush_edit_survives_a_reload`
+        // above does.
+        drop(app);
+
+        // --- Phase 2: the same scene with occlusion_culling = false ---
+        write_occlusion_project(root, false);
+        let mut app = build_test_app(&project_dir, None, false);
+        step_until_meshes_ready(&mut app, mesh_entity_count);
+
+        let off_stats =
+            crate::test_query::run_query(app.world_mut(), "get_frame_stats", &json!({}))
+                .expect("get_frame_stats should succeed once RenderPlugin has drawn a frame");
+        let off_occluded = off_stats["occluded_count"]
+            .as_u64()
+            .expect("get_frame_stats should report occluded_count as a number");
+        let off_draws = off_stats["draw_calls"]
+            .as_u64()
+            .expect("get_frame_stats should report draw_calls as a number");
+        println!("occlusion OFF: occluded_count={off_occluded} draw_calls={off_draws}");
+
+        assert_eq!(
+            off_occluded, 0,
+            "`[render] occlusion_culling = false` in project.toml must reach the render \
+             path: with the identical scene it still reported occluded_count={off_occluded}"
+        );
+        assert!(
+            off_draws >= 2 * mesh_entity_count as u64,
+            "with culling off every one of the {mesh_entity_count} mesh entities must be \
+             drawn twice (shadow + opaque), i.e. at least {} draw calls, but the profiler \
+             reported {off_draws} -- if the full count is not restored then phase 1's drop \
+             was not attributable to occlusion",
+            2 * mesh_entity_count
+        );
+        assert_eq!(
+            off_draws - on_draws,
+            2 * on_occluded,
+            "the whole difference between the two runs should be exactly the culled \
+             entities' own draw calls: {on_occluded} culled x 2 passes each. Got \
+             off={off_draws}, on={on_draws}. Anything else means the toggle changed \
+             something beyond occlusion, or the two runs did not render the same scene"
+        );
+    }
 }

--- a/crates/bsengine-runtime/src/test_query.rs
+++ b/crates/bsengine-runtime/src/test_query.rs
@@ -215,6 +215,7 @@ pub fn get_frame_stats(world: &mut World) -> Result<Value, String> {
         })).collect::<Vec<_>>(),
         "draw_calls": stats.draw_calls,
         "triangles": stats.triangles,
+        "occluded_count": stats.occluded_count,
         "texture_memory_bytes": stats.texture_memory_bytes,
         "texture_count": stats.texture_count,
     }))


### PR DESCRIPTION
## Summary
Implements ENGINE_ROADMAP item 46 (오클루전 컬링). Entities completely hidden behind an explicitly-marked occluder are dropped from the frame's draw calls, resolved within the same frame on the CPU.

**Why CPU software rasterization over GPU occlusion queries:** wgpu 22.1.0 does support `QueryType::Occlusion` with no extra feature flag, so this wasn't an availability problem — it's latency. A GPU query's result only becomes readable after an async readback, so real engines using it cull *this* frame with *last* frame's answer, which pops when the camera moves and can't be verified deterministically. The CPU path resolves in-frame and its core logic is pure functions unit-testable with no GPU at all.

## The correctness rule this is built around
Occlusion culling has one failure mode that matters: **culling something actually visible**. A missed opportunity costs a little performance; a false cull is a visible rendering bug. Two mechanisms make over-culling structurally impossible, and they compose:

1. **The occluder box is a conservative under-estimate** — `Occluder` carries a box that must fit *inside* the real geometry, never a bounding box.
2. **Rasterization is inner-conservative** — a pixel is written only when all four of its corners are inside the projected triangle. Edge pixels and seams between a box's triangles are left unwritten, and a hole reads as "not known to be covered", which can only under-cull.

The candidate side is deliberately asymmetric: a candidate is tested as a cube around its bounding sphere — an *over*-estimate — making it harder to declare occluded, never easier.

## Changes
- New `crates/bsengine-render/src/occlusion.rs`: `OcclusionBuffer` (128×128 f32), `rasterize_occluder_box`, `box_occluded`. No ECS, no GPU.
- New `Occluder { center, half_extents }` component (both `ReflectVec3`), registered for reflection.
- `render_frame` gains an occluder pre-pass and one extra rejection test placed **after** the existing frustum check, so the two culling stages compose without duplicating work (roadmap condition). Buffer lives in a `Local`, so its 64 KB allocation persists across frames.
- Terrain chunks auto-attach a conservative `Occluder` rising from local y=0 to the chunk's **minimum** height, keeping it under the real surface everywhere.
- `[render] occlusion_culling` in `project.toml`, plumbed through a new `RenderSection` into `bsengine_core::OcclusionCullingEnabled`, inserted at both the windowed and headless app-construction sites. Absent resource means enabled, matching frustum culling.
- `FrameStats.occluded_count`, surfaced in the editor's profiler panel and the `get_frame_stats` query tool (roadmap condition: culled-object count observable via the profiler).

## Measured effect
The E2E test drives the real headless app over a scene with a wall, 30 entities hidden behind it, and 3 standing clear:

| | occluded_count | draw_calls |
|---|---|---|
| culling on | 30 | 11 |
| culling off | 0 | 71 |

The test asserts the delta *exactly*: `off_draws - on_draws == 2 * on_occluded` (two passes per entity). It also puts a hard floor under `draw_calls` from the wall plus the entities beside it, so an over-culling implementation fails loudly rather than passing on a happy `occluded_count > 0`.

## Test plan
- [x] `cargo test -p bsengine-render --lib` — 54/54 (10 occlusion unit tests incl. the named `a_box_beside_the_occluder_is_never_occluded` regression test, plus an integration test proving both directions through the real render loop)
- [x] `cargo test -p bsengine-app --lib` — 92/92 (incl. terrain occluder-stays-under-the-surface test asserting against the chunk's own collider heightfield)
- [x] `cargo test -p bsengine-runtime --bins` — 59/59 (incl. the toggle's absent/empty/explicit three-way agreement and the E2E proof)
- [x] `cargo test --workspace --exclude bsengine-editor` — zero failures
- [x] `cargo test -p bsengine-editor --lib` — 937/937 (isolated, per this repo's CI split)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` — 59 components, 0 violations
- [x] `cargo clippy --workspace --all-targets` — identical to the pre-existing baseline, 0 new warnings
- [x] `cargo +nightly fmt --all` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)