### PR TITLE
feat: image-based lighting (IBL)

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/ibl.rs
+++ b/crates/bsengine-rhi-wgpu/src/ibl.rs
@@ -1,0 +1,502 @@
+//! Image-based lighting: turns the skybox into the diffuse irradiance and
+//! prefiltered specular maps the PBR shader samples in place of a flat
+//! ambient constant.
+//!
+//! Four GPU passes, on two different schedules:
+//!   - The BRDF integration LUT depends only on the BRDF -- not the
+//!     environment, scene, or camera -- so it is built once at startup and
+//!     reused for every skybox thereafter.
+//!   - Equirect->cubemap, irradiance, and prefilter all depend on the
+//!     environment, so they rerun whenever the skybox changes.
+//!
+//! See `docs/superpowers/specs/2026-08-30-ibl-design.md`.
+
+use crate::profiler::{create_tracked_texture, TrackedTexture};
+
+/// Edge length of each face of the environment cubemap.
+pub const ENV_CUBE_SIZE: u32 = 256;
+/// Edge length of each irradiance cubemap face. Small deliberately:
+/// irradiance is very low-frequency, so resolution buys nothing.
+pub const IRRADIANCE_CUBE_SIZE: u32 = 32;
+/// Edge length of the prefiltered cubemap's mip 0.
+pub const PREFILTER_CUBE_SIZE: u32 = 128;
+/// Mip levels in the prefiltered cubemap. Mip 0 is mirror-sharp; the last
+/// is fully rough. The shader maps `roughness` linearly onto this range.
+pub const PREFILTER_MIP_LEVELS: u32 = 5;
+/// Edge length of the square BRDF integration LUT.
+pub const BRDF_LUT_SIZE: u32 = 512;
+
+/// Format of the BRDF integration LUT: two 16-bit floats holding the `f0`
+/// scale (`.r`) and bias (`.g`). Two channels because that is all the
+/// split-sum second term produces, and 16-bit float rather than 8-bit unorm
+/// because the scale term is read directly as a multiplier, where banding
+/// would show up as stepped reflectance.
+pub const BRDF_LUT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rg16Float;
+
+/// A cubemap has six faces; in wgpu they are six array layers of a 2D
+/// texture, in the fixed order +X, -X, +Y, -Y, +Z, -Z.
+const CUBE_FACES: u32 = 6;
+
+/// Creates a cube texture: `size` x `size`, six array layers, `mip_levels`
+/// mips.
+///
+/// In wgpu a cubemap *is* a six-layer 2D texture -- the cube-ness lives on
+/// the view ([`cube_view`]), not on the texture -- so callers that want to
+/// render into one face at a time can just take a [`face_view`] of the same
+/// texture.
+///
+/// Allocation goes through [`crate::profiler::create_tracked_texture`] so
+/// this memory is counted in the profiler totals exactly like every other
+/// render target this crate creates.
+pub fn create_cubemap(
+    device: &wgpu::Device,
+    label: &str,
+    size: u32,
+    mip_levels: u32,
+    format: wgpu::TextureFormat,
+    usage: wgpu::TextureUsages,
+) -> TrackedTexture {
+    create_tracked_texture(
+        device,
+        &wgpu::TextureDescriptor {
+            label: Some(label),
+            size: wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: CUBE_FACES,
+            },
+            mip_level_count: mip_levels,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage,
+            view_formats: &[],
+        },
+    )
+}
+
+/// A `TextureViewDimension::Cube` view over all six faces and every mip, for
+/// binding as a `texture_cube<f32>` and sampling by direction.
+///
+/// The point-light cube shadows in `surface.rs` deliberately do *not* do this
+/// -- they bind a `texture_2d_array` and pick the face by hand -- because
+/// their `R32Float` depth format is not natively filterable. IBL maps are
+/// ordinary filterable colour formats, so a real cube view applies here and
+/// gets correct hardware filtering across face seams for free.
+pub fn cube_view(texture: &wgpu::Texture) -> wgpu::TextureView {
+    texture.create_view(&wgpu::TextureViewDescriptor {
+        label: Some("ibl cube view"),
+        dimension: Some(wgpu::TextureViewDimension::Cube),
+        ..Default::default()
+    })
+}
+
+/// A single-layer, single-mip 2D view of one cube face, for use as a render
+/// attachment: the preprocessing passes render one face at a time, and the
+/// prefilter chain one (face, mip) pair at a time.
+///
+/// `face` indexes wgpu's cubemap layer order: +X, -X, +Y, -Y, +Z, -Z as 0..5.
+pub fn face_view(texture: &wgpu::Texture, face: u32, mip: u32) -> wgpu::TextureView {
+    texture.create_view(&wgpu::TextureViewDescriptor {
+        label: Some("ibl cube face view"),
+        dimension: Some(wgpu::TextureViewDimension::D2),
+        base_array_layer: face,
+        array_layer_count: Some(1),
+        base_mip_level: mip,
+        mip_level_count: Some(1),
+        ..Default::default()
+    })
+}
+
+const BRDF_LUT_WGSL: &str = r#"
+const PI: f32 = 3.14159265359;
+// Sample count for the Monte Carlo integration. 1024 Hammersley points is the
+// standard figure; because this LUT is generated once ever, the cost is paid
+// at startup and never again.
+const SAMPLE_COUNT: u32 = 1024u;
+
+struct FullscreenOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0), vec2<f32>(-1.0, 1.0), vec2<f32>(3.0, 1.0),
+    );
+    let p = positions[vi];
+    var out: FullscreenOut;
+    out.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+    out.uv = vec2<f32>(p.x * 0.5 + 0.5, -p.y * 0.5 + 0.5);
+    return out;
+}
+
+// Van der Corput radical inverse: reverse the bits of `bits_in` and read them
+// back as a binary fraction.
+fn radical_inverse_vdc(bits_in: u32) -> f32 {
+    var bits = bits_in;
+    bits = (bits << 16u) | (bits >> 16u);
+    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+    return f32(bits) * 2.3283064365386963e-10; // 1 / 2^32
+}
+
+// The Hammersley low-discrepancy sequence: i/N paired with its radical
+// inverse. Converges far faster than uniform random sampling for the same
+// sample count, which is what keeps 1024 samples enough.
+fn hammersley(i: u32, n: u32) -> vec2<f32> {
+    return vec2<f32>(f32(i) / f32(n), radical_inverse_vdc(i));
+}
+
+// GGX/Trowbridge-Reitz importance sampling: maps a uniform point in the unit
+// square onto a half-vector distributed by the GGX normal distribution around
+// `n`, so samples land where the specular lobe actually has energy.
+fn importance_sample_ggx(xi: vec2<f32>, n: vec3<f32>, roughness: f32) -> vec3<f32> {
+    let a = roughness * roughness;
+    let phi = 2.0 * PI * xi.x;
+    let cos_theta = sqrt((1.0 - xi.y) / (1.0 + (a * a - 1.0) * xi.y));
+    // max() against 0: cos_theta is <= 1 analytically, but rounding can push
+    // it a hair past, and sqrt of a negative is NaN.
+    let sin_theta = sqrt(max(1.0 - cos_theta * cos_theta, 0.0));
+    let h_tangent = vec3<f32>(cos(phi) * sin_theta, sin(phi) * sin_theta, cos_theta);
+    let up = select(vec3<f32>(1.0, 0.0, 0.0), vec3<f32>(0.0, 0.0, 1.0), abs(n.z) < 0.999);
+    let tangent = normalize(cross(up, n));
+    let bitangent = cross(n, tangent);
+    return normalize(tangent * h_tangent.x + bitangent * h_tangent.y + n * h_tangent.z);
+}
+
+// Smith geometry term with the IBL remapping k = a^2/2. Direct lighting uses
+// k = (roughness + 1)^2 / 8 instead; substituting the direct k here would
+// visibly darken the split-sum result at high roughness.
+fn geometry_schlick_ggx(n_dot_x: f32, roughness: f32) -> f32 {
+    let a = roughness;
+    let k = (a * a) / 2.0;
+    return n_dot_x / (n_dot_x * (1.0 - k) + k);
+}
+
+fn geometry_smith(n_dot_v: f32, n_dot_l: f32, roughness: f32) -> f32 {
+    return geometry_schlick_ggx(n_dot_v, roughness) * geometry_schlick_ggx(n_dot_l, roughness);
+}
+
+// The second half of the split-sum approximation: with Fresnel's F0 factored
+// out of the Cook-Torrance integral, what remains is a scale and a bias that
+// depend only on n_dot_v and roughness. That is the whole reason this LUT can
+// be generated once and reused for every environment.
+fn integrate_brdf(n_dot_v: f32, roughness: f32) -> vec2<f32> {
+    // Work in a canonical frame: the normal is +Z and the view vector lies in
+    // the XZ plane at the requested n_dot_v. The integral is rotationally
+    // symmetric about the normal, so this loses nothing.
+    let n = vec3<f32>(0.0, 0.0, 1.0);
+    let v = vec3<f32>(sqrt(max(1.0 - n_dot_v * n_dot_v, 0.0)), 0.0, n_dot_v);
+    var scale = 0.0;
+    var bias = 0.0;
+    for (var i = 0u; i < SAMPLE_COUNT; i++) {
+        let xi = hammersley(i, SAMPLE_COUNT);
+        let h = importance_sample_ggx(xi, n, roughness);
+        let l = normalize(2.0 * dot(v, h) * h - v);
+        let n_dot_l = max(l.z, 0.0);
+        let n_dot_h = max(h.z, 0.0);
+        // clamp, not max: dot() of two normalized vectors can land a hair
+        // above 1.0, and pow() of a negative base below is a NaN.
+        let v_dot_h = clamp(dot(v, h), 0.0, 1.0);
+        if (n_dot_l > 0.0) {
+            let g = geometry_smith(n_dot_v, n_dot_l, roughness);
+            let g_vis = (g * v_dot_h) / (n_dot_h * n_dot_v);
+            let fc = pow(1.0 - v_dot_h, 5.0);
+            scale += (1.0 - fc) * g_vis;
+            bias += fc * g_vis;
+        }
+    }
+    return vec2<f32>(scale, bias) / f32(SAMPLE_COUNT);
+}
+
+@fragment
+fn fs_brdf_lut(in: FullscreenOut) -> @location(0) vec2<f32> {
+    // U is n_dot_v, V is roughness. Both are clamped off zero: n_dot_v == 0
+    // divides by zero in the visibility term, and a zero-area microfacet
+    // distribution is degenerate. Texel centres never actually reach zero at
+    // this resolution, so the clamp is a guard rather than a bias.
+    let n_dot_v = clamp(in.uv.x, 0.001, 1.0);
+    let roughness = clamp(in.uv.y, 0.001, 1.0);
+    return integrate_brdf(n_dot_v, roughness);
+}
+"#;
+
+/// Generates the BRDF integration LUT: a [`BRDF_LUT_SIZE`]-square
+/// [`BRDF_LUT_FORMAT`] texture whose `.r` is the `f0` scale and `.g` the
+/// `f0` bias of the split-sum approximation, indexed by `n_dot_v` along U
+/// and `roughness` along V.
+///
+/// **Schedule.** This is the one IBL pass that depends on nothing but the
+/// BRDF itself -- not the environment, not the scene, not the camera -- so it
+/// is generated **once at startup and reused for every skybox thereafter**.
+/// The three environment passes (equirect->cubemap, irradiance, prefilter)
+/// rerun whenever the skybox changes; this one never does.
+///
+/// Returns the tracked texture, which the caller must keep alive for the
+/// profiler to keep counting it, alongside a 2D view for binding.
+pub fn generate_brdf_lut(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+) -> (TrackedTexture, wgpu::TextureView) {
+    let texture = create_tracked_texture(
+        device,
+        &wgpu::TextureDescriptor {
+            label: Some("ibl brdf lut"),
+            size: wgpu::Extent3d {
+                width: BRDF_LUT_SIZE,
+                height: BRDF_LUT_SIZE,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: BRDF_LUT_FORMAT,
+            // COPY_SRC so the generated table can be read back and asserted
+            // on; it is a pure function of the BRDF, so its values are
+            // checkable numbers rather than something only an eyeball test
+            // could judge.
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        },
+    );
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("ibl brdf lut shader"),
+        source: wgpu::ShaderSource::Wgsl(BRDF_LUT_WGSL.into()),
+    });
+    // No bind groups at all: the integration reads nothing but its own
+    // fragment coordinates.
+    let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("ibl brdf lut pll"),
+        bind_group_layouts: &[],
+        push_constant_ranges: &[],
+    });
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("ibl brdf lut pipeline"),
+        layout: Some(&layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: "vs_fullscreen",
+            buffers: &[],
+            compilation_options: Default::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: "fs_brdf_lut",
+            targets: &[Some(wgpu::ColorTargetState {
+                format: BRDF_LUT_FORMAT,
+                blend: Some(wgpu::BlendState::REPLACE),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: Default::default(),
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview: None,
+        cache: None,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("ibl brdf lut encoder"),
+    });
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("ibl brdf lut pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            ..Default::default()
+        });
+        pass.set_pipeline(&pipeline);
+        pass.draw(0..3, 0..1);
+    }
+    queue.submit(std::iter::once(encoder.finish()));
+
+    (texture, view)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::surface::WgpuSurface;
+
+    /// Decodes one IEEE-754 binary16 value. `Rg16Float` readback comes back
+    /// as raw half-floats, and nothing in this crate's dependency tree
+    /// decodes them. Deliberately preserves infinities and NaNs rather than
+    /// sanitising them, because "every texel is finite" is one of the
+    /// properties under test.
+    fn f16_to_f32(bits: u16) -> f32 {
+        let sign = if bits & 0x8000 != 0 { -1.0f32 } else { 1.0 };
+        let exp = ((bits >> 10) & 0x1f) as i32;
+        let frac = (bits & 0x03ff) as f32;
+        if exp == 0 {
+            // Subnormal (and zero): value is frac * 2^-24.
+            sign * frac * 2.0f32.powi(-24)
+        } else if exp == 0x1f {
+            if frac == 0.0 {
+                sign * f32::INFINITY
+            } else {
+                f32::NAN
+            }
+        } else {
+            sign * (1.0 + frac / 1024.0) * 2.0f32.powi(exp - 15)
+        }
+    }
+
+    /// Generates the LUT on a real device and reads it back as
+    /// `(scale, bias)` pairs in row-major order, row 0 being roughness ~= 0.
+    ///
+    /// Reuses `crate::output::read_pixels`, the crate's existing texture
+    /// readback: its 4-bytes-per-texel assumption is exactly right for
+    /// `Rg16Float` (two halves), and at 512 wide the rows are already
+    /// 256-byte aligned.
+    fn read_back_lut() -> Vec<(f32, f32)> {
+        let (device, queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        let (texture, _view) = generate_brdf_lut(&device, &queue);
+        let raw =
+            crate::output::read_pixels(&device, &queue, &texture, BRDF_LUT_SIZE, BRDF_LUT_SIZE);
+        assert_eq!(raw.len(), (BRDF_LUT_SIZE * BRDF_LUT_SIZE * 4) as usize);
+        raw.chunks_exact(4)
+            .map(|t| {
+                (
+                    f16_to_f32(u16::from_le_bytes([t[0], t[1]])),
+                    f16_to_f32(u16::from_le_bytes([t[2], t[3]])),
+                )
+            })
+            .collect()
+    }
+
+    fn texel(lut: &[(f32, f32)], n_dot_v_index: u32, roughness_index: u32) -> (f32, f32) {
+        lut[(roughness_index * BRDF_LUT_SIZE + n_dot_v_index) as usize]
+    }
+
+    #[test]
+    fn brdf_lut_values_are_in_range_and_scale_approaches_one_at_normal_incidence() {
+        let lut = read_back_lut();
+
+        // Column 511 is n_dot_v ~= 0.999 (texel centre 511.5/512), row 0 is
+        // roughness ~= 0.001. At n_dot_v = 1, roughness = 0 a perfect mirror
+        // reflects f0 exactly, so the scale term must approach 1 and the bias
+        // approach 0. A LUT that is merely non-empty would pass a weaker
+        // assertion while being completely wrong.
+        let (mirror_scale, mirror_bias) = texel(&lut, BRDF_LUT_SIZE - 1, 0);
+        assert!(
+            mirror_scale > 0.99 && mirror_scale <= 1.0,
+            "at n_dot_v ~= 1, roughness ~= 0 the f0 scale must approach 1, got {mirror_scale}"
+        );
+        assert!(
+            mirror_bias.abs() < 0.01,
+            "at n_dot_v ~= 1, roughness ~= 0 the f0 bias must approach 0, got {mirror_bias}"
+        );
+
+        // The opposite end of the same row: a fully rough surface at the same
+        // viewing angle loses a large part of that energy to the geometry
+        // term. Without this, a shader that simply wrote (1, 0) everywhere
+        // would satisfy the assertions above.
+        let (rough_scale, _) = texel(&lut, BRDF_LUT_SIZE - 1, BRDF_LUT_SIZE - 1);
+        assert!(
+            rough_scale < mirror_scale - 0.1,
+            "the f0 scale must fall off with roughness -- a constant table is \
+             not an integration; mirror {mirror_scale} vs rough {rough_scale}"
+        );
+
+        // Grazing incidence at mirror smoothness is the other known corner:
+        // the Fresnel weight moves almost entirely into the bias term.
+        let (grazing_scale, grazing_bias) = texel(&lut, 0, 0);
+        assert!(
+            grazing_bias > grazing_scale,
+            "at grazing incidence and zero roughness the split-sum weight \
+             belongs to the bias, got scale {grazing_scale} bias {grazing_bias}"
+        );
+    }
+
+    #[test]
+    fn brdf_lut_texels_are_all_finite_and_within_zero_to_one() {
+        let lut = read_back_lut();
+        // One f16 ulp at 1.0 is 2^-10. The analytic bound is [0, 1] and this
+        // GPU lands exactly on it (measured scale range [0.0043, 1.0], bias
+        // [0.0, 0.9937]); the slack only tolerates a different GPU's rounding
+        // pushing a 1.0 up by a single representable step, not a real
+        // out-of-range result.
+        const F16_SLACK: f32 = 0.000_976_562_5;
+        for (i, &(scale, bias)) in lut.iter().enumerate() {
+            let n_dot_v_index = i as u32 % BRDF_LUT_SIZE;
+            let roughness_index = i as u32 / BRDF_LUT_SIZE;
+            assert!(
+                scale.is_finite() && bias.is_finite(),
+                "texel (n_dot_v {n_dot_v_index}, roughness {roughness_index}) is not finite: \
+                 scale {scale}, bias {bias}"
+            );
+            assert!(
+                (-F16_SLACK..=1.0 + F16_SLACK).contains(&scale),
+                "f0 scale out of [0, 1] at (n_dot_v {n_dot_v_index}, roughness \
+                 {roughness_index}): {scale}"
+            );
+            assert!(
+                (-F16_SLACK..=1.0 + F16_SLACK).contains(&bias),
+                "f0 bias out of [0, 1] at (n_dot_v {n_dot_v_index}, roughness \
+                 {roughness_index}): {bias}"
+            );
+        }
+    }
+
+    /// A cube view over a texture that is not six-layered, or a face view
+    /// whose layer range runs past the end, is a `wgpu` validation error and
+    /// nothing else -- it produces no wrong pixels to notice later. The error
+    /// scope is the only thing that surfaces it.
+    #[test]
+    fn cubemap_views_are_valid_for_the_gpu() {
+        let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+        let cube = create_cubemap(
+            &device,
+            "cubemap helper test",
+            PREFILTER_CUBE_SIZE,
+            PREFILTER_MIP_LEVELS,
+            wgpu::TextureFormat::Rgba16Float,
+            wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+        );
+        assert_eq!(
+            cube.size().depth_or_array_layers,
+            6,
+            "a cubemap is six array layers; anything else cannot be viewed as a cube"
+        );
+        assert_eq!(cube.mip_level_count(), PREFILTER_MIP_LEVELS);
+
+        let _cube_view = cube_view(&cube);
+        // Every (face, mip) pair the prefilter pass will render into.
+        for face in 0..CUBE_FACES {
+            for mip in 0..PREFILTER_MIP_LEVELS {
+                let _face_view = face_view(&cube, face, mip);
+            }
+        }
+
+        device.poll(wgpu::Maintain::Wait);
+        assert!(
+            pollster::block_on(device.pop_error_scope()).is_none(),
+            "creating the cube and face views must not raise a validation error"
+        );
+    }
+
+    #[test]
+    fn brdf_lut_is_two_channel_half_float() {
+        // The shader's fragment entry returns a vec2<f32>; a format with a
+        // different channel count would be a pipeline validation error.
+        assert_eq!(BRDF_LUT_FORMAT, wgpu::TextureFormat::Rg16Float);
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/ibl.rs
+++ b/crates/bsengine-rhi-wgpu/src/ibl.rs
@@ -128,6 +128,166 @@ pub fn face_view(texture: &wgpu::Texture, face: u32, mip: u32) -> wgpu::TextureV
     })
 }
 
+/// The bind group layout every face-rendering pass shares: a dynamic-offset
+/// uniform record saying which face (and, for the prefilter, which roughness)
+/// this pass is writing, the source environment, and its sampler.
+///
+/// `source_dimension` is the only thing that varies between the three passes:
+/// the equirect conversion reads a flat 2D panorama, while both convolutions
+/// read the cubemap that conversion produced.
+fn face_pass_bind_group_layout(
+    device: &wgpu::Device,
+    label: &str,
+    uniform_size: u64,
+    source_dimension: wgpu::TextureViewDimension,
+) -> wgpu::BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some(label),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    min_binding_size: wgpu::BufferSize::new(uniform_size),
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: source_dimension,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            },
+        ],
+    })
+}
+
+/// The bind group for [`face_pass_bind_group_layout`], built once and reused by
+/// every face pass with a differing dynamic offset.
+fn face_pass_bind_group(
+    device: &wgpu::Device,
+    label: &str,
+    layout: &wgpu::BindGroupLayout,
+    uniforms: &wgpu::Buffer,
+    uniform_size: u64,
+    source: &wgpu::TextureView,
+    sampler: &wgpu::Sampler,
+) -> wgpu::BindGroup {
+    device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some(label),
+        layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                // An explicit binding size, not `as_entire_binding`: with a
+                // dynamic offset the bound range starts at the offset, so a
+                // whole-buffer size would run past the end on every pass but
+                // the first.
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: uniforms,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(uniform_size),
+                }),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(source),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::Sampler(sampler),
+            },
+        ],
+    })
+}
+
+/// The fullscreen-triangle pipeline every face pass runs: no vertex buffers, no
+/// depth, one colour target, `vs_fullscreen` from [`COMMON_WGSL`] paired with
+/// whichever fragment entry the pass supplies.
+fn face_pass_pipeline(
+    device: &wgpu::Device,
+    label: &str,
+    wgsl: &str,
+    fragment_entry: &str,
+    bgl: &wgpu::BindGroupLayout,
+    format: wgpu::TextureFormat,
+) -> wgpu::RenderPipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some(label),
+        source: wgpu::ShaderSource::Wgsl(wgsl.into()),
+    });
+    let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some(label),
+        bind_group_layouts: &[bgl],
+        push_constant_ranges: &[],
+    });
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some(label),
+        layout: Some(&layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: "vs_fullscreen",
+            buffers: &[],
+            compilation_options: Default::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: fragment_entry,
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: Some(wgpu::BlendState::REPLACE),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: Default::default(),
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview: None,
+        cache: None,
+    })
+}
+
+/// Draws the shared fullscreen triangle into `target`, selecting this pass's
+/// uniform record with `dynamic_offset`.
+fn draw_face_pass(
+    encoder: &mut wgpu::CommandEncoder,
+    label: &str,
+    target: &wgpu::TextureView,
+    pipeline: &wgpu::RenderPipeline,
+    bind_group: &wgpu::BindGroup,
+    dynamic_offset: u64,
+) {
+    let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some(label),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: target,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                store: wgpu::StoreOp::Store,
+            },
+        })],
+        depth_stencil_attachment: None,
+        ..Default::default()
+    });
+    pass.set_pipeline(pipeline);
+    pass.set_bind_group(0, bind_group, &[dynamic_offset as wgpu::DynamicOffset]);
+    pass.draw(0..3, 0..1);
+}
+
 /// WGSL every IBL pass needs, prepended to each pass's own source rather than
 /// copied into it.
 ///
@@ -188,12 +348,15 @@ fn cube_face_direction(face: u32, uv: vec2<f32>) -> vec3<f32> {
 }
 "#;
 
-const BRDF_LUT_WGSL: &str = r#"
-// Sample count for the Monte Carlo integration. 1024 Hammersley points is the
-// standard figure; because this LUT is generated once ever, the cost is paid
-// at startup and never again.
-const SAMPLE_COUNT: u32 = 1024u;
-
+/// GGX importance sampling, shared by the BRDF LUT and the specular prefilter.
+///
+/// Kept apart from either pass rather than duplicated into both: the two are
+/// the *same* integral split in half -- the LUT integrates the BRDF with the
+/// environment factored out, the prefilter integrates the environment with the
+/// BRDF factored out -- so if their sample distributions ever drifted apart,
+/// recombining the halves in the material shader would no longer reconstruct
+/// the integral they came from.
+const IMPORTANCE_SAMPLING_WGSL: &str = r#"
 // Van der Corput radical inverse: reverse the bits of `bits_in` and read them
 // back as a binary fraction.
 fn radical_inverse_vdc(bits_in: u32) -> f32 {
@@ -229,6 +392,13 @@ fn importance_sample_ggx(xi: vec2<f32>, n: vec3<f32>, roughness: f32) -> vec3<f3
     let bitangent = cross(n, tangent);
     return normalize(tangent * h_tangent.x + bitangent * h_tangent.y + n * h_tangent.z);
 }
+"#;
+
+const BRDF_LUT_WGSL: &str = r#"
+// Sample count for the Monte Carlo integration. 1024 Hammersley points is the
+// standard figure; because this LUT is generated once ever, the cost is paid
+// at startup and never again.
+const SAMPLE_COUNT: u32 = 1024u;
 
 // Smith geometry term with the IBL remapping k = a^2/2. Direct lighting uses
 // k = (roughness + 1)^2 / 8 instead; substituting the direct k here would
@@ -331,7 +501,9 @@ pub fn generate_brdf_lut(
 
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("ibl brdf lut shader"),
-        source: wgpu::ShaderSource::Wgsl(format!("{COMMON_WGSL}{BRDF_LUT_WGSL}").into()),
+        source: wgpu::ShaderSource::Wgsl(
+            format!("{COMMON_WGSL}{IMPORTANCE_SAMPLING_WGSL}{BRDF_LUT_WGSL}").into(),
+        ),
     });
     // No bind groups at all: the integration reads nothing but its own
     // fragment coordinates.
@@ -468,15 +640,57 @@ pub fn equirect_to_cubemap(
             | wgpu::TextureUsages::COPY_SRC,
     );
 
-    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-        label: Some("ibl equirect to cube shader"),
-        source: wgpu::ShaderSource::Wgsl(format!("{COMMON_WGSL}{EQUIRECT_TO_CUBE_WGSL}").into()),
-    });
+    let face_buffer = write_face_uniforms(device, queue, "ibl equirect to cube uniform");
 
-    // One record per face, indexed by dynamic offset, so all six passes share
-    // a single buffer and bind group and the whole conversion is one submit.
-    let face_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-        label: Some("ibl face uniform"),
+    let bgl = face_pass_bind_group_layout(
+        device,
+        "ibl equirect to cube bgl",
+        FACE_UNIFORM_SIZE,
+        wgpu::TextureViewDimension::D2,
+    );
+    let bind_group = face_pass_bind_group(
+        device,
+        "ibl equirect to cube bg",
+        &bgl,
+        &face_buffer,
+        FACE_UNIFORM_SIZE,
+        equirect_view,
+        sampler,
+    );
+    let pipeline = face_pass_pipeline(
+        device,
+        "ibl equirect to cube",
+        &format!("{COMMON_WGSL}{EQUIRECT_TO_CUBE_WGSL}"),
+        "fs_equirect_to_cube",
+        &bgl,
+        ENV_CUBE_FORMAT,
+    );
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("ibl equirect to cube encoder"),
+    });
+    for face in 0..CUBE_FACES {
+        draw_face_pass(
+            &mut encoder,
+            "ibl equirect to cube pass",
+            &face_view(&texture, face, 0),
+            &pipeline,
+            &bind_group,
+            face as u64 * FACE_UNIFORM_STRIDE,
+        );
+    }
+    queue.submit(std::iter::once(encoder.finish()));
+
+    let view = cube_view(&texture);
+    (texture, view)
+}
+
+/// Fills a uniform buffer with one [`FACE_UNIFORM_SIZE`] record per cube face,
+/// each at its own [`FACE_UNIFORM_STRIDE`] offset, so the six face passes share
+/// a single buffer and bind group and differ only by dynamic offset.
+fn write_face_uniforms(device: &wgpu::Device, queue: &wgpu::Queue, label: &str) -> wgpu::Buffer {
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
         size: FACE_UNIFORM_STRIDE * CUBE_FACES as u64,
         usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
@@ -484,123 +698,311 @@ pub fn equirect_to_cubemap(
     for face in 0..CUBE_FACES {
         let mut record = [0u8; FACE_UNIFORM_SIZE as usize];
         record[..4].copy_from_slice(&face.to_le_bytes());
-        queue.write_buffer(&face_buffer, face as u64 * FACE_UNIFORM_STRIDE, &record);
+        queue.write_buffer(&buffer, face as u64 * FACE_UNIFORM_STRIDE, &record);
+    }
+    buffer
+}
+
+const IRRADIANCE_WGSL: &str = r#"
+// Steps around the normal and from the normal down to the horizon. 128 x 32
+// midpoint samples put the cosine-weighted integral of a constant environment
+// within 0.05% of the analytic answer -- far tighter than half-float storage
+// can even represent, so more steps would buy nothing measurable.
+const PHI_STEPS: u32 = 128u;
+const THETA_STEPS: u32 = 32u;
+
+struct FaceUniform {
+    face: vec4<u32>,
+};
+@group(0) @binding(0) var<uniform> face_data: FaceUniform;
+@group(0) @binding(1) var t_env: texture_cube<f32>;
+@group(0) @binding(2) var s_env: sampler;
+
+@fragment
+fn fs_irradiance(in: FullscreenOut) -> @location(0) vec4<f32> {
+    let n = cube_face_direction(face_data.face.x, in.uv);
+
+    // Any frame perpendicular to n will do: the integral covers the whole
+    // hemisphere, so rolling the frame about n cannot change the answer. The
+    // select() guards the one case that is not free -- crossing n with an up
+    // vector parallel to it gives a zero-length vector, and normalizing that
+    // writes NaN into exactly the texels nearest the poles.
+    let up = select(vec3<f32>(1.0, 0.0, 0.0), vec3<f32>(0.0, 1.0, 0.0), abs(n.y) < 0.999);
+    let right = normalize(cross(up, n));
+    let forward = cross(n, right);
+
+    let d_phi = 2.0 * PI / f32(PHI_STEPS);
+    let d_theta = 0.5 * PI / f32(THETA_STEPS);
+
+    var sum = vec3<f32>(0.0);
+    for (var i = 0u; i < PHI_STEPS; i++) {
+        // Midpoint, not left edge: a left-edge sum over theta double-counts
+        // the pole and misses the horizon, and lands about 0.5% high.
+        let phi = (f32(i) + 0.5) * d_phi;
+        let cos_phi = cos(phi);
+        let sin_phi = sin(phi);
+        for (var j = 0u; j < THETA_STEPS; j++) {
+            let theta = (f32(j) + 0.5) * d_theta;
+            let sin_theta = sin(theta);
+            let cos_theta = cos(theta);
+            let dir = right * (sin_theta * cos_phi)
+                + forward * (sin_theta * sin_phi)
+                + n * cos_theta;
+            // cos_theta is Lambert's law; sin_theta is the Jacobian of the
+            // (theta, phi) parametrisation of solid angle, not part of the
+            // BRDF. Dropping either one is the classic wrong-normalisation
+            // bug, and both produce a map that still looks plausible.
+            sum += textureSampleLevel(t_env, s_env, dir, 0.0).rgb * cos_theta * sin_theta;
+        }
     }
 
-    let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-        label: Some("ibl equirect to cube bgl"),
-        entries: &[
-            wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: true,
-                    min_binding_size: wgpu::BufferSize::new(FACE_UNIFORM_SIZE),
-                },
-                count: None,
-            },
-            wgpu::BindGroupLayoutEntry {
-                binding: 1,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Texture {
-                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                    view_dimension: wgpu::TextureViewDimension::D2,
-                    multisampled: false,
-                },
-                count: None,
-            },
-            wgpu::BindGroupLayoutEntry {
-                binding: 2,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                count: None,
-            },
-        ],
-    });
-    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        label: Some("ibl equirect to cube bg"),
-        layout: &bgl,
-        entries: &[
-            wgpu::BindGroupEntry {
-                binding: 0,
-                // An explicit binding size, not `as_entire_binding`: with a
-                // dynamic offset the bound range starts at the offset, so a
-                // whole-buffer size would run past the end on every face but
-                // the first.
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &face_buffer,
-                    offset: 0,
-                    size: wgpu::BufferSize::new(FACE_UNIFORM_SIZE),
-                }),
-            },
-            wgpu::BindGroupEntry {
-                binding: 1,
-                resource: wgpu::BindingResource::TextureView(equirect_view),
-            },
-            wgpu::BindGroupEntry {
-                binding: 2,
-                resource: wgpu::BindingResource::Sampler(sampler),
-            },
-        ],
-    });
+    // sum * d_theta * d_phi is the irradiance E, which is PI * L for a
+    // constant environment of radiance L. What gets stored is E / PI: the
+    // Lambert BRDF is albedo / PI, so folding the 1/PI in here lets the
+    // material shader write `irradiance * albedo` with no stray constant, and
+    // makes a uniform environment come back out as its own colour.
+    let irradiance = sum * d_theta * d_phi / PI;
+    return vec4<f32>(irradiance, 1.0);
+}
+"#;
 
-    let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-        label: Some("ibl equirect to cube pll"),
-        bind_group_layouts: &[&bgl],
-        push_constant_ranges: &[],
-    });
-    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("ibl equirect to cube pipeline"),
-        layout: Some(&layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: "vs_fullscreen",
-            buffers: &[],
-            compilation_options: Default::default(),
-        },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: "fs_equirect_to_cube",
-            targets: &[Some(wgpu::ColorTargetState {
-                format: ENV_CUBE_FORMAT,
-                blend: Some(wgpu::BlendState::REPLACE),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-            compilation_options: Default::default(),
-        }),
-        primitive: wgpu::PrimitiveState::default(),
-        depth_stencil: None,
-        multisample: wgpu::MultisampleState::default(),
-        multiview: None,
-        cache: None,
-    });
+/// Convolves an environment cubemap into a diffuse irradiance cubemap: an
+/// [`IRRADIANCE_CUBE_SIZE`]-square [`ENV_CUBE_FORMAT`] texture whose texel for
+/// direction `n` holds the cosine-weighted average of the environment over the
+/// hemisphere around `n`, divided by PI.
+///
+/// That division is why a uniform environment convolves to its own colour, and
+/// why the material shader can multiply the result straight by albedo: the
+/// Lambert BRDF's 1/PI is already folded in here.
+///
+/// [`IRRADIANCE_CUBE_SIZE`] is 32 on purpose. Irradiance is the environment
+/// smeared over an entire hemisphere, so it has no detail above the very
+/// lowest frequencies -- a larger map would store the same image at more
+/// expense.
+///
+/// One render pass per face, six in one submit. Returns the tracked texture,
+/// which the caller must keep alive for the profiler to keep counting it,
+/// alongside a `Cube` view for binding.
+pub fn irradiance_from_cubemap(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    env_cube_view: &wgpu::TextureView,
+    sampler: &wgpu::Sampler,
+) -> (TrackedTexture, wgpu::TextureView) {
+    let texture = create_cubemap(
+        device,
+        "ibl irradiance cube",
+        IRRADIANCE_CUBE_SIZE,
+        1,
+        ENV_CUBE_FORMAT,
+        wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            // COPY_SRC so the convolution can be read back and checked against
+            // the one environment whose answer is known exactly -- a constant
+            // one, which must convolve to that same constant. A map that is
+            // uniformly twice too bright looks entirely fine on screen.
+            | wgpu::TextureUsages::COPY_SRC,
+    );
+
+    let face_buffer = write_face_uniforms(device, queue, "ibl irradiance uniform");
+    let bgl = face_pass_bind_group_layout(
+        device,
+        "ibl irradiance bgl",
+        FACE_UNIFORM_SIZE,
+        wgpu::TextureViewDimension::Cube,
+    );
+    let bind_group = face_pass_bind_group(
+        device,
+        "ibl irradiance bg",
+        &bgl,
+        &face_buffer,
+        FACE_UNIFORM_SIZE,
+        env_cube_view,
+        sampler,
+    );
+    let pipeline = face_pass_pipeline(
+        device,
+        "ibl irradiance",
+        &format!("{COMMON_WGSL}{IRRADIANCE_WGSL}"),
+        "fs_irradiance",
+        &bgl,
+        ENV_CUBE_FORMAT,
+    );
 
     let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-        label: Some("ibl equirect to cube encoder"),
+        label: Some("ibl irradiance encoder"),
     });
     for face in 0..CUBE_FACES {
-        let target = face_view(&texture, face, 0);
-        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("ibl equirect to cube pass"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &target,
-                resolve_target: None,
-                ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
-                    store: wgpu::StoreOp::Store,
-                },
-            })],
-            depth_stencil_attachment: None,
-            ..Default::default()
-        });
-        pass.set_pipeline(&pipeline);
-        pass.set_bind_group(
-            0,
+        draw_face_pass(
+            &mut encoder,
+            "ibl irradiance pass",
+            &face_view(&texture, face, 0),
+            &pipeline,
             &bind_group,
-            &[(face as u64 * FACE_UNIFORM_STRIDE) as wgpu::DynamicOffset],
+            face as u64 * FACE_UNIFORM_STRIDE,
         );
-        pass.draw(0..3, 0..1);
+    }
+    queue.submit(std::iter::once(encoder.finish()));
+
+    let view = cube_view(&texture);
+    (texture, view)
+}
+
+/// Size of one prefilter uniform record: the cube face this pass writes and the
+/// roughness it convolves at, each rounded up to 16 bytes by WGSL's uniform
+/// layout rules.
+const PREFILTER_UNIFORM_SIZE: u64 = 32;
+
+const PREFILTER_WGSL: &str = r#"
+// 1024 GGX-importance-sampled directions per texel. Matches the BRDF LUT's
+// count deliberately: the two are the same integral split in half, and the
+// prefilter is the half where too few samples show up as visible fireflies
+// around bright spots rather than as a small bias.
+const SAMPLE_COUNT: u32 = 1024u;
+
+struct PrefilterUniform {
+    // .x is the cube face this pass renders.
+    face: vec4<u32>,
+    // .x is the roughness this mip represents.
+    params: vec4<f32>,
+};
+@group(0) @binding(0) var<uniform> pf: PrefilterUniform;
+@group(0) @binding(1) var t_env: texture_cube<f32>;
+@group(0) @binding(2) var s_env: sampler;
+
+@fragment
+fn fs_prefilter(in: FullscreenOut) -> @location(0) vec4<f32> {
+    let n = cube_face_direction(pf.face.x, in.uv);
+    // The split-sum approximation's first half is evaluated with n = v = r, so
+    // one map per roughness can be indexed by reflection direction alone.
+    // That is what makes this a cubemap instead of a five-dimensional table;
+    // the price is that grazing reflections come out a little too round, which
+    // is the standard trade every real-time IBL implementation makes.
+    let v = n;
+    let roughness = pf.params.x;
+
+    var color = vec3<f32>(0.0);
+    var weight = 0.0;
+    for (var i = 0u; i < SAMPLE_COUNT; i++) {
+        let xi = hammersley(i, SAMPLE_COUNT);
+        let h = importance_sample_ggx(xi, n, roughness);
+        let l = normalize(2.0 * dot(v, h) * h - v);
+        let n_dot_l = dot(n, l);
+        if (n_dot_l > 0.0) {
+            // Weighted by n_dot_l rather than averaged flat: grazing samples
+            // contribute proportionally less, which is measurably closer to
+            // ground truth at any sample count that is affordable here.
+            color += textureSampleLevel(t_env, s_env, l, 0.0).rgb * n_dot_l;
+            weight += n_dot_l;
+        }
+    }
+    // At roughness 0 the GGX lobe collapses to a single direction, every
+    // sample lands on n, and this returns the environment unblurred. Nothing
+    // special-cases that -- it falls out of the same loop.
+    return vec4<f32>(color / max(weight, 1e-4), 1.0);
+}
+"#;
+
+/// Convolves an environment cubemap into the prefiltered specular map: a
+/// [`PREFILTER_CUBE_SIZE`]-square [`ENV_CUBE_FORMAT`] cubemap with
+/// [`PREFILTER_MIP_LEVELS`] mips, mip `m` holding the environment convolved
+/// with the GGX lobe at `roughness = m / (PREFILTER_MIP_LEVELS - 1)`.
+///
+/// So mip 0 is roughness 0 -- a mirror, the environment unchanged -- and the
+/// last mip is roughness 1. The material shader picks a level with
+/// `roughness * (PREFILTER_MIP_LEVELS - 1)` and lets hardware trilinear
+/// filtering interpolate between the two nearest.
+///
+/// **This runs 6 x [`PREFILTER_MIP_LEVELS`] = 30 render passes**, one per
+/// (face, mip) pair, because each pair convolves at a different roughness and
+/// writes a different [`face_view`]. That is not a mistake to optimise away:
+/// it happens once per skybox change, not once per frame.
+///
+/// Returns the tracked texture, which the caller must keep alive for the
+/// profiler to keep counting it, alongside a `Cube` view spanning every mip.
+pub fn prefilter_from_cubemap(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    env_cube_view: &wgpu::TextureView,
+    sampler: &wgpu::Sampler,
+) -> (TrackedTexture, wgpu::TextureView) {
+    let texture = create_cubemap(
+        device,
+        "ibl prefilter cube",
+        PREFILTER_CUBE_SIZE,
+        PREFILTER_MIP_LEVELS,
+        ENV_CUBE_FORMAT,
+        wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            // COPY_SRC so a test can read mip 0 and the last mip back and
+            // confirm they are not the same image. If the roughness-per-mip
+            // mapping were dropped entirely, every downstream test would still
+            // pass while specular IBL was silently a mirror at every gloss.
+            | wgpu::TextureUsages::COPY_SRC,
+    );
+
+    // One record per (face, mip) pair, so all 30 passes share one buffer and
+    // one bind group and differ only by dynamic offset.
+    let pass_count = CUBE_FACES * PREFILTER_MIP_LEVELS;
+    let uniforms = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("ibl prefilter uniform"),
+        size: FACE_UNIFORM_STRIDE * pass_count as u64,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let prefilter_offset =
+        |face: u32, mip: u32| (mip * CUBE_FACES + face) as u64 * FACE_UNIFORM_STRIDE;
+    for mip in 0..PREFILTER_MIP_LEVELS {
+        // Mip 0 is a mirror and the last mip is fully rough; everything in
+        // between is spaced evenly, which is exactly the mapping the material
+        // shader inverts when it converts a material's roughness into a level.
+        let roughness = mip as f32 / (PREFILTER_MIP_LEVELS - 1) as f32;
+        for face in 0..CUBE_FACES {
+            let mut record = [0u8; PREFILTER_UNIFORM_SIZE as usize];
+            record[..4].copy_from_slice(&face.to_le_bytes());
+            record[16..20].copy_from_slice(&roughness.to_le_bytes());
+            queue.write_buffer(&uniforms, prefilter_offset(face, mip), &record);
+        }
+    }
+
+    let bgl = face_pass_bind_group_layout(
+        device,
+        "ibl prefilter bgl",
+        PREFILTER_UNIFORM_SIZE,
+        wgpu::TextureViewDimension::Cube,
+    );
+    let bind_group = face_pass_bind_group(
+        device,
+        "ibl prefilter bg",
+        &bgl,
+        &uniforms,
+        PREFILTER_UNIFORM_SIZE,
+        env_cube_view,
+        sampler,
+    );
+    let pipeline = face_pass_pipeline(
+        device,
+        "ibl prefilter",
+        &format!("{COMMON_WGSL}{IMPORTANCE_SAMPLING_WGSL}{PREFILTER_WGSL}"),
+        "fs_prefilter",
+        &bgl,
+        ENV_CUBE_FORMAT,
+    );
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("ibl prefilter encoder"),
+    });
+    for mip in 0..PREFILTER_MIP_LEVELS {
+        for face in 0..CUBE_FACES {
+            draw_face_pass(
+                &mut encoder,
+                "ibl prefilter pass",
+                &face_view(&texture, face, mip),
+                &pipeline,
+                &bind_group,
+                prefilter_offset(face, mip),
+            );
+        }
     }
     queue.submit(std::iter::once(encoder.finish()));
 
@@ -784,13 +1186,13 @@ mod tests {
     // Equirect -> cubemap
     // ---------------------------------------------------------------------
 
-    /// Reads one array layer of an [`ENV_CUBE_FORMAT`] texture back as linear
-    /// RGBA floats.
+    /// Reads one mip of one array layer of an [`ENV_CUBE_FORMAT`] texture back
+    /// as linear RGBA floats.
     ///
     /// Same padded-row idiom as [`crate::output::read_pixels`], which Task 1
     /// reused for the LUT, widened where a cube face does not fit it: that one
-    /// is hard-wired to array layer 0 and four bytes per texel, and a face is
-    /// layer `layer` of eight-byte texels.
+    /// is hard-wired to mip 0 of array layer 0 at four bytes per texel, and a
+    /// prefiltered face is mip `mip` of layer `layer` at eight bytes per texel.
     fn read_rgba16f_layer(
         device: &wgpu::Device,
         queue: &wgpu::Queue,
@@ -798,6 +1200,7 @@ mod tests {
         width: u32,
         height: u32,
         layer: u32,
+        mip: u32,
     ) -> Vec<[f32; 4]> {
         const BYTES_PER_TEXEL: u32 = 8;
         let unpadded_bytes_per_row = width * BYTES_PER_TEXEL;
@@ -817,7 +1220,7 @@ mod tests {
         encoder.copy_texture_to_buffer(
             wgpu::ImageCopyTexture {
                 texture,
-                mip_level: 0,
+                mip_level: mip,
                 // The layer selector: for a 2D array, `origin.z` is the layer.
                 origin: wgpu::Origin3d {
                     x: 0,
@@ -903,6 +1306,18 @@ mod tests {
     /// latitude measured downwards), so it is by construction the thing that
     /// mapping expects to read.
     fn direction_encoded_equirect() -> Vec<u8> {
+        build_equirect(encode_direction)
+    }
+
+    /// Builds an equirectangular panorama by asking `texel` what colour the
+    /// direction each texel represents should be.
+    ///
+    /// The direction it passes is the inverse of `fs_sky`'s mapping (`u` is
+    /// longitude, `v` is latitude measured downwards), so every environment
+    /// built through here is by construction the thing that mapping expects to
+    /// read -- and every test environment agrees with every other about where a
+    /// given direction lives.
+    fn build_equirect(texel: impl Fn(Vec3) -> [u8; 4]) -> Vec<u8> {
         let mut pixels = Vec::with_capacity((TEST_EQUIRECT_W * TEST_EQUIRECT_H * 4) as usize);
         for j in 0..TEST_EQUIRECT_H {
             let v = (j as f32 + 0.5) / TEST_EQUIRECT_H as f32;
@@ -915,25 +1330,36 @@ mod tests {
                     theta.sin(),
                     theta.cos() * phi.sin(),
                 );
-                pixels.extend_from_slice(&encode_direction(dir));
+                pixels.extend_from_slice(&texel(dir));
             }
         }
         pixels
     }
 
-    /// Uploads [`direction_encoded_equirect`] and returns it with a sampler
+    /// Uploads [`direction_encoded_equirect`] with a skybox-shaped sampler.
+    fn upload_direction_encoded_equirect(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) -> (wgpu::Texture, wgpu::TextureView, wgpu::Sampler) {
+        upload_equirect(device, queue, &direction_encoded_equirect())
+    }
+
+    /// Uploads an equirectangular panorama and returns it with a sampler
     /// configured exactly as `set_skybox_from_rgba`'s is -- `Repeat` across the
     /// longitude seam, `ClampToEdge` at the poles, linear both ways.
     ///
     /// **`Rgba8Unorm`, not the `Rgba8UnormSrgb` the real skybox uses.** These
-    /// texels are an encoded direction rather than a colour, and an sRGB decode
-    /// would bend the encoding out of shape before it could be read back. The
-    /// conversion pass reads whatever the view's format declares and does
-    /// nothing format-specific, so this narrows nothing about what is under
-    /// test: where directions land, not colour management.
-    fn upload_direction_encoded_equirect(
+    /// texels are encoded test data -- a direction, or a known linear radiance
+    /// -- rather than photographic colour, and an sRGB decode would bend both
+    /// out of shape before they could be checked against the numbers they were
+    /// written as. Every pass here reads whatever the view's format declares
+    /// and does nothing format-specific, so this narrows nothing about what is
+    /// under test: where directions land and how energy is normalised, not
+    /// colour management.
+    fn upload_equirect(
         device: &wgpu::Device,
         queue: &wgpu::Queue,
+        pixels: &[u8],
     ) -> (wgpu::Texture, wgpu::TextureView, wgpu::Sampler) {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("direction-encoded equirect"),
@@ -951,7 +1377,7 @@ mod tests {
         });
         queue.write_texture(
             texture.as_image_copy(),
-            &direction_encoded_equirect(),
+            pixels,
             wgpu::ImageDataLayout {
                 offset: 0,
                 bytes_per_row: Some(4 * TEST_EQUIRECT_W),
@@ -1164,7 +1590,7 @@ fn fs_probe(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         }
         queue.submit(std::iter::once(encoder.finish()));
 
-        read_rgba16f_layer(device, queue, &target, PROBE_COUNT as u32, 1, 0)
+        read_rgba16f_layer(device, queue, &target, PROBE_COUNT as u32, 1, 0, 0)
             .into_iter()
             .map(decode_direction)
             .collect()
@@ -1204,6 +1630,7 @@ fn fs_probe(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
                 ENV_CUBE_SIZE,
                 ENV_CUBE_SIZE,
                 face as u32,
+                0,
             );
             assert_eq!(texels.len(), (ENV_CUBE_SIZE * ENV_CUBE_SIZE) as usize);
             let got = decode_direction(texels[centre]);
@@ -1271,6 +1698,232 @@ fn fs_probe(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         assert!(
             pollster::block_on(device.pop_error_scope()).is_none(),
             "the conversion must not raise a validation error"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Irradiance convolution
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn irradiance_of_a_uniform_environment_is_that_same_colour() {
+        let (device, queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+        // 51, 153 and 102 over 255 are exactly 0.2, 0.6 and 0.4 -- three
+        // different values on purpose, so a swapped channel or a collapse to
+        // luminance shows up as the wrong colour rather than merely the wrong
+        // brightness.
+        const WANT: [f32; 3] = [0.2, 0.6, 0.4];
+        let (_src, src_view, src_sampler) =
+            upload_equirect(&device, &queue, &build_equirect(|_| [51, 153, 102, 255]));
+        let (_env, env_view) = equirect_to_cubemap(&device, &queue, &src_view, &src_sampler);
+        let (irradiance, _irradiance_view) =
+            irradiance_from_cubemap(&device, &queue, &env_view, &src_sampler);
+
+        assert_eq!(irradiance.width(), IRRADIANCE_CUBE_SIZE);
+        assert_eq!(irradiance.height(), IRRADIANCE_CUBE_SIZE);
+        assert_eq!(irradiance.size().depth_or_array_layers, CUBE_FACES);
+
+        // The cosine-weighted hemisphere integral of a constant radiance L is
+        // exactly PI * L, and this pass divides by PI, so every texel of every
+        // face must come back as L itself. That is the point of checking a
+        // uniform environment: the answer is a number, not a judgement. A pass
+        // that dropped the sin(theta) Jacobian, or divided by the sample count
+        // instead of scaling by the step sizes, produces a map that is
+        // uniformly too bright or too dark -- and a uniformly 2x map looks
+        // entirely plausible on screen.
+        //
+        // The tolerance covers three known, bounded error sources and nothing
+        // else: the midpoint rule's 0.04% discretisation bias, and half-float
+        // rounding of both the environment cube and this map, each ~0.05%.
+        // Measured worst case across all 6144 texels is 0.065%, so 1% leaves
+        // fifteen times that for another GPU's rounding, while anything
+        // structurally wrong misses by tens of percent at least.
+        const TOLERANCE: f32 = 0.01;
+
+        let mut worst = 0.0f32;
+        for face in 0..CUBE_FACES {
+            let texels = read_rgba16f_layer(
+                &device,
+                &queue,
+                &irradiance,
+                IRRADIANCE_CUBE_SIZE,
+                IRRADIANCE_CUBE_SIZE,
+                face,
+                0,
+            );
+            assert_eq!(
+                texels.len(),
+                (IRRADIANCE_CUBE_SIZE * IRRADIANCE_CUBE_SIZE) as usize
+            );
+            for (i, texel) in texels.iter().enumerate() {
+                let x = i as u32 % IRRADIANCE_CUBE_SIZE;
+                let y = i as u32 / IRRADIANCE_CUBE_SIZE;
+                for (channel, want) in WANT.iter().enumerate() {
+                    let got = texel[channel];
+                    // is_finite first: the tangent frame degenerates where the
+                    // normal is parallel to the up vector, and an unguarded
+                    // normalize() there writes NaN into the texels nearest the
+                    // poles -- which a relative comparison alone reports as a
+                    // baffling magnitude failure instead.
+                    assert!(
+                        got.is_finite(),
+                        "face {face} texel ({x}, {y}) channel {channel} is not finite: {got}"
+                    );
+                    let relative_error = (got - want).abs() / want;
+                    worst = worst.max(relative_error);
+                    assert!(
+                        relative_error < TOLERANCE,
+                        "a uniform environment must convolve to its own colour: face {face} \
+                         texel ({x}, {y}) channel {channel} is {got}, want {want} \
+                         (relative error {relative_error})"
+                    );
+                }
+            }
+        }
+
+        // Not a restatement of the loop: it pins how much of the budget the
+        // pass actually uses, so a future change that quietly eats most of the
+        // tolerance shows up here rather than at the moment it finally crosses
+        // the line.
+        assert!(
+            worst < TOLERANCE * 0.5,
+            "the convolution should sit well inside its tolerance, not at the \
+             edge of it; worst relative error was {worst}"
+        );
+
+        device.poll(wgpu::Maintain::Wait);
+        assert!(
+            pollster::block_on(device.pop_error_scope()).is_none(),
+            "the irradiance convolution must not raise a validation error"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Specular prefilter
+    // ---------------------------------------------------------------------
+
+    /// Minimum, maximum and mean of the RGB average over one prefiltered face.
+    ///
+    /// The prefilter test's environment is white-on-grey, so all three channels
+    /// carry the same signal and averaging them is only noise reduction.
+    fn face_stats(texels: &[[f32; 4]]) -> (f32, f32, f32) {
+        let mut min = f32::INFINITY;
+        let mut max = f32::NEG_INFINITY;
+        let mut total = 0.0;
+        for texel in texels {
+            let value = (texel[0] + texel[1] + texel[2]) / 3.0;
+            assert!(
+                value.is_finite(),
+                "prefiltered texel is not finite: {texel:?}"
+            );
+            min = min.min(value);
+            max = max.max(value);
+            total += value;
+        }
+        (min, max, total / texels.len() as f32)
+    }
+
+    #[test]
+    fn prefilter_mip_zero_is_sharp_and_the_last_mip_is_blurred() {
+        let (device, queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+        // A dim environment with one bright spot straight down +Z, which is the
+        // direction the centre of cube face 4 looks along. A smooth environment
+        // could not tell a sharp convolution from a blurred one: blurring
+        // something already flat changes nothing.
+        //
+        // The spot's angular radius is not free to pick. The last mip's face is
+        // only 8 x 8, each texel covering about 11 degrees, so a spot smaller
+        // than that falls between texel centres and vanishes from the last mip
+        // *whatever* roughness it was convolved at -- and this test would then
+        // pass on an unblurred map, which is exactly the failure it exists to
+        // catch. 20 degrees is comfortably wider than one texel there while
+        // still occupying only a tenth of the face at mip 0.
+        const SPOT_RADIUS_DEGREES: f32 = 20.0;
+        const SPOT_FACE: u32 = 4;
+        let cos_radius = SPOT_RADIUS_DEGREES.to_radians().cos();
+        let pixels = build_equirect(|dir| {
+            if dir.normalize().dot(Vec3::Z) >= cos_radius {
+                [255, 255, 255, 255]
+            } else {
+                [5, 5, 5, 255]
+            }
+        });
+        let (_src, src_view, src_sampler) = upload_equirect(&device, &queue, &pixels);
+        let (_env, env_view) = equirect_to_cubemap(&device, &queue, &src_view, &src_sampler);
+        let (prefiltered, _prefiltered_view) =
+            prefilter_from_cubemap(&device, &queue, &env_view, &src_sampler);
+
+        assert_eq!(prefiltered.width(), PREFILTER_CUBE_SIZE);
+        assert_eq!(prefiltered.height(), PREFILTER_CUBE_SIZE);
+        assert_eq!(prefiltered.size().depth_or_array_layers, CUBE_FACES);
+        assert_eq!(prefiltered.mip_level_count(), PREFILTER_MIP_LEVELS);
+
+        let last_mip = PREFILTER_MIP_LEVELS - 1;
+        let last_size = PREFILTER_CUBE_SIZE >> last_mip;
+        let read = |mip: u32, size: u32| {
+            read_rgba16f_layer(&device, &queue, &prefiltered, size, size, SPOT_FACE, mip)
+        };
+        let (sharp_min, sharp_max, sharp_mean) = face_stats(&read(0, PREFILTER_CUBE_SIZE));
+        let (blurred_min, blurred_max, blurred_mean) = face_stats(&read(last_mip, last_size));
+        let sharp_contrast = sharp_max - sharp_min;
+        let blurred_contrast = blurred_max - blurred_min;
+
+        // Mip 0 is roughness 0, where the GGX lobe collapses to a single
+        // direction: the spot must still be a spot, at very nearly its full
+        // brightness against the dim background.
+        assert!(
+            sharp_max > 0.9,
+            "mip 0 is a mirror and must still hold the bright spot at full \
+             brightness, but its brightest texel is only {sharp_max}"
+        );
+        assert!(
+            sharp_contrast > 0.8,
+            "mip 0 must keep the spot sharply separated from its surroundings, \
+             but its contrast is only {sharp_contrast} \
+             (min {sharp_min}, max {sharp_max})"
+        );
+
+        // The last mip is roughness 1, where the lobe covers the hemisphere and
+        // smears the spot across the whole face. If both mips came out equally
+        // sharp, the roughness-per-mip mapping is not being applied at all --
+        // and every downstream test would still pass while specular IBL was
+        // silently a mirror at every gloss.
+        assert!(
+            blurred_contrast < sharp_contrast * 0.2,
+            "the last mip must be visibly blurrier than mip 0, but their \
+             contrasts are {blurred_contrast} and {sharp_contrast} -- the \
+             roughness-per-mip mapping is not being applied"
+        );
+        // The peak says the same thing from the other side, and independently
+        // of the background: a mirror-sharp last mip still reads 1.0 at the
+        // spot, while a properly convolved one cannot, because the spot's
+        // energy is now spread over the whole lobe.
+        assert!(
+            blurred_max < sharp_max * 0.5,
+            "the last mip must not still contain the spot at near-full \
+             brightness: mip 0 peak {sharp_max} vs last mip peak {blurred_max}"
+        );
+
+        // The opposite-direction regression, and the reason those two are not
+        // enough on their own: a pass that wrote black, or garbage, or nothing
+        // at all into the high mips would have neither contrast nor a peak and
+        // would sail through both. Blurring redistributes energy, it does not
+        // destroy it, so the blurred face's mean must stay in the same
+        // neighbourhood as the sharp one's.
+        assert!(
+            blurred_mean > sharp_mean * 0.5 && blurred_mean < sharp_mean * 2.0,
+            "blurring must redistribute the environment's energy, not discard \
+             it: mip 0 mean {sharp_mean} vs last mip mean {blurred_mean}"
+        );
+
+        device.poll(wgpu::Maintain::Wait);
+        assert!(
+            pollster::block_on(device.pop_error_scope()).is_none(),
+            "the specular prefilter must not raise a validation error"
         );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/ibl.rs
+++ b/crates/bsengine-rhi-wgpu/src/ibl.rs
@@ -33,9 +33,29 @@ pub const BRDF_LUT_SIZE: u32 = 512;
 /// would show up as stepped reflectance.
 pub const BRDF_LUT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rg16Float;
 
+/// Format of the environment cubemap and the maps convolved from it.
+///
+/// Half float rather than the 8-bit sRGB the skybox itself is stored in: these
+/// are *linear* radiance values that the irradiance and prefilter passes then
+/// sum thousands of samples of, and an 8-bit linear intermediate bands visibly
+/// in the dark end of that sum. Filterable on every backend, so the cube views
+/// still get hardware trilinear filtering across face seams.
+pub const ENV_CUBE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
+
 /// A cubemap has six faces; in wgpu they are six array layers of a 2D
 /// texture, in the fixed order +X, -X, +Y, -Y, +Z, -Z.
 const CUBE_FACES: u32 = 6;
+
+/// Stride between the per-face uniform records the face passes index with a
+/// dynamic offset. 256 rather than the record's actual size because that is
+/// wgpu's minimum uniform-buffer offset alignment on every backend -- the same
+/// convention `surface.rs` uses for `MODEL_STRIDE` and `POINT_SHADOW_STRIDE`.
+const FACE_UNIFORM_STRIDE: u64 = 256;
+
+/// Size of one face-uniform record: a single `u32` face index padded out to a
+/// `vec4<u32>`, because WGSL's uniform layout rules round struct members up to
+/// 16 bytes anyway.
+const FACE_UNIFORM_SIZE: u64 = 16;
 
 /// Creates a cube texture: `size` x `size`, six array layers, `mip_levels`
 /// mips.
@@ -108,18 +128,24 @@ pub fn face_view(texture: &wgpu::Texture, face: u32, mip: u32) -> wgpu::TextureV
     })
 }
 
-const BRDF_LUT_WGSL: &str = r#"
+/// WGSL every IBL pass needs, prepended to each pass's own source rather than
+/// copied into it.
+///
+/// The fullscreen triangle is shared because it is what decides what `uv`
+/// means, and [`cube_face_direction`](self) is built directly on that: if one
+/// pass's triangle disagreed with another's, their faces would come out
+/// flipped relative to each other with nothing to say so.
+const COMMON_WGSL: &str = r#"
 const PI: f32 = 3.14159265359;
-// Sample count for the Monte Carlo integration. 1024 Hammersley points is the
-// standard figure; because this LUT is generated once ever, the cost is paid
-// at startup and never again.
-const SAMPLE_COUNT: u32 = 1024u;
 
 struct FullscreenOut {
     @builtin(position) pos: vec4<f32>,
     @location(0) uv: vec2<f32>,
 }
 
+// One oversized triangle covering the whole target. `uv` is (0, 0) at the
+// target's top-left texel and (1, 1) at its bottom-right -- image order, the
+// same order the texels are stored in, not NDC order.
 @vertex
 fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
     var positions = array<vec2<f32>, 3>(
@@ -131,6 +157,42 @@ fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
     out.uv = vec2<f32>(p.x * 0.5 + 0.5, -p.y * 0.5 + 0.5);
     return out;
 }
+
+// The direction the cube-face texel at `uv` on `face` looks along.
+//
+// `face` is wgpu's cubemap layer order, +X, -X, +Y, -Y, +Z, -Z as 0..5, and
+// the per-face axes below are the fixed cubemap convention that order belongs
+// to: wgpu hands a Cube view straight to the backend's cube image type
+// (`vk::ImageViewType::CUBE` in wgpu-hal's Vulkan `conv.rs`, `TextureCube` in
+// D3D12), so the sampling convention is the backends', not wgpu's to choose.
+// This function is the inverse of their shared (major axis, sc, tc) table,
+// with `uv` in stored image order -- which is why every face's vertical axis
+// comes out negated.
+//
+// Do not "tidy" a sign here. Every one of them is load-bearing and a wrong one
+// produces a plausible-looking image, mirrored, that only a direction test
+// catches.
+fn cube_face_direction(face: u32, uv: vec2<f32>) -> vec3<f32> {
+    let a = 2.0 * uv.x - 1.0;
+    let b = 2.0 * uv.y - 1.0;
+    var dir = vec3<f32>(0.0, 0.0, 1.0);
+    switch face {
+        case 0u: { dir = vec3<f32>( 1.0,   -b,   -a); }
+        case 1u: { dir = vec3<f32>(-1.0,   -b,    a); }
+        case 2u: { dir = vec3<f32>(   a,  1.0,    b); }
+        case 3u: { dir = vec3<f32>(   a, -1.0,   -b); }
+        case 4u: { dir = vec3<f32>(   a,   -b,  1.0); }
+        default: { dir = vec3<f32>(  -a,   -b, -1.0); }
+    }
+    return normalize(dir);
+}
+"#;
+
+const BRDF_LUT_WGSL: &str = r#"
+// Sample count for the Monte Carlo integration. 1024 Hammersley points is the
+// standard figure; because this LUT is generated once ever, the cost is paid
+// at startup and never again.
+const SAMPLE_COUNT: u32 = 1024u;
 
 // Van der Corput radical inverse: reverse the bits of `bits_in` and read them
 // back as a binary fraction.
@@ -269,7 +331,7 @@ pub fn generate_brdf_lut(
 
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("ibl brdf lut shader"),
-        source: wgpu::ShaderSource::Wgsl(BRDF_LUT_WGSL.into()),
+        source: wgpu::ShaderSource::Wgsl(format!("{COMMON_WGSL}{BRDF_LUT_WGSL}").into()),
     });
     // No bind groups at all: the integration reads nothing but its own
     // fragment coordinates.
@@ -329,10 +391,228 @@ pub fn generate_brdf_lut(
     (texture, view)
 }
 
+const EQUIRECT_TO_CUBE_WGSL: &str = r#"
+struct FaceUniform {
+    // .x is the cube face this pass renders; the rest is padding to the
+    // 16-byte uniform stride.
+    face: vec4<u32>,
+};
+@group(0) @binding(0) var<uniform> face_data: FaceUniform;
+@group(0) @binding(1) var t_equirect: texture_2d<f32>;
+@group(0) @binding(2) var s_equirect: sampler;
+
+// Direction -> equirectangular UV.
+//
+// COPIED VERBATIM from `fs_sky` in `surface.rs`, which is what actually draws
+// the sky the player sees. It is not derived here and must not be "cleaned
+// up": an independently derived mapping that looks equivalent is how the IBL
+// environment ends up rotated or mirrored against the visible skybox, which
+// reads as plausible reflections that are subtly, permanently wrong.
+fn equirect_uv(dir: vec3<f32>) -> vec2<f32> {
+    let phi = atan2(dir.z, dir.x);
+    let theta = asin(clamp(dir.y, -1.0, 1.0));
+    let u = phi / (2.0 * PI) + 0.5;
+    let v = 0.5 - theta / PI;
+    return vec2<f32>(u, v);
+}
+
+@fragment
+fn fs_equirect_to_cube(in: FullscreenOut) -> @location(0) vec4<f32> {
+    let dir = cube_face_direction(face_data.face.x, in.uv);
+    // SampleLevel, not Sample: `u` jumps by a full turn across the longitude
+    // seam, so the implicit derivative there is enormous and would pick a mip
+    // that is not the one this pass means to read.
+    return textureSampleLevel(t_equirect, s_equirect, equirect_uv(dir), 0.0);
+}
+"#;
+
+/// Projects an equirectangular (lat-long) environment image onto a real
+/// cubemap: an [`ENV_CUBE_SIZE`]-square [`ENV_CUBE_FORMAT`] texture of six
+/// faces, plus a `Cube` view of it for sampling by direction.
+///
+/// One render pass per face, each writing a [`face_view`] of the target. The
+/// fragment shader turns the face texel's `uv` into a world direction with
+/// [`COMMON_WGSL`]'s `cube_face_direction`, then reads the source through the
+/// **same** direction->UV mapping `surface.rs`'s `fs_sky` uses, so the
+/// environment the material shader reflects sits exactly where the sky the
+/// camera sees does.
+///
+/// `equirect_view` and `sampler` are the skybox's own texture view and
+/// sampler; nothing about the source's format is assumed beyond its being
+/// filterable, so the sRGB decode the real skybox texture carries applies
+/// here exactly as it does in `fs_sky`.
+///
+/// Handles the equirectangular projection only. `SkyboxProjection::Cubemap`
+/// exists in `bsengine-core` but nothing reads it -- neither the loader nor
+/// `fs_sky` branches on it -- so a cross-layout image is already sampled as
+/// though it were equirectangular today, and this pass changes nothing about
+/// that.
+pub fn equirect_to_cubemap(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    equirect_view: &wgpu::TextureView,
+    sampler: &wgpu::Sampler,
+) -> (TrackedTexture, wgpu::TextureView) {
+    let texture = create_cubemap(
+        device,
+        "ibl env cube",
+        ENV_CUBE_SIZE,
+        1,
+        ENV_CUBE_FORMAT,
+        wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            // COPY_SRC so the faces can be read back and checked against the
+            // directions they are supposed to hold. A mirrored conversion is
+            // invisible in any smooth environment, so "it rendered something"
+            // is not evidence of anything.
+            | wgpu::TextureUsages::COPY_SRC,
+    );
+
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("ibl equirect to cube shader"),
+        source: wgpu::ShaderSource::Wgsl(format!("{COMMON_WGSL}{EQUIRECT_TO_CUBE_WGSL}").into()),
+    });
+
+    // One record per face, indexed by dynamic offset, so all six passes share
+    // a single buffer and bind group and the whole conversion is one submit.
+    let face_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("ibl face uniform"),
+        size: FACE_UNIFORM_STRIDE * CUBE_FACES as u64,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    for face in 0..CUBE_FACES {
+        let mut record = [0u8; FACE_UNIFORM_SIZE as usize];
+        record[..4].copy_from_slice(&face.to_le_bytes());
+        queue.write_buffer(&face_buffer, face as u64 * FACE_UNIFORM_STRIDE, &record);
+    }
+
+    let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("ibl equirect to cube bgl"),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    min_binding_size: wgpu::BufferSize::new(FACE_UNIFORM_SIZE),
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            },
+        ],
+    });
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("ibl equirect to cube bg"),
+        layout: &bgl,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                // An explicit binding size, not `as_entire_binding`: with a
+                // dynamic offset the bound range starts at the offset, so a
+                // whole-buffer size would run past the end on every face but
+                // the first.
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &face_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(FACE_UNIFORM_SIZE),
+                }),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(equirect_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::Sampler(sampler),
+            },
+        ],
+    });
+
+    let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("ibl equirect to cube pll"),
+        bind_group_layouts: &[&bgl],
+        push_constant_ranges: &[],
+    });
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("ibl equirect to cube pipeline"),
+        layout: Some(&layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: "vs_fullscreen",
+            buffers: &[],
+            compilation_options: Default::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: "fs_equirect_to_cube",
+            targets: &[Some(wgpu::ColorTargetState {
+                format: ENV_CUBE_FORMAT,
+                blend: Some(wgpu::BlendState::REPLACE),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: Default::default(),
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview: None,
+        cache: None,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("ibl equirect to cube encoder"),
+    });
+    for face in 0..CUBE_FACES {
+        let target = face_view(&texture, face, 0);
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("ibl equirect to cube pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &target,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            ..Default::default()
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(
+            0,
+            &bind_group,
+            &[(face as u64 * FACE_UNIFORM_STRIDE) as wgpu::DynamicOffset],
+        );
+        pass.draw(0..3, 0..1);
+    }
+    queue.submit(std::iter::once(encoder.finish()));
+
+    let view = cube_view(&texture);
+    (texture, view)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::surface::WgpuSurface;
+    use glam::Vec3;
 
     /// Decodes one IEEE-754 binary16 value. `Rg16Float` readback comes back
     /// as raw half-floats, and nothing in this crate's dependency tree
@@ -498,5 +778,499 @@ mod tests {
         // The shader's fragment entry returns a vec2<f32>; a format with a
         // different channel count would be a pipeline validation error.
         assert_eq!(BRDF_LUT_FORMAT, wgpu::TextureFormat::Rg16Float);
+    }
+
+    // ---------------------------------------------------------------------
+    // Equirect -> cubemap
+    // ---------------------------------------------------------------------
+
+    /// Reads one array layer of an [`ENV_CUBE_FORMAT`] texture back as linear
+    /// RGBA floats.
+    ///
+    /// Same padded-row idiom as [`crate::output::read_pixels`], which Task 1
+    /// reused for the LUT, widened where a cube face does not fit it: that one
+    /// is hard-wired to array layer 0 and four bytes per texel, and a face is
+    /// layer `layer` of eight-byte texels.
+    fn read_rgba16f_layer(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+        width: u32,
+        height: u32,
+        layer: u32,
+    ) -> Vec<[f32; 4]> {
+        const BYTES_PER_TEXEL: u32 = 8;
+        let unpadded_bytes_per_row = width * BYTES_PER_TEXEL;
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(align) * align;
+
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("ibl face readback"),
+            size: (padded_bytes_per_row * height) as u64,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("ibl face readback encoder"),
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::ImageCopyTexture {
+                texture,
+                mip_level: 0,
+                // The layer selector: for a 2D array, `origin.z` is the layer.
+                origin: wgpu::Origin3d {
+                    x: 0,
+                    y: 0,
+                    z: layer,
+                },
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::ImageCopyBuffer {
+                buffer: &buffer,
+                layout: wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(height),
+                },
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let slice = buffer.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .expect("map_async never reported a result")
+            .expect("mapping the readback buffer failed");
+
+        let mapped = slice.get_mapped_range();
+        let mut texels = Vec::with_capacity((width * height) as usize);
+        for row in 0..height {
+            let start = (row * padded_bytes_per_row) as usize;
+            let end = start + unpadded_bytes_per_row as usize;
+            for t in mapped[start..end].chunks_exact(BYTES_PER_TEXEL as usize) {
+                texels.push([
+                    f16_to_f32(u16::from_le_bytes([t[0], t[1]])),
+                    f16_to_f32(u16::from_le_bytes([t[2], t[3]])),
+                    f16_to_f32(u16::from_le_bytes([t[4], t[5]])),
+                    f16_to_f32(u16::from_le_bytes([t[6], t[7]])),
+                ]);
+            }
+        }
+        drop(mapped);
+        buffer.unmap();
+        texels
+    }
+
+    /// Size of the synthetic equirectangular source. 2:1, as every lat-long
+    /// panorama is.
+    const TEST_EQUIRECT_W: u32 = 512;
+    const TEST_EQUIRECT_H: u32 = 256;
+
+    /// Encodes a unit direction as a colour: `[-1, 1]` onto `[0, 1]` per
+    /// component.
+    fn encode_direction(d: Vec3) -> [u8; 4] {
+        let q = |x: f32| ((x * 0.5 + 0.5) * 255.0).round().clamp(0.0, 255.0) as u8;
+        [q(d.x), q(d.y), q(d.z), 255]
+    }
+
+    /// The inverse of [`encode_direction`]. Not renormalised here -- callers
+    /// that want a unit vector say so, and the raw length is occasionally the
+    /// thing that tells you the readback itself went wrong.
+    fn decode_direction(c: [f32; 4]) -> Vec3 {
+        Vec3::new(c[0] * 2.0 - 1.0, c[1] * 2.0 - 1.0, c[2] * 2.0 - 1.0)
+    }
+
+    /// An equirectangular panorama whose every texel stores **the direction
+    /// that texel represents**, encoded as its colour.
+    ///
+    /// This is what makes the conversion checkable at all. A photograph, a
+    /// gradient, or six flat octant colours all survive a mirrored or rotated
+    /// conversion looking entirely reasonable; a direction-encoded source does
+    /// not, because whatever comes out of a cube face texel decodes straight
+    /// back into the direction the source believed it was.
+    ///
+    /// Built from the inverse of `fs_sky`'s mapping (`u` is longitude, `v` is
+    /// latitude measured downwards), so it is by construction the thing that
+    /// mapping expects to read.
+    fn direction_encoded_equirect() -> Vec<u8> {
+        let mut pixels = Vec::with_capacity((TEST_EQUIRECT_W * TEST_EQUIRECT_H * 4) as usize);
+        for j in 0..TEST_EQUIRECT_H {
+            let v = (j as f32 + 0.5) / TEST_EQUIRECT_H as f32;
+            let theta = (0.5 - v) * std::f32::consts::PI;
+            for i in 0..TEST_EQUIRECT_W {
+                let u = (i as f32 + 0.5) / TEST_EQUIRECT_W as f32;
+                let phi = (u - 0.5) * 2.0 * std::f32::consts::PI;
+                let dir = Vec3::new(
+                    theta.cos() * phi.cos(),
+                    theta.sin(),
+                    theta.cos() * phi.sin(),
+                );
+                pixels.extend_from_slice(&encode_direction(dir));
+            }
+        }
+        pixels
+    }
+
+    /// Uploads [`direction_encoded_equirect`] and returns it with a sampler
+    /// configured exactly as `set_skybox_from_rgba`'s is -- `Repeat` across the
+    /// longitude seam, `ClampToEdge` at the poles, linear both ways.
+    ///
+    /// **`Rgba8Unorm`, not the `Rgba8UnormSrgb` the real skybox uses.** These
+    /// texels are an encoded direction rather than a colour, and an sRGB decode
+    /// would bend the encoding out of shape before it could be read back. The
+    /// conversion pass reads whatever the view's format declares and does
+    /// nothing format-specific, so this narrows nothing about what is under
+    /// test: where directions land, not colour management.
+    fn upload_direction_encoded_equirect(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) -> (wgpu::Texture, wgpu::TextureView, wgpu::Sampler) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("direction-encoded equirect"),
+            size: wgpu::Extent3d {
+                width: TEST_EQUIRECT_W,
+                height: TEST_EQUIRECT_H,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        queue.write_texture(
+            texture.as_image_copy(),
+            &direction_encoded_equirect(),
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(4 * TEST_EQUIRECT_W),
+                rows_per_image: Some(TEST_EQUIRECT_H),
+            },
+            wgpu::Extent3d {
+                width: TEST_EQUIRECT_W,
+                height: TEST_EQUIRECT_H,
+                depth_or_array_layers: 1,
+            },
+        );
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("direction-encoded equirect sampler"),
+            address_mode_u: wgpu::AddressMode::Repeat,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+        (texture, view, sampler)
+    }
+
+    /// How many directions [`sample_cube_by_direction`] probes at once. Must
+    /// match the array length hard-coded in `PROBE_WGSL`.
+    const PROBE_COUNT: usize = 16;
+    const _: () = assert!(PROBE_COUNT == 16, "PROBE_WGSL declares array<_, 16>");
+
+    const PROBE_WGSL: &str = r#"
+struct Probes {
+    dirs: array<vec4<f32>, 16>,
+};
+@group(0) @binding(0) var<uniform> probes: Probes;
+@group(0) @binding(1) var t_cube: texture_cube<f32>;
+@group(0) @binding(2) var s_cube: sampler;
+
+@vertex
+fn vs_probe(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4<f32> {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0), vec2<f32>(-1.0, 1.0), vec2<f32>(3.0, 1.0),
+    );
+    let p = positions[vi];
+    return vec4<f32>(p.x, p.y, 0.0, 1.0);
+}
+
+// The target is PROBE_COUNT x 1, so the fragment's x is the probe index.
+@fragment
+fn fs_probe(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
+    let i = u32(pos.x);
+    return textureSampleLevel(t_cube, s_cube, normalize(probes.dirs[i].xyz), 0.0);
+}
+"#;
+
+    /// Samples `cube` at each of `dirs` **through the GPU's own cube sampler**
+    /// and returns what came back.
+    ///
+    /// This is the half of the direction test that is not circular. Reading
+    /// face texels back and comparing them against a Rust copy of the same
+    /// face-direction table the shader uses would pass just as happily if both
+    /// copies were mirrored. Asking the hardware to sample by direction cannot
+    /// be fooled that way: the cubemap convention it applies is fixed by the
+    /// backend, so if the conversion wrote a face mirrored, the colour returned
+    /// for direction `d` decodes to a different direction and the assertion
+    /// fails.
+    fn sample_cube_by_direction(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        cube: &wgpu::TextureView,
+        dirs: &[Vec3; PROBE_COUNT],
+    ) -> Vec<Vec3> {
+        let mut records = [[0f32; 4]; PROBE_COUNT];
+        for (record, dir) in records.iter_mut().zip(dirs) {
+            let d = dir.normalize();
+            *record = [d.x, d.y, d.z, 0.0];
+        }
+        let uniform = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("ibl probe uniform"),
+            size: (PROBE_COUNT * 16) as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&uniform, 0, bytemuck::cast_slice(records.as_slice()));
+
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("ibl probe target"),
+            size: wgpu::Extent3d {
+                width: PROBE_COUNT as u32,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: ENV_CUBE_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let target_view = target.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("ibl probe shader"),
+            source: wgpu::ShaderSource::Wgsl(PROBE_WGSL.into()),
+        });
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("ibl probe bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new((PROBE_COUNT * 16) as u64),
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::Cube,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("ibl probe sampler"),
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("ibl probe bg"),
+            layout: &bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: uniform.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(cube),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+            ],
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("ibl probe pll"),
+            bind_group_layouts: &[&bgl],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("ibl probe pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_probe",
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_probe",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: ENV_CUBE_FORMAT,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("ibl probe encoder"),
+        });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("ibl probe pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &target_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+        queue.submit(std::iter::once(encoder.finish()));
+
+        read_rgba16f_layer(device, queue, &target, PROBE_COUNT as u32, 1, 0)
+            .into_iter()
+            .map(decode_direction)
+            .collect()
+    }
+
+    #[test]
+    fn equirect_to_cubemap_puts_each_direction_on_the_right_face() {
+        let (device, queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+        let (_src, src_view, src_sampler) = upload_direction_encoded_equirect(&device, &queue);
+        let (cube, cube_v) = equirect_to_cubemap(&device, &queue, &src_view, &src_sampler);
+
+        assert_eq!(cube.width(), ENV_CUBE_SIZE);
+        assert_eq!(cube.height(), ENV_CUBE_SIZE);
+        assert_eq!(cube.size().depth_or_array_layers, CUBE_FACES);
+
+        // Part 1: every face looks along its own axis.
+        //
+        // The centre texel of face `i` must decode to the axis wgpu's layer
+        // order assigns to layer `i`. This is what catches a permuted or
+        // off-by-one face loop -- the failure that puts the sky on the floor.
+        let axes = [
+            (Vec3::X, "+X"),
+            (Vec3::NEG_X, "-X"),
+            (Vec3::Y, "+Y"),
+            (Vec3::NEG_Y, "-Y"),
+            (Vec3::Z, "+Z"),
+            (Vec3::NEG_Z, "-Z"),
+        ];
+        let centre = (ENV_CUBE_SIZE / 2 * ENV_CUBE_SIZE + ENV_CUBE_SIZE / 2) as usize;
+        for (face, (axis, name)) in axes.iter().enumerate() {
+            let texels = read_rgba16f_layer(
+                &device,
+                &queue,
+                &cube,
+                ENV_CUBE_SIZE,
+                ENV_CUBE_SIZE,
+                face as u32,
+            );
+            assert_eq!(texels.len(), (ENV_CUBE_SIZE * ENV_CUBE_SIZE) as usize);
+            let got = decode_direction(texels[centre]);
+            assert!(
+                got.length() > 0.5,
+                "face {face} ({name}) centre carries no direction at all -- \
+                 the pass wrote nothing there: {got:?}"
+            );
+            let alignment = got.normalize().dot(*axis);
+            assert!(
+                alignment > 0.999,
+                "face {face} must look along {name}, but its centre texel \
+                 decodes to {:?} (alignment {alignment})",
+                got.normalize(),
+            );
+        }
+
+        // Part 2: nothing inside a face is mirrored or rotated.
+        //
+        // Face centres alone cannot see this: mirror a face about either of
+        // its own axes and its centre texel does not move. So probe the cube
+        // through the hardware's cube sampler at directions that are
+        // asymmetric within their face -- two per face, off-centre in both
+        // axes -- and require each to hand back the direction it asked for.
+        // Any mirror, any 90-degree rotation, moves the answer far outside the
+        // tolerance below.
+        let probes = [
+            Vec3::X,
+            Vec3::NEG_X,
+            Vec3::Y,
+            Vec3::NEG_Y,
+            Vec3::Z,
+            Vec3::NEG_Z,
+            Vec3::new(1.0, 0.5, 0.3),
+            Vec3::new(1.0, -0.6, 0.2),
+            Vec3::new(-1.0, 0.4, 0.7),
+            Vec3::new(-1.0, -0.3, -0.55),
+            Vec3::new(0.3, 1.0, 0.6),
+            Vec3::new(-0.55, 1.0, -0.25),
+            Vec3::new(0.5, -1.0, -0.3),
+            Vec3::new(-0.2, -1.0, 0.65),
+            Vec3::new(0.2, 0.6, 1.0),
+            Vec3::new(-0.4, 0.3, -1.0),
+        ];
+        let sampled = sample_cube_by_direction(&device, &queue, &cube_v, &probes);
+        assert_eq!(sampled.len(), PROBE_COUNT);
+        for (probe, got) in probes.iter().zip(&sampled) {
+            let want = probe.normalize();
+            let alignment = got.normalize().dot(want);
+            // 0.999 is ~2.6 degrees. The real error is quantisation of the
+            // 8-bit source encoding plus one bilinear tap, both well under
+            // half a degree; the smallest mistake this is guarding against --
+            // a mirror about a face axis -- costs far more than 2.6 degrees
+            // for every one of the ten asymmetric probes.
+            assert!(
+                alignment > 0.999,
+                "sampling the cube along {want:?} returned the encoding of \
+                 {:?} (alignment {alignment}) -- the conversion is mirrored \
+                 or rotated within a face",
+                got.normalize(),
+            );
+        }
+
+        device.poll(wgpu::Maintain::Wait);
+        assert!(
+            pollster::block_on(device.pop_error_scope()).is_none(),
+            "the conversion must not raise a validation error"
+        );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/ibl.rs
+++ b/crates/bsengine-rhi-wgpu/src/ibl.rs
@@ -1010,6 +1010,66 @@ pub fn prefilter_from_cubemap(
     (texture, view)
 }
 
+/// The environment-dependent IBL maps, rebuilt whenever the skybox changes.
+///
+/// **The BRDF integration LUT is deliberately not in here.** It depends only on
+/// the BRDF -- not the environment, the scene, or the camera -- so it is
+/// generated once at startup, lives on the surface, and outlives every skybox.
+/// These two are convolutions *of* a particular environment, so they are thrown
+/// away and rebuilt each time that environment changes. Two schedules, two
+/// homes: putting the LUT here would mean re-integrating it on every skybox
+/// swap for a table that cannot have changed.
+pub struct IblMaps {
+    /// Cube view of the irradiance map: diffuse IBL, sampled by surface normal.
+    pub irradiance_view: wgpu::TextureView,
+    /// Held only to keep the texture `irradiance_view` looks at alive -- and
+    /// counted in the profiler -- for as long as that view can be bound.
+    _irradiance: TrackedTexture,
+    /// Cube view of the roughness-mipped prefiltered map: specular IBL, sampled
+    /// by reflection direction at a mip level chosen from roughness.
+    pub prefilter_view: wgpu::TextureView,
+    /// Held alive for the same reason as [`Self::_irradiance`].
+    _prefilter: TrackedTexture,
+}
+
+impl IblMaps {
+    /// Runs all three environment passes against an equirectangular source:
+    /// [`equirect_to_cubemap`], then [`irradiance_from_cubemap`] and
+    /// [`prefilter_from_cubemap`] over the cubemap that produced.
+    ///
+    /// `equirect_view` and `sampler` are the skybox's own texture view and
+    /// sampler, so the environment reflected off materials is read through the
+    /// same texture, with the same sRGB decode and the same filtering, as the
+    /// sky the camera sees.
+    ///
+    /// **The sharp environment cubemap is an intermediate and is not kept.**
+    /// Nothing downstream samples it: the sky itself is still drawn from the
+    /// original equirectangular texture by `fs_sky`, and materials read only the
+    /// two convolutions. Dropping it here is safe even though its passes have
+    /// only been submitted, not completed -- wgpu keeps a resource alive until
+    /// the submissions referencing it finish.
+    ///
+    /// This is not cheap: 6 + 6 + 30 render passes, each Monte-Carlo
+    /// integrating per texel. It runs once per skybox change, never per frame.
+    pub fn generate(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        equirect_view: &wgpu::TextureView,
+        sampler: &wgpu::Sampler,
+    ) -> Self {
+        let (_env_cube, env_view) = equirect_to_cubemap(device, queue, equirect_view, sampler);
+        let (irradiance, irradiance_view) =
+            irradiance_from_cubemap(device, queue, &env_view, sampler);
+        let (prefilter, prefilter_view) = prefilter_from_cubemap(device, queue, &env_view, sampler);
+        Self {
+            irradiance_view,
+            _irradiance: irradiance,
+            prefilter_view,
+            _prefilter: prefilter,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -15,6 +15,9 @@
 
 /// Screen-space translate/rotate gizmo math and drawing.
 pub mod gizmo;
+/// Image-based lighting: cubemap helpers, the BRDF integration LUT, and the
+/// environment preprocessing passes.
+pub mod ibl;
 /// GPU mesh generation and the mesh registry.
 pub mod mesh;
 /// Minimal glTF parsing + a small dedicated render pipeline for the Asset

--- a/crates/bsengine-rhi-wgpu/src/profiler.rs
+++ b/crates/bsengine-rhi-wgpu/src/profiler.rs
@@ -39,7 +39,9 @@ pub(crate) fn bytes_per_texel(format: wgpu::TextureFormat) -> u64 {
         wgpu::TextureFormat::Rgba8Unorm
         | wgpu::TextureFormat::Rgba8UnormSrgb
         | wgpu::TextureFormat::Depth32Float
-        | wgpu::TextureFormat::R32Float => 4,
+        | wgpu::TextureFormat::R32Float
+        // The BRDF integration LUT: two 16-bit floats, so also 4 bytes.
+        | wgpu::TextureFormat::Rg16Float => 4,
         wgpu::TextureFormat::Rgba16Float => 8,
         other => {
             tracing::warn!(
@@ -230,5 +232,6 @@ mod tests {
         assert_eq!(bytes_per_texel(wgpu::TextureFormat::Rgba16Float), 8);
         assert_eq!(bytes_per_texel(wgpu::TextureFormat::Depth32Float), 4);
         assert_eq!(bytes_per_texel(wgpu::TextureFormat::R32Float), 4);
+        assert_eq!(bytes_per_texel(wgpu::TextureFormat::Rg16Float), 4);
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -997,6 +997,27 @@ pub struct WgpuSurface {
     egui_renderer: egui_wgpu::Renderer,
     skybox: Option<SkyboxState>,
     loaded_skybox_path: Option<String>,
+    /// The irradiance and prefiltered specular maps convolved from the current
+    /// skybox, or `None` when no skybox is loaded.
+    ///
+    /// Rebuilt by [`Self::set_skybox_from_rgba`] and dropped by
+    /// [`Self::clear_skybox`], because both maps are convolutions of one
+    /// specific environment and mean nothing once that environment is gone.
+    ibl: Option<crate::ibl::IblMaps>,
+    /// The BRDF integration LUT, sampled by `(n_dot_v, roughness)` for the
+    /// split-sum approximation's second term.
+    ///
+    /// Unlike [`Self::ibl`] this is **not** optional and is never rebuilt: it is
+    /// a pure function of the BRDF, so one table generated at construction
+    /// serves every skybox, and every frame without one.
+    ///
+    /// `allow(dead_code)` only until the material bind group binds it: the
+    /// table is generated and owned here now, and nothing samples it yet.
+    #[allow(dead_code)]
+    brdf_lut_view: wgpu::TextureView,
+    /// Held only to keep the texture [`Self::brdf_lut_view`] looks at alive --
+    /// and counted in the profiler -- for the lifetime of the surface.
+    _brdf_lut_texture: crate::profiler::TrackedTexture,
     pipeline_layout: wgpu::PipelineLayout,
     terrain_pipeline: wgpu::RenderPipeline,
     terrain_bgl: wgpu::BindGroupLayout,
@@ -1904,6 +1925,14 @@ impl WgpuSurface {
         let post_process =
             crate::post_process::PostProcessState::new(&device, width, height, &depth_view, format);
 
+        // Generated here, with the other one-time GPU resources, because the
+        // split-sum BRDF table depends on nothing but the BRDF: no environment,
+        // no scene, no camera. One integration at construction serves every
+        // skybox this surface ever loads -- and every frame it loads none.
+        // Both constructors reach this point, so an offscreen surface has the
+        // LUT on exactly the same terms a windowed one does.
+        let (brdf_lut_texture, brdf_lut_view) = crate::ibl::generate_brdf_lut(&device, &queue);
+
         Ok(Self {
             output,
             device,
@@ -1937,6 +1966,10 @@ impl WgpuSurface {
             egui_renderer,
             skybox: None,
             loaded_skybox_path: None,
+            // No skybox yet, so there is no environment to have convolved.
+            ibl: None,
+            brdf_lut_view,
+            _brdf_lut_texture: brdf_lut_texture,
             pipeline_layout,
             terrain_pipeline,
             terrain_bgl,
@@ -2244,6 +2277,20 @@ impl WgpuSurface {
                 cache: None,
             });
 
+        // The environment changed, so everything convolved from the old one is
+        // stale: rebuild the irradiance and prefiltered maps from the texture
+        // and sampler this very skybox is about to be drawn with, so what
+        // materials reflect and what the camera sees are the same image.
+        //
+        // Here rather than lazily at first use because it is a heavy one-off
+        // (42 render passes) that belongs to the load, not to a frame.
+        self.ibl = Some(crate::ibl::IblMaps::generate(
+            &self.device,
+            &self.queue,
+            &tex_view,
+            &sampler,
+        ));
+
         self.skybox = Some(SkyboxState {
             pipeline,
             uniform_buffer,
@@ -2258,11 +2305,21 @@ impl WgpuSurface {
     pub fn clear_skybox(&mut self) {
         self.skybox = None;
         self.loaded_skybox_path = None;
+        // The IBL maps are convolutions of the skybox that just went away;
+        // keeping them would light the scene with an environment no longer
+        // being rendered.
+        self.ibl = None;
     }
 
     /// Whether a skybox is currently loaded and will be rendered.
     pub fn has_skybox(&self) -> bool {
         self.skybox.is_some()
+    }
+
+    /// Whether image-based lighting maps are currently available -- true
+    /// exactly when a skybox is loaded, since they are generated from it.
+    pub fn has_ibl(&self) -> bool {
+        self.ibl.is_some()
     }
 
     /// Path of the currently loaded skybox texture, if any.

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -66,8 +66,11 @@ struct LightUniform {
     num_point_lights: u32,
     point_lights: array<PointLightEntry, 8>,
     num_spot_lights: u32,
-    _pad2: f32,
-    _pad3: f32,
+    // Two of the three spare floats that used to sit here. Both shaders read
+    // the *same* uniform buffer, so both must declare this struct identically
+    // -- even the terrain shader, which does not sample IBL.
+    ibl_enabled: u32,
+    ibl_max_mip: f32,
     _pad4: f32,
     spot_lights: array<SpotLightEntry, 8>,
 };
@@ -79,6 +82,16 @@ struct LightUniform {
 @group(2) @binding(1) var shadow_sampler: sampler_comparison;
 @group(2) @binding(2) var shadow_map: texture_depth_2d;
 @group(2) @binding(4) var point_shadow_map: texture_2d_array<f32>;
+// Image-based lighting. These are always bound -- with 1x1 dummies when no
+// skybox is loaded -- because a bind group layout cannot vary per frame;
+// `light.ibl_enabled` is what actually decides whether they are read.
+@group(2) @binding(5) var irradiance_cube: texture_cube<f32>;
+@group(2) @binding(6) var prefilter_cube: texture_cube<f32>;
+@group(2) @binding(7) var brdf_lut: texture_2d<f32>;
+// Binding 8, not 3: 3 is already taken in the bind group layout by the point
+// shadow sampler, which no shader declares (the cube lookup uses textureLoad)
+// but which is bound all the same, as a non-filtering sampler.
+@group(2) @binding(8) var ibl_sampler: sampler;
 
 struct VertIn {
     @location(0) pos: vec3<f32>,
@@ -201,6 +214,12 @@ fn geometry_smith(n_dot_v: f32, n_dot_l: f32, roughness: f32) -> f32 {
 fn fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
     return f0 + (vec3<f32>(1.0, 1.0, 1.0) - f0) * pow(clamp(1.0 - cos_theta, 0.0, 1.0), 5.0);
 }
+// Schlick with a roughness term. The plain Fresnel is derived for a perfect
+// mirror and over-brightens rough metals at grazing angles.
+fn fresnel_schlick_roughness(cos_theta: f32, f0: vec3<f32>, roughness: f32) -> vec3<f32> {
+    let inv_rough = vec3<f32>(1.0 - roughness);
+    return f0 + (max(inv_rough, f0) - f0) * pow(clamp(1.0 - cos_theta, 0.0, 1.0), 5.0);
+}
 @fragment
 fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
     let n = normalize(in.world_normal);
@@ -270,7 +289,31 @@ fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
             }
         }
     }
-    let color = light.ambient * albedo + lo + model_data.emissive;
+    // With no skybox this is exactly the old flat-ambient term, evaluated by
+    // exactly the old expression -- the branch is on a uniform, so every
+    // no-skybox frame stays bit-for-bit what it was before IBL existed.
+    //
+    // No ambient-occlusion factor multiplies the IBL term: SSAO here is a
+    // post-process pass over the depth buffer, so no AO value exists at this
+    // point in the frame, and SSAO keeps attenuating the composited result
+    // exactly as it does today.
+    var ambient_term = light.ambient * albedo;
+    if (light.ibl_enabled != 0u) {
+        let f_ibl = fresnel_schlick_roughness(n_dot_v, f0, roughness);
+        let kd_ibl = (vec3<f32>(1.0) - f_ibl) * (1.0 - metallic);
+        let irradiance = textureSample(irradiance_cube, ibl_sampler, n).rgb;
+        let diffuse_ibl = irradiance * albedo * kd_ibl;
+
+        let r = reflect(-v, n);
+        let prefiltered = textureSampleLevel(
+            prefilter_cube, ibl_sampler, r, roughness * light.ibl_max_mip
+        ).rgb;
+        let brdf = textureSample(brdf_lut, ibl_sampler, vec2<f32>(n_dot_v, roughness)).rg;
+        let specular_ibl = prefiltered * (f_ibl * brdf.x + brdf.y);
+
+        ambient_term = diffuse_ibl + specular_ibl;
+    }
+    let color = ambient_term + lo + model_data.emissive;
     return vec4<f32>(color, model_data.opacity);
 }
 "#;
@@ -328,8 +371,11 @@ struct LightUniform {
     num_point_lights: u32,
     point_lights: array<PointLightEntry, 8>,
     num_spot_lights: u32,
-    _pad2: f32,
-    _pad3: f32,
+    // Two of the three spare floats that used to sit here. Both shaders read
+    // the *same* uniform buffer, so both must declare this struct identically
+    // -- even the terrain shader, which does not sample IBL.
+    ibl_enabled: u32,
+    ibl_max_mip: f32,
     _pad4: f32,
     spot_lights: array<SpotLightEntry, 8>,
 };
@@ -655,6 +701,14 @@ const SKY_UNIFORM_SIZE: u64 = 64;
 // direction(16) + color(16) + ambient+count(16) + 8×PointLightGpu(48=384) +
 // num_spot+pad(16) + 8×SpotLightGpu(64=512) = 960
 const LIGHT_UNIFORM_SIZE: u64 = 960;
+// The IBL flags took two of the three spare floats in that `num_spot+pad(16)`
+// block rather than growing the struct, so this must still hold. It is also
+// the layout's `min_binding_size`, so a mismatch would be a bind group
+// validation failure at runtime rather than here.
+const _: () = assert!(
+    std::mem::size_of::<LightUniformData>() as u64 == LIGHT_UNIFORM_SIZE,
+    "LightUniformData must stay exactly LIGHT_UNIFORM_SIZE bytes"
+);
 // Vertex stride: position(12) + color(12) + normal(12) + uv(8) = 44 bytes
 const VERTEX_STRIDE: u64 = 44;
 const SHADOW_MAP_SIZE: u32 = 2048;
@@ -825,8 +879,16 @@ struct LightUniformData {
     num_point_lights: u32,
     point_lights: [PointLightGpu; 8],
     num_spot_lights: u32,
-    _pad2: f32,
-    _pad3: f32,
+    /// Non-zero when `WgpuSurface::ibl` holds maps for the current skybox.
+    /// Zero makes the shader fall back to the flat `ambient * albedo` term,
+    /// which is why the IBL bindings can be dummies without changing a pixel.
+    ///
+    /// Took `_pad2`'s slot, and a `u32` is the same 4 bytes that `f32` was, so
+    /// `LIGHT_UNIFORM_SIZE` is still 960.
+    ibl_enabled: u32,
+    /// Highest mip index of the prefiltered specular cube, i.e. the mip the
+    /// shader samples at `roughness == 1`. Took `_pad3`'s slot.
+    ibl_max_mip: f32,
     _pad4: f32,
     spot_lights: [SpotLightGpu; 8],
 }
@@ -961,6 +1023,79 @@ fn point_light_face_view_projs(position: Vec3, range: f32) -> [Mat4; 6] {
     dirs.map(|(dir, up)| proj * Mat4::look_at_rh(position, position + dir, up))
 }
 
+/// Everything group 2 ("light") binds, gathered into one struct.
+///
+/// The group is built twice -- once in the constructor and again every time
+/// the skybox changes, since a bind group is immutable and the IBL views it
+/// holds are not -- and only the two cube views differ between those calls.
+/// Passing nine loose references to a helper twice is exactly how the two
+/// call sites would drift apart, so they pass this instead.
+struct LightBindings<'a> {
+    light_buffer: &'a wgpu::Buffer,
+    shadow_sampler: &'a wgpu::Sampler,
+    shadow_map_view: &'a wgpu::TextureView,
+    point_shadow_sampler: &'a wgpu::Sampler,
+    point_shadow_view: &'a wgpu::TextureView,
+    ibl_sampler: &'a wgpu::Sampler,
+    /// Real irradiance cube, or the 1x1x6 dummy when no skybox is loaded.
+    irradiance_view: &'a wgpu::TextureView,
+    /// Real prefiltered cube, or that same dummy.
+    prefilter_view: &'a wgpu::TextureView,
+    brdf_lut_view: &'a wgpu::TextureView,
+}
+
+/// Builds the light bind group. The single place the group-2 binding numbers
+/// appear on the Rust side, so a skybox load cannot bind them differently from
+/// how construction did.
+fn create_light_bind_group(
+    device: &wgpu::Device,
+    layout: &wgpu::BindGroupLayout,
+    bindings: &LightBindings,
+) -> wgpu::BindGroup {
+    device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("light bg"),
+        layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: bindings.light_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::Sampler(bindings.shadow_sampler),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::TextureView(bindings.shadow_map_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: wgpu::BindingResource::Sampler(bindings.point_shadow_sampler),
+            },
+            wgpu::BindGroupEntry {
+                binding: 4,
+                resource: wgpu::BindingResource::TextureView(bindings.point_shadow_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 5,
+                resource: wgpu::BindingResource::TextureView(bindings.irradiance_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 6,
+                resource: wgpu::BindingResource::TextureView(bindings.prefilter_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 7,
+                resource: wgpu::BindingResource::TextureView(bindings.brdf_lut_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 8,
+                resource: wgpu::BindingResource::Sampler(bindings.ibl_sampler),
+            },
+        ],
+    })
+}
+
 /// Owns the render output target (a window's swapchain or an offscreen
 /// texture), all GPU pipelines/buffers for the main scene and shadow passes,
 /// the egui renderer, and per-frame render state.
@@ -979,18 +1114,25 @@ pub struct WgpuSurface {
     model_bind_group: wgpu::BindGroup,
     light_buffer: wgpu::Buffer,
     light_bind_group: wgpu::BindGroup,
+    /// Kept because `light_bind_group` is rebuilt whenever the skybox changes:
+    /// a bind group is immutable, so swapping the dummy IBL maps for real ones
+    /// (or back) means building a new one against this same layout.
+    light_bgl: wgpu::BindGroupLayout,
     _white_texture: crate::profiler::TrackedTexture,
     _sampler: wgpu::Sampler,
     default_texture_bind_group: wgpu::BindGroup,
     shadow_pipeline: wgpu::RenderPipeline,
     _shadow_map_texture: crate::profiler::TrackedTexture,
     shadow_map_view: wgpu::TextureView,
-    _shadow_comparison_sampler: wgpu::Sampler,
+    // No longer underscore-prefixed: the two shadow samplers and the point
+    // shadow array view are read back whenever `light_bind_group` is rebuilt.
+    shadow_comparison_sampler: wgpu::Sampler,
     point_shadow_pipeline: wgpu::RenderPipeline,
     _point_shadow_color_texture: crate::profiler::TrackedTexture,
     _point_shadow_depth_texture: crate::profiler::TrackedTexture,
+    point_shadow_color_full_view: wgpu::TextureView,
     point_shadow_depth_view: wgpu::TextureView,
-    _point_shadow_sampler: wgpu::Sampler,
+    point_shadow_sampler: wgpu::Sampler,
     point_shadow_uniform_buffer: wgpu::Buffer,
     point_shadow_bind_group: wgpu::BindGroup,
     egui_ctx: egui::Context,
@@ -1009,15 +1151,26 @@ pub struct WgpuSurface {
     ///
     /// Unlike [`Self::ibl`] this is **not** optional and is never rebuilt: it is
     /// a pure function of the BRDF, so one table generated at construction
-    /// serves every skybox, and every frame without one.
-    ///
-    /// `allow(dead_code)` only until the material bind group binds it: the
-    /// table is generated and owned here now, and nothing samples it yet.
-    #[allow(dead_code)]
+    /// serves every skybox, and every frame without one. That is also why it
+    /// needs no dummy counterpart -- it is bound at group 2 binding 7 in every
+    /// frame, skybox or not.
     brdf_lut_view: wgpu::TextureView,
     /// Held only to keep the texture [`Self::brdf_lut_view`] looks at alive --
     /// and counted in the profiler -- for the lifetime of the surface.
     _brdf_lut_texture: crate::profiler::TrackedTexture,
+    /// Trilinear clamped sampler for all three IBL bindings.
+    ibl_sampler: wgpu::Sampler,
+    /// A 1x1x6 black cubemap bound at bindings 5 and 6 whenever [`Self::ibl`]
+    /// is `None`.
+    ///
+    /// A bind group layout is fixed at creation, so the IBL bindings exist in
+    /// every scene -- including the many that never load a skybox. Rather than
+    /// branch the layout (two layouts means two pipelines and two code paths
+    /// that can disagree), those scenes bind this and set `ibl_enabled` to 0,
+    /// which stops the shader reading it at all.
+    dummy_ibl_cube_view: wgpu::TextureView,
+    /// Held only to keep [`Self::dummy_ibl_cube_view`]'s texture alive.
+    _dummy_ibl_cube_texture: crate::profiler::TrackedTexture,
     pipeline_layout: wgpu::PipelineLayout,
     terrain_pipeline: wgpu::RenderPipeline,
     terrain_bgl: wgpu::BindGroupLayout,
@@ -1433,7 +1586,102 @@ impl WgpuSurface {
                     },
                     count: None,
                 },
+                // 5/6/7/8 are the IBL maps and their sampler. A layout is
+                // fixed at creation, so these entries exist even in scenes
+                // that never load a skybox; the dummies bound in that case
+                // are never sampled, because `ibl_enabled` is 0.
+                wgpu::BindGroupLayoutEntry {
+                    binding: 5,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::Cube,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 6,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::Cube,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 7,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 8,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
             ],
+        });
+
+        // Bound at 5 and 6 whenever no skybox is loaded. 1x1x6 and cleared to
+        // black: the shader never samples it (`ibl_enabled` is 0 in that case),
+        // so its only job is to satisfy the layout, and the smallest possible
+        // texture is the one least likely to be mistaken for real lighting if
+        // that flag ever went wrong.
+        //
+        // The BRDF LUT needs no equivalent: it is a pure function of the BRDF,
+        // exists unconditionally on the surface, and so is bound at 7 in both
+        // cases.
+        let dummy_ibl_cube_texture = crate::ibl::create_cubemap(
+            &device,
+            "ibl dummy cube",
+            1,
+            1,
+            crate::ibl::ENV_CUBE_FORMAT,
+            wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        );
+        // Explicitly zeroed rather than left to wgpu's lazy zero-init, so the
+        // contents are a property of this code and not of a backend detail.
+        // 8 bytes per Rgba16Float texel, one texel per face, six faces.
+        queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &dummy_ibl_cube_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &[0u8; 48],
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(8),
+                rows_per_image: Some(1),
+            },
+            wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 6,
+            },
+        );
+        let dummy_ibl_cube_view = crate::ibl::cube_view(&dummy_ibl_cube_texture);
+
+        // Trilinear and clamped: the prefiltered cube's roughness lookup lands
+        // between mips, and a nearest sampler would turn that continuous
+        // roughness response into five visible steps.
+        let ibl_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("ibl sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
         });
 
         let (white_texture, sampler, texture_bgl, default_texture_bind_group) =
@@ -1568,32 +1816,32 @@ impl WgpuSurface {
             }],
         });
 
-        let light_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("light bg"),
-            layout: &light_bgl,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: light_buffer.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::Sampler(&shadow_comparison_sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::TextureView(&shadow_map_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 3,
-                    resource: wgpu::BindingResource::Sampler(&point_shadow_sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 4,
-                    resource: wgpu::BindingResource::TextureView(&point_shadow_color_full_view),
-                },
-            ],
-        });
+        // Generated here, with the other one-time GPU resources, because the
+        // split-sum BRDF table depends on nothing but the BRDF: no environment,
+        // no scene, no camera. One integration at construction serves every
+        // skybox this surface ever loads -- and every frame it loads none.
+        // Both constructors reach this point, so an offscreen surface has the
+        // LUT on exactly the same terms a windowed one does.
+        let (brdf_lut_texture, brdf_lut_view) = crate::ibl::generate_brdf_lut(&device, &queue);
+
+        // No skybox at construction, so the cube bindings get the dummy. Every
+        // later rebuild goes through `rebuild_light_bind_group`, which binds
+        // the same way from the same struct.
+        let light_bind_group = create_light_bind_group(
+            &device,
+            &light_bgl,
+            &LightBindings {
+                light_buffer: &light_buffer,
+                shadow_sampler: &shadow_comparison_sampler,
+                shadow_map_view: &shadow_map_view,
+                point_shadow_sampler: &point_shadow_sampler,
+                point_shadow_view: &point_shadow_color_full_view,
+                ibl_sampler: &ibl_sampler,
+                irradiance_view: &dummy_ibl_cube_view,
+                prefilter_view: &dummy_ibl_cube_view,
+                brdf_lut_view: &brdf_lut_view,
+            },
+        );
 
         let vertex_buffer_layout = wgpu::VertexBufferLayout {
             array_stride: VERTEX_STRIDE,
@@ -1925,14 +2173,6 @@ impl WgpuSurface {
         let post_process =
             crate::post_process::PostProcessState::new(&device, width, height, &depth_view, format);
 
-        // Generated here, with the other one-time GPU resources, because the
-        // split-sum BRDF table depends on nothing but the BRDF: no environment,
-        // no scene, no camera. One integration at construction serves every
-        // skybox this surface ever loads -- and every frame it loads none.
-        // Both constructors reach this point, so an offscreen surface has the
-        // LUT on exactly the same terms a windowed one does.
-        let (brdf_lut_texture, brdf_lut_view) = crate::ibl::generate_brdf_lut(&device, &queue);
-
         Ok(Self {
             output,
             device,
@@ -1948,18 +2188,20 @@ impl WgpuSurface {
             model_bind_group,
             light_buffer,
             light_bind_group,
+            light_bgl,
             _white_texture: white_texture,
             _sampler: sampler,
             default_texture_bind_group,
             shadow_pipeline,
             _shadow_map_texture: shadow_map_texture,
             shadow_map_view,
-            _shadow_comparison_sampler: shadow_comparison_sampler,
+            shadow_comparison_sampler,
             point_shadow_pipeline,
             _point_shadow_color_texture: point_shadow_color_texture,
             _point_shadow_depth_texture: point_shadow_depth_texture,
+            point_shadow_color_full_view,
             point_shadow_depth_view,
-            _point_shadow_sampler: point_shadow_sampler,
+            point_shadow_sampler,
             point_shadow_uniform_buffer,
             point_shadow_bind_group,
             egui_ctx,
@@ -1970,6 +2212,9 @@ impl WgpuSurface {
             ibl: None,
             brdf_lut_view,
             _brdf_lut_texture: brdf_lut_texture,
+            ibl_sampler,
+            dummy_ibl_cube_view,
+            _dummy_ibl_cube_texture: dummy_ibl_cube_texture,
             pipeline_layout,
             terrain_pipeline,
             terrain_bgl,
@@ -2290,6 +2535,9 @@ impl WgpuSurface {
             &tex_view,
             &sampler,
         ));
+        // The group-2 bind group still points at the dummy cube (or the
+        // previous skybox's maps); a bind group cannot be edited in place.
+        self.rebuild_light_bind_group();
 
         self.skybox = Some(SkyboxState {
             pipeline,
@@ -2309,6 +2557,40 @@ impl WgpuSurface {
         // keeping them would light the scene with an environment no longer
         // being rendered.
         self.ibl = None;
+        // Back to the dummy cube. Dropping the maps without this would leave
+        // the bind group holding views into freed textures.
+        self.rebuild_light_bind_group();
+    }
+
+    /// Rebuilds the group-2 bind group so bindings 5 and 6 point at whatever
+    /// [`Self::ibl`] currently is: the real maps, or the dummy cube when there
+    /// is no skybox.
+    ///
+    /// Must be called after *every* assignment to `self.ibl`. The uniform's
+    /// `ibl_enabled` flag is written from `self.ibl` each frame, so a stale
+    /// bind group here would mean the shader sampling one skybox's maps while
+    /// the flag describes another's.
+    fn rebuild_light_bind_group(&mut self) {
+        let (irradiance_view, prefilter_view) = match &self.ibl {
+            Some(maps) => (&maps.irradiance_view, &maps.prefilter_view),
+            None => (&self.dummy_ibl_cube_view, &self.dummy_ibl_cube_view),
+        };
+        let bind_group = create_light_bind_group(
+            &self.device,
+            &self.light_bgl,
+            &LightBindings {
+                light_buffer: &self.light_buffer,
+                shadow_sampler: &self.shadow_comparison_sampler,
+                shadow_map_view: &self.shadow_map_view,
+                point_shadow_sampler: &self.point_shadow_sampler,
+                point_shadow_view: &self.point_shadow_color_full_view,
+                ibl_sampler: &self.ibl_sampler,
+                irradiance_view,
+                prefilter_view,
+                brdf_lut_view: &self.brdf_lut_view,
+            },
+        );
+        self.light_bind_group = bind_group;
     }
 
     /// Whether a skybox is currently loaded and will be rendered.
@@ -2580,8 +2862,10 @@ impl WgpuSurface {
             num_point_lights,
             point_lights: point_lights_gpu,
             num_spot_lights,
-            _pad2: 0.0,
-            _pad3: 0.0,
+            // The maps and the flag come from the same place, so the shader
+            // can never sample dummy cubemaps as if they were an environment.
+            ibl_enabled: u32::from(self.ibl.is_some()),
+            ibl_max_mip: (crate::ibl::PREFILTER_MIP_LEVELS - 1) as f32,
             _pad4: 0.0,
             spot_lights: spot_lights_gpu,
         };

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -89,6 +89,18 @@ impl Draw {
         self
     }
 
+    /// 1.0 makes `base_color` the reflectance; 0.0 leaves the dielectric
+    /// `f0 = 0.04`.
+    pub fn metallic(mut self, m: f32) -> Self {
+        self.metallic = m;
+        self
+    }
+
+    pub fn roughness(mut self, r: f32) -> Self {
+        self.roughness = r;
+        self
+    }
+
     /// Below 1.0 sends the draw to the transparent pass.
     pub fn opacity(mut self, a: f32) -> Self {
         self.opacity = a;
@@ -383,6 +395,33 @@ struct VertOut {{
     /// Puts a single flat colour in the skybox.
     pub fn set_test_skybox(&mut self, rgba: [u8; 4]) {
         self.surface.set_skybox_from_rgba(1, 1, &rgba);
+    }
+
+    /// Installs an arbitrary equirectangular skybox image.
+    ///
+    /// A flat one-texel sky is enough to prove a reflection picks up the
+    /// environment's *colour*, but not that it picks up its *structure*: every
+    /// prefiltered mip of a constant environment is that same constant, so a
+    /// roughness test against [`Self::set_test_skybox`] would pass with mip
+    /// selection removed entirely. Tests that care about blur need a sky with
+    /// something in it to blur.
+    pub fn set_test_skybox_image(&mut self, width: u32, height: u32, rgba: &[u8]) {
+        assert_eq!(
+            rgba.len() as u32,
+            width * height * 4,
+            "the equirect data must be exactly width * height RGBA texels"
+        );
+        self.surface.set_skybox_from_rgba(width, height, rgba);
+    }
+
+    /// Unloads the skybox, taking the IBL maps with it.
+    pub fn clear_test_skybox(&mut self) {
+        self.surface.clear_skybox();
+    }
+
+    /// Whether the renderer currently holds IBL maps.
+    pub fn has_ibl(&self) -> bool {
+        self.surface.has_ibl()
     }
 
     /// Draws one frame and reads it back.

--- a/crates/bsengine-rhi-wgpu/tests/pixels_ibl.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_ibl.rs
@@ -1,0 +1,324 @@
+//! Image-based lighting, measured at the pixel.
+//!
+//! The trap this file is written around: an assertion that merely detects *a
+//! change* would pass just as happily if IBL simply brightened every frame by
+//! a constant. So no test here settles for "the pixels differ". Each one
+//! measures a *direction* -- towards the environment's colour, away from it as
+//! roughness rises, tinted by albedo on a metal and not on a dielectric -- and
+//! each is paired with the opposite-direction case that would catch a uniform
+//! brightening.
+//!
+//! Two deliberate choices about the fixtures:
+//!
+//! - The mesh is the **plane**, not the cube. `cube_vertices` paints each face
+//!   a different vertex colour and those multiply into the albedo, so a cube
+//!   could never be given a white or a black albedo to reflect with. The plane
+//!   is the one mesh with white vertex colours.
+//! - `with_skybox` stays **false** even in the tests that load one. The skybox
+//!   is then never drawn into the background, so a green pixel at the centre of
+//!   the frame can only have come off the surface. Were the sky drawn, a
+//!   surface that had drifted out of frame would leave the test measuring the
+//!   sky itself and passing for the wrong reason.
+
+mod common;
+
+use common::{Draw, Harness, Light, Pixels, Scene};
+use glam::Vec3;
+
+/// Straight down at the plane, whose normal is +Y. The reflection vector at the
+/// centre pixel is therefore +Y as well, which pins exactly which part of the
+/// environment the surface is reflecting.
+const OVERHEAD: Vec3 = Vec3::new(0.0, 6.0, 0.01);
+
+/// Direct lighting switched off, so every lit photon in the frame arrives from
+/// the environment. Without this the directional light's diffuse and specular
+/// swamp the IBL term and none of the measurements below mean anything.
+fn ibl_only_light() -> Light {
+    Light {
+        direction: Vec3::new(0.0, -1.0, 0.0),
+        color: Vec3::ZERO,
+        ambient: Vec3::splat(0.2),
+        points: Vec::new(),
+    }
+}
+
+/// A plane filling the middle of the frame, with the material under test.
+fn surface(plane: u64, metallic: f32, roughness: f32, albedo: Vec3) -> Scene {
+    Scene {
+        draws: vec![Draw::new(plane, Vec3::ZERO)
+            .scaled(Vec3::new(6.0, 1.0, 6.0), Vec3::ZERO)
+            .colour(albedo)
+            .metallic(metallic)
+            .roughness(roughness)],
+        light: ibl_only_light(),
+        camera_pos: OVERHEAD,
+        ..Scene::default()
+    }
+}
+
+/// Sum of the per-channel gaps between the centre pixel and `target`.
+///
+/// Per-channel rather than luma on purpose: a frame that got uniformly
+/// brighter moves *closer* in luma to a bright environment while moving no
+/// closer in hue. Summing the channel gaps only falls when the pixel actually
+/// takes on the environment's colour.
+fn distance_to(pixels: &Pixels, target: [u8; 3]) -> u32 {
+    let p = pixels.centre();
+    (0..3).map(|i| p[i].abs_diff(target[i]) as u32).sum()
+}
+
+/// An equirectangular sky: a bright cap of `cap_rows` rows around +Y over a
+/// dark remainder.
+///
+/// `v = 0` is the +Y pole in the equirect mapping the skybox shader uses, so
+/// the top rows are exactly the patch a flat upward-facing mirror reflects. A
+/// mirror sees the cap; a fully rough surface averages the cap against all the
+/// darkness around it. That difference is the only thing prefilter mip
+/// selection can produce, which is why the roughness test needs a structured
+/// sky rather than the flat one.
+fn sky_with_a_bright_cap(cap_rows: u32) -> (u32, u32, Vec<u8>) {
+    const W: u32 = 64;
+    const H: u32 = 32;
+    const CAP: [u8; 4] = [0, 255, 0, 255];
+    const REST: [u8; 4] = [8, 8, 8, 255];
+
+    let mut data = Vec::with_capacity((W * H * 4) as usize);
+    for y in 0..H {
+        for _ in 0..W {
+            data.extend_from_slice(if y < cap_rows { &CAP } else { &REST });
+        }
+    }
+    (W, H, data)
+}
+
+/// The colour of the flat environments used below, as the framebuffer would
+/// have to show it for a perfect mirror.
+const GREEN_SKY: [u8; 4] = [0, 255, 0, 255];
+const WHITE_SKY: [u8; 4] = [255, 255, 255, 255];
+
+#[test]
+fn a_smooth_metal_reflects_the_environment_colour() {
+    let mut h = Harness::new();
+    let plane = h.plane();
+    let mirror = surface(plane, 1.0, 0.0, Vec3::ONE);
+
+    let without = h.render(&mirror);
+    assert!(!h.has_ibl(), "no skybox has been loaded yet");
+
+    h.set_test_skybox(GREEN_SKY);
+    assert!(h.has_ibl(), "loading a skybox should have built the IBL maps");
+    let with_sky = h.render(&mirror);
+
+    let env = [GREEN_SKY[0], GREEN_SKY[1], GREEN_SKY[2]];
+    let far = distance_to(&without, env);
+    let near = distance_to(&with_sky, env);
+    let [r0, g0, b0, _] = without.centre();
+    let [r1, g1, b1, _] = with_sky.centre();
+
+    // Every channel has to move the right way individually. A frame that had
+    // simply been brightened would raise the red and blue channels too, and
+    // fail here even though its total distance to a bright green might have
+    // fallen.
+    assert!(
+        r1 <= r0 && g1 >= g0 && b1 <= b0,
+        "each channel should move towards the green environment: \
+         {:?} -> {:?}",
+        [r0, g0, b0],
+        [r1, g1, b1]
+    );
+    assert!(
+        near * 4 < far,
+        "a roughness-0 metal should end up far closer to the environment's \
+         colour: distance {far} without the sky ({:?}), {near} with it ({:?})",
+        [r0, g0, b0],
+        [r1, g1, b1]
+    );
+    assert!(
+        g1 > 150 && r1 < 40 && b1 < 40,
+        "the mirror should read as green rather than merely greener, saw {}",
+        with_sky.describe()
+    );
+}
+
+#[test]
+fn a_rough_surface_barely_reflects() {
+    let mut h = Harness::new();
+    let plane = h.plane();
+    let smooth = surface(plane, 1.0, 0.0, Vec3::ONE);
+    let rough = surface(plane, 1.0, 1.0, Vec3::ONE);
+
+    // First under a flat sky. Every prefiltered mip of a constant environment
+    // is that same constant, so whatever gap appears here is the split-sum
+    // BRDF term alone -- nothing to do with mip selection.
+    h.set_test_skybox(GREEN_SKY);
+    let flat_smooth = h.render(&smooth).centre()[1] as f32;
+    let flat_rough = h.render(&rough).centre()[1] as f32;
+
+    // Then under a sky with a bright cap at +Y and darkness everywhere else.
+    // The BRDF term is identical to the flat case; any *extra* falloff can
+    // only be the rough surface reading a blurrier mip, where the cap has been
+    // averaged against the dark surroundings.
+    let (w, ht, data) = sky_with_a_bright_cap(4);
+    h.set_test_skybox_image(w, ht, &data);
+    let capped_smooth = h.render(&smooth).centre()[1] as f32;
+    let capped_rough = h.render(&rough).centre()[1] as f32;
+
+    assert!(
+        capped_smooth > 150.0,
+        "the mirror should still find the bright cap, saw green {capped_smooth}"
+    );
+    assert!(
+        capped_rough * 3.0 < capped_smooth,
+        "a roughness-1 surface should show far less of the cap than a mirror: \
+         green {capped_rough} against {capped_smooth}"
+    );
+
+    let flat_retained = flat_rough / flat_smooth;
+    let capped_retained = capped_rough / capped_smooth;
+    assert!(
+        capped_retained * 2.0 < flat_retained,
+        "roughness must cost more under a structured sky than under a flat \
+         one -- the difference is the prefilter blur. Retained: {capped_retained} \
+         with the cap, {flat_retained} flat. Equal retention means the shader \
+         is sampling one mip at every roughness."
+    );
+}
+
+#[test]
+fn a_scene_with_no_skybox_is_pixel_identical() {
+    let mut h = Harness::new();
+    let plane = h.plane();
+    let mirror = surface(plane, 1.0, 0.0, Vec3::ONE);
+
+    let before = h.render(&mirror);
+    assert!(!h.has_ibl());
+
+    // The identity check below is only worth anything if this scene is one IBL
+    // would visibly change. Prove that first, twice, with two different
+    // environments -- otherwise "unchanged" could just mean "insensitive".
+    h.set_test_skybox(GREEN_SKY);
+    let green = h.render(&mirror);
+    assert!(
+        green.differs_from(&before) && green.centre()[1] > before.centre()[1] + 60,
+        "the green sky should have visibly lit the mirror, saw {}",
+        green.describe()
+    );
+    h.set_test_skybox(WHITE_SKY);
+    let white = h.render(&mirror);
+    assert!(
+        white.differs_from(&green),
+        "a different environment should give a different frame"
+    );
+
+    h.clear_test_skybox();
+    assert!(!h.has_ibl(), "clearing the skybox drops the IBL maps");
+    let after = h.render(&mirror);
+
+    assert_eq!(
+        after.data, before.data,
+        "with no skybox the frame must be byte-for-byte what it was before any \
+         IBL existed. It is not -- so the dummy-bound fallback is leaking \
+         environment light into every skyboxless scene, which is exactly the \
+         'IBL just brightened the whole frame' failure this test exists for."
+    );
+
+    // And the fallback must still be the *old expression*, not merely a
+    // constant. `light.ambient * albedo` is a product: halving one factor and
+    // doubling the other has to land on the same pixel. An IBL term added on
+    // top -- which depends on albedo but not on ambient -- would break that.
+    let mut dim_albedo = surface(plane, 0.0, 0.5, Vec3::splat(0.5));
+    dim_albedo.light.ambient = Vec3::splat(0.4);
+    let mut dim_ambient = surface(plane, 0.0, 0.5, Vec3::ONE);
+    dim_ambient.light.ambient = Vec3::splat(0.2);
+    assert_eq!(
+        h.render(&dim_albedo).data,
+        h.render(&dim_ambient).data,
+        "the no-skybox path should still be exactly `ambient * albedo`"
+    );
+
+    // And `light.ambient` must still be *reaching* the surface. Byte-equality
+    // above would hold just as well if the fallback had stopped evaluating the
+    // ambient term at all -- if, say, `ibl_enabled` were stuck on and every
+    // skyboxless frame were quietly lit by the black dummy cube instead. Two
+    // ambients, one twice the other, must give two different pixels.
+    let mut bright_ambient = surface(plane, 0.0, 0.5, Vec3::ONE);
+    bright_ambient.light.ambient = Vec3::splat(0.4);
+    let dim = h.render(&dim_ambient).centre_luma();
+    let bright = h.render(&bright_ambient).centre_luma();
+    assert!(
+        bright > dim + 20.0,
+        "doubling the ambient should brighten a skyboxless frame: {dim} -> \
+         {bright}. It did not, so the flat-ambient fallback is not what the \
+         shader is evaluating."
+    );
+}
+
+#[test]
+fn metal_tints_its_reflection_but_a_dielectric_does_not() {
+    let mut h = Harness::new();
+    let plane = h.plane();
+
+    // A white environment, so any colour in these frames is the material's
+    // doing rather than the sky's.
+    h.set_test_skybox(WHITE_SKY);
+
+    let red = Vec3::new(1.0, 0.0, 0.0);
+    let metal_red = h.render(&surface(plane, 1.0, 0.0, red));
+    let metal_black = h.render(&surface(plane, 1.0, 0.0, Vec3::ZERO));
+    let dielectric_black = h.render(&surface(plane, 0.0, 0.0, Vec3::ZERO));
+    let dielectric_red = h.render(&surface(plane, 0.0, 0.0, red));
+
+    // A metal's f0 *is* its albedo, so a red metal under a white sky reflects
+    // red.
+    let [mr, mg, mb, _] = metal_red.centre();
+    assert!(
+        mr > 150 && mg < 20 && mb < 20,
+        "a red metal should reflect a white environment as red, saw {}",
+        metal_red.describe()
+    );
+
+    // The other half of the same claim, and the one that stops "tinted"
+    // meaning "brightened": with no albedo a metal has no f0 and so reflects
+    // essentially nothing.
+    assert!(
+        metal_black.centre_luma() < 5.0,
+        "a black metal has f0 = 0 and should reflect almost nothing, saw {}",
+        metal_black.describe()
+    );
+
+    // A dielectric's f0 is 0.04 white regardless of albedo, so the same black
+    // surface that killed the metal's reflection still shows a dim, neutral
+    // one.
+    let [dr, dg, db, _] = dielectric_black.centre();
+    let spread = dr.max(dg).max(db) - dr.min(dg).min(db);
+    assert!(
+        spread <= 3,
+        "a dielectric's reflection should be achromatic, saw {}",
+        dielectric_black.describe()
+    );
+    assert!(
+        dielectric_black.centre_luma() > 15.0,
+        "f0 = 0.04 should still be visible against black, saw {}",
+        dielectric_black.describe()
+    );
+    assert!(
+        dielectric_black.centre_luma() > metal_black.centre_luma() + 10.0,
+        "the dielectric floor is what separates these two: dielectric {}, \
+         metal {}",
+        dielectric_black.describe(),
+        metal_black.describe()
+    );
+
+    // Finally: the dielectric's reflection is albedo-*independent*, not just
+    // achromatic. Painting the same surface red must leave the off-albedo
+    // channels exactly where the black one put them -- the red arrives through
+    // the diffuse term, the neutral reflection through f0.
+    let [_, rg, rb, _] = dielectric_red.centre();
+    assert!(
+        rg.abs_diff(dg) <= 3 && rb.abs_diff(db) <= 3,
+        "a dielectric's reflection should not pick up albedo: black {:?} \
+         against red {:?}",
+        [dr, dg, db],
+        dielectric_red.centre()
+    );
+}

--- a/crates/bsengine-rhi-wgpu/tests/pixels_ibl.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_ibl.rs
@@ -106,7 +106,10 @@ fn a_smooth_metal_reflects_the_environment_colour() {
     assert!(!h.has_ibl(), "no skybox has been loaded yet");
 
     h.set_test_skybox(GREEN_SKY);
-    assert!(h.has_ibl(), "loading a skybox should have built the IBL maps");
+    assert!(
+        h.has_ibl(),
+        "loading a skybox should have built the IBL maps"
+    );
     let with_sky = h.render(&mirror);
 
     let env = [GREEN_SKY[0], GREEN_SKY[1], GREEN_SKY[2]];

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -2368,4 +2368,302 @@ mod tests {
              something beyond occlusion, or the two runs did not render the same scene"
         );
     }
+
+    /// The environment colour the IBL demo scene's skybox is painted, as
+    /// authored in the image file.
+    const IBL_SKY_RGB: [u8; 3] = [0, 255, 0];
+
+    /// Writes a throwaway project holding one metallic sphere, optionally under
+    /// a strongly coloured skybox.
+    ///
+    /// `[window]` is pinned small on purpose: the offscreen surface takes its
+    /// size from the manifest, and this test only reads a patch in the middle.
+    fn write_ibl_project(root: &std::path::Path, with_skybox: bool) {
+        std::fs::create_dir_all(root.join("assets/scenes")).unwrap();
+        std::fs::write(
+            root.join("project.toml"),
+            "[project]\nname = \"IBL E2E\"\n\
+             entry_scene = \"assets/scenes/main.ron\"\n\
+             [window]\nwidth = 200\nheight = 150\n",
+        )
+        .unwrap();
+
+        // A flat, saturated green sky. Flat because this test asks whether the
+        // environment reaches the surface at all, not how it is filtered --
+        // `bsengine-rhi-wgpu`'s `pixels_ibl.rs` covers the structure of the
+        // reflection with a sky that has something in it to blur. Green
+        // because the clear colour and the ambient term are both grey, so
+        // green cannot arrive here by accident.
+        let [r, g, b] = IBL_SKY_RGB;
+        let sky = image::RgbaImage::from_pixel(64, 32, image::Rgba([r, g, b, 255]));
+        sky.save(root.join("assets/scenes/sky.png"))
+            .expect("write the temp project's skybox image");
+
+        // `Material` has no typed `EntityDescriptor` field -- `color:` writes
+        // the albedo and nothing else -- so metallic and roughness are
+        // authored through the generic reflected `components:` list, the same
+        // way the occlusion test above authors `Occluder`. Every field is
+        // spelled out, and `run_and_screenshot` checks the component actually
+        // landed rather than inferring it: a reflected value that does not
+        // match its type's shape is skipped with a warning, which would leave
+        // the sphere a rough dielectric reflecting almost nothing, and this
+        // test would then report that IBL does not work.
+        //
+        // The sun is switched off (`color: (0.0, 0.0, 0.0)`) so every photon
+        // reaching the sphere came from the environment. With a white sun the
+        // direct specular highlight alone would move these pixels further than
+        // IBL does and the measurement would mean nothing.
+        let skybox_line = if with_skybox {
+            "\n    skybox: Some(\"sky.png\"),"
+        } else {
+            ""
+        };
+        std::fs::write(
+            root.join("assets/scenes/main.ron"),
+            format!(
+                r#"SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Camera",
+        camera: true,
+        transform: Some((position: (0.0, 0.0, 5.0))),
+        look_at: Some((0.0, 0.0, 0.0)),
+    ),
+    EntityDescriptor(
+        name: "Sun",
+        directional_light: Some((
+            direction: (0.0, -1.0, 0.0),
+            color: (0.0, 0.0, 0.0),
+            ambient: (0.2, 0.2, 0.2),
+        )),
+    ),
+    EntityDescriptor(
+        name: "Ball",
+        primitive: Some(Sphere),
+        transform: Some((position: (0.0, 0.0, 0.0), scale: (3.0, 3.0, 3.0))),
+        components: [
+            ("bsengine_core::material::Material", "(texture_id: None, metallic: 1.0, roughness: 0.0, emissive: (0.0, 0.0, 0.0), base_color: (1.0, 1.0, 1.0), opacity: 1.0)"),
+        ],
+    ),
+],{skybox_line}
+)"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// Runs the temp project until it has drawn a settled frame, then returns
+    /// that frame decoded from the `screenshot` query's base64 PNG.
+    fn run_and_screenshot(project_dir: &str, expect_ibl: bool) -> image::RgbaImage {
+        let mut app = build_test_app(project_dir, None, false);
+
+        // The skybox loads asynchronously and the IBL maps are built when it
+        // arrives, so "has the environment reached the renderer" has to be
+        // waited on rather than assumed. Waiting on `has_ibl` rather than a
+        // fixed frame count also gives the skyboxless run a real assertion:
+        // the maps are still absent after as many frames as were enough to
+        // build them.
+        let mut ready = false;
+        for _ in 0..300 {
+            app.update();
+            let has_ibl = app
+                .world()
+                .get_resource::<bsengine_rhi_wgpu::WgpuSurfaceResource>()
+                .expect("WgpuRHIPlugin::offscreen should have inserted the surface")
+                .0
+                .has_ibl();
+            let meshes = app
+                .world_mut()
+                .query::<&bsengine_render::components::MeshRenderer>()
+                .iter(app.world())
+                .count();
+            if meshes >= 1 && has_ibl == expect_ibl {
+                ready = true;
+                break;
+            }
+        }
+        assert!(
+            ready,
+            "within 300 frames the temp project never reached one MeshRenderer with \
+             has_ibl() == {expect_ibl}: either the sphere primitive never resolved to a \
+             mesh, or the skybox never loaded and no IBL maps were generated. Either way \
+             nothing below would be measuring image-based lighting"
+        );
+        // A few more frames, so the sphere is drawn with the maps in place
+        // rather than in the frame that built them.
+        for _ in 0..3 {
+            app.update();
+        }
+
+        {
+            let mut q = app
+                .world_mut()
+                .query::<(&bsengine_scene::Name, &bsengine_core::Material)>();
+            let material = q
+                .iter(app.world())
+                .find(|(n, _)| n.0 == "Ball")
+                .map(|(_, m)| m.clone())
+                .expect(
+                    "Ball must carry the Material authored in its scene `components:` list -- \
+                     an unparseable reflected component is only warned about, so its absence \
+                     here means the type path or the RON value is wrong",
+                );
+            assert_eq!(material.metallic, 1.0, "Ball should be fully metallic");
+            assert_eq!(material.roughness, 0.0, "Ball should be mirror-smooth");
+        }
+
+        let stats = crate::test_query::run_query(app.world_mut(), "get_frame_stats", &json!({}))
+            .expect("get_frame_stats should succeed once RenderPlugin has drawn a frame");
+        assert!(
+            stats["triangles"].as_u64().unwrap_or(0) > 0,
+            "no geometry was drawn at all, so the pixels below are not a sphere: {stats}"
+        );
+
+        let shot = crate::test_query::run_query(app.world_mut(), "screenshot", &json!({}))
+            .expect("screenshot should succeed once RenderPlugin has drawn a frame");
+        use base64::Engine;
+        let png_bytes = base64::engine::general_purpose::STANDARD
+            .decode(
+                shot["data_base64"]
+                    .as_str()
+                    .expect("screenshot should return a data_base64 string"),
+            )
+            .expect("data_base64 should be valid base64");
+        image::load_from_memory(&png_bytes)
+            .expect("the screenshot PNG should decode")
+            .to_rgba8()
+    }
+
+    /// Mean colour of the disc of `radius` pixels around the frame's centre.
+    ///
+    /// A patch rather than the single centre pixel, for two reasons found by
+    /// looking at the frames rather than guessing at them. The sphere's exact
+    /// centre carries a small dark shading artifact -- present in the
+    /// skyboxless run too, where the shader takes the pre-IBL path, so it
+    /// predates this work and is not IBL's doing -- and the outermost ring of
+    /// the silhouette sits against the background. Radius 22 of a silhouette
+    /// that reaches past 30 is all surface, and averaging over it makes the
+    /// measurement independent of exactly where the sphere lands.
+    fn disc_mean(image: &image::RgbaImage, radius: f32) -> [f32; 3] {
+        let (cx, cy) = (image.width() as f32 / 2.0, image.height() as f32 / 2.0);
+        let mut sum = [0.0f32; 3];
+        let mut count = 0.0f32;
+        for y in 0..image.height() {
+            for x in 0..image.width() {
+                let dx = x as f32 - cx;
+                let dy = y as f32 - cy;
+                if dx * dx + dy * dy <= radius * radius {
+                    let px = image.get_pixel(x, y).0;
+                    for c in 0..3 {
+                        sum[c] += px[c] as f32;
+                    }
+                    count += 1.0;
+                }
+            }
+        }
+        [sum[0] / count, sum[1] / count, sum[2] / count]
+    }
+
+    /// Sum of the per-channel gaps between a measured colour and a target.
+    ///
+    /// Per-channel rather than luma: a frame that merely got brighter closes
+    /// the luma gap to a bright environment while taking on none of its hue.
+    fn gap_to(colour: [f32; 3], target: [f32; 3]) -> f32 {
+        (0..3).map(|i| (colour[i] - target[i]).abs()).sum()
+    }
+
+    /// Completion condition 4: the same demo scene, rendered with and without
+    /// a skybox and compared as screenshots, must show image-based lighting on
+    /// a metallic surface.
+    ///
+    /// Both runs are captured through the `screenshot` query and its base64
+    /// PNG is decoded here -- the round trip
+    /// `screenshot_returns_a_decodable_png` above establishes -- so this is
+    /// literally the on/off screenshot comparison rather than a proxy for one.
+    ///
+    /// The assertions are written so that a change alone cannot pass them. An
+    /// IBL that simply brightened every frame would raise all three channels;
+    /// what is required here is that red and blue *fall* to nothing while
+    /// green climbs, which only reflecting a green environment can do.
+    #[test]
+    fn ibl_visibly_changes_a_metallic_surface_under_a_skybox() {
+        const SPHERE_RADIUS_PX: f32 = 22.0;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let project_dir = root.to_str().unwrap().to_string();
+
+        write_ibl_project(root, true);
+        let with_sky = run_and_screenshot(&project_dir, true);
+
+        // The second app builds its own GPU device, so the first one has to be
+        // gone by now: `run_and_screenshot` drops its `App` on return, the
+        // same ordering `occlusion_culling_reduces_draw_calls_without_hiding_
+        // visible_objects` above keeps between its two phases.
+        write_ibl_project(root, false);
+        let without_sky = run_and_screenshot(&project_dir, false);
+
+        let lit = disc_mean(&with_sky, SPHERE_RADIUS_PX);
+        let unlit = disc_mean(&without_sky, SPHERE_RADIUS_PX);
+        // The environment as the renderer actually displays it, read out of
+        // the skybox run's own corner rather than assumed from the image file:
+        // the sky goes through the same HDR buffer and output encoding the
+        // sphere does, and a mirror can only ever match what that produces.
+        let env = {
+            let px = with_sky.get_pixel(2, 2).0;
+            [px[0] as f32, px[1] as f32, px[2] as f32]
+        };
+        let background = {
+            let px = without_sky.get_pixel(2, 2).0;
+            [px[0] as f32, px[1] as f32, px[2] as f32]
+        };
+        println!(
+            "IBL on: sphere {lit:?} sky {env:?} | IBL off: sphere {unlit:?} \
+             background {background:?}"
+        );
+
+        // Before anything is claimed about the sphere's colour, establish that
+        // these pixels are the sphere. Were they not, the skybox run would be
+        // measuring the green sky itself and would pass whatever the shader
+        // did. The scene, camera and geometry are identical between the runs,
+        // so proving it in the skyboxless one -- where the background is the
+        // grey clear colour rather than the sky -- proves it in both.
+        assert!(
+            gap_to(unlit, background) > 30.0,
+            "the measured patch is barely distinguishable from the frame's corner \
+             ({unlit:?} against {background:?}), so the sphere is not covering the middle \
+             of the frame and neither measurement below is of a surface at all"
+        );
+
+        // Each channel individually, so a uniform brightening cannot pass it:
+        // that would raise red and blue as well as green.
+        assert!(
+            lit[0] <= unlit[0] && lit[1] >= unlit[1] && lit[2] <= unlit[2],
+            "every channel of the metallic sphere should move towards the green \
+             environment: {unlit:?} without the skybox, {lit:?} with it"
+        );
+
+        let near = gap_to(lit, env);
+        let far = gap_to(unlit, env);
+        assert!(
+            near * 2.0 < far,
+            "the sphere should end up far closer to the environment's colour under the \
+             skybox: per-channel gap {far} without it ({unlit:?}), {near} with it \
+             ({lit:?}), against an environment of {env:?}"
+        );
+
+        // The strongest form of the claim, and the one a brightening cannot
+        // imitate: the off-environment channels collapse rather than merely
+        // holding still, while the environment's own channel climbs.
+        assert!(
+            lit[0] < 20.0 && lit[2] < 20.0,
+            "a mirror under a pure green sky should reflect no red and no blue: {lit:?}"
+        );
+        assert!(
+            lit[1] > unlit[1] + 30.0,
+            "the green the sphere reflects should be well above the grey it shows with no \
+             environment: {} against {}",
+            lit[1],
+            unlit[1]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Implements ENGINE_ROADMAP item 48 (GI / 실시간 리플렉션 / IBL), **sub-step 1/2: IBL**. Replaces the scene shader's flat constant ambient term with real environment lighting — diffuse irradiance and prefiltered specular reflection — integrated through the PBR BRDF that was already there.

Light-probe GI is **sub-step 2/2**, deferred: probe placement, storage, interpolation and a bake step are all new infrastructure sharing nothing with this.

## Why this landed cleanly
The shader already implemented full Cook-Torrance (`distribution_ggx`, `geometry_smith`, `fresnel_schlick`, `f0 = mix(vec3(0.04), albedo, metallic)`) and ended with:

```wgsl
let color = light.ambient * albedo + lo + model_data.emissive;
```

That flat `light.ambient * albedo` stood in for all indirect light — exactly the term IBL replaces. Because `f0`/`metallic`/`roughness` were already in scope there, completion condition 3 ("반사가 표면 속성을 반영") fell out of the integration rather than needing separate work.

## What's here
- **Real cubemaps** (`TextureViewDimension::Cube`, 6 array layers) — new infrastructure for this engine. Point-light shadows already used 6-layer arrays but with manual face selection, for a documented reason (R32Float isn't filterable) that doesn't apply here, so IBL uses genuine hardware cube filtering.
- **Four GPU passes on two schedules:** equirect→cubemap, irradiance convolution, and specular prefilter (5 mips × 6 faces) rerun whenever the skybox changes; the **BRDF integration LUT is generated once at startup and reused for every skybox**, since it depends only on the BRDF — not the environment, scene, or camera.
- **A real 512×512 `Rg16Float` BRDF LUT**, not the analytic Karis fit, which has visible error at grazing angles and low roughness.
- **Shader integration** with `fresnel_schlick_roughness` (plain Schlick is derived for a perfect mirror and over-brightens rough metals at grazing angles). No AO factor — SSAO is a post-process pass, so no AO value exists in the forward shader; it keeps attenuating the composite exactly as before.
- **No-skybox fallback via dummy 1×1 resources + an `ibl_enabled` uniform flag.** wgpu bind group layouts are fixed, so the bindings must always be satisfied; the guard makes the no-skybox path byte-identical to before. The flag fits in `LightUniform`'s existing spare padding, so **`LIGHT_UNIFORM_SIZE` stays 960** and nothing downstream resizes.

## Verification
Each test is paired with its opposite-direction regression, because an assertion that merely detects *a change* would pass just as happily if IBL brightened everything:

- `a_smooth_metal_reflects_the_environment_colour` — the surface moves *toward* the environment colour, not merely differs
- `a_rough_surface_barely_reflects` — catches broken prefilter mip selection
- **`a_scene_with_no_skybox_is_pixel_identical`** — catches "IBL just brightened the frame"
- `metal_tints_its_reflection_but_a_dielectric_does_not` — proves completion condition 3 directly

Unit tests target the bugs that are otherwise silent: `equirect_to_cubemap_puts_each_direction_on_the_right_face` (mirroring is invisible in a smooth gradient), `irradiance_of_a_uniform_environment_is_that_same_colour` (catches a wrong normalisation factor — a map 2× too bright looks fine in isolation), `prefilter_mip_zero_is_sharp_and_the_last_mip_is_blurred`, and BRDF LUT corner values that a shader writing `(1, 0)` everywhere would fail.

## Test plan
- [x] `cargo test -p bsengine-rhi-wgpu --lib ibl` — 11 passing
- [x] `cargo test -p bsengine-rhi-wgpu --test pixels_ibl` — 4/4
- [x] `cargo test -p bsengine-runtime --bins` — incl. the demo-scene screenshot proof (completion condition 4)
- [x] **All eight pre-existing `pixels_*.rs` files pass unchanged** — the no-skybox fallback is what this branch rests on
- [x] `cargo test --workspace --exclude bsengine-editor` — zero failures
- [x] `cargo test -p bsengine-editor --lib` — 937/937 (isolated, per CI's split)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` — 60 components, 0 violations (no new components)
- [x] `cargo clippy --workspace --all-targets` — identical to the pre-existing baseline
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)