### PR TITLE
feat: temporal anti-aliasing (TAA) core

### DIFF
--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -81,6 +81,8 @@ pub mod screen_size;
 pub mod shield;
 /// Skybox background component and its projection mode.
 pub mod skybox;
+/// Temporal antialiasing post-process settings.
+pub mod taa;
 /// Frame and elapsed-time resource driven by the app's main loop.
 pub mod time;
 /// Simple countdown timer component.
@@ -136,6 +138,7 @@ pub use save_data::SaveData;
 pub use screen_size::ScreenSize;
 pub use shield::Shield;
 pub use skybox::{Skybox, SkyboxPath, SkyboxProjection};
+pub use taa::Taa;
 pub use time::Time;
 pub use timer::Timer;
 pub use tone_map::{ToneMap, ToneMappingMode};

--- a/crates/bsengine-core/src/taa.rs
+++ b/crates/bsengine-core/src/taa.rs
@@ -1,0 +1,63 @@
+//! Temporal antialiasing settings for a camera.
+
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
+
+/// Temporal antialiasing applied by a camera.
+///
+/// Accumulates sub-pixel-jittered frames over time, reprojecting the
+/// previous frame through the camera's motion, to smooth edges that would
+/// otherwise stair-step and crawl.
+///
+/// **Absent means off.** A camera without this component renders exactly as
+/// it always has — which is what lets every existing pixel test keep
+/// passing unchanged.
+///
+/// Reprojection is depth-based and camera-only in this version, so it is
+/// exact for static geometry under any camera motion. Moving objects
+/// reproject incorrectly and are held in check by `clamp_strength` rather
+/// than corrected; per-object motion vectors are a separate piece of work.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Default)]
+pub struct Taa {
+    /// Whether the effect is applied at all.
+    pub enabled: bool,
+    /// Fraction of the reprojected history blended into each pixel, in
+    /// `[0, 1)`. This is the quality knob: lower converges in fewer frames
+    /// but antialiases less, higher is smoother but ghosts more readily.
+    /// 0.9 is the usual starting point and the default here.
+    pub history_blend: f32,
+    /// How far outside the current frame's local 3x3 colour range the
+    /// reprojected history is allowed to sit, as a multiple of that range.
+    /// Lower clamps harder: less ghosting, less smoothing. 1.0 clamps to
+    /// exactly the neighbourhood.
+    pub clamp_strength: f32,
+}
+
+impl Default for Taa {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            history_blend: 0.9,
+            clamp_strength: 1.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_enabled_and_blends_mostly_history() {
+        let t = Taa::default();
+        assert!(t.enabled);
+        assert!(
+            t.history_blend > 0.5 && t.history_blend < 1.0,
+            "history_blend must favour history to antialias, but stay below \
+             1.0 or the current frame never contributes and the image freezes"
+        );
+        assert!(t.clamp_strength > 0.0);
+    }
+}

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -3,7 +3,7 @@ use bevy_ecs::prelude::{EventReader, IntoSystemConfigs, Local, ParamSet, Query, 
 use bsengine_core::{
     AmbientOcclusion, Bloom, Camera, CustomShader, DirectionalLight, EditorPanelRegistry,
     EditorPlayState, GlobalTransform, HudTexts, InspectorState, Material, PointLight, SkyboxPath,
-    SpotLight, Time, ToneMap, Transform, UiState, Visible,
+    SpotLight, Taa, Time, ToneMap, Transform, UiState, Visible,
 };
 use bsengine_ecs::Res;
 use bsengine_input::{Input, KeyCode, KeyInput, MouseButton, MouseState};
@@ -532,6 +532,7 @@ fn render_frame(
             Option<&Bloom>,
             Option<&ToneMap>,
             Option<&AmbientOcclusion>,
+            Option<&Taa>,
         )>,
         Query<(
             &MeshRenderer,
@@ -577,9 +578,18 @@ fn render_frame(
     // this system reads it -- so it does not belong in the ECS world -- but
     // its 64 KB backing allocation should persist across frames rather than
     // be rebuilt every one.
-    (occlusion_enabled, mut occlusion_buf): (
+    //
+    // `taa_frame_index` rides along in the same tuple for exactly the reason
+    // above: with the tuple counted as one, this function already stands at
+    // 16 top-level params, and `bevy_ecs` 0.14 stops implementing
+    // `SystemParamFunction` at 16 (`all_tuples!(impl_system_function, 0, 16,
+    // F)`). It is a `Local` for the same reason the buffer is -- it is this
+    // system's own frame counter, driving the Halton jitter cycle, and no
+    // one else reads it.
+    (occlusion_enabled, mut occlusion_buf, mut taa_frame_index): (
         Option<Res<bsengine_core::OcclusionCullingEnabled>>,
         Local<crate::occlusion::OcclusionBuffer>,
+        Local<u32>,
     ),
 ) {
     let (Some(mut surface), Some(registry)) = (surface, registry) else {
@@ -615,12 +625,12 @@ fn render_frame(
         .map(|k| k.is_pressed(&KeyCode::AltLeft) || k.is_pressed(&KeyCode::AltRight))
         .unwrap_or(false);
 
-    let (mut view_proj, mut cam_pos, mut cam_proj, bloom, tone_map, ambient_occlusion) =
+    let (mut view_proj, mut cam_pos, mut cam_proj, bloom, tone_map, ambient_occlusion, taa) =
         render_queries
             .p0()
             .iter()
             .next()
-            .map(|(cam, t, b, tm, ao)| {
+            .map(|(cam, t, b, tm, ao, taa)| {
                 let proj = cam.projection_matrix();
                 (
                     proj * t.view_matrix(),
@@ -629,9 +639,18 @@ fn render_frame(
                     b.copied(),
                     tm.copied(),
                     ao.copied(),
+                    taa.copied(),
                 )
             })
-            .unwrap_or((Mat4::IDENTITY, Vec3::ZERO, Mat4::IDENTITY, None, None, None));
+            .unwrap_or((
+                Mat4::IDENTITY,
+                Vec3::ZERO,
+                Mat4::IDENTITY,
+                None,
+                None,
+                None,
+                None,
+            ));
 
     // While editing (not Playing), override camera matrices from the orbit
     // camera computed by EditorPlugin. Once Play starts, the viewport should
@@ -646,9 +665,35 @@ fn render_frame(
         }
     }
 
+    // TAA reprojection inputs, computed *after* the editor override above and
+    // never before it: whichever camera won that block is the one this frame
+    // rasterizes with, so it must also be the one the next frame reprojects
+    // against. Capturing the game camera's matrix here instead would make the
+    // editor viewport smear every time the orbit camera moved.
+    //
+    // `view_proj` itself stays unjittered -- everything downstream of it
+    // (occlusion rasterization, frustum culling, and the reprojection matrix
+    // below) wants the camera's true matrix. The jitter is a separate offset
+    // that `WgpuSurface::render_frame` applies to the rasterization
+    // projection alone.
+    let unjittered_view_proj = view_proj;
+    let jitter_clip = if taa.map(|t| t.enabled).unwrap_or(false) {
+        bsengine_rhi_wgpu::taa_jitter::jitter_clip_offset(
+            *taa_frame_index,
+            surface.0.width(),
+            surface.0.height(),
+        )
+    } else {
+        (0.0, 0.0)
+    };
+    // Advanced every frame, not only the TAA ones, so the cycle never stalls
+    // on a repeated offset. `wrapping_add` because this counts frames
+    // forever; `jitter_clip_offset` takes it modulo the cycle length anyway.
+    *taa_frame_index = taa_frame_index.wrapping_add(1);
+
     // Rotation-only VP inverse for skybox (no translation → direction-only)
     let sky_vp_inv: Option<Mat4> = if surface.0.has_skybox() {
-        render_queries.p0().iter().next().map(|(cam, t, _, _, _)| {
+        render_queries.p0().iter().next().map(|(cam, t, ..)| {
             let proj = cam.projection_matrix();
             let view = t.view_matrix();
             let view_rot = Mat4::from_cols(view.x_axis, view.y_axis, view.z_axis, Vec4::W);
@@ -893,6 +938,9 @@ fn render_frame(
         type_registry.as_deref(),
         time.as_deref().map(|t| t.elapsed_seconds).unwrap_or(0.0),
         &particle_batches,
+        taa,
+        jitter_clip,
+        unjittered_view_proj,
     ) {
         Ok(clicked) => {
             if let Some(ref mut state) = ui_state {

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -36,6 +36,7 @@ pub mod post_process;
 pub mod profiler;
 /// Swapchain/frame lifecycle and the main scene render pass.
 pub mod surface;
+pub mod taa_jitter;
 /// GPU texture loading and the texture registry.
 pub mod texture;
 pub mod theme;

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -226,19 +226,58 @@ fn fs_composite(in: FullscreenOut) -> @location(0) vec4<f32> {
 
 /// The temporal-antialiasing resolve pass.
 ///
-/// Right now it is a straight passthrough: it copies the composite pass's LDR
-/// result to the swapchain unchanged, so the frame is pixel-identical to the
-/// composite-writes-straight-to-the-swapchain arrangement it replaces. The
-/// pass exists at this point only to establish the structure -- composite ->
-/// readable LDR texture -> final blit -- that the real resolve needs, because
-/// a pass cannot sample the texture it is rendering into.
+/// It reads the composite pass's LDR result, reprojects the previous frame's
+/// resolved image through the camera's motion, clamps that history to the
+/// local 3x3 neighbourhood of the current frame, and blends the two. The
+/// result is written twice -- to the swapchain and to the history target the
+/// next frame will reproject from -- which is why the pass exists as a
+/// separate blit at all: a pass cannot sample the texture it renders into.
+///
+/// Reprojection here is **camera-only**: there are no per-object motion
+/// vectors, so a moving object's history lands at the wrong pixel by design.
+/// The neighbourhood clamp is what keeps that error from smearing across the
+/// frame -- it is not an optional quality knob.
+///
+/// With `config.taa_enabled == 0u` the shader returns the current frame
+/// untouched, so the pass stays the exact passthrough it replaced.
 const TAA_WGSL: &str = r#"
 struct FullscreenOut {
     @builtin(position) pos: vec4<f32>,
     @location(0) uv: vec2<f32>,
 }
+struct PostProcessConfig {
+    bloom_threshold: f32, bloom_softness: f32, bloom_intensity: f32, bloom_radius: f32,
+    bloom_enabled: u32, tonemap_mode: u32, tonemap_exposure: f32, tonemap_enabled: u32,
+    ssao_radius: f32, ssao_bias: f32, ssao_intensity: f32, ssao_sample_count: u32,
+    ssao_enabled: u32, taa_enabled: u32, taa_history_blend: f32, taa_clamp_strength: f32,
+}
+struct TaaCamera {
+    inv_view_proj: mat4x4<f32>,
+    prev_view_proj: mat4x4<f32>,
+}
 @group(0) @binding(0) var ldr_tex: texture_2d<f32>;
 @group(0) @binding(1) var ldr_sampler: sampler;
+@group(1) @binding(0) var history_tex: texture_2d<f32>;
+@group(1) @binding(1) var history_sampler: sampler;
+@group(2) @binding(0) var depth_tex: texture_depth_2d;
+// Both uniforms share group 3: four groups is the WebGPU baseline
+// `max_bind_groups`, and LDR/history/depth already take three.
+@group(3) @binding(0) var<uniform> config: PostProcessConfig;
+@group(3) @binding(1) var<uniform> cam: TaaCamera;
+
+// The resolved colour goes to two attachments: @location(0) is the swapchain,
+// @location(1) is next frame's history. They are always the same colour.
+struct TaaOut {
+    @location(0) color: vec4<f32>,
+    @location(1) history: vec4<f32>,
+}
+
+fn taa_out(c: vec4<f32>) -> TaaOut {
+    var out: TaaOut;
+    out.color = c;
+    out.history = c;
+    return out;
+}
 
 @vertex
 fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
@@ -253,8 +292,80 @@ fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
 }
 
 @fragment
-fn fs_taa(in: FullscreenOut) -> @location(0) vec4<f32> {
-    return textureSample(ldr_tex, ldr_sampler, in.uv);
+fn fs_taa(in: FullscreenOut) -> TaaOut {
+    let current = textureSample(ldr_tex, ldr_sampler, in.uv);
+    if config.taa_enabled == 0u {
+        return taa_out(current);
+    }
+
+    let dims = vec2<f32>(textureDimensions(ldr_tex, 0));
+    let texel = vec2<f32>(1.0 / dims.x, 1.0 / dims.y);
+
+    // Neighbourhood bounds, gathered from THIS frame before any history is
+    // consulted: the clamp below is only meaningful against the range the
+    // current frame actually contains. These `textureSample` calls also have
+    // to happen here, above the per-pixel early-outs, because implicit
+    // derivatives are only legal in uniform control flow.
+    var lo = current.rgb;
+    var hi = current.rgb;
+    for (var dy: i32 = -1; dy <= 1; dy = dy + 1) {
+        for (var dx: i32 = -1; dx <= 1; dx = dx + 1) {
+            let s = textureSample(
+                ldr_tex, ldr_sampler,
+                in.uv + vec2<f32>(f32(dx), f32(dy)) * texel
+            ).rgb;
+            lo = min(lo, s);
+            hi = max(hi, s);
+        }
+    }
+
+    let depth_dims = vec2<i32>(textureDimensions(depth_tex, 0));
+    let coord = clamp(
+        vec2<i32>(in.uv * vec2<f32>(depth_dims)),
+        vec2<i32>(0),
+        depth_dims - vec2<i32>(1)
+    );
+    let depth = textureLoad(depth_tex, coord, 0);
+    // Nothing was drawn here: sky/background has no reliable surface to
+    // reproject, so trust the current frame.
+    if depth >= 1.0 {
+        return taa_out(current);
+    }
+
+    // Pixel + depth -> world position -> where it was last frame.
+    let ndc = vec4<f32>(in.uv.x * 2.0 - 1.0, 1.0 - in.uv.y * 2.0, depth, 1.0);
+    let world_h = cam.inv_view_proj * ndc;
+    let world = world_h.xyz / world_h.w;
+    let prev_clip = cam.prev_view_proj * vec4<f32>(world, 1.0);
+    // Behind the eye last frame: there is no previous-frame pixel to find.
+    if prev_clip.w <= 0.0 {
+        return taa_out(current);
+    }
+    let prev_ndc = prev_clip.xyz / prev_clip.w;
+    let prev_uv = vec2<f32>(prev_ndc.x * 0.5 + 0.5, 0.5 - prev_ndc.y * 0.5);
+
+    // History from outside the previous frame simply does not exist.
+    if prev_uv.x < 0.0 || prev_uv.x > 1.0 || prev_uv.y < 0.0 || prev_uv.y > 1.0 {
+        return taa_out(current);
+    }
+
+    // `textureSampleLevel`, not `textureSample`: this read sits under the
+    // per-pixel branches above, and an implicit-derivative sample there is
+    // non-uniform control flow. The history texture has a single mip, so
+    // level 0 is the only level either call could have read.
+    let history = textureSampleLevel(history_tex, history_sampler, prev_uv, 0.0).rgb;
+
+    // Clamp history into the local range. This is what stops a moving
+    // object -- which this version reprojects incorrectly, by design --
+    // from smearing across the frame.
+    let centre = (lo + hi) * 0.5;
+    let extent = (hi - lo) * 0.5 * config.taa_clamp_strength;
+    let clamped = clamp(history, centre - extent, centre + extent);
+
+    return taa_out(vec4<f32>(
+        mix(current.rgb, clamped, config.taa_history_blend),
+        current.a
+    ));
 }
 "#;
 
@@ -370,9 +481,6 @@ pub struct PostProcessState {
     history_bgs: [wgpu::BindGroup; 2],
     /// Index of the history texture holding the PREVIOUS frame's result.
     /// Flipped at the end of every `apply`.
-    // Only read once the resolve pass actually samples history; the
-    // passthrough blit in `apply` does not.
-    #[allow(dead_code)]
     history_read: usize,
     /// False until a frame has been written to history. The first frame has
     /// no history to reproject, so it must pass through unblended rather
@@ -389,18 +497,19 @@ pub struct PostProcessState {
     ssao_cam_buffer: wgpu::Buffer,
     ssao_cam_bg: wgpu::BindGroup,
     taa_cam_buffer: wgpu::Buffer,
-    // Bound once the resolve pass reprojects; the passthrough blit in `apply`
-    // takes no camera uniform.
-    #[allow(dead_code)]
-    taa_cam_bg: wgpu::BindGroup,
+    /// The TAA pass's single uniform group: the shared config buffer at
+    /// binding 0 and `taa_cam_buffer` at binding 1. One group rather than the
+    /// two the other passes use, because the resolve is already at the
+    /// four-bind-group WebGPU baseline limit.
+    taa_uniform_bg: wgpu::BindGroup,
     /// Pipeline for the bright-pass bloom extraction shader.
     pub bloom_pipeline: wgpu::RenderPipeline,
     /// Pipeline for the SSAO occlusion shader.
     pub ssao_pipeline: wgpu::RenderPipeline,
     /// Pipeline for the final composite (HDR + bloom + AO, tonemapped) shader.
     pub composite_pipeline: wgpu::RenderPipeline,
-    /// Pipeline for the temporal-antialiasing resolve that writes the
-    /// swapchain image. Currently a passthrough blit of the composite result.
+    /// Pipeline for the temporal-antialiasing resolve. Writes both the
+    /// swapchain image and next frame's history target.
     pub taa_pipeline: wgpu::RenderPipeline,
     tex2d_bgl: wgpu::BindGroupLayout,
     depth_bgl: wgpu::BindGroupLayout,
@@ -493,18 +602,33 @@ impl PostProcessState {
             }],
         });
 
-        let taa_cam_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("pp taa cam bgl"),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: wgpu::BufferSize::new(TAA_CAM_SIZE),
+        // The resolve pass already needs four groups (LDR, history, depth,
+        // uniforms) and `max_bind_groups` is 4 on the WebGPU baseline, so the
+        // config and camera uniforms share one group rather than taking two.
+        let taa_uniform_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp taa uniform bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(CONFIG_SIZE),
+                    },
+                    count: None,
                 },
-                count: None,
-            }],
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(TAA_CAM_SIZE),
+                    },
+                    count: None,
+                },
+            ],
         });
 
         let config_buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -543,13 +667,19 @@ impl PostProcessState {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let taa_cam_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("pp taa cam bg"),
-            layout: &taa_cam_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: taa_cam_buffer.as_entire_binding(),
-            }],
+        let taa_uniform_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pp taa uniform bg"),
+            layout: &taa_uniform_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: config_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: taa_cam_buffer.as_entire_binding(),
+                },
+            ],
         });
 
         let bloom_pipeline = Self::make_bloom_pipeline(device, &tex2d_bgl, &config_bgl);
@@ -557,7 +687,13 @@ impl PostProcessState {
             Self::make_ssao_pipeline(device, &depth_bgl, &config_bgl, &ssao_cam_bgl);
         let composite_pipeline =
             Self::make_composite_pipeline(device, &tex2d_bgl, &config_bgl, surface_format);
-        let taa_pipeline = Self::make_taa_pipeline(device, &tex2d_bgl, surface_format);
+        let taa_pipeline = Self::make_taa_pipeline(
+            device,
+            &tex2d_bgl,
+            &depth_bgl,
+            &taa_uniform_bgl,
+            surface_format,
+        );
 
         let targets = Self::create_targets(
             device,
@@ -595,7 +731,7 @@ impl PostProcessState {
             ssao_cam_buffer,
             ssao_cam_bg,
             taa_cam_buffer,
-            taa_cam_bg,
+            taa_uniform_bg,
             bloom_pipeline,
             ssao_pipeline,
             composite_pipeline,
@@ -842,9 +978,15 @@ impl PostProcessState {
         })
     }
 
+    /// Two color targets, both `surface_format`: `@location(0)` is the
+    /// swapchain and `@location(1)` is next frame's history. Writing both in
+    /// one pass is why the history pair can hold exactly the image that was
+    /// presented, with no extra copy.
     fn make_taa_pipeline(
         device: &wgpu::Device,
         tex2d_bgl: &wgpu::BindGroupLayout,
+        depth_bgl: &wgpu::BindGroupLayout,
+        taa_uniform_bgl: &wgpu::BindGroupLayout,
         surface_format: wgpu::TextureFormat,
     ) -> wgpu::RenderPipeline {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -853,8 +995,13 @@ impl PostProcessState {
         });
         let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("taa pll"),
-            bind_group_layouts: &[tex2d_bgl],
+            bind_group_layouts: &[tex2d_bgl, tex2d_bgl, depth_bgl, taa_uniform_bgl],
             push_constant_ranges: &[],
+        });
+        let color_target = Some(wgpu::ColorTargetState {
+            format: surface_format,
+            blend: Some(wgpu::BlendState::REPLACE),
+            write_mask: wgpu::ColorWrites::ALL,
         });
         device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("taa pipeline"),
@@ -868,11 +1015,7 @@ impl PostProcessState {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_taa",
-                targets: &[Some(wgpu::ColorTargetState {
-                    format: surface_format,
-                    blend: Some(wgpu::BlendState::REPLACE),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
+                targets: &[color_target.clone(), color_target],
                 compilation_options: Default::default(),
             }),
             primitive: wgpu::PrimitiveState::default(),
@@ -915,12 +1058,23 @@ impl PostProcessState {
         self.history_bgs = t.history_bgs;
         // The freshly created history pair is uninitialised at the new
         // resolution, so nothing in it may be blended against.
-        self.history_valid = false;
+        self.invalidate_history();
         self.hdr_bg = t.hdr_bg;
         self.bloom_bg = t.bloom_bg;
         self.ao_bg = t.ao_bg;
         self.ldr_bg = t.ldr_bg;
         self.depth_bg = t.depth_bg;
+    }
+
+    /// Discards the accumulated TAA history, so the next resolve blends the
+    /// frame with itself instead of with a stale or uninitialised image.
+    ///
+    /// Anything that makes the history textures stop describing the frame the
+    /// next resolve will produce has to call this -- a resize above being the
+    /// standing example, since the reallocated pair holds garbage at the new
+    /// resolution.
+    pub fn invalidate_history(&mut self) {
+        self.history_valid = false;
     }
 
     /// Uploads new bloom/tonemap/SSAO settings to the config uniform buffer.
@@ -943,9 +1097,14 @@ impl PostProcessState {
     /// the final tonemapped result into `surface_view`.
     ///
     /// Composite writes into an intermediate LDR target rather than straight
-    /// into `surface_view`; the TAA pass then reads that target and writes the
-    /// swapchain. The TAA pass is a passthrough for now, so the image reaching
-    /// `surface_view` is the same one composite used to write there directly.
+    /// into `surface_view`; the TAA pass then reads that target and writes both
+    /// the swapchain and next frame's history target. With `taa_enabled` zero
+    /// the resolve returns the composite result untouched, so the image
+    /// reaching `surface_view` is the same one composite used to write there
+    /// directly.
+    ///
+    /// Takes `&mut self` because the resolve advances the history ping-pong:
+    /// the target just written becomes next frame's read source.
     ///
     /// `fast_render` skips the bloom/SSAO shading work but still clears both
     /// targets to their neutral values (black = "no bloom contribution",
@@ -957,7 +1116,7 @@ impl PostProcessState {
     /// Returns the `(draw_calls, triangles)` issued by this call, so the
     /// caller can fold them into its own per-frame counters.
     pub fn apply(
-        &self,
+        &mut self,
         encoder: &mut wgpu::CommandEncoder,
         surface_view: &wgpu::TextureView,
         fast_render: bool,
@@ -1038,25 +1197,54 @@ impl PostProcessState {
         }
 
         {
+            // Without a valid history the source is this frame's own LDR, so
+            // the blend degenerates to `mix(current, current, blend)` -- a
+            // no-op -- instead of reading an uninitialised texture.
+            let history_src = if self.history_valid {
+                &self.history_bgs[self.history_read]
+            } else {
+                &self.ldr_bg
+            };
+            // Write into the half NOT being sampled; the flip below makes it
+            // next frame's read source.
+            let history_dst = &self.history_views[1 - self.history_read];
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("taa pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: surface_view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
+                color_attachments: &[
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: surface_view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    }),
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: history_dst,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    }),
+                ],
                 depth_stencil_attachment: None,
                 ..Default::default()
             });
             pass.set_pipeline(&self.taa_pipeline);
             pass.set_bind_group(0, &self.ldr_bg, &[]);
+            pass.set_bind_group(1, history_src, &[]);
+            pass.set_bind_group(2, &self.depth_bg, &[]);
+            pass.set_bind_group(3, &self.taa_uniform_bg, &[]);
             pass.draw(0..3, 0..1);
             draw_calls += 1;
             triangles += 1;
         }
+
+        // The target just written holds the frame the next resolve reprojects.
+        self.history_read = 1 - self.history_read;
+        self.history_valid = true;
+
         (draw_calls, triangles)
     }
 }
@@ -1120,5 +1308,81 @@ mod tests {
             label: None,
             source: wgpu::ShaderSource::Wgsl(TAA_WGSL.into()),
         });
+    }
+
+    /// The resolve binds five groups and writes two colour attachments, and
+    /// every one of them has to line up with the WGSL: a wrong group index, a
+    /// binding the layout does not declare, or a second target the fragment
+    /// entry does not return is a `wgpu` validation error. Compiling the
+    /// shader alone proves none of that -- outside this test the mismatch
+    /// would surface only as a panic deep inside a pixel test.
+    ///
+    /// Two `apply` calls, because the two history states take different
+    /// branches: the first has no history and binds the current LDR, the
+    /// second binds what the first wrote.
+    #[test]
+    fn taa_pass_records_without_validation_errors() {
+        let (device, queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        let width = 64;
+        let height = 64;
+        let depth_texture = crate::profiler::create_tracked_texture(
+            &device,
+            &wgpu::TextureDescriptor {
+                label: Some("taa test depth"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: crate::surface::DEPTH_FORMAT,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            },
+        );
+        let depth_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let target = crate::output::create_offscreen_texture(&device, width, height);
+        let target_view = target.create_view(&wgpu::TextureViewDescriptor::default());
+
+        device.push_error_scope(wgpu::ErrorFilter::Validation);
+        let mut pp = PostProcessState::new(
+            &device,
+            width,
+            height,
+            &depth_view,
+            crate::output::OFFSCREEN_FORMAT,
+        );
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        pp.apply(&mut encoder, &target_view, false);
+        queue.submit(Some(encoder.finish()));
+        assert!(
+            pp.history_valid,
+            "the first resolve writes a history target, so the second one has \
+             something to reproject"
+        );
+        assert_eq!(
+            pp.history_read, 1,
+            "the ping-pong must advance: the half just written is next \
+             frame's read source, and never the half read this frame"
+        );
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        pp.apply(&mut encoder, &target_view, false);
+        queue.submit(Some(encoder.finish()));
+        assert_eq!(pp.history_read, 0, "the second resolve flips it back");
+
+        device.poll(wgpu::Maintain::Wait);
+        assert!(
+            pollster::block_on(device.pop_error_scope()).is_none(),
+            "the TAA resolve pass must record cleanly; a validation error here \
+             means the pipeline layout, the bind groups, or the two colour \
+             attachments disagree with the shader"
+        );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -223,6 +223,40 @@ fn fs_composite(in: FullscreenOut) -> @location(0) vec4<f32> {
 }
 "#;
 
+/// The temporal-antialiasing resolve pass.
+///
+/// Right now it is a straight passthrough: it copies the composite pass's LDR
+/// result to the swapchain unchanged, so the frame is pixel-identical to the
+/// composite-writes-straight-to-the-swapchain arrangement it replaces. The
+/// pass exists at this point only to establish the structure -- composite ->
+/// readable LDR texture -> final blit -- that the real resolve needs, because
+/// a pass cannot sample the texture it is rendering into.
+const TAA_WGSL: &str = r#"
+struct FullscreenOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+@group(0) @binding(0) var ldr_tex: texture_2d<f32>;
+@group(0) @binding(1) var ldr_sampler: sampler;
+
+@vertex
+fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0), vec2<f32>(-1.0, 1.0), vec2<f32>(3.0, 1.0),
+    );
+    let p = positions[vi];
+    var out: FullscreenOut;
+    out.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+    out.uv = vec2<f32>(p.x * 0.5 + 0.5, -p.y * 0.5 + 0.5);
+    return out;
+}
+
+@fragment
+fn fs_taa(in: FullscreenOut) -> @location(0) vec4<f32> {
+    return textureSample(ldr_tex, ldr_sampler, in.uv);
+}
+"#;
+
 /// GPU-uniform-buffer layout for bloom/tonemap/SSAO settings, matching the
 /// `PostProcessConfig` struct declared in the WGSL shaders above.
 #[repr(C)]
@@ -283,6 +317,9 @@ struct PostProcessTargets {
     ao_texture: crate::profiler::TrackedTexture,
     ao_view: wgpu::TextureView,
     ao_bg: wgpu::BindGroup,
+    ldr_texture: crate::profiler::TrackedTexture,
+    ldr_view: wgpu::TextureView,
+    ldr_bg: wgpu::BindGroup,
     depth_bg: wgpu::BindGroup,
 }
 
@@ -296,9 +333,16 @@ pub struct PostProcessState {
     _bloom_texture: crate::profiler::TrackedTexture,
     ao_view: wgpu::TextureView,
     _ao_texture: crate::profiler::TrackedTexture,
+    /// LDR output of the composite pass. Composite used to write straight to
+    /// the swapchain; it writes here instead so the TAA pass has a readable
+    /// copy of this frame's finished colour -- a pass cannot sample the
+    /// texture it is rendering into.
+    ldr_view: wgpu::TextureView,
+    _ldr_texture: crate::profiler::TrackedTexture,
     hdr_bg: wgpu::BindGroup,
     bloom_bg: wgpu::BindGroup,
     ao_bg: wgpu::BindGroup,
+    ldr_bg: wgpu::BindGroup,
     depth_bg: wgpu::BindGroup,
     sampler: wgpu::Sampler,
     config_buffer: wgpu::Buffer,
@@ -311,8 +355,15 @@ pub struct PostProcessState {
     pub ssao_pipeline: wgpu::RenderPipeline,
     /// Pipeline for the final composite (HDR + bloom + AO, tonemapped) shader.
     pub composite_pipeline: wgpu::RenderPipeline,
+    /// Pipeline for the temporal-antialiasing resolve that writes the
+    /// swapchain image. Currently a passthrough blit of the composite result.
+    pub taa_pipeline: wgpu::RenderPipeline,
     tex2d_bgl: wgpu::BindGroupLayout,
     depth_bgl: wgpu::BindGroupLayout,
+    /// Format of the final swapchain image. The LDR intermediate target must
+    /// match it exactly, or the round trip through it would requantize the
+    /// frame; kept here so `resize_targets` can recreate that target.
+    surface_format: wgpu::TextureFormat,
 }
 
 impl PostProcessState {
@@ -433,9 +484,17 @@ impl PostProcessState {
             Self::make_ssao_pipeline(device, &depth_bgl, &config_bgl, &ssao_cam_bgl);
         let composite_pipeline =
             Self::make_composite_pipeline(device, &tex2d_bgl, &config_bgl, surface_format);
+        let taa_pipeline = Self::make_taa_pipeline(device, &tex2d_bgl, surface_format);
 
         let targets = Self::create_targets(
-            device, width, height, depth_view, &sampler, &tex2d_bgl, &depth_bgl,
+            device,
+            width,
+            height,
+            depth_view,
+            &sampler,
+            &tex2d_bgl,
+            &depth_bgl,
+            surface_format,
         );
 
         Self {
@@ -445,9 +504,12 @@ impl PostProcessState {
             _bloom_texture: targets.bloom_texture,
             ao_view: targets.ao_view,
             _ao_texture: targets.ao_texture,
+            ldr_view: targets.ldr_view,
+            _ldr_texture: targets.ldr_texture,
             hdr_bg: targets.hdr_bg,
             bloom_bg: targets.bloom_bg,
             ao_bg: targets.ao_bg,
+            ldr_bg: targets.ldr_bg,
             depth_bg: targets.depth_bg,
             sampler,
             config_buffer,
@@ -457,11 +519,14 @@ impl PostProcessState {
             bloom_pipeline,
             ssao_pipeline,
             composite_pipeline,
+            taa_pipeline,
             tex2d_bgl,
             depth_bgl,
+            surface_format,
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn create_targets(
         device: &wgpu::Device,
         width: u32,
@@ -470,6 +535,7 @@ impl PostProcessState {
         sampler: &wgpu::Sampler,
         tex2d_bgl: &wgpu::BindGroupLayout,
         depth_bgl: &wgpu::BindGroupLayout,
+        surface_format: wgpu::TextureFormat,
     ) -> PostProcessTargets {
         let make_tex = |label: &str, fmt: wgpu::TextureFormat| {
             crate::profiler::create_tracked_texture(
@@ -498,6 +564,11 @@ impl PostProcessState {
         let bloom_view = bloom_texture.create_view(&wgpu::TextureViewDescriptor::default());
         let ao_texture = make_tex("pp ao", AO_FORMAT);
         let ao_view = ao_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        // `surface_format`, not HDR_FORMAT: this holds the already-tonemapped
+        // LDR image on its way to the swapchain, so matching the swapchain's
+        // format keeps the round trip through it exact.
+        let ldr_texture = make_tex("pp ldr", surface_format);
+        let ldr_view = ldr_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         let make_tex2d_bg = |label: &str, view: &wgpu::TextureView| {
             device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -519,6 +590,7 @@ impl PostProcessState {
         let hdr_bg = make_tex2d_bg("pp hdr bg", &hdr_view);
         let bloom_bg = make_tex2d_bg("pp bloom bg", &bloom_view);
         let ao_bg = make_tex2d_bg("pp ao bg", &ao_view);
+        let ldr_bg = make_tex2d_bg("pp ldr bg", &ldr_view);
 
         let depth_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("pp depth bg"),
@@ -539,6 +611,9 @@ impl PostProcessState {
             ao_texture,
             ao_view,
             ao_bg,
+            ldr_texture,
+            ldr_view,
+            ldr_bg,
             depth_bg,
         }
     }
@@ -668,8 +743,49 @@ impl PostProcessState {
         })
     }
 
-    /// Recreates the sized render targets (HDR/bloom/AO/depth bind group) for
-    /// a new surface resolution, leaving pipelines and samplers untouched.
+    fn make_taa_pipeline(
+        device: &wgpu::Device,
+        tex2d_bgl: &wgpu::BindGroupLayout,
+        surface_format: wgpu::TextureFormat,
+    ) -> wgpu::RenderPipeline {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("taa shader"),
+            source: wgpu::ShaderSource::Wgsl(TAA_WGSL.into()),
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("taa pll"),
+            bind_group_layouts: &[tex2d_bgl],
+            push_constant_ranges: &[],
+        });
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("taa pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_fullscreen",
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_taa",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        })
+    }
+
+    /// Recreates the sized render targets (HDR/bloom/AO/LDR/depth bind group)
+    /// for a new surface resolution, leaving pipelines and samplers untouched.
     pub fn resize_targets(
         &mut self,
         device: &wgpu::Device,
@@ -685,6 +801,7 @@ impl PostProcessState {
             &self.sampler,
             &self.tex2d_bgl,
             &self.depth_bgl,
+            self.surface_format,
         );
         self.hdr_view = t.hdr_view;
         self._hdr_texture = t.hdr_texture;
@@ -692,9 +809,12 @@ impl PostProcessState {
         self._bloom_texture = t.bloom_texture;
         self.ao_view = t.ao_view;
         self._ao_texture = t.ao_texture;
+        self.ldr_view = t.ldr_view;
+        self._ldr_texture = t.ldr_texture;
         self.hdr_bg = t.hdr_bg;
         self.bloom_bg = t.bloom_bg;
         self.ao_bg = t.ao_bg;
+        self.ldr_bg = t.ldr_bg;
         self.depth_bg = t.depth_bg;
     }
 
@@ -708,8 +828,13 @@ impl PostProcessState {
         queue.write_buffer(&self.ssao_cam_buffer, 0, bytemuck::cast_slice(&[cam]));
     }
 
-    /// Runs the bloom, SSAO, and composite passes in sequence, writing the
-    /// final tonemapped result into `surface_view`.
+    /// Runs the bloom, SSAO, composite, and TAA passes in sequence, writing
+    /// the final tonemapped result into `surface_view`.
+    ///
+    /// Composite writes into an intermediate LDR target rather than straight
+    /// into `surface_view`; the TAA pass then reads that target and writes the
+    /// swapchain. The TAA pass is a passthrough for now, so the image reaching
+    /// `surface_view` is the same one composite used to write there directly.
     ///
     /// `fast_render` skips the bloom/SSAO shading work but still clears both
     /// targets to their neutral values (black = "no bloom contribution",
@@ -781,7 +906,7 @@ impl PostProcessState {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("composite pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: surface_view,
+                    view: &self.ldr_view,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
@@ -796,6 +921,27 @@ impl PostProcessState {
             pass.set_bind_group(1, &self.bloom_bg, &[]);
             pass.set_bind_group(2, &self.ao_bg, &[]);
             pass.set_bind_group(3, &self.config_bg, &[]);
+            pass.draw(0..3, 0..1);
+            draw_calls += 1;
+            triangles += 1;
+        }
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("taa pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: surface_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(&self.taa_pipeline);
+            pass.set_bind_group(0, &self.ldr_bg, &[]);
             pass.draw(0..3, 0..1);
             draw_calls += 1;
             triangles += 1;
@@ -848,6 +994,15 @@ mod tests {
         let _m = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: None,
             source: wgpu::ShaderSource::Wgsl(COMPOSITE_WGSL.into()),
+        });
+    }
+
+    #[test]
+    fn taa_shader_compiles() {
+        let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        let _m = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(TAA_WGSL.into()),
         });
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -4,6 +4,7 @@ const BLOOM_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
 const AO_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
 const CONFIG_SIZE: u64 = 64;
 const SSAO_CAM_SIZE: u64 = 128;
+const TAA_CAM_SIZE: u64 = 128;
 
 const BLOOM_WGSL: &str = r#"
 struct FullscreenOut {
@@ -14,7 +15,7 @@ struct PostProcessConfig {
     bloom_threshold: f32, bloom_softness: f32, bloom_intensity: f32, bloom_radius: f32,
     bloom_enabled: u32, tonemap_mode: u32, tonemap_exposure: f32, tonemap_enabled: u32,
     ssao_radius: f32, ssao_bias: f32, ssao_intensity: f32, ssao_sample_count: u32,
-    ssao_enabled: u32, _pad0: f32, _pad1: f32, _pad2: f32,
+    ssao_enabled: u32, taa_enabled: u32, taa_history_blend: f32, taa_clamp_strength: f32,
 }
 @group(0) @binding(0) var hdr_tex: texture_2d<f32>;
 @group(0) @binding(1) var tex_sampler: sampler;
@@ -73,7 +74,7 @@ struct PostProcessConfig {
     bloom_threshold: f32, bloom_softness: f32, bloom_intensity: f32, bloom_radius: f32,
     bloom_enabled: u32, tonemap_mode: u32, tonemap_exposure: f32, tonemap_enabled: u32,
     ssao_radius: f32, ssao_bias: f32, ssao_intensity: f32, ssao_sample_count: u32,
-    ssao_enabled: u32, _pad0: f32, _pad1: f32, _pad2: f32,
+    ssao_enabled: u32, taa_enabled: u32, taa_history_blend: f32, taa_clamp_strength: f32,
 }
 struct SsaoCamera {
     proj: mat4x4<f32>,
@@ -164,7 +165,7 @@ struct PostProcessConfig {
     bloom_threshold: f32, bloom_softness: f32, bloom_intensity: f32, bloom_radius: f32,
     bloom_enabled: u32, tonemap_mode: u32, tonemap_exposure: f32, tonemap_enabled: u32,
     ssao_radius: f32, ssao_bias: f32, ssao_intensity: f32, ssao_sample_count: u32,
-    ssao_enabled: u32, _pad0: f32, _pad1: f32, _pad2: f32,
+    ssao_enabled: u32, taa_enabled: u32, taa_history_blend: f32, taa_clamp_strength: f32,
 }
 @group(0) @binding(0) var hdr_tex: texture_2d<f32>;
 @group(0) @binding(1) var hdr_sampler: sampler;
@@ -288,12 +289,13 @@ pub struct PostProcessConfigGpu {
     pub ssao_sample_count: u32,
     /// Nonzero to enable the SSAO pass; zero always returns full visibility.
     pub ssao_enabled: u32,
-    /// Padding to satisfy uniform buffer alignment; unused.
-    pub _pad0: f32,
-    /// Padding to satisfy uniform buffer alignment; unused.
-    pub _pad1: f32,
-    /// Padding to satisfy uniform buffer alignment; unused.
-    pub _pad2: f32,
+    /// Nonzero to enable the TAA pass; zero passes the composite result
+    /// through unchanged.
+    pub taa_enabled: u32,
+    /// See `Taa::history_blend`.
+    pub taa_history_blend: f32,
+    /// See `Taa::clamp_strength`.
+    pub taa_clamp_strength: f32,
 }
 
 /// GPU-uniform-buffer layout for the camera matrices the SSAO pass needs to
@@ -305,6 +307,24 @@ pub struct SsaoCameraGpu {
     pub proj: [[f32; 4]; 4],
     /// Inverse of `proj`, used to unproject depth back to view space.
     pub inv_proj: [[f32; 4]; 4],
+}
+
+/// GPU-uniform-buffer layout for the matrices the TAA pass needs to
+/// reproject a pixel into the previous frame.
+///
+/// Both matrices are deliberately **unjittered**. Jitter belongs to
+/// rasterization only: reprojecting with jittered matrices would chase the
+/// jitter instead of the camera, and the accumulated image would never
+/// converge.
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct TaaCameraGpu {
+    /// Inverse of this frame's UNJITTERED view-projection, used to turn a
+    /// pixel plus its depth back into a world-space position.
+    pub inv_view_proj: [[f32; 4]; 4],
+    /// The PREVIOUS frame's unjittered view-projection, used to find where
+    /// that world position appeared last frame.
+    pub prev_view_proj: [[f32; 4]; 4],
 }
 
 struct PostProcessTargets {
@@ -320,6 +340,9 @@ struct PostProcessTargets {
     ldr_texture: crate::profiler::TrackedTexture,
     ldr_view: wgpu::TextureView,
     ldr_bg: wgpu::BindGroup,
+    history_textures: [crate::profiler::TrackedTexture; 2],
+    history_views: [wgpu::TextureView; 2],
+    history_bgs: [wgpu::BindGroup; 2],
     depth_bg: wgpu::BindGroup,
 }
 
@@ -339,6 +362,22 @@ pub struct PostProcessState {
     /// texture it is rendering into.
     ldr_view: wgpu::TextureView,
     _ldr_texture: crate::profiler::TrackedTexture,
+    /// Two history targets, swapped each frame: one holds the previous
+    /// frame's TAA output while the other receives this frame's. A single
+    /// texture cannot be sampled and rendered to in the same pass.
+    history_views: [wgpu::TextureView; 2],
+    _history_textures: [crate::profiler::TrackedTexture; 2],
+    history_bgs: [wgpu::BindGroup; 2],
+    /// Index of the history texture holding the PREVIOUS frame's result.
+    /// Flipped at the end of every `apply`.
+    // Only read once the resolve pass actually samples history; the
+    // passthrough blit in `apply` does not.
+    #[allow(dead_code)]
+    history_read: usize,
+    /// False until a frame has been written to history. The first frame has
+    /// no history to reproject, so it must pass through unblended rather
+    /// than blending against an uninitialised texture.
+    history_valid: bool,
     hdr_bg: wgpu::BindGroup,
     bloom_bg: wgpu::BindGroup,
     ao_bg: wgpu::BindGroup,
@@ -349,6 +388,11 @@ pub struct PostProcessState {
     config_bg: wgpu::BindGroup,
     ssao_cam_buffer: wgpu::Buffer,
     ssao_cam_bg: wgpu::BindGroup,
+    taa_cam_buffer: wgpu::Buffer,
+    // Bound once the resolve pass reprojects; the passthrough blit in `apply`
+    // takes no camera uniform.
+    #[allow(dead_code)]
+    taa_cam_bg: wgpu::BindGroup,
     /// Pipeline for the bright-pass bloom extraction shader.
     pub bloom_pipeline: wgpu::RenderPipeline,
     /// Pipeline for the SSAO occlusion shader.
@@ -449,6 +493,20 @@ impl PostProcessState {
             }],
         });
 
+        let taa_cam_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp taa cam bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(TAA_CAM_SIZE),
+                },
+                count: None,
+            }],
+        });
+
         let config_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("pp config buffer"),
             size: CONFIG_SIZE,
@@ -479,6 +537,21 @@ impl PostProcessState {
             }],
         });
 
+        let taa_cam_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pp taa cam buffer"),
+            size: TAA_CAM_SIZE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let taa_cam_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pp taa cam bg"),
+            layout: &taa_cam_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: taa_cam_buffer.as_entire_binding(),
+            }],
+        });
+
         let bloom_pipeline = Self::make_bloom_pipeline(device, &tex2d_bgl, &config_bgl);
         let ssao_pipeline =
             Self::make_ssao_pipeline(device, &depth_bgl, &config_bgl, &ssao_cam_bgl);
@@ -506,6 +579,11 @@ impl PostProcessState {
             _ao_texture: targets.ao_texture,
             ldr_view: targets.ldr_view,
             _ldr_texture: targets.ldr_texture,
+            history_views: targets.history_views,
+            _history_textures: targets.history_textures,
+            history_bgs: targets.history_bgs,
+            history_read: 0,
+            history_valid: false,
             hdr_bg: targets.hdr_bg,
             bloom_bg: targets.bloom_bg,
             ao_bg: targets.ao_bg,
@@ -516,6 +594,8 @@ impl PostProcessState {
             config_bg,
             ssao_cam_buffer,
             ssao_cam_bg,
+            taa_cam_buffer,
+            taa_cam_bg,
             bloom_pipeline,
             ssao_pipeline,
             composite_pipeline,
@@ -569,6 +649,18 @@ impl PostProcessState {
         // format keeps the round trip through it exact.
         let ldr_texture = make_tex("pp ldr", surface_format);
         let ldr_view = ldr_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        // The TAA history ping-pong pair. Both hold a finished LDR frame, so
+        // like the LDR target they use `surface_format` at the full surface
+        // size; a pair rather than one texture because the resolve pass has
+        // to sample last frame's history while rendering this frame's.
+        let history_textures = [
+            make_tex("pp history 0", surface_format),
+            make_tex("pp history 1", surface_format),
+        ];
+        let history_views = [
+            history_textures[0].create_view(&wgpu::TextureViewDescriptor::default()),
+            history_textures[1].create_view(&wgpu::TextureViewDescriptor::default()),
+        ];
 
         let make_tex2d_bg = |label: &str, view: &wgpu::TextureView| {
             device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -591,6 +683,10 @@ impl PostProcessState {
         let bloom_bg = make_tex2d_bg("pp bloom bg", &bloom_view);
         let ao_bg = make_tex2d_bg("pp ao bg", &ao_view);
         let ldr_bg = make_tex2d_bg("pp ldr bg", &ldr_view);
+        let history_bgs = [
+            make_tex2d_bg("pp history bg 0", &history_views[0]),
+            make_tex2d_bg("pp history bg 1", &history_views[1]),
+        ];
 
         let depth_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("pp depth bg"),
@@ -614,6 +710,9 @@ impl PostProcessState {
             ldr_texture,
             ldr_view,
             ldr_bg,
+            history_textures,
+            history_views,
+            history_bgs,
             depth_bg,
         }
     }
@@ -811,6 +910,12 @@ impl PostProcessState {
         self._ao_texture = t.ao_texture;
         self.ldr_view = t.ldr_view;
         self._ldr_texture = t.ldr_texture;
+        self.history_views = t.history_views;
+        self._history_textures = t.history_textures;
+        self.history_bgs = t.history_bgs;
+        // The freshly created history pair is uninitialised at the new
+        // resolution, so nothing in it may be blended against.
+        self.history_valid = false;
         self.hdr_bg = t.hdr_bg;
         self.bloom_bg = t.bloom_bg;
         self.ao_bg = t.ao_bg;
@@ -826,6 +931,12 @@ impl PostProcessState {
     /// Uploads the current frame's camera projection matrices for SSAO depth reconstruction.
     pub fn update_ssao_camera(&self, queue: &wgpu::Queue, cam: SsaoCameraGpu) {
         queue.write_buffer(&self.ssao_cam_buffer, 0, bytemuck::cast_slice(&[cam]));
+    }
+
+    /// Uploads the unjittered view-projection matrices the TAA pass reprojects
+    /// with: this frame's inverse and the previous frame's forward matrix.
+    pub fn update_taa_camera(&self, queue: &wgpu::Queue, cam: TaaCameraGpu) {
+        queue.write_buffer(&self.taa_cam_buffer, 0, bytemuck::cast_slice(&[cam]));
     }
 
     /// Runs the bloom, SSAO, composite, and TAA passes in sequence, writing
@@ -963,6 +1074,11 @@ mod tests {
     #[test]
     fn ssao_cam_gpu_size() {
         assert_eq!(std::mem::size_of::<SsaoCameraGpu>(), 128);
+    }
+
+    #[test]
+    fn taa_cam_gpu_size() {
+        assert_eq!(std::mem::size_of::<TaaCameraGpu>(), 128);
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2549,9 +2549,11 @@ impl WgpuSurface {
                 ssao_intensity: ao.intensity,
                 ssao_sample_count: ao.sample_count,
                 ssao_enabled: ao.enabled as u32,
-                _pad0: 0.0,
-                _pad1: 0.0,
-                _pad2: 0.0,
+                // Not yet driven by the camera's `Taa` component, so the TAA
+                // pass stays disabled and passes colour straight through.
+                taa_enabled: 0,
+                taa_history_blend: 0.0,
+                taa_clamp_strength: 0.0,
             };
             self.post_process.update_config(&self.queue, pp_config);
             let inv_proj = cam_proj.inverse();

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -3771,6 +3771,20 @@ impl WgpuSurface {
             .resize_targets(&self.device, &self.depth_view, width, height);
     }
 
+    /// Throws away the accumulated TAA history, so the next
+    /// [`Self::render_frame`] starts a fresh temporal accumulation instead of
+    /// blending against whatever was rendered before.
+    ///
+    /// A surface is long-lived and its history survives across frames by
+    /// design -- that accumulation *is* the effect. Anything that wants a
+    /// frame to depend only on the scene it was handed, rather than on the
+    /// scene rendered before it, has to say so explicitly; the pixel-test
+    /// harness calls this before every one-shot `render` for exactly that
+    /// reason.
+    pub fn invalidate_taa_history(&mut self) {
+        self.post_process.invalidate_history();
+    }
+
     /// Checks that `wgsl` is a shader `wgpu` will accept, without touching the
     /// GPU. `path` only labels the message.
     ///

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -916,6 +916,33 @@ fn map_keycode_to_egui(code: bsengine_input::KeyCode) -> Option<egui::Key> {
     })
 }
 
+/// Applies a TAA sub-pixel jitter to the view-projection used for
+/// rasterization, leaving the caller's unjittered matrix alone.
+///
+/// The offset goes on the **projection's third column** (glam is
+/// column-major, so `z_axis.x`/`z_axis.y` are rows 0 and 1 of that column).
+/// That is the column the perspective divide scales by `w`, so the resulting
+/// NDC shift is the same sub-pixel amount at every depth. Adding the offset to
+/// the *combined* view-projection instead would scale it by the world-space z
+/// coordinate — a shear, not a sub-pixel nudge.
+///
+/// `cam_proj` is the projection factor of `view_proj` (every caller builds the
+/// latter as `cam_proj * view`), so `cam_proj.inverse() * view_proj` recovers
+/// the view matrix to re-compose the jittered projection against.
+///
+/// A degenerate `cam_proj` returns `view_proj` unchanged rather than a matrix
+/// full of NaNs: the editor override hands over an all-zero `editor_proj`
+/// until its orbit camera has run once.
+fn jittered_view_proj(view_proj: Mat4, cam_proj: Mat4, jitter_clip: (f32, f32)) -> Mat4 {
+    if jitter_clip == (0.0, 0.0) || cam_proj.determinant().abs() < f32::EPSILON {
+        return view_proj;
+    }
+    let mut jittered_proj = cam_proj;
+    jittered_proj.z_axis.x += jitter_clip.0;
+    jittered_proj.z_axis.y += jitter_clip.1;
+    jittered_proj * (cam_proj.inverse() * view_proj)
+}
+
 /// Computes the 6 face view-projection matrices for a point light's cube shadow
 /// map, one per axis-aligned direction, using the standard cubemap face
 /// orientation convention (+Y/-Y up-vectors on the X/Z faces to avoid a
@@ -1006,6 +1033,19 @@ pub struct WgpuSurface {
     /// [`Self::frame_stats_history`].
     frame_stats_history:
         std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<crate::profiler::FrameStats>>>,
+    /// The previous frame's **unjittered** view-projection, which the TAA
+    /// resolve reprojects through to find where this frame's pixel sat in the
+    /// image it is blending against.
+    ///
+    /// Deliberately unjittered: the jitter exists only to move the
+    /// rasterization sample point inside a pixel, so reprojecting with it
+    /// would chase the jitter instead of the camera and the accumulation
+    /// would never converge.
+    ///
+    /// Updated at the end of every `render_frame`, whether or not TAA is
+    /// enabled, so enabling it mid-run reprojects against the frame that
+    /// actually preceded it rather than an arbitrarily old one.
+    prev_unjittered_view_proj: Mat4,
 }
 
 impl WgpuSurface {
@@ -1902,6 +1942,11 @@ impl WgpuSurface {
             terrain_bgl,
             custom_pipelines: std::collections::HashMap::new(),
             post_process,
+            // No frame has been rendered yet, so there is no previous
+            // view-projection. It is never read before the first frame
+            // stores one: `PostProcessState` starts with `history_valid`
+            // false, and the resolve does not reproject without history.
+            prev_unjittered_view_proj: Mat4::IDENTITY,
             start_time: std::time::Instant::now(),
             dock_state: None,
             last_saved_layout_json: None,
@@ -2394,12 +2439,24 @@ impl WgpuSurface {
         type_registry: Option<&bevy_ecs::reflect::AppTypeRegistry>,
         elapsed_seconds: f32,
         particles: &[crate::particles::ParticleBatch],
+        taa: Option<bsengine_core::Taa>,
+        jitter_clip: (f32, f32),
+        unjittered_view_proj: Mat4,
     ) -> Result<std::collections::HashSet<String>, String> {
         // Wall-clock CPU time for this call, for `FrameStats::cpu_frame_time_ms`.
         let frame_start = std::time::Instant::now();
 
+        // The sub-pixel TAA jitter belongs to *rasterization only*, so it is
+        // applied here rather than by the caller, and only to the matrix the
+        // vertex shader uses. `unjittered_view_proj` stays untouched and is
+        // what the reprojection matrices uploaded below are built from --
+        // reprojecting through a jittered matrix would chase the jitter
+        // instead of the camera and never converge. See `jittered_view_proj`
+        // for why the offset goes where it does.
+        let raster_view_proj = jittered_view_proj(view_proj, cam_proj, jitter_clip);
+
         let camera_data = CameraUniformData {
-            view_proj: view_proj.to_cols_array_2d(),
+            view_proj: raster_view_proj.to_cols_array_2d(),
             light_view_proj: light_view_proj.to_cols_array_2d(),
             cam_pos: cam_pos.to_array(),
             time: elapsed_seconds,
@@ -2549,11 +2606,13 @@ impl WgpuSurface {
                 ssao_intensity: ao.intensity,
                 ssao_sample_count: ao.sample_count,
                 ssao_enabled: ao.enabled as u32,
-                // Not yet driven by the camera's `Taa` component, so the TAA
-                // pass stays disabled and passes colour straight through.
-                taa_enabled: 0,
-                taa_history_blend: 0.0,
-                taa_clamp_strength: 0.0,
+                // Not `taa.unwrap_or_default()` like the three effects above:
+                // `Taa::default()` is enabled, and for TAA an absent component
+                // has to mean *off* -- that is what leaves every pre-existing
+                // pixel test rendering exactly as it did before.
+                taa_enabled: taa.map(|t| t.enabled).unwrap_or(false) as u32,
+                taa_history_blend: taa.map(|t| t.history_blend).unwrap_or(0.0),
+                taa_clamp_strength: taa.map(|t| t.clamp_strength).unwrap_or(0.0),
             };
             self.post_process.update_config(&self.queue, pp_config);
             let inv_proj = cam_proj.inverse();
@@ -2562,6 +2621,16 @@ impl WgpuSurface {
                 crate::post_process::SsaoCameraGpu {
                     proj: cam_proj.to_cols_array_2d(),
                     inv_proj: inv_proj.to_cols_array_2d(),
+                },
+            );
+            // Both matrices are the unjittered ones on purpose -- see
+            // `TaaCameraGpu` and the jitter comment at the top of this
+            // function.
+            self.post_process.update_taa_camera(
+                &self.queue,
+                crate::post_process::TaaCameraGpu {
+                    inv_view_proj: unjittered_view_proj.inverse().to_cols_array_2d(),
+                    prev_view_proj: self.prev_unjittered_view_proj.to_cols_array_2d(),
                 },
             );
         }
@@ -3681,6 +3750,10 @@ impl WgpuSurface {
             }
         }
 
+        // This frame's camera becomes next frame's reprojection source. Stored
+        // last, after the resolve above has consumed the previous value.
+        self.prev_unjittered_view_proj = unjittered_view_proj;
+
         Ok(clicked)
     }
 
@@ -3881,6 +3954,97 @@ pub struct WgpuSurfaceResource(pub WgpuSurface);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A `(view_proj, cam_proj)` pair of the exact shape `render_frame`
+    // receives. The camera is deliberately off-origin and rotated: with a
+    // camera at the origin looking down -Z the view matrix is the identity,
+    // `view_proj == cam_proj`, and jittering the combined matrix would be
+    // indistinguishable from jittering the projection -- the test would
+    // certify nothing.
+    fn test_camera() -> (Mat4, Mat4) {
+        let proj = Mat4::perspective_rh(60.0_f32.to_radians(), 16.0 / 9.0, 0.1, 100.0);
+        let view = Mat4::look_at_rh(
+            Vec3::new(3.0, 2.0, 5.0),
+            Vec3::new(-1.0, 0.5, -2.0),
+            Vec3::Y,
+        );
+        (proj * view, proj)
+    }
+
+    fn ndc(view_proj: Mat4, world: Vec3) -> (f32, f32) {
+        let clip = view_proj * world.extend(1.0);
+        (clip.x / clip.w, clip.y / clip.w)
+    }
+
+    #[test]
+    fn jitter_shifts_ndc_by_the_same_amount_at_every_depth() {
+        // The whole reason the offset goes on the projection's third column
+        // (the one scaled by `w`) rather than onto the combined
+        // view-projection: a sub-pixel nudge has to move near and far
+        // geometry by the SAME amount in NDC. Applied to the combined matrix
+        // the shift would scale with world-space z, shearing the scene
+        // instead of resampling it, and TAA would blur rather than resolve.
+        let (view_proj, proj) = test_camera();
+        let jitter = (0.004_f32, -0.003_f32);
+        let jittered = jittered_view_proj(view_proj, proj, jitter);
+
+        // Four points spread over two decades of distance and off the view
+        // axis in both screen directions, so a shift that scaled with depth
+        // (or with a world coordinate) could not hide.
+        let probes = [
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(-2.0, 1.5, -1.0),
+            Vec3::new(4.0, -3.0, -20.0),
+            Vec3::new(-6.0, 2.0, -55.0),
+        ];
+        let shifts: Vec<(f32, f32)> = probes
+            .iter()
+            .map(|p| {
+                let (a, b) = ndc(view_proj, *p);
+                let (c, d) = ndc(jittered, *p);
+                (c - a, d - b)
+            })
+            .collect();
+        for (i, s) in shifts.iter().enumerate() {
+            assert!(
+                (s.0 - shifts[0].0).abs() < 1e-5 && (s.1 - shifts[0].1).abs() < 1e-5,
+                "jitter must be depth-independent, but probe {i} at {:?} shifted \
+                 by {s:?} while the first shifted by {:?}",
+                probes[i],
+                shifts[0]
+            );
+        }
+        // ...and by exactly the amount asked for. The sign flips because the
+        // third column is multiplied by view-space z while the divide is by
+        // `w = -z`, so a `+jitter` column entry lands as a `-jitter` NDC
+        // shift. Which direction is irrelevant to TAA -- the Halton offsets
+        // are symmetric about zero -- but pinning it keeps the magnitude
+        // assertion from passing on a matrix that merely moved *somewhere*.
+        assert!(
+            (shifts[0].0 + jitter.0).abs() < 1e-5 && (shifts[0].1 + jitter.1).abs() < 1e-5,
+            "expected an NDC shift of {:?}, got {:?}",
+            (-jitter.0, -jitter.1),
+            shifts[0]
+        );
+    }
+
+    #[test]
+    fn zero_jitter_leaves_the_matrix_bit_for_bit_alone() {
+        // Every camera without a `Taa` component takes this path, so any
+        // drift here would change what all eight existing pixel tests render.
+        let (view_proj, proj) = test_camera();
+        assert_eq!(jittered_view_proj(view_proj, proj, (0.0, 0.0)), view_proj);
+    }
+
+    #[test]
+    fn a_degenerate_projection_falls_back_instead_of_producing_nans() {
+        // `InspectorState::editor_proj` starts as an all-zero matrix, and the
+        // editor override installs it before the orbit camera has ever run.
+        // Inverting it would poison the whole frame.
+        let (view_proj, _) = test_camera();
+        let jittered = jittered_view_proj(view_proj, Mat4::ZERO, (0.004, -0.003));
+        assert_eq!(jittered, view_proj);
+    }
 
     #[test]
     fn point_light_face_view_projs_all_invertible() {

--- a/crates/bsengine-rhi-wgpu/src/taa_jitter.rs
+++ b/crates/bsengine-rhi-wgpu/src/taa_jitter.rs
@@ -1,0 +1,123 @@
+//! Sub-pixel jitter offsets for temporal antialiasing.
+//!
+//! Each frame the projection matrix is nudged by a fraction of a pixel so
+//! successive frames sample different points inside the same pixel;
+//! accumulating those samples over time is what antialiases the edge. The
+//! offsets come from a Halton sequence rather than random values because it
+//! is low-discrepancy -- it spreads samples evenly instead of clumping the
+//! way uniform random does over a short window, which matters when only a
+//! handful of frames contribute before the history is clamped away.
+//!
+//! Pure math, deliberately GPU-free, so the sequence is unit-testable
+//! without an adapter.
+
+/// Length of the jitter cycle. After this many frames the offsets repeat,
+/// which bounds the pattern and keeps it deterministic for tests.
+pub const JITTER_SEQUENCE_LENGTH: u32 = 8;
+
+/// The `index`-th value of the radical-inverse (van der Corput) sequence in
+/// `base`, in `[0, 1)`. Halton is just this evaluated in two coprime bases.
+fn radical_inverse(mut index: u32, base: u32) -> f32 {
+    let mut result = 0.0f32;
+    let mut fraction = 1.0f32 / base as f32;
+    while index > 0 {
+        result += (index % base) as f32 * fraction;
+        index /= base;
+        fraction /= base as f32;
+    }
+    result
+}
+
+/// Sub-pixel offset for `frame_index`, in **pixels**, each component in
+/// `[-0.5, 0.5)`. Halton(2, 3), the standard choice for TAA.
+///
+/// The offset is centered on zero so the jittered image stays aligned with
+/// the unjittered one on average; an uncentered `[0, 1)` offset would shift
+/// the whole picture half a pixel.
+pub fn jitter_offset_pixels(frame_index: u32) -> (f32, f32) {
+    let i = frame_index % JITTER_SEQUENCE_LENGTH + 1; // +1: index 0 gives (0,0), a wasted frame
+    (radical_inverse(i, 2) - 0.5, radical_inverse(i, 3) - 0.5)
+}
+
+/// Converts a pixel-space jitter offset into the clip-space translation to
+/// apply to a projection matrix. Clip space spans 2 units across `width`
+/// pixels, hence `2 / width`; the Y term is negated because clip-space Y
+/// points up while pixel-space Y points down.
+pub fn jitter_clip_offset(frame_index: u32, width: u32, height: u32) -> (f32, f32) {
+    if width == 0 || height == 0 {
+        return (0.0, 0.0);
+    }
+    let (jx, jy) = jitter_offset_pixels(frame_index);
+    (2.0 * jx / width as f32, -2.0 * jy / height as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn radical_inverse_matches_known_values() {
+        // Base 2: 1 -> 0.5, 2 -> 0.25, 3 -> 0.75. These are the textbook
+        // van der Corput values; getting them right is what makes the
+        // sequence low-discrepancy rather than merely varied.
+        assert!((radical_inverse(1, 2) - 0.5).abs() < 1e-6);
+        assert!((radical_inverse(2, 2) - 0.25).abs() < 1e-6);
+        assert!((radical_inverse(3, 2) - 0.75).abs() < 1e-6);
+        // Base 3: 1 -> 1/3, 2 -> 2/3.
+        assert!((radical_inverse(1, 3) - 1.0 / 3.0).abs() < 1e-6);
+        assert!((radical_inverse(2, 3) - 2.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn every_offset_stays_inside_one_pixel() {
+        for frame in 0..64 {
+            let (x, y) = jitter_offset_pixels(frame);
+            assert!(
+                (-0.5..0.5).contains(&x) && (-0.5..0.5).contains(&y),
+                "frame {frame} jittered outside its own pixel: ({x}, {y}) -- an \
+                 offset past half a pixel samples the neighbouring pixel and \
+                 blurs instead of antialiasing"
+            );
+        }
+    }
+
+    #[test]
+    fn no_offset_repeats_within_one_cycle() {
+        let mut seen: Vec<(f32, f32)> = Vec::new();
+        for frame in 0..JITTER_SEQUENCE_LENGTH {
+            let o = jitter_offset_pixels(frame);
+            for prev in &seen {
+                assert!(
+                    (prev.0 - o.0).abs() > 1e-6 || (prev.1 - o.1).abs() > 1e-6,
+                    "frame {frame} repeats offset {o:?} within the cycle -- a \
+                     repeated sample contributes no new information"
+                );
+            }
+            seen.push(o);
+        }
+    }
+
+    #[test]
+    fn the_sequence_repeats_after_a_full_cycle() {
+        assert_eq!(
+            jitter_offset_pixels(0),
+            jitter_offset_pixels(JITTER_SEQUENCE_LENGTH),
+            "the cycle must be exactly JITTER_SEQUENCE_LENGTH long"
+        );
+    }
+
+    #[test]
+    fn a_zero_sized_target_gets_no_jitter_instead_of_a_division_by_zero() {
+        assert_eq!(jitter_clip_offset(3, 0, 0), (0.0, 0.0));
+    }
+
+    #[test]
+    fn clip_offset_shrinks_as_the_target_grows() {
+        // The same sub-pixel nudge is a smaller slice of clip space on a
+        // bigger target -- if this did not hold, jitter would be resolution
+        // dependent and over-blur small windows.
+        let (small, _) = jitter_clip_offset(1, 100, 100);
+        let (large, _) = jitter_clip_offset(1, 1000, 1000);
+        assert!(small.abs() > large.abs());
+    }
+}

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -67,6 +67,20 @@ impl Draw {
         self
     }
 
+    /// Rotates the draw about Z, keeping its current scale and translation.
+    ///
+    /// Exists for the antialiasing tests: an axis-aligned box lands on exact
+    /// pixel columns and rows and so has no stair-steps to smooth, which makes
+    /// it useless as a fixture for anything about edge quality. Turning it a
+    /// few degrees puts the silhouette across the pixel grid at an angle,
+    /// which is where aliasing actually lives.
+    pub fn rotated_z(mut self, radians: f32) -> Self {
+        let (scale, _, translation) = self.transform.to_scale_rotation_translation();
+        self.transform =
+            Mat4::from_scale_rotation_translation(scale, Quat::from_rotation_z(radians), translation);
+        self
+    }
+
     pub fn textured(mut self, id: u64) -> Self {
         self.texture = Some(id);
         self
@@ -154,6 +168,10 @@ pub struct Scene {
     pub bloom: Option<bsengine_core::Bloom>,
     pub tone_map: Option<bsengine_core::ToneMap>,
     pub ssao: Option<bsengine_core::AmbientOcclusion>,
+    /// Absent means off, exactly as it does on a real camera. Note that
+    /// `render` shows almost nothing of TAA even when this is set -- it
+    /// accumulates over frames, so use [`Harness::render_converged`].
+    pub taa: Option<bsengine_core::Taa>,
     pub hud: HashMap<String, String>,
     pub with_skybox: bool,
     /// Particle batches for the pass that runs after transparency.
@@ -170,6 +188,7 @@ impl Default for Scene {
             bloom: None,
             tone_map: None,
             ssao: None,
+            taa: None,
             hud: HashMap::new(),
             with_skybox: false,
             particles: Vec::new(),
@@ -364,7 +383,46 @@ struct VertOut {{
     }
 
     /// Draws one frame and reads it back.
+    ///
+    /// The TAA history is discarded first, so this is always a single fresh
+    /// frame. The surface is reused across every call on a `Harness`, and
+    /// without the reset a frame would blend against whatever the previous
+    /// `render` on the same harness drew -- every existing pixel test calls
+    /// this two or more times, so results would silently depend on test
+    /// order.
     pub fn render(&mut self, scene: &Scene) -> Pixels {
+        self.surface.invalidate_taa_history();
+        self.render_frame_at(scene, 0)
+    }
+
+    /// Renders `frames` consecutive frames of the same scene and returns the
+    /// last one.
+    ///
+    /// TAA accumulates: each frame samples a different sub-pixel position and
+    /// blends into the history built by the ones before it, so a single
+    /// `render` call can never show its effect. A test that used one would be
+    /// measuring the un-antialiased first frame and calling it a pass.
+    ///
+    /// History is discarded once at the start and then deliberately allowed to
+    /// carry across the frames -- that accumulation is the thing under test.
+    pub fn render_converged(&mut self, scene: &Scene, frames: u32) -> Pixels {
+        assert!(frames > 0, "render_converged needs at least one frame");
+        self.surface.invalidate_taa_history();
+        let mut last = None;
+        for frame in 0..frames {
+            last = Some(self.render_frame_at(scene, frame));
+        }
+        last.expect("the loop runs at least once")
+    }
+
+    /// One frame at jitter position `frame_index`, with the history left
+    /// exactly as it was.
+    ///
+    /// The jitter is computed the same way `bsengine-render`'s `render_frame`
+    /// system computes it -- from the frame counter when TAA is on, and not at
+    /// all when it is off. Deriving it independently here would let the
+    /// harness antialias with a sequence the engine never uses.
+    fn render_frame_at(&mut self, scene: &Scene, frame_index: u32) -> Pixels {
         let aspect = WIDTH as f32 / HEIGHT as f32;
         let proj = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
         let view = Mat4::look_at_rh(scene.camera_pos, scene.look_at, Vec3::Y);
@@ -389,6 +447,12 @@ struct VertOut {{
             Some(view_proj.inverse())
         } else {
             None
+        };
+
+        let jitter_clip = if scene.taa.map(|t| t.enabled).unwrap_or(false) {
+            bsengine_rhi_wgpu::taa_jitter::jitter_clip_offset(frame_index, WIDTH, HEIGHT)
+        } else {
+            (0.0, 0.0)
         };
 
         self.surface
@@ -422,11 +486,10 @@ struct VertOut {{
                 None,
                 0.0,
                 &scene.particles,
-                // No TAA, no jitter: a single `render` call is one frame, and
-                // TAA needs several to accumulate. Task 7 gives `Scene` its
-                // own `taa` field plus a multi-frame path.
-                None,
-                (0.0, 0.0),
+                scene.taa,
+                jitter_clip,
+                // The unjittered matrix, on purpose: reprojection has to track
+                // the camera, not the jitter.
                 view_proj,
             )
             .expect("render_frame failed");

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -422,6 +422,12 @@ struct VertOut {{
                 None,
                 0.0,
                 &scene.particles,
+                // No TAA, no jitter: a single `render` call is one frame, and
+                // TAA needs several to accumulate. Task 7 gives `Scene` its
+                // own `taa` field plus a multi-frame path.
+                None,
+                (0.0, 0.0),
+                view_proj,
             )
             .expect("render_frame failed");
 

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -76,8 +76,11 @@ impl Draw {
     /// which is where aliasing actually lives.
     pub fn rotated_z(mut self, radians: f32) -> Self {
         let (scale, _, translation) = self.transform.to_scale_rotation_translation();
-        self.transform =
-            Mat4::from_scale_rotation_translation(scale, Quat::from_rotation_z(radians), translation);
+        self.transform = Mat4::from_scale_rotation_translation(
+            scale,
+            Quat::from_rotation_z(radians),
+            translation,
+        );
         self
     }
 

--- a/crates/bsengine-rhi-wgpu/tests/pixels_taa.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_taa.rs
@@ -1,0 +1,434 @@
+//! TAA: does temporal antialiasing actually soften a diagonal edge, and does
+//! it leave everything else alone?
+//!
+//! Both halves matter. "The edge looks smoother" is not an assertion, and a
+//! test that only checked *that something changed* would pass just as happily
+//! for an implementation that blurred the whole frame. So this file measures
+//! the intended effect on the edge and, separately, the absence of any effect
+//! where there is no edge.
+
+mod common;
+
+use common::{Draw, Harness, Light, Pixels, Scene};
+use glam::Vec3;
+
+/// How far the rotated square is turned out of pixel alignment.
+///
+/// The angle is the whole point of the fixture. An axis-aligned rectangle
+/// lands on exact pixel columns and rows, produces no stair-steps, and so
+/// gives antialiasing nothing to do -- a test built on one proves nothing
+/// while appearing to pass. Thirty degrees is far from every multiple of
+/// ninety and is not a slope with a short repeating period, so the edge
+/// crosses the pixel grid at a fresh sub-pixel offset on essentially every
+/// row.
+const EDGE_ANGLE_DEGREES: f32 = 30.0;
+
+/// Emissive value of the backdrop, and of the square in front of it.
+///
+/// The two are far apart because aliasing is only visible across contrast:
+/// on a low-contrast edge the "in between" tones are within rounding of both
+/// sides and nothing can be counted.
+const BACKDROP_EMISSIVE: f32 = 0.05;
+const SQUARE_EMISSIVE: f32 = 1.0;
+
+/// A bright square, turned [`EDGE_ANGLE_DEGREES`] out of alignment, on a dark
+/// backdrop.
+///
+/// Everything is lit purely by emission -- `colour(Vec3::ZERO)` with a black
+/// light -- so both surfaces are exactly flat in colour. A shaded surface has
+/// its own gradients, and every one of them would be counted as an
+/// "intermediate tone" whether or not TAA ran.
+///
+/// The backdrop is a flattened cube rather than empty space on purpose: the
+/// resolve pass has nothing to reproject where the depth buffer is still at
+/// its far value, so an edge against the sky would exercise the early-out
+/// instead of the accumulation this file is about.
+///
+/// Bloom, tone mapping and SSAO are each switched off explicitly, because the
+/// surface applies `Default` for any of them a scene leaves absent and all
+/// three default to enabled. Bloom spills light across the silhouette and
+/// SSAO shades near it; either would manufacture intermediate tones with TAA
+/// off and hide what TAA did.
+fn rotated_square_scene(cube: u64, taa: Option<bsengine_core::Taa>) -> Scene {
+    Scene {
+        draws: vec![
+            Draw::new(cube, Vec3::ZERO)
+                .scaled(Vec3::new(40.0, 40.0, 0.2), Vec3::new(0.0, 0.0, -5.0))
+                .colour(Vec3::ZERO)
+                .emissive(Vec3::splat(BACKDROP_EMISSIVE)),
+            Draw::new(cube, Vec3::ZERO)
+                .scaled(Vec3::splat(1.5), Vec3::ZERO)
+                .rotated_z(EDGE_ANGLE_DEGREES.to_radians())
+                .colour(Vec3::ZERO)
+                .emissive(Vec3::splat(SQUARE_EMISSIVE)),
+        ],
+        light: Light {
+            color: Vec3::ZERO,
+            ambient: Vec3::ZERO,
+            ..Light::default()
+        },
+        bloom: Some(bsengine_core::Bloom {
+            enabled: false,
+            ..Default::default()
+        }),
+        tone_map: Some(bsengine_core::ToneMap {
+            enabled: false,
+            ..Default::default()
+        }),
+        ssao: Some(bsengine_core::AmbientOcclusion {
+            enabled: false,
+            ..Default::default()
+        }),
+        taa,
+        ..Scene::default()
+    }
+}
+
+/// How many frames a converged reading accumulates over.
+///
+/// Twice the Halton cycle length, so every sub-pixel position in the sequence
+/// has contributed at least twice.
+const CONVERGED_FRAMES: u32 = 16;
+
+/// Counts pixels that are neither clearly the square nor clearly the backdrop.
+///
+/// On a hard aliased edge every pixel is one or the other: the rasterizer
+/// either covered the pixel centre or it did not, and the emissive fixture
+/// makes both outcomes exactly flat. Antialiasing is precisely the appearance
+/// of values in between, so this count is the countable form of "the edge got
+/// smoother".
+///
+/// The two reference tones are read from the frame itself -- a corner, which
+/// only the backdrop reaches, and the centre, which is deep inside the square
+/// -- rather than hardcoded, so the measure survives any change to the clear
+/// colour or the transfer function.
+fn intermediate_tone_count(p: &Pixels) -> u32 {
+    let backdrop = p.luma(0, 0);
+    let square = p.centre_luma();
+    assert!(
+        square - backdrop > 100.0,
+        "the fixture must be high contrast for this measure to mean anything, \
+         but the backdrop reads {backdrop} and the square {square}"
+    );
+    // A tenth of the way in from either end. Anything closer to an end than
+    // that is "clearly" that side; the band still catches a single blend step,
+    // which at the default history weight moves a pixel a tenth of the range.
+    let margin = 0.1 * (square - backdrop);
+    let (lo, hi) = (backdrop + margin, square - margin);
+
+    let mut count = 0;
+    for y in 0..p.height {
+        for x in 0..p.width {
+            let l = p.luma(x, y);
+            if l > lo && l < hi {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+/// One 8-bit sRGB channel as the linear value the shader actually blended.
+///
+/// The post-process targets are sRGB, so `textureSample` hands the resolve
+/// decoded light and the write re-encodes it. Reasoning about a blend weight
+/// in 8-bit units without undoing that would be off by the transfer function.
+fn srgb_to_linear(c: u8) -> f32 {
+    let c = c as f32 / 255.0;
+    if c <= 0.04045 {
+        c / 12.92
+    } else {
+        ((c + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// The inverse of [`srgb_to_linear`], in 8-bit units but unrounded so a
+/// difference of two encoded values keeps its fractional part.
+fn linear_to_srgb(c: f32) -> f32 {
+    let s = if c <= 0.003_130_8 {
+        c * 12.92
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    };
+    s * 255.0
+}
+
+#[test]
+fn taa_softens_a_diagonal_edge() {
+    let mut h = Harness::new();
+    let cube = h.cube();
+
+    let off = h.render(&rotated_square_scene(cube, None));
+    let on = h.render_converged(
+        &rotated_square_scene(cube, Some(bsengine_core::Taa::default())),
+        CONVERGED_FRAMES,
+    );
+
+    let off_count = intermediate_tone_count(&off);
+    let on_count = intermediate_tone_count(&on);
+    eprintln!("intermediate-tone pixels: TAA off = {off_count}, TAA on = {on_count}");
+
+    // With no antialiasing anywhere in the pipeline and a flat-shaded fixture,
+    // a pixel is one side of the edge or the other. Not "few": none.
+    assert_eq!(
+        off_count, 0,
+        "without TAA the edge must be hard -- {off_count} intermediate pixels \
+         means something else in the pipeline is already softening it, and \
+         this test would be measuring that instead. Frame: {}",
+        off.describe()
+    );
+
+    // The square is ~100px tall with four diagonal sides, so a working resolve
+    // has hundreds of edge pixels to work with. Requiring a hundred is well
+    // clear of noise while not pinning the exact geometry.
+    assert!(
+        on_count >= 100,
+        "converged TAA should put intermediate tones along the diagonal edge, \
+         but only {on_count} pixels landed between the backdrop and the \
+         square. Frame: {}",
+        on.describe()
+    );
+}
+
+#[test]
+fn taa_leaves_the_interior_of_a_solid_region_alone() {
+    let mut h = Harness::new();
+    let cube = h.cube();
+
+    let off = h.render(&rotated_square_scene(cube, None));
+    let on = h.render_converged(
+        &rotated_square_scene(cube, Some(bsengine_core::Taa::default())),
+        CONVERGED_FRAMES,
+    );
+
+    // Well inside the square. Its half-height on screen is about 50 pixels, so
+    // +-12 from the centre stays clear of every edge even as the sub-pixel
+    // jitter moves the silhouette around.
+    let (cx, cy) = (off.width / 2, off.height / 2);
+    let interior = [
+        (cx, cy),
+        (cx - 12, cy),
+        (cx + 12, cy),
+        (cx, cy - 12),
+        (cx, cy + 12),
+    ];
+
+    // This is the regression that makes `taa_softens_a_diagonal_edge`
+    // meaningful. Without it, an implementation that smeared the entire frame
+    // -- a plain blur, say -- would satisfy the edge test perfectly.
+    for (x, y) in interior {
+        let a = off.at(x, y);
+        let b = on.at(x, y);
+        for c in 0..3 {
+            assert!(
+                a[c].abs_diff(b[c]) <= 2,
+                "TAA changed a pixel that is nowhere near an edge: ({x}, {y}) \
+                 went from {a:?} to {b:?}. Antialiasing is supposed to touch \
+                 the silhouette, not the flat interior"
+            );
+        }
+    }
+
+    // And the backdrop, for the same reason from the other side.
+    let corner_off = off.at(2, 2);
+    let corner_on = on.at(2, 2);
+    for c in 0..3 {
+        assert!(
+            corner_off[c].abs_diff(corner_on[c]) <= 2,
+            "TAA changed the empty backdrop: {corner_off:?} -> {corner_on:?}"
+        );
+    }
+
+    // Five samples prove five pixels. The same claim over the whole frame:
+    // every pixel TAA moved has to sit on the silhouette. An effect that
+    // leaked outward -- a global exposure shift, an image displaced by the
+    // jitter it was supposed to cancel, history sampled at the wrong offset --
+    // would move pixels the aliased edge never reached.
+    let on_silhouette = silhouette_mask(&off, 2);
+    let mut strays = Vec::new();
+    for y in 0..off.height {
+        for x in 0..off.width {
+            let (a, b) = (off.at(x, y), on.at(x, y));
+            let moved = (0..3).any(|c| a[c].abs_diff(b[c]) > 2);
+            if moved && !on_silhouette[(y * off.width + x) as usize] {
+                strays.push((x, y, a, b));
+            }
+        }
+    }
+    assert!(
+        strays.is_empty(),
+        "{} pixels changed away from the silhouette, e.g. {:?} -- TAA must \
+         work on the edge, not on the picture",
+        strays.len(),
+        &strays[..strays.len().min(5)]
+    );
+}
+
+/// Marks every pixel within `radius` of a tone change in `p`.
+///
+/// Built from the TAA-off frame, where the fixture is strictly two-toned, so
+/// the mask is exactly "the aliased edge and its immediate surroundings" --
+/// the only place antialiasing has any business changing anything.
+fn silhouette_mask(p: &Pixels, radius: i32) -> Vec<bool> {
+    let mut edge = vec![false; (p.width * p.height) as usize];
+    for y in 0..p.height {
+        for x in 0..p.width {
+            let here = p.luma(x, y);
+            let differs = (x > 0 && p.luma(x - 1, y) != here)
+                || (x + 1 < p.width && p.luma(x + 1, y) != here)
+                || (y > 0 && p.luma(x, y - 1) != here)
+                || (y + 1 < p.height && p.luma(x, y + 1) != here);
+            if differs {
+                edge[(y * p.width + x) as usize] = true;
+            }
+        }
+    }
+
+    let mut dilated = vec![false; edge.len()];
+    for y in 0..p.height as i32 {
+        for x in 0..p.width as i32 {
+            if !edge[(y * p.width as i32 + x) as usize] {
+                continue;
+            }
+            for dy in -radius..=radius {
+                for dx in -radius..=radius {
+                    let (nx, ny) = (x + dx, y + dy);
+                    if nx >= 0 && ny >= 0 && nx < p.width as i32 && ny < p.height as i32 {
+                        dilated[(ny * p.width as i32 + nx) as usize] = true;
+                    }
+                }
+            }
+        }
+    }
+    dilated
+}
+
+#[test]
+fn taa_converges_instead_of_shimmering() {
+    let mut h = Harness::new();
+    let cube = h.cube();
+    let scene = || rotated_square_scene(cube, Some(bsengine_core::Taa::default()));
+
+    // The camera never moves, so once the accumulation has settled one more
+    // frame should barely move it. A resolve that never settled would swing
+    // between jitter positions instead, and the two readings would differ by
+    // the full contrast of the fixture wherever the silhouette moved.
+    let a = h.render_converged(&scene(), CONVERGED_FRAMES);
+    let b = h.render_converged(&scene(), CONVERGED_FRAMES + 1);
+
+    let mut worst = (0u8, 0u32, 0u32);
+    let mut moved = 0u32;
+    for y in 0..a.height {
+        for x in 0..a.width {
+            let (pa, pb) = (a.at(x, y), b.at(x, y));
+            let d = (0..3).map(|c| pa[c].abs_diff(pb[c])).max().unwrap_or(0);
+            if d > worst.0 {
+                worst = (d, x, y);
+            }
+            if d > 2 {
+                moved += 1;
+            }
+        }
+    }
+    eprintln!(
+        "frame {CONVERGED_FRAMES} vs {}: worst channel delta {} at ({}, {}), \
+         {moved} pixels moved by more than 2",
+        CONVERGED_FRAMES + 1,
+        worst.0,
+        worst.1,
+        worst.2
+    );
+
+    // One more frame can only pull a pixel `1 - history_blend` of the way from
+    // where it stands toward the incoming colour. That is what "converged"
+    // means here, and the bound is read off the component rather than tuned to
+    // the measurement.
+    //
+    // The step has to be measured in *linear* light: the resolve blends values
+    // the sampler decoded from the sRGB target, while the readback is
+    // re-encoded. A tenth of the range is a much larger 8-bit jump near black
+    // than near white, so the worst case is a pixel sitting at the backdrop
+    // tone -- which is exactly where a silhouette pixel that just changed
+    // coverage sits.
+    let backdrop = srgb_to_linear(a.at(0, 0)[1]);
+    let square = srgb_to_linear(a.centre()[1]);
+    let step = (1.0 - bsengine_core::Taa::default().history_blend) * (square - backdrop);
+    let bound = (linear_to_srgb(backdrop + step) - linear_to_srgb(backdrop)).ceil() as u8 + 2;
+    assert!(
+        worst.0 <= bound,
+        "an extra frame moved a pixel by {} levels at ({}, {}), more than the \
+         {bound} a single blend step can account for -- the image is still \
+         swinging between jitter positions rather than converging",
+        worst.0,
+        worst.1,
+        worst.2
+    );
+
+    // And the movement must be confined to the silhouette, not spread over the
+    // frame: the fixture's edge is a few hundred pixels out of 30000.
+    assert!(
+        moved < (a.width * a.height) / 10,
+        "{moved} of {} pixels were still moving between consecutive converged \
+         frames; convergence should leave only the silhouette in motion",
+        a.width * a.height
+    );
+}
+
+/// Turning the component off must return the exact rendering of not having it
+/// at all -- an "off" switch that leaves a residue is not off.
+///
+/// Note what this does *not* isolate: both the jitter and the resolve are
+/// gated on `enabled`, in the harness as in `bsengine-render`, so a static
+/// scene cannot separate the two gates. That the `taa_enabled` uniform itself
+/// reaches the shader is certified by `taa_softens_a_diagonal_edge`, which
+/// cannot produce a single intermediate tone unless the flag arrives set.
+#[test]
+fn taa_disabled_matches_no_taa_component_at_all() {
+    let mut h = Harness::new();
+    let cube = h.cube();
+
+    // `Taa::default()` is enabled, so the disabled case has to be spelled out.
+    let disabled = || {
+        Some(bsengine_core::Taa {
+            enabled: false,
+            ..Default::default()
+        })
+    };
+
+    // One frame, and then the full accumulation. The single frame alone would
+    // be a weak claim: with no history yet, the resolve degenerates to a
+    // passthrough whatever the flag says, so it would agree even for an
+    // implementation that ignored `enabled` entirely.
+    let absent_once = h.render(&rotated_square_scene(cube, None));
+    let disabled_once = h.render(&rotated_square_scene(cube, disabled()));
+    assert!(
+        !disabled_once.differs_from(&absent_once),
+        "a disabled Taa component should render exactly as no component does; \
+         absent gave {}, disabled gave {}",
+        absent_once.describe(),
+        disabled_once.describe()
+    );
+
+    let absent = h.render_converged(&rotated_square_scene(cube, None), CONVERGED_FRAMES);
+    let off = h.render_converged(&rotated_square_scene(cube, disabled()), CONVERGED_FRAMES);
+    assert!(
+        !off.differs_from(&absent),
+        "over {CONVERGED_FRAMES} frames a disabled Taa component should still \
+         match no component at all; absent gave {}, disabled gave {}",
+        absent.describe(),
+        off.describe()
+    );
+
+    // And the comparison above must not be two ways of saying "nothing
+    // happened": the same fixture with the component enabled has to differ.
+    let on = h.render_converged(
+        &rotated_square_scene(cube, Some(bsengine_core::Taa::default())),
+        CONVERGED_FRAMES,
+    );
+    assert!(
+        on.differs_from(&off),
+        "enabling the component changed nothing, so the equality above proves \
+         nothing either; both frames read {}",
+        on.describe()
+    );
+}

--- a/crates/bsengine-rhi-wgpu/tests/pixels_taa.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_taa.rs
@@ -171,7 +171,8 @@ fn taa_softens_a_diagonal_edge() {
     // With no antialiasing anywhere in the pipeline and a flat-shaded fixture,
     // a pixel is one side of the edge or the other. Not "few": none.
     assert_eq!(
-        off_count, 0,
+        off_count,
+        0,
         "without TAA the edge must be hard -- {off_count} intermediate pixels \
          means something else in the pipeline is already softening it, and \
          this test would be measuring that instead. Frame: {}",

--- a/crates/bsengine-rhi-wgpu/tests/terrain_draw.rs
+++ b/crates/bsengine-rhi-wgpu/tests/terrain_draw.rs
@@ -70,6 +70,11 @@ fn a_terrain_draw_call_does_not_panic_alongside_regular_draw_calls() {
         None,
         0.0,
         &[],
+        // No `Taa`, no jitter: this test only checks that a terrain draw call
+        // records without a validation error.
+        None,
+        (0.0, 0.0),
+        Mat4::IDENTITY,
     );
 
     assert!(

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -889,6 +889,7 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
     app.register_type::<bsengine_core::SaveData>();
     app.register_type::<bsengine_core::Shield>();
     app.register_type::<bsengine_core::Skybox>();
+    app.register_type::<bsengine_core::Taa>();
     app.register_type::<bsengine_core::Timer>();
     app.register_type::<bsengine_core::ToneMap>();
     app.register_type::<bsengine_core::Visible>();


### PR DESCRIPTION
## Summary
Implements ENGINE_ROADMAP item 47 (안티에일리어싱), **sub-step 1/2: TAA core**. Scene edges are antialiased by accumulating sub-pixel-jittered frames over time, reprojecting the previous frame through the camera's motion and clamping it to the local neighborhood.

Per-object motion vectors are **sub-step 2/2**, deliberately deferred: they require every scene pipeline (mesh, terrain, particles) to write velocity into an additional render target — a G-buffer change touching the whole scene pass at once.

## Why TAA, and why not MSAA
MSAA was not rejected on preference but on a concrete pipeline conflict: the SSAO shader declares `depth_tex: texture_depth_2d` and reads depth directly via `textureLoad` to reconstruct view-space position. Enabling MSAA makes that `texture_depth_multisampled_2d`, and wgpu's core API resolves color attachments only — there is no automatic depth resolve. MSAA would therefore require an SSAO rewrite or a separate depth prepass, colliding head-on with the completion condition "포스트프로세스 체인과 순서 충돌 없이 합성".

## How it works
- **`Taa { enabled, history_blend, clamp_strength }`** on the camera, following `Bloom`/`ToneMap`/`AmbientOcclusion` exactly (registered in `register_gameplay_reflect_types`, not the windowed-only `RenderPlugin`). **Absent means off** — which is what keeps all eight existing `pixels_*.rs` files passing untouched.
- **Halton(2,3) jitter** (`taa_jitter.rs`) — pure, GPU-free, 6 unit tests. Offsets are centered on zero so the jittered image stays aligned on average, and applied to the **rasterization projection only**; the reprojection matrices stay unjittered, or the resolve would chase the jitter instead of the camera and never converge.
- **Composite redirected to an intermediate LDR target**, with the TAA pass writing the final image — done as its own behavior-preserving commit so a later pixel-test failure is attributable to the TAA math, not the restructure.
- **History ping-pong** (two `TrackedTexture`s, so they stay counted in the item 43 profiler), written via dual color attachments alongside the swapchain.
- **Depth-based camera reprojection** with the previous frame's view-projection (stored nowhere in the engine before this). Exact for static geometry under any camera motion; moving objects are held in check by 3×3 neighborhood clamping rather than corrected — that is what sub-step 2/2 addresses.
- TAA runs **last, after composite**, so it operates on tonemapped LDR and touches neither bloom's nor SSAO's inputs. UI/gizmos render afterward and are naturally excluded.

## Measured effect
`pixels_taa.rs` renders a 30°-rotated cube against a high-contrast background and counts pixels that are neither clearly foreground nor clearly background — the countable form of "the edge got smoother":

| | intermediate-tone pixels |
|---|---|
| TAA off | **0** |
| TAA on (16 frames) | **123** |

Zero without TAA is the expected fully-aliased result: every pixel is pure foreground or pure background.

Crucially the file also asserts the **opposite direction** — `taa_leaves_the_interior_of_a_solid_region_alone`. Without it, an implementation that blurred the entire frame would pass the count assertion just as happily.

## Test plan
- [x] `cargo test -p bsengine-rhi-wgpu --test pixels_taa` — 4/4 (edge softening, interior-unchanged regression, convergence stability, `enabled: false` matching component-absence)
- [x] `cargo test -p bsengine-rhi-wgpu` — incl. Halton unit tests, TAA shader-compile and pass-record tests, and **all eight pre-existing `pixels_*.rs` files passing unchanged**
- [x] `cargo test --workspace --exclude bsengine-editor` — zero failures
- [x] `cargo test -p bsengine-editor --lib` — 937/937 (isolated, per this repo's CI split)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` — 60 components, 0 violations
- [x] `cargo clippy --workspace --all-targets` — identical to the pre-existing baseline, 0 new warnings
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)