### PR TITLE
feat: light-probe global illumination

### DIFF
--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -38,6 +38,8 @@ pub mod inspector;
 pub mod lifetime;
 /// Directional, point, and spot light components.
 pub mod light;
+/// Baked light-probe volume providing position-varying indirect lighting.
+pub mod light_probe;
 /// Engine-wide logging initialization.
 pub mod logging;
 /// PBR material properties component.
@@ -118,6 +120,7 @@ pub use inspector::{
 };
 pub use lifetime::Lifetime;
 pub use light::{DirectionalLight, PointLight, SpotLight};
+pub use light_probe::{LightProbeVolume, MAX_PROBES};
 pub use logging::init_logging;
 pub use material::{Material, TexturePath};
 pub use nav_mesh::NavMesh;

--- a/crates/bsengine-core/src/light_probe.rs
+++ b/crates/bsengine-core/src/light_probe.rs
@@ -1,0 +1,101 @@
+//! Baked light-probe volume for indirect lighting.
+
+use crate::ReflectVec3;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
+
+/// Largest number of probes a single volume may hold, matching the GPU
+/// uniform array. A volume asking for more is clamped rather than
+/// rejected -- an over-specified scene should still render.
+pub const MAX_PROBES: usize = 32;
+
+/// A box filled with a regular grid of baked light probes, giving
+/// position-varying indirect light inside it.
+///
+/// Probes sit on the grid's **lattice points**, not cell centres: trilinear
+/// interpolation is defined by the eight corners of a cell, so corner
+/// placement is what makes the interpolation well-formed.
+///
+/// Absent means no probe GI, and the existing IBL path runs unchanged.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Default)]
+pub struct LightProbeVolume {
+    /// Half-extents of the box, relative to the entity's `Transform`.
+    pub half_extents: ReflectVec3,
+    /// Probe count along each axis. The product is clamped to
+    /// [`MAX_PROBES`]. `[4, 2, 4]` gives exactly 32.
+    pub resolution: [u32; 3],
+}
+
+impl Default for LightProbeVolume {
+    fn default() -> Self {
+        Self {
+            half_extents: glam::Vec3::splat(5.0).into(),
+            resolution: [4, 2, 4],
+        }
+    }
+}
+
+impl LightProbeVolume {
+    /// Resolution with each axis at least 2 (one probe per axis cannot
+    /// interpolate) and the product clamped to [`MAX_PROBES`].
+    pub fn clamped_resolution(&self) -> [u32; 3] {
+        let mut r = [
+            self.resolution[0].max(2),
+            self.resolution[1].max(2),
+            self.resolution[2].max(2),
+        ];
+        while (r[0] * r[1] * r[2]) as usize > MAX_PROBES {
+            // Shrink the largest axis first, keeping the grid as even as
+            // possible rather than collapsing one direction.
+            let largest = if r[0] >= r[1] && r[0] >= r[2] {
+                0
+            } else if r[1] >= r[2] {
+                1
+            } else {
+                2
+            };
+            if r[largest] <= 2 {
+                break;
+            }
+            r[largest] -= 1;
+        }
+        r
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_resolution_fits_max_probes_exactly() {
+        let v = LightProbeVolume::default();
+        let r = v.clamped_resolution();
+        assert_eq!((r[0] * r[1] * r[2]) as usize, MAX_PROBES);
+    }
+
+    #[test]
+    fn an_oversized_resolution_is_clamped_not_rejected() {
+        let v = LightProbeVolume {
+            resolution: [16, 16, 16],
+            ..Default::default()
+        };
+        let r = v.clamped_resolution();
+        assert!((r[0] * r[1] * r[2]) as usize <= MAX_PROBES);
+        assert!(
+            r.iter().all(|&a| a >= 2),
+            "every axis must keep >= 2 probes"
+        );
+    }
+
+    #[test]
+    fn a_degenerate_resolution_is_raised_to_two_per_axis() {
+        let v = LightProbeVolume {
+            resolution: [1, 0, 1],
+            ..Default::default()
+        };
+        assert_eq!(v.clamped_resolution(), [2, 2, 2]);
+    }
+}

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -586,10 +586,22 @@ fn render_frame(
     // F)`). It is a `Local` for the same reason the buffer is -- it is this
     // system's own frame counter, driving the Halton jitter cycle, and no
     // one else reads it.
-    (occlusion_enabled, mut occlusion_buf, mut taa_frame_index): (
+    //
+    // The light-probe volume query joins this tuple for exactly that reason.
+    // Both limits above are already at their maximum, so a 17th top-level
+    // parameter and a 9th `ParamSet` entry are equally impossible -- the
+    // `ParamSet` comment names this same remedy, "the same treatment applied
+    // one level down (a tuple ...)". The query is read-only and touches no
+    // component the `ParamSet` writes, so it conflicts with nothing.
+    (occlusion_enabled, mut occlusion_buf, mut taa_frame_index, probe_volumes): (
         Option<Res<bsengine_core::OcclusionCullingEnabled>>,
         Local<crate::occlusion::OcclusionBuffer>,
         Local<u32>,
+        Query<(
+            &bsengine_core::LightProbeVolume,
+            &Transform,
+            Option<&GlobalTransform>,
+        )>,
     ),
 ) {
     let (Some(mut surface), Some(registry)) = (surface, registry) else {
@@ -702,6 +714,31 @@ fn render_frame(
     } else {
         None
     };
+
+    // The baked-probe volume, read in one self-contained block for the same
+    // reason the occlusion pre-pass below is one: the whole query is consumed
+    // here and nothing downstream holds a borrow of it.
+    //
+    // Only the first volume counts. The GPU side has one `MAX_PROBES` grid,
+    // and picking silently among several would be worse than ignoring the
+    // extras -- there is nothing sensible to blend between two boxes.
+    //
+    // The box is axis-aligned in world space: the entity's translation moves
+    // it, but its rotation and scale do not, because `inside_probe_volume` and
+    // the trilinear lookup in the scene shader are both written against an
+    // AABB. `half_extents` is therefore taken as world units directly, not
+    // scaled by the transform.
+    let light_probes = probe_volumes.iter().next().map(|(volume, t, gt)| {
+        let centre = gt
+            .map(|g| g.to_matrix().w_axis.truncate())
+            .unwrap_or(t.position.0);
+        let half = *volume.half_extents;
+        bsengine_rhi_wgpu::ProbeVolumeParams {
+            origin: centre - half,
+            extent: half * 2.0,
+            resolution: volume.clamped_resolution(),
+        }
+    });
 
     // Occlusion pre-pass. It has to finish before the draw-call loop below
     // borrows `p1()`: a ParamSet lends exactly one sub-query at a time, so
@@ -941,6 +978,7 @@ fn render_frame(
         taa,
         jitter_clip,
         unjittered_view_proj,
+        light_probes,
     ) {
         Ok(clicked) => {
             if let Some(ref mut state) = ui_state {

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -52,6 +52,7 @@ pub use mesh::{
 };
 pub use plugin::{GpuQueueResource, WgpuRHIPlugin};
 pub use surface::{
-    LightData, MaterialParams, PointLightEntry, SpotLightEntry, WgpuSurfaceResource,
+    LightData, MaterialParams, PointLightEntry, ProbeVolumeParams, SpotLightEntry,
+    WgpuSurfaceResource,
 };
 pub use texture::GpuTextureRegistry;

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -37,6 +37,9 @@ pub mod post_process;
 /// Frame/GPU statistics: texture memory tracking, draw-call/triangle
 /// counting, and feature-gated GPU pass timing.
 pub mod profiler;
+/// Spherical-harmonic (L2) projection, irradiance evaluation and trilinear
+/// blending for light probes.
+pub mod sh;
 /// Swapchain/frame lifecycle and the main scene render pass.
 pub mod surface;
 pub mod taa_jitter;

--- a/crates/bsengine-rhi-wgpu/src/sh.rs
+++ b/crates/bsengine-rhi-wgpu/src/sh.rs
@@ -1,0 +1,222 @@
+//! Spherical harmonics (L2, 9 coefficients) for light probes.
+//!
+//! Deliberately GPU-free: projection, evaluation and interpolation are all
+//! pure functions over `glam` types, so the normalisation constants -- the
+//! part of this that is easy to get wrong and hard to notice -- can be
+//! asserted exactly rather than eyeballed in a render.
+
+use glam::Vec3;
+
+/// Coefficient count for an L2 (order-3) spherical harmonic expansion.
+pub const SH_COEFF_COUNT: usize = 9;
+
+/// One probe's radiance, as L2 spherical-harmonic coefficients (RGB each).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ShL2 {
+    /// The nine coefficients, in the standard l-major order:
+    /// index 0 is l=0; 1..=3 are l=1; 4..=8 are l=2.
+    pub coeffs: [Vec3; SH_COEFF_COUNT],
+}
+
+impl Default for ShL2 {
+    fn default() -> Self {
+        Self {
+            coeffs: [Vec3::ZERO; SH_COEFF_COUNT],
+        }
+    }
+}
+
+/// The nine real SH basis functions evaluated in direction `d`
+/// (`d` must be normalized).
+pub fn sh_basis(d: Vec3) -> [f32; SH_COEFF_COUNT] {
+    [
+        0.282_095,       // l=0
+        0.488_603 * d.y, // l=1
+        0.488_603 * d.z,
+        0.488_603 * d.x,
+        1.092_548 * d.x * d.y, // l=2
+        1.092_548 * d.y * d.z,
+        0.315_392 * (3.0 * d.z * d.z - 1.0),
+        1.092_548 * d.x * d.z,
+        0.546_274 * (d.x * d.x - d.y * d.y),
+    ]
+}
+
+impl ShL2 {
+    /// Accumulates one sample of `radiance` arriving from direction `dir`,
+    /// covering `solid_angle` steradians.
+    pub fn accumulate(&mut self, dir: Vec3, radiance: Vec3, solid_angle: f32) {
+        let basis = sh_basis(dir);
+        for (coeff, b) in self.coeffs.iter_mut().zip(basis) {
+            *coeff += radiance * b * solid_angle;
+        }
+    }
+
+    /// Evaluates the **irradiance** (not radiance) arriving at a surface
+    /// with normal `n`, using the standard cosine-lobe convolution
+    /// constants. These per-band factors are what turn a radiance
+    /// expansion into the diffuse irradiance a Lambertian surface sees;
+    /// omitting them is the classic bug that leaves probe lighting looking
+    /// plausible but far too directional.
+    pub fn eval_irradiance(&self, n: Vec3) -> Vec3 {
+        // The cosine-lobe convolution factors are exactly pi, 2pi/3 and
+        // pi/4; written in closed form both because it is more accurate
+        // than the decimal expansion and because clippy's `approx_constant`
+        // rejects a literal pi.
+        const A0: f32 = std::f32::consts::PI;
+        const A1: f32 = 2.0 * std::f32::consts::PI / 3.0;
+        const A2: f32 = std::f32::consts::FRAC_PI_4;
+        let basis = sh_basis(n);
+        let band = [A0, A1, A1, A1, A2, A2, A2, A2, A2];
+        let mut out = Vec3::ZERO;
+        for i in 0..SH_COEFF_COUNT {
+            out += self.coeffs[i] * basis[i] * band[i];
+        }
+        // Irradiance is never negative; ringing from a truncated expansion
+        // can push it below zero, which would darken rather than light.
+        out.max(Vec3::ZERO)
+    }
+
+    /// Component-wise linear blend, used by trilinear interpolation.
+    /// Blending coefficients and evaluating once is both cheaper than and
+    /// equivalent to evaluating each probe and blending the results,
+    /// because SH evaluation is linear in the coefficients.
+    pub fn lerp(a: &ShL2, b: &ShL2, t: f32) -> ShL2 {
+        let mut out = ShL2::default();
+        for i in 0..SH_COEFF_COUNT {
+            out.coeffs[i] = a.coeffs[i].lerp(b.coeffs[i], t);
+        }
+        out
+    }
+}
+
+/// The eight trilinear weights for `frac` (each component in `[0, 1]`),
+/// ordered so index bit 0 is x, bit 1 is y, bit 2 is z.
+pub fn trilinear_weights(frac: Vec3) -> [f32; 8] {
+    let mut w = [0.0f32; 8];
+    for (i, slot) in w.iter_mut().enumerate() {
+        let wx = if i & 1 == 0 { 1.0 - frac.x } else { frac.x };
+        let wy = if i & 2 == 0 { 1.0 - frac.y } else { frac.y };
+        let wz = if i & 4 == 0 { 1.0 - frac.z } else { frac.z };
+        *slot = wx * wy * wz;
+    }
+    w
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Integrating a constant environment must leave only the l=0
+    /// coefficient non-zero: every higher band's basis function integrates
+    /// to zero over the sphere. This is exact and is the assertion that
+    /// catches a wrong normalisation constant -- a bug that otherwise just
+    /// reads as "the scene looks a bit bright".
+    #[test]
+    fn a_uniform_environment_projects_onto_l0_only() {
+        let mut sh = ShL2::default();
+        // Fibonacci sphere: even coverage without pole clustering.
+        let n = 4096;
+        let solid_angle = 4.0 * std::f32::consts::PI / n as f32;
+        for i in 0..n {
+            let y = 1.0 - 2.0 * (i as f32 + 0.5) / n as f32;
+            let r = (1.0 - y * y).max(0.0).sqrt();
+            let theta = std::f32::consts::PI * (1.0 + 5.0f32.sqrt()) * i as f32;
+            let dir = Vec3::new(theta.cos() * r, y, theta.sin() * r).normalize();
+            sh.accumulate(dir, Vec3::ONE, solid_angle);
+        }
+        assert!(
+            (sh.coeffs[0].x - 0.282_095 * 4.0 * std::f32::consts::PI).abs() < 0.05,
+            "l=0 must equal the basis constant times the full solid angle, got {}",
+            sh.coeffs[0].x
+        );
+        for (i, c) in sh.coeffs.iter().enumerate().skip(1) {
+            assert!(
+                c.length() < 0.05,
+                "coefficient {i} should vanish for a uniform environment, got {c:?}"
+            );
+        }
+    }
+
+    /// Reconstruction of a uniform environment must return that same
+    /// constant in every direction -- the round trip is the real check.
+    #[test]
+    fn a_uniform_environment_reconstructs_to_its_own_colour() {
+        let mut sh = ShL2::default();
+        let n = 4096;
+        let solid_angle = 4.0 * std::f32::consts::PI / n as f32;
+        for i in 0..n {
+            let y = 1.0 - 2.0 * (i as f32 + 0.5) / n as f32;
+            let r = (1.0 - y * y).max(0.0).sqrt();
+            let theta = std::f32::consts::PI * (1.0 + 5.0f32.sqrt()) * i as f32;
+            let dir = Vec3::new(theta.cos() * r, y, theta.sin() * r).normalize();
+            sh.accumulate(dir, Vec3::splat(0.5), solid_angle);
+        }
+        for probe_dir in [Vec3::X, Vec3::Y, Vec3::Z, Vec3::NEG_X, -Vec3::Y] {
+            let e = sh.eval_irradiance(probe_dir.normalize());
+            assert!(
+                (e.x - 0.5 * std::f32::consts::PI).abs() < 0.1,
+                "uniform 0.5 environment should give pi*0.5 irradiance in \
+                 every direction, got {e:?} for {probe_dir:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bright_direction_dominates_the_reconstruction() {
+        // A single bright lobe must read brighter from that side than the
+        // opposite side -- otherwise the l=1 terms carry no direction and
+        // the probe is just an ambient constant.
+        let mut sh = ShL2::default();
+        sh.accumulate(Vec3::X, Vec3::new(10.0, 0.0, 0.0), 1.0);
+        let front = sh.eval_irradiance(Vec3::X);
+        let back = sh.eval_irradiance(Vec3::NEG_X);
+        assert!(
+            front.x > back.x,
+            "the lit side must be brighter: front {front:?} back {back:?}"
+        );
+    }
+
+    #[test]
+    fn trilinear_weights_always_sum_to_one() {
+        for &f in &[
+            Vec3::ZERO,
+            Vec3::ONE,
+            Vec3::splat(0.5),
+            Vec3::new(0.1, 0.9, 0.3),
+            Vec3::new(0.75, 0.25, 1.0),
+        ] {
+            let sum: f32 = trilinear_weights(f).iter().sum();
+            assert!(
+                (sum - 1.0).abs() < 1e-5,
+                "weights for {f:?} summed to {sum}, not 1.0 -- a partition of \
+                 unity is what keeps interpolation from brightening or \
+                 darkening the result"
+            );
+        }
+    }
+
+    #[test]
+    fn a_point_on_a_lattice_corner_takes_that_corner_alone() {
+        let w = trilinear_weights(Vec3::ZERO);
+        assert!((w[0] - 1.0).abs() < 1e-6);
+        for x in &w[1..] {
+            assert!(x.abs() < 1e-6);
+        }
+        let w = trilinear_weights(Vec3::ONE);
+        assert!((w[7] - 1.0).abs() < 1e-6);
+        for x in &w[..7] {
+            assert!(x.abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn lerp_at_the_ends_returns_the_endpoints() {
+        let mut a = ShL2::default();
+        a.coeffs[0] = Vec3::X;
+        let mut b = ShL2::default();
+        b.coeffs[0] = Vec3::Y;
+        assert_eq!(ShL2::lerp(&a, &b, 0.0).coeffs[0], Vec3::X);
+        assert_eq!(ShL2::lerp(&a, &b, 1.0).coeffs[0], Vec3::Y);
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -92,6 +92,29 @@ struct LightUniform {
 // shadow sampler, which no shader declares (the cube lookup uses textureLoad)
 // but which is bound all the same, as a non-filtering sampler.
 @group(2) @binding(8) var ibl_sampler: sampler;
+// Baked light probes. A uniform buffer with a fixed maximum, not a storage
+// buffer: this engine uses no storage buffers anywhere, and fixed-size uniform
+// arrays are its established pattern (see MAX_POINT_LIGHTS above). 32 probes x
+// 9 coefficients x vec4 is 4608 bytes, well inside the 64 KiB uniform limit.
+//
+// Bound in every frame, exactly like the IBL maps: a bind group layout is fixed
+// at creation, so a scene with no volume uploads `enabled: 0` and zeroed
+// coefficients rather than skipping the binding.
+struct ProbeUniform {
+    // MAX_PROBES(32) * 9 coefficients. vec4 rather than vec3 because std140
+    // pads a vec3 array element out to 16 bytes anyway.
+    coeffs: array<vec4<f32>, 288>,
+    // World-space minimum corner of the volume.
+    origin: vec3<f32>,
+    enabled: u32,
+    // World-space size of the volume (full extent, not half).
+    extent: vec3<f32>,
+    _pad0: f32,
+    // Probes per axis, sitting on the grid's lattice points.
+    resolution: vec3<u32>,
+    _pad1: u32,
+};
+@group(2) @binding(9) var<uniform> probes: ProbeUniform;
 
 struct VertIn {
     @location(0) pos: vec3<f32>,
@@ -220,6 +243,87 @@ fn fresnel_schlick_roughness(cos_theta: f32, f0: vec3<f32>, roughness: f32) -> v
     let inv_rough = vec3<f32>(1.0 - roughness);
     return f0 + (max(inv_rough, f0) - f0) * pow(clamp(1.0 - cos_theta, 0.0, 1.0), 5.0);
 }
+// True when `world_pos` is inside the baked volume's box. Outside it there are
+// no surrounding probes to interpolate between, so the IBL path stands.
+fn inside_probe_volume(world_pos: vec3<f32>) -> bool {
+    let local = world_pos - probes.origin;
+    return all(local >= vec3<f32>(0.0, 0.0, 0.0)) && all(local <= probes.extent);
+}
+// `world_pos` in lattice units. Probes sit on the grid's *corners*, so a volume
+// with `resolution` probes along an axis spans `resolution - 1` cells, and the
+// last probe lands exactly on the far face rather than one cell short of it.
+fn probe_grid_coord(world_pos: vec3<f32>) -> vec3<f32> {
+    let cells = max(vec3<f32>(probes.resolution) - vec3<f32>(1.0, 1.0, 1.0), vec3<f32>(1.0, 1.0, 1.0));
+    let extent = max(probes.extent, vec3<f32>(1e-6, 1e-6, 1e-6));
+    let t = (world_pos - probes.origin) / extent;
+    return clamp(t, vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(1.0, 1.0, 1.0)) * cells;
+}
+// Index of probe (ix, iy, iz)'s first coefficient. x fastest, then y, then z --
+// the same order the CPU walks the lattice in when it uploads them.
+fn probe_coeff_base(ix: u32, iy: u32, iz: u32) -> u32 {
+    let idx = (iz * probes.resolution.y + iy) * probes.resolution.x + ix;
+    // MAX_PROBES - 1. A resolution the CPU side never produces would otherwise
+    // read past the end of the array.
+    return min(idx, 31u) * 9u;
+}
+// The probe grid's irradiance at `world_pos` for a surface facing `n`, in the
+// same units the irradiance cube stores: E / PI, with the Lambert BRDF's 1/PI
+// folded in, so callers write `* albedo` with no stray constant exactly as the
+// IBL path does.
+//
+// The eight surrounding probes' COEFFICIENTS are blended and the result
+// evaluated once, rather than evaluating eight probes and blending the results.
+// SH evaluation is linear in the coefficients, so the two are equivalent -- and
+// this one does an eighth of the evaluation work.
+fn eval_probe_sh(world_pos: vec3<f32>, n: vec3<f32>) -> vec3<f32> {
+    let g = probe_grid_coord(world_pos);
+    let last = vec3<i32>(probes.resolution) - vec3<i32>(1, 1, 1);
+    let i0 = clamp(vec3<i32>(floor(g)), vec3<i32>(0, 0, 0), last);
+    let i1 = min(i0 + vec3<i32>(1, 1, 1), last);
+    let frac = clamp(g - floor(g), vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(1.0, 1.0, 1.0));
+
+    var blended: array<vec4<f32>, 9>;
+    for (var c: u32 = 0u; c < 9u; c++) {
+        blended[c] = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    // Corner bit 0 is x, bit 1 is y, bit 2 is z -- the same ordering
+    // `trilinear_weights` in sh.rs uses, so the two cannot disagree.
+    for (var corner: u32 = 0u; corner < 8u; corner++) {
+        let hi_x = (corner & 1u) != 0u;
+        let hi_y = (corner & 2u) != 0u;
+        let hi_z = (corner & 4u) != 0u;
+        let w = select(1.0 - frac.x, frac.x, hi_x)
+            * select(1.0 - frac.y, frac.y, hi_y)
+            * select(1.0 - frac.z, frac.z, hi_z);
+        let base = probe_coeff_base(
+            u32(select(i0.x, i1.x, hi_x)),
+            u32(select(i0.y, i1.y, hi_y)),
+            u32(select(i0.z, i1.z, hi_z)),
+        );
+        for (var c: u32 = 0u; c < 9u; c++) {
+            blended[c] = blended[c] + probes.coeffs[base + c] * w;
+        }
+    }
+
+    // Cosine-lobe convolution constants: the per-band factors that turn a
+    // radiance expansion into the irradiance a Lambertian surface receives.
+    // Identical to `ShL2::eval_irradiance` in sh.rs, which asserts them.
+    let a0 = 3.141593;
+    let a1 = 2.094395;
+    let a2 = 0.785398;
+    var e = blended[0].rgb * (0.282095 * a0);
+    e = e + blended[1].rgb * (0.488603 * n.y * a1);
+    e = e + blended[2].rgb * (0.488603 * n.z * a1);
+    e = e + blended[3].rgb * (0.488603 * n.x * a1);
+    e = e + blended[4].rgb * (1.092548 * n.x * n.y * a2);
+    e = e + blended[5].rgb * (1.092548 * n.y * n.z * a2);
+    e = e + blended[6].rgb * (0.315392 * (3.0 * n.z * n.z - 1.0) * a2);
+    e = e + blended[7].rgb * (1.092548 * n.x * n.z * a2);
+    e = e + blended[8].rgb * (0.546274 * (n.x * n.x - n.y * n.y) * a2);
+    // Ringing in a truncated expansion can drive irradiance below zero, which
+    // would darken a surface rather than light it.
+    return max(e, vec3<f32>(0.0, 0.0, 0.0)) / PI;
+}
 @fragment
 fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
     let n = normalize(in.world_normal);
@@ -297,10 +401,18 @@ fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
     // post-process pass over the depth buffer, so no AO value exists at this
     // point in the frame, and SSAO keeps attenuating the composited result
     // exactly as it does today.
+    //
+    // The diffuse/specular energy split is hoisted out of the IBL branch
+    // because the probe path below needs `kd_ibl` too, and a probe volume in a
+    // scene with no skybox still has to light something. It depends only on the
+    // material and the view angle, so computing it unconditionally changes no
+    // pixel: `ambient_term` is still exactly `light.ambient * albedo` whenever
+    // both branches are skipped.
+    let f_ibl = fresnel_schlick_roughness(n_dot_v, f0, roughness);
+    let kd_ibl = (vec3<f32>(1.0) - f_ibl) * (1.0 - metallic);
+    var specular_ibl = vec3<f32>(0.0, 0.0, 0.0);
     var ambient_term = light.ambient * albedo;
     if (light.ibl_enabled != 0u) {
-        let f_ibl = fresnel_schlick_roughness(n_dot_v, f0, roughness);
-        let kd_ibl = (vec3<f32>(1.0) - f_ibl) * (1.0 - metallic);
         let irradiance = textureSample(irradiance_cube, ibl_sampler, n).rgb;
         let diffuse_ibl = irradiance * albedo * kd_ibl;
 
@@ -309,9 +421,19 @@ fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
             prefilter_cube, ibl_sampler, r, roughness * light.ibl_max_mip
         ).rgb;
         let brdf = textureSample(brdf_lut, ibl_sampler, vec2<f32>(n_dot_v, roughness)).rg;
-        let specular_ibl = prefiltered * (f_ibl * brdf.x + brdf.y);
+        specular_ibl = prefiltered * (f_ibl * brdf.x + brdf.y);
 
         ambient_term = diffuse_ibl + specular_ibl;
+    }
+    if (probes.enabled != 0u && inside_probe_volume(in.world_pos)) {
+        // REPLACES the ambient/IBL irradiance, never adds to it. The probes
+        // captured the real scene *including the skybox background and the flat
+        // ambient term*, so their SH already carries the sky's contribution;
+        // adding would double-count sky light and wash the scene out. The
+        // specular half is kept as-is -- probes are a diffuse-only, L2
+        // representation and carry no reflection to replace it with.
+        let probe_irradiance = eval_probe_sh(in.world_pos, n);
+        ambient_term = probe_irradiance * albedo * kd_ibl + specular_ibl;
     }
     let color = ambient_term + lo + model_data.emissive;
     return vec4<f32>(color, model_data.opacity);
@@ -1084,6 +1206,50 @@ const PROBE_CAPTURE_RANGE: f32 = 200.0;
 /// probe radiance is pre-tonemap and routinely exceeds 1.0, and clipping it to
 /// 8-bit here would quietly cap how much light a probe can carry.
 const PROBE_CAPTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
+/// Size of [`ProbeUniformData`], and the group-2 binding-9 `min_binding_size`.
+///
+/// `MAX_PROBES(32) * 9 coefficients * vec4(16)` = 4608 bytes of coefficients,
+/// plus 48 bytes describing the volume's box and grid. Far inside the 64 KiB
+/// uniform binding limit, which is what makes a fixed-size uniform array a
+/// workable substitute for the storage buffer this engine does not use.
+const PROBE_UNIFORM_SIZE: u64 = 4656;
+
+/// GPU-uniform layout for the baked probe grid. Mirrors `ProbeUniform` in
+/// [`MESH_WGSL`].
+///
+/// A uniform buffer with a fixed maximum rather than a storage buffer: this
+/// engine uses no storage buffers anywhere, and fixed-size uniform arrays are
+/// its established pattern (`MAX_POINT_LIGHTS`).
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct ProbeUniformData {
+    /// Nine coefficients per probe, `vec4` each because std140 pads a `vec3`
+    /// array element out to 16 bytes regardless. Nested rather than a flat
+    /// `[[f32; 4]; 288]` purely so the probe index is visible at the use site;
+    /// the bytes are identical, and the shader reads them flat.
+    coeffs: [[[f32; 4]; crate::sh::SH_COEFF_COUNT]; bsengine_core::MAX_PROBES],
+    /// World-space minimum corner of the volume.
+    origin: [f32; 3],
+    /// Nonzero when probe GI should be sampled at all. Zero -- with zeroed
+    /// coefficients -- is what a scene with no volume uploads: a bind group
+    /// layout is fixed at creation, so the binding cannot simply be skipped.
+    enabled: u32,
+    /// World-space size of the volume (full extent, not half).
+    extent: [f32; 3],
+    _pad0: f32,
+    /// Probes per axis, on the grid's lattice points.
+    resolution: [u32; 3],
+    _pad1: u32,
+}
+
+// The layout's `min_binding_size`, so a mismatch here would surface as a bind
+// group validation failure at runtime rather than at compile time. It also has
+// to match `ProbeUniform` in MESH_WGSL byte for byte: a shorter Rust struct
+// would leave the shader reading the volume's bounds out of coefficient data.
+const _: () = assert!(
+    std::mem::size_of::<ProbeUniformData>() as u64 == PROBE_UNIFORM_SIZE,
+    "ProbeUniformData must stay exactly PROBE_UNIFORM_SIZE bytes"
+);
 
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
@@ -1538,6 +1704,9 @@ struct LightBindings<'a> {
     /// Real prefiltered cube, or that same dummy.
     prefilter_view: &'a wgpu::TextureView,
     brdf_lut_view: &'a wgpu::TextureView,
+    /// The baked probe grid. Always present; `enabled` is 0 when no volume
+    /// has been baked.
+    probe_buffer: &'a wgpu::Buffer,
 }
 
 /// Builds the light bind group. The single place the group-2 binding numbers
@@ -1587,6 +1756,10 @@ fn create_light_bind_group(
             wgpu::BindGroupEntry {
                 binding: 8,
                 resource: wgpu::BindingResource::Sampler(bindings.ibl_sampler),
+            },
+            wgpu::BindGroupEntry {
+                binding: 9,
+                resource: bindings.probe_buffer.as_entire_binding(),
             },
         ],
     })
@@ -1653,6 +1826,13 @@ pub struct WgpuSurface {
     /// pass its own per-face uniform buffer.
     probe_capture_uniform_buffer: wgpu::Buffer,
     probe_capture_bind_group: wgpu::BindGroup,
+    /// The baked probe grid the scene shader samples, at group 2 binding 9.
+    ///
+    /// Bound in every frame, not only when a volume exists: a bind group layout
+    /// is fixed at creation, so the no-probe case is expressed as `enabled: 0`
+    /// with zeroed coefficients rather than as a missing binding -- the same
+    /// arrangement [`Self::dummy_ibl_cube_view`] gives the IBL maps.
+    probe_buffer: wgpu::Buffer,
     /// Layout of the skybox's texture+sampler group. Held here rather than
     /// built inside `set_skybox_from_rgba` because `probe_capture_sky_pipeline`
     /// is built once at construction and has to bind `SkyboxState::texture_bg`
@@ -2149,6 +2329,21 @@ impl WgpuSurface {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
+                // 9 is the baked probe grid. Like the IBL entries above it is
+                // present in every scene, including the many with no probe
+                // volume; those upload `enabled: 0` and zeroed coefficients.
+                // Binding 3 is the only other free slot and is taken by the
+                // point shadow sampler, which no shader declares.
+                wgpu::BindGroupLayoutEntry {
+                    binding: 9,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(PROBE_UNIFORM_SIZE),
+                    },
+                    count: None,
+                },
             ],
         });
 
@@ -2347,6 +2542,23 @@ impl WgpuSurface {
         // LUT on exactly the same terms a windowed one does.
         let (brdf_lut_texture, brdf_lut_view) = crate::ibl::generate_brdf_lut(&device, &queue);
 
+        let probe_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("probe uniform"),
+            size: PROBE_UNIFORM_SIZE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        // Explicitly zeroed rather than left to wgpu's lazy zero-init, for the
+        // same reason the dummy IBL cube is: `enabled: 0` is exactly what keeps
+        // every scene without a probe volume rendering as it did before probes
+        // existed, and that should be a property of this code rather than of a
+        // backend detail.
+        queue.write_buffer(
+            &probe_buffer,
+            0,
+            bytemuck::bytes_of(&<ProbeUniformData as bytemuck::Zeroable>::zeroed()),
+        );
+
         // No skybox at construction, so the cube bindings get the dummy. Every
         // later rebuild goes through `rebuild_light_bind_group`, which binds
         // the same way from the same struct.
@@ -2363,6 +2575,7 @@ impl WgpuSurface {
                 irradiance_view: &dummy_ibl_cube_view,
                 prefilter_view: &dummy_ibl_cube_view,
                 brdf_lut_view: &brdf_lut_view,
+                probe_buffer: &probe_buffer,
             },
         );
 
@@ -2935,6 +3148,7 @@ impl WgpuSurface {
             probe_capture_sky_pipeline,
             probe_capture_uniform_buffer,
             probe_capture_bind_group,
+            probe_buffer,
             sky_tex_bgl,
             egui_ctx,
             egui_renderer,
@@ -3301,6 +3515,7 @@ impl WgpuSurface {
                 irradiance_view,
                 prefilter_view,
                 brdf_lut_view: &self.brdf_lut_view,
+                probe_buffer: &self.probe_buffer,
             },
         );
         self.light_bind_group = bind_group;
@@ -5739,6 +5954,54 @@ mod tests {
             "LightUniform must still declare ibl_enabled: this shader reads the \
              same buffer MESH_WGSL does, and a shorter struct would misalign \
              every field after it"
+        );
+    }
+
+    /// Inside a volume the probe irradiance **replaces** the ambient/IBL
+    /// irradiance; it must never be added to it.
+    ///
+    /// The probes captured the real scene including its skybox background and
+    /// its flat ambient term, so their SH already carries both. Adding would
+    /// count sky light twice and wash the scene out -- and, like the recursive
+    /// bake this file's other source-level guard catches, the failure is merely
+    /// *brighter* rather than obviously broken, so no pixel test would flag it.
+    #[test]
+    fn the_scene_shader_replaces_the_ibl_irradiance_inside_a_probe_volume() {
+        assert!(
+            MESH_WGSL.contains("ambient_term = probe_irradiance * albedo * kd_ibl + specular_ibl;"),
+            "the probe branch must assign `ambient_term`, replacing whatever the \
+             ambient/IBL path produced"
+        );
+        for adding in ["ambient_term +=", "ambient_term = ambient_term +"] {
+            assert!(
+                !MESH_WGSL.contains(adding),
+                "`{adding}` accumulates onto the ambient term; probe irradiance \
+                 already contains the sky, so adding double-counts it"
+            );
+        }
+    }
+
+    /// The shader's coefficient array is a hand-written literal, so nothing but
+    /// this ties it to `MAX_PROBES`. Raising `MAX_PROBES` without raising it
+    /// would leave the upper probes writing past the end of the uniform.
+    #[test]
+    fn the_scene_shader_probe_array_is_sized_from_max_probes() {
+        let expected = format!(
+            "array<vec4<f32>, {}>",
+            bsengine_core::MAX_PROBES * crate::sh::SH_COEFF_COUNT
+        );
+        assert!(
+            MESH_WGSL.contains(&expected),
+            "MESH_WGSL must declare `{expected}`; MAX_PROBES is \
+             {} and there are {} coefficients per probe",
+            bsengine_core::MAX_PROBES,
+            crate::sh::SH_COEFF_COUNT
+        );
+        // The shader's own out-of-range clamp, which cannot be written in terms
+        // of a Rust constant.
+        assert!(
+            MESH_WGSL.contains(&format!("min(idx, {}u)", bsengine_core::MAX_PROBES - 1)),
+            "the shader's probe-index clamp must be MAX_PROBES - 1"
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1251,6 +1251,57 @@ const _: () = assert!(
     "ProbeUniformData must stay exactly PROBE_UNIFORM_SIZE bytes"
 );
 
+/// The world-space box and grid one probe bake was performed for.
+///
+/// [`WgpuSurface::render_frame`] takes this per frame and re-bakes only when it
+/// differs from the last bake, which is what turns "bake once after load" into
+/// a rule the render system can enforce without a second ECS system or any
+/// `Added`/`Changed` bookkeeping.
+///
+/// It describes the **volume**, not the scene inside it. Moving a wall after
+/// load does not re-bake, and the floor keeps the colour the wall used to
+/// bleed onto it -- the accepted cost of baking once rather than every frame.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ProbeVolumeParams {
+    /// World-space minimum corner of the box.
+    pub origin: Vec3,
+    /// World-space size of the box (full extent, not half).
+    pub extent: Vec3,
+    /// Probes per axis, already through
+    /// [`bsengine_core::LightProbeVolume::clamped_resolution`].
+    pub resolution: [u32; 3],
+}
+
+/// World positions of one volume's probes, in the order the scene shader
+/// indexes them: x fastest, then y, then z.
+///
+/// The first probe on each axis sits exactly on the box's minimum face and the
+/// last exactly on its maximum face. Trilinear interpolation is defined by the
+/// eight *corners* of a cell, so lattice-point placement is what makes the
+/// interpolation well-formed; probes at cell centres would leave the outer
+/// half-cell of the volume extrapolating instead.
+fn probe_positions(params: &ProbeVolumeParams) -> Vec<Vec3> {
+    let [rx, ry, rz] = params.resolution;
+    let mut out = Vec::with_capacity((rx * ry * rz) as usize);
+    // `clamped_resolution` guarantees at least 2 per axis; a single probe on an
+    // axis has no cell to span, so it sits on the minimum face.
+    let t = |i: u32, r: u32| {
+        if r <= 1 {
+            0.0
+        } else {
+            i as f32 / (r - 1) as f32
+        }
+    };
+    for z in 0..rz {
+        for y in 0..ry {
+            for x in 0..rx {
+                out.push(params.origin + params.extent * Vec3::new(t(x, rx), t(y, ry), t(z, rz)));
+            }
+        }
+    }
+    out
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 struct CameraUniformData {
@@ -1833,6 +1884,14 @@ pub struct WgpuSurface {
     /// with zeroed coefficients rather than as a missing binding -- the same
     /// arrangement [`Self::dummy_ibl_cube_view`] gives the IBL maps.
     probe_buffer: wgpu::Buffer,
+    /// The volume [`Self::probe_buffer`]'s contents were baked for, or `None`
+    /// when nothing has been baked and the buffer is still the zeroed,
+    /// `enabled: 0` one construction wrote.
+    ///
+    /// Comparing this against each frame's volume is the whole of the
+    /// bake-once policy: a bake happens when a volume appears or its own
+    /// parameters change, and never otherwise.
+    baked_probe_volume: Option<ProbeVolumeParams>,
     /// Layout of the skybox's texture+sampler group. Held here rather than
     /// built inside `set_skybox_from_rgba` because `probe_capture_sky_pipeline`
     /// is built once at construction and has to bind `SkyboxState::texture_bg`
@@ -2544,8 +2603,15 @@ impl WgpuSurface {
 
         let probe_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("probe uniform"),
+            // COPY_SRC so a test can read back what the bake actually uploaded.
+            // A bake's result is otherwise entirely invisible to the CPU -- it
+            // goes straight from a texture readback into a uniform only the
+            // shader ever sees -- and "the probes were baked" would then only
+            // be assertable indirectly, through pixels.
+            usage: wgpu::BufferUsages::UNIFORM
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
             size: PROBE_UNIFORM_SIZE,
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
         // Explicitly zeroed rather than left to wgpu's lazy zero-init, for the
@@ -3149,6 +3215,8 @@ impl WgpuSurface {
             probe_capture_uniform_buffer,
             probe_capture_bind_group,
             probe_buffer,
+            // Nothing baked yet, and `probe_buffer` was just zeroed to match.
+            baked_probe_volume: None,
             sky_tex_bgl,
             egui_ctx,
             egui_renderer,
@@ -3690,9 +3758,6 @@ impl WgpuSurface {
     ///
     /// Probes past [`bsengine_core::MAX_PROBES`] are ignored, matching the
     /// uniform array's fixed size.
-    // Exercised by this module's tests; `render_frame` starts calling it when
-    // the bake is driven from `bsengine-render` (roadmap item 48, task 5).
-    #[allow(dead_code)]
     fn capture_probes(
         &self,
         encoder: &mut wgpu::CommandEncoder,
@@ -3827,8 +3892,6 @@ impl WgpuSurface {
     /// capture matrices were built from) and `solid_angle` from
     /// [`probe_face_texel_solid_angle`] (the real projected solid angle, not a
     /// flat share of the sphere).
-    // See `capture_probes` for why this is `allow(dead_code)` for now.
-    #[allow(dead_code)]
     fn project_captures_to_sh(&self, probe_count: usize) -> Vec<crate::sh::ShL2> {
         let probes = probe_count.min(bsengine_core::MAX_PROBES);
         if probes == 0 {
@@ -3918,6 +3981,97 @@ impl WgpuSurface {
         out
     }
 
+    /// Bakes `volume`'s probe grid into [`Self::probe_buffer`], or uploads a
+    /// disabled grid when `volume` is `None`.
+    ///
+    /// Runs on its own command encoder, submitted before returning, because
+    /// [`Self::project_captures_to_sh`] blocks on a buffer map and so cannot
+    /// see anything still sitting in the frame's unsubmitted encoder.
+    ///
+    /// Expensive by design -- up to `MAX_PROBES * 6` render passes plus a
+    /// synchronous readback -- which is why the caller runs it once rather than
+    /// per frame.
+    fn bake_probes(
+        &self,
+        light_view_proj: Mat4,
+        draw_calls: &[(u64, Mat4, Option<u64>, MaterialParams, Option<String>)],
+        registry: &GpuMeshRegistry,
+        tex_registry: Option<&crate::texture::GpuTextureRegistry>,
+        volume: Option<ProbeVolumeParams>,
+    ) {
+        let mut data = <ProbeUniformData as bytemuck::Zeroable>::zeroed();
+        if let Some(params) = volume {
+            let positions = probe_positions(&params);
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("probe bake encoder"),
+                });
+            self.capture_probes(
+                &mut encoder,
+                light_view_proj,
+                draw_calls,
+                registry,
+                tex_registry,
+                &positions,
+            );
+            self.queue.submit(std::iter::once(encoder.finish()));
+
+            for (probe, sh) in self
+                .project_captures_to_sh(positions.len())
+                .iter()
+                .enumerate()
+            {
+                for (slot, coeff) in sh.coeffs.iter().enumerate() {
+                    data.coeffs[probe][slot] = [coeff.x, coeff.y, coeff.z, 0.0];
+                }
+            }
+            data.origin = params.origin.to_array();
+            data.enabled = 1;
+            data.extent = params.extent.to_array();
+            data.resolution = params.resolution;
+        }
+        // Written even in the `None` case: the binding exists in every frame,
+        // so "no probes" has to be expressed as `enabled: 0` with zeroed
+        // coefficients rather than as a skipped upload -- otherwise removing a
+        // volume would leave the previous bake lighting the scene forever.
+        self.queue
+            .write_buffer(&self.probe_buffer, 0, bytemuck::bytes_of(&data));
+    }
+
+    /// Reads [`Self::probe_buffer`] back, so a test can assert on what the
+    /// shader is actually about to sample rather than on a CPU-side mirror of
+    /// it. Blocks on a buffer map; not for use in a frame.
+    #[cfg(test)]
+    fn read_probe_uniform(&self) -> ProbeUniformData {
+        let staging = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("probe uniform readback"),
+            size: PROBE_UNIFORM_SIZE,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("probe uniform readback encoder"),
+            });
+        encoder.copy_buffer_to_buffer(&self.probe_buffer, 0, &staging, 0, PROBE_UNIFORM_SIZE);
+        self.queue.submit(std::iter::once(encoder.finish()));
+
+        let slice = staging.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        self.device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .expect("map_async never reported a result")
+            .expect("mapping the probe uniform readback buffer failed");
+        let data = *bytemuck::from_bytes::<ProbeUniformData>(&slice.get_mapped_range());
+        staging.unmap();
+        data
+    }
+
     /// Renders one full frame: shadow map, main scene pass, post-processing,
     /// skybox, and the game/editor UI overlay, then presents the swapchain.
     /// Returns the ids of any `UiWidget::Button`s clicked this frame.
@@ -3956,6 +4110,7 @@ impl WgpuSurface {
         taa: Option<bsengine_core::Taa>,
         jitter_clip: (f32, f32),
         unjittered_view_proj: Mat4,
+        light_probes: Option<ProbeVolumeParams>,
     ) -> Result<std::collections::HashSet<String>, String> {
         // Wall-clock CPU time for this call, for `FrameStats::cpu_frame_time_ms`.
         let frame_start = std::time::Instant::now();
@@ -4067,6 +4222,36 @@ impl WgpuSurface {
                 i as u64 * MODEL_STRIDE,
                 bytemuck::cast_slice(&[data]),
             );
+        }
+
+        // --- light probe bake ---
+        // Here, after the light and model uniforms are written and before the
+        // frame's own encoder exists: `capture_probes` reuses both of those
+        // buffers, and `bake_probes` submits its own encoder and blocks on a
+        // readback, which is cleaner to do outside the frame's encoder than
+        // interleaved with it.
+        //
+        // `fast_render` never bakes. 192 render passes plus a synchronous map
+        // is precisely the expensive work that mode exists to skip, and the
+        // neutral result -- an `enabled: 0` grid -- is what the shadow pass's
+        // "clear to nothing occludes anything" is for shadows. Folding it into
+        // the comparison rather than guarding the call keeps a fast_render
+        // surface at zero bakes rather than one per frame.
+        let volume_to_bake = if self.fast_render { None } else { light_probes };
+        // A bake happens only when the volume appears or its own parameters
+        // change. Note this tracks the *volume*, not the scene inside it:
+        // moving a wall after load does not re-bake, and the floor keeps the
+        // colour that wall used to bleed onto it. That is the accepted cost of
+        // baking once, which is what item 48 asked for.
+        if self.baked_probe_volume != volume_to_bake {
+            self.bake_probes(
+                light_view_proj,
+                draw_calls,
+                registry,
+                tex_registry,
+                volume_to_bake,
+            );
+            self.baked_probe_volume = volume_to_bake;
         }
 
         // Per-frame draw-call/triangle counters for the profiler. Local to
@@ -6129,7 +6314,11 @@ mod tests {
         /// *as seen from the origin*, so the front face points at the probe
         /// and back-face culling does not swallow it.
         fn new(corners: [Vec3; 4], emissive: Vec3) -> Self {
-            let surface = pollster::block_on(WgpuSurface::new_offscreen(64, 64, false))
+            Self::build(corners, emissive, false)
+        }
+
+        fn build(corners: [Vec3; 4], emissive: Vec3, fast_render: bool) -> Self {
+            let surface = pollster::block_on(WgpuSurface::new_offscreen(64, 64, fast_render))
                 .expect("an offscreen surface is what every GPU test here uses");
             let mut registry = crate::mesh::GpuMeshRegistry::new(surface.device.clone());
             let normal = (corners[1] - corners[0])
@@ -6225,6 +6414,80 @@ mod tests {
             self.surface.queue.submit(std::iter::once(encoder.finish()));
             self.surface.project_captures_to_sh(positions.len())
         }
+
+        /// One real `render_frame`, with everything this scene does not care
+        /// about at its neutral value. The `Result` is returned rather than
+        /// swallowed so a wgpu validation error fails the test instead of
+        /// becoming a log line.
+        fn render(
+            &mut self,
+            volume: Option<ProbeVolumeParams>,
+        ) -> Result<std::collections::HashSet<String>, String> {
+            let ui_state = bsengine_core::UiState::default();
+            self.surface.render_frame(
+                Mat4::IDENTITY,
+                Vec3::new(0.0, 0.0, 5.0),
+                Mat4::IDENTITY,
+                None,
+                &self.draw_calls,
+                &[],
+                0,
+                &self.registry,
+                LightData::default(),
+                None,
+                &std::collections::HashMap::new(),
+                &ui_state,
+                0.0,
+                0.0,
+                false,
+                false,
+                Mat4::IDENTITY,
+                None,
+                None,
+                None,
+                None,
+                &[],
+                false,
+                false,
+                false,
+                None,
+                None,
+                0.0,
+                &[],
+                None,
+                (0.0, 0.0),
+                Mat4::IDENTITY,
+                volume,
+            )
+        }
+
+        /// Repaints the quad, so a later frame's capture would differ from an
+        /// earlier one's -- the lever that makes "it did not re-bake"
+        /// observable rather than merely asserted about a cached field.
+        fn set_emissive(&mut self, emissive: Vec3) {
+            self.draw_calls[0].3.emissive = emissive;
+        }
+    }
+
+    /// A test volume big enough to hold `ProbeBakeScene`'s quad.
+    fn test_volume(origin: Vec3) -> ProbeVolumeParams {
+        ProbeVolumeParams {
+            origin,
+            extent: Vec3::splat(8.0),
+            resolution: [2, 2, 2],
+        }
+    }
+
+    fn a_red_quad_scene() -> ProbeBakeScene {
+        ProbeBakeScene::new(
+            [
+                Vec3::new(3.0, 0.75, 0.0),
+                Vec3::new(3.0, 0.75, 1.5),
+                Vec3::new(3.0, 2.25, 1.5),
+                Vec3::new(3.0, 2.25, 0.0),
+            ],
+            Vec3::new(20.0, 0.0, 0.0),
+        )
     }
 
     /// The direction an L2 expansion attributes its brightest lobe to, read
@@ -6348,6 +6611,167 @@ mod tests {
             first[0], first[1],
             "two probes at different positions saw identical radiance, which \
              means the per-probe view-projections are not being applied"
+        );
+    }
+
+    /// Probes sit on the grid's lattice points and are indexed x-fastest, and
+    /// the scene shader's `probe_coeff_base` hardcodes that same order. Nothing
+    /// but this ties the two together -- swap them and every probe would be
+    /// read from the wrong lattice corner, which still looks like lighting.
+    #[test]
+    fn probe_positions_sit_on_the_lattice_corners_of_the_box() {
+        let params = ProbeVolumeParams {
+            origin: Vec3::new(-2.0, 1.0, 5.0),
+            extent: Vec3::new(4.0, 6.0, 10.0),
+            // Deliberately unequal per axis: an implementation that walked the
+            // grid in the wrong nesting order still passes on a cube.
+            resolution: [2, 3, 4],
+        };
+        let positions = probe_positions(&params);
+        assert_eq!(positions.len(), 2 * 3 * 4);
+        assert_eq!(
+            positions[0], params.origin,
+            "the first probe must sit exactly on the box's minimum corner"
+        );
+        assert_eq!(
+            positions[positions.len() - 1],
+            params.origin + params.extent,
+            "the last probe must sit exactly on the box's maximum corner -- \
+             probes on cell centres would leave the outer half-cell of the \
+             volume extrapolating"
+        );
+        // x fastest, then y, then z: index (z*ry + y)*rx + x, exactly what
+        // `probe_coeff_base` computes in MESH_WGSL.
+        let [rx, ry, _rz] = params.resolution;
+        for (i, p) in positions.iter().enumerate() {
+            let x = i as u32 % rx;
+            let y = (i as u32 / rx) % ry;
+            let z = i as u32 / (rx * ry);
+            let expected = params.origin
+                + params.extent
+                    * Vec3::new(
+                        x as f32 / (rx - 1) as f32,
+                        y as f32 / (ry - 1) as f32,
+                        z as f32 / 3.0,
+                    );
+            assert!(
+                (*p - expected).length() < 1e-5,
+                "probe {i} is at {p:?} but x-fastest ordering puts it at \
+                 {expected:?}"
+            );
+        }
+    }
+
+    /// "Automatic bake once after load", as actually enforced: a volume is
+    /// baked when it appears, is **not** re-baked while it is unchanged even
+    /// though the scene inside it moved, is re-baked when the volume itself
+    /// changes, and is replaced by a disabled grid when it goes away.
+    ///
+    /// The middle case is the one worth writing a GPU test for. It is the
+    /// documented cost of baking once -- move a wall after load and the floor
+    /// keeps the old colour -- and it is asserted here by repainting the quad
+    /// between two frames and requiring the uploaded coefficients not to
+    /// budge. Asserting on `baked_probe_volume` alone would only restate the
+    /// cache key back to itself.
+    #[test]
+    fn a_volume_is_baked_once_and_rebaked_only_when_the_volume_itself_changes() {
+        let mut scene = a_red_quad_scene();
+        assert_eq!(scene.surface.baked_probe_volume, None);
+        assert_eq!(
+            scene.surface.read_probe_uniform().enabled,
+            0,
+            "a fresh surface must start with probes disabled, or every scene \
+             that never places a volume would be lit by whatever the buffer \
+             happened to contain"
+        );
+
+        let volume = test_volume(Vec3::splat(-4.0));
+        scene.render(Some(volume)).expect(
+            "a frame with a probe volume must render without a \
+                     validation error",
+        );
+        assert_eq!(scene.surface.baked_probe_volume, Some(volume));
+        let baked = scene.surface.read_probe_uniform();
+        assert_eq!(baked.enabled, 1);
+        assert_eq!(baked.origin, volume.origin.to_array());
+        assert_eq!(baked.extent, volume.extent.to_array());
+        assert_eq!(baked.resolution, volume.resolution);
+        assert!(
+            baked.coeffs[..8]
+                .iter()
+                .all(|probe| probe[0][0].abs() > 1e-4),
+            "every probe of a 2x2x2 grid must have captured something; an \
+             all-zero l=0 means the bake ran but drew nothing"
+        );
+
+        // Same volume, different scene. The bake must not re-run.
+        scene.set_emissive(Vec3::new(0.0, 20.0, 0.0));
+        scene
+            .render(Some(volume))
+            .expect("a second frame must render");
+        let after = scene.surface.read_probe_uniform();
+        assert_eq!(
+            after.coeffs[0], baked.coeffs[0],
+            "the volume did not change, so no re-bake should have happened -- \
+             repainting the quad red-to-green must leave the baked \
+             coefficients exactly as they were"
+        );
+
+        // Moving the volume is a change to the volume, so it does re-bake --
+        // and now picks up the green quad.
+        let moved = test_volume(Vec3::splat(-3.0));
+        scene
+            .render(Some(moved))
+            .expect("a third frame must render");
+        assert_eq!(scene.surface.baked_probe_volume, Some(moved));
+        let rebaked = scene.surface.read_probe_uniform();
+        assert_eq!(rebaked.origin, moved.origin.to_array());
+        assert!(
+            rebaked.coeffs[0][0][1] > rebaked.coeffs[0][0][0],
+            "the re-bake must see the *current* scene: the quad is green now, \
+             so probe 0's l=0 should be green-dominant, got {:?}",
+            rebaked.coeffs[0][0]
+        );
+
+        // Removing the volume uploads the disabled grid rather than leaving
+        // the last bake lighting the scene forever.
+        scene.render(None).expect("a fourth frame must render");
+        assert_eq!(scene.surface.baked_probe_volume, None);
+        let cleared = scene.surface.read_probe_uniform();
+        assert_eq!(cleared.enabled, 0);
+        assert_eq!(cleared.coeffs[0][0], [0.0; 4]);
+    }
+
+    /// `fast_render` -- the mode CI's headless replays use -- must never bake.
+    /// A bake is up to 192 render passes and a synchronous readback, which is
+    /// exactly the expensive work that mode exists to skip; the neutral result
+    /// is a disabled grid, the same way the shadow pass still clears its map
+    /// to "nothing occludes anything".
+    #[test]
+    fn a_fast_render_surface_never_bakes_a_probe_volume() {
+        let mut scene = ProbeBakeScene::build(
+            [
+                Vec3::new(3.0, 0.75, 0.0),
+                Vec3::new(3.0, 0.75, 1.5),
+                Vec3::new(3.0, 2.25, 1.5),
+                Vec3::new(3.0, 2.25, 0.0),
+            ],
+            Vec3::new(20.0, 0.0, 0.0),
+            true,
+        );
+        scene
+            .render(Some(test_volume(Vec3::splat(-4.0))))
+            .expect("a fast_render frame with a volume must still render");
+        assert_eq!(
+            scene.surface.baked_probe_volume, None,
+            "fast_render must leave the surface with nothing baked, so the \
+             next frame does not try again"
+        );
+        assert_eq!(
+            scene.surface.read_probe_uniform().enabled,
+            0,
+            "fast_render skips the bake, so probes must be disabled rather \
+             than enabled over zeroed coefficients"
         );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -691,6 +691,348 @@ fn fs_sky(in: SkyOut) -> @location(0) vec4<f32> {
 }
 "#;
 
+/// The scene shader used to capture light probes.
+///
+/// A near-copy of [`MESH_WGSL`] with exactly two deliberate differences:
+///
+///  1. The camera comes from a per-face dynamic-offset uniform instead of
+///     `camera`, because one bake renders `probes * 6` views inside a single
+///     command encoder and `queue.write_buffer` cannot vary between passes of
+///     one submission -- the same reason the point-shadow pass has its own
+///     per-face uniform.
+///  2. **It shades direct light only**: the directional light, the point
+///     lights, the spot lights, the flat ambient term and emissive. It never
+///     samples the IBL cubes and never samples probes.
+///
+/// Point 2 is not an optimisation, it is what makes the bake terminate.
+/// Probe irradiance is *derived from* what this shader outputs; if this
+/// shader also read probe or IBL irradiance, the bake would be feeding its
+/// own output back in -- probes lighting probes, and (with IBL) sky light
+/// counted twice, since the skybox is already captured as this pass's
+/// background. The result is deliberately **one bounce**.
+///
+/// `LightUniform` must stay byte-identical to the copies in [`MESH_WGSL`] and
+/// [`TERRAIN_WGSL`]: all three read the same `light_buffer`.
+const PROBE_CAPTURE_WGSL: &str = r#"
+const MAX_POINT_LIGHTS: u32 = 8u;
+const MAX_SPOT_LIGHTS: u32 = 8u;
+const PI: f32 = 3.14159265358979323846;
+struct CaptureUniform {
+    view_proj: mat4x4<f32>,
+    light_view_proj: mat4x4<f32>,
+    inv_view_proj: mat4x4<f32>,
+    probe_pos: vec3<f32>,
+    _pad: f32,
+};
+struct ModelUniform {
+    model: mat4x4<f32>,
+    metallic: f32,
+    roughness: f32,
+    _pad0: f32,
+    _pad1: f32,
+    emissive: vec3<f32>,
+    _pad2: f32,
+    base_color: vec3<f32>,
+    opacity: f32,
+};
+struct PointLightEntry {
+    position: vec3<f32>,
+    _pad0: f32,
+    color: vec3<f32>,
+    intensity: f32,
+    range: f32,
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
+};
+struct SpotLightEntry {
+    position: vec3<f32>,
+    _pad0: f32,
+    direction: vec3<f32>,
+    inner_cos: f32,
+    color: vec3<f32>,
+    outer_cos: f32,
+    intensity: f32,
+    range: f32,
+    _pad1: f32,
+    _pad2: f32,
+};
+struct LightUniform {
+    direction: vec3<f32>,
+    _pad0: f32,
+    color: vec3<f32>,
+    _pad1: f32,
+    ambient: vec3<f32>,
+    num_point_lights: u32,
+    point_lights: array<PointLightEntry, 8>,
+    num_spot_lights: u32,
+    ibl_enabled: u32,
+    ibl_max_mip: f32,
+    _pad4: f32,
+    spot_lights: array<SpotLightEntry, 8>,
+};
+@group(0) @binding(0) var<uniform> capture: CaptureUniform;
+@group(1) @binding(0) var<uniform> model_data: ModelUniform;
+@group(2) @binding(0) var<uniform> light: LightUniform;
+@group(2) @binding(1) var shadow_sampler: sampler_comparison;
+@group(2) @binding(2) var shadow_map: texture_depth_2d;
+@group(2) @binding(4) var point_shadow_map: texture_2d_array<f32>;
+// Bindings 3 and 5..8 of group 2 exist in the layout (the point-shadow
+// sampler and the three IBL resources) and are deliberately NOT declared
+// here: an unused binding is legal, and declaring the IBL cubes is the first
+// step toward accidentally sampling them.
+@group(3) @binding(0) var t_diffuse: texture_2d<f32>;
+@group(3) @binding(1) var s_diffuse: sampler;
+
+struct VertIn {
+    @location(0) pos: vec3<f32>,
+    @location(1) col: vec3<f32>,
+    @location(2) normal: vec3<f32>,
+    @location(3) uv: vec2<f32>,
+}
+struct VertOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) col: vec3<f32>,
+    @location(1) world_normal: vec3<f32>,
+    @location(2) uv: vec2<f32>,
+    @location(3) world_pos: vec3<f32>,
+    @location(4) light_space_pos: vec4<f32>,
+}
+@vertex
+fn vs_capture(in: VertIn) -> VertOut {
+    var out: VertOut;
+    let world_pos4 = model_data.model * vec4<f32>(in.pos, 1.0);
+    out.clip_pos = capture.view_proj * world_pos4;
+    out.world_pos = world_pos4.xyz;
+    out.col = in.col;
+    let normal_matrix = mat3x3<f32>(
+        model_data.model[0].xyz,
+        model_data.model[1].xyz,
+        model_data.model[2].xyz,
+    );
+    out.world_normal = normalize(normal_matrix * in.normal);
+    out.uv = in.uv;
+    out.light_space_pos = capture.light_view_proj * world_pos4;
+    return out;
+}
+fn shadow_factor(lsp: vec4<f32>) -> f32 {
+    let proj = lsp.xyz / lsp.w;
+    let uv = proj.xy * vec2<f32>(0.5, -0.5) + vec2<f32>(0.5, 0.5);
+    let depth = proj.z;
+    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 || depth < 0.0 || depth > 1.0) {
+        return 1.0;
+    }
+    return textureSampleCompare(shadow_map, shadow_sampler, uv, depth - 0.003);
+}
+fn point_shadow_factor(light_index: u32, to_frag: vec3<f32>) -> f32 {
+    let ax = abs(to_frag.x);
+    let ay = abs(to_frag.y);
+    let az = abs(to_frag.z);
+    var face: u32;
+    var u: f32;
+    var v: f32;
+    var ma: f32;
+    if (ax >= ay && ax >= az) {
+        ma = ax;
+        if (to_frag.x > 0.0) {
+            face = 0u;
+            u = -to_frag.z;
+            v = -to_frag.y;
+        } else {
+            face = 1u;
+            u = to_frag.z;
+            v = -to_frag.y;
+        }
+    } else if (ay >= ax && ay >= az) {
+        ma = ay;
+        if (to_frag.y > 0.0) {
+            face = 2u;
+            u = to_frag.x;
+            v = to_frag.z;
+        } else {
+            face = 3u;
+            u = to_frag.x;
+            v = -to_frag.z;
+        }
+    } else {
+        ma = az;
+        if (to_frag.z > 0.0) {
+            face = 4u;
+            u = to_frag.x;
+            v = -to_frag.y;
+        } else {
+            face = 5u;
+            u = -to_frag.x;
+            v = -to_frag.y;
+        }
+    }
+    let ndc = vec2<f32>(u, v) / max(ma, 0.0001);
+    let uv = ndc * vec2<f32>(0.5, -0.5) + vec2<f32>(0.5, 0.5);
+    let size = 512.0;
+    let px = vec2<i32>(clamp(uv, vec2<f32>(0.0), vec2<f32>(0.999999)) * size);
+    let layer = i32(light_index * 6u + face);
+    let stored = textureLoad(point_shadow_map, px, layer, 0).r;
+    let dist = length(to_frag);
+    if (dist - 0.1 > stored) {
+        return 0.0;
+    }
+    return 1.0;
+}
+fn distribution_ggx(n_dot_h: f32, roughness: f32) -> f32 {
+    let a = roughness * roughness;
+    let a2 = a * a;
+    let denom = n_dot_h * n_dot_h * (a2 - 1.0) + 1.0;
+    return a2 / (PI * denom * denom);
+}
+fn geometry_schlick_ggx(ndotx: f32, roughness: f32) -> f32 {
+    let r = roughness + 1.0;
+    let k = r * r / 8.0;
+    return ndotx / (ndotx * (1.0 - k) + k);
+}
+fn geometry_smith(n_dot_v: f32, n_dot_l: f32, roughness: f32) -> f32 {
+    return geometry_schlick_ggx(n_dot_v, roughness) * geometry_schlick_ggx(n_dot_l, roughness);
+}
+fn fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
+    return f0 + (vec3<f32>(1.0, 1.0, 1.0) - f0) * pow(clamp(1.0 - cos_theta, 0.0, 1.0), 5.0);
+}
+@fragment
+fn fs_capture(in: VertOut) -> @location(0) vec4<f32> {
+    let n = normalize(in.world_normal);
+    // The "eye" for this capture is the probe itself: what the probe records
+    // is the radiance leaving each surface *toward the probe*.
+    let v = normalize(capture.probe_pos - in.world_pos);
+    let albedo = textureSample(t_diffuse, s_diffuse, in.uv).rgb * in.col * model_data.base_color;
+    let metallic = model_data.metallic;
+    let roughness = max(model_data.roughness, 0.04);
+    let f0 = mix(vec3<f32>(0.04, 0.04, 0.04), albedo, metallic);
+    let n_dot_v = max(dot(n, v), 0.0001);
+    let lit = shadow_factor(in.light_space_pos);
+
+    var lo = vec3<f32>(0.0, 0.0, 0.0);
+    {
+        let l = normalize(-light.direction);
+        let h = normalize(v + l);
+        let n_dot_l = max(dot(n, l), 0.0);
+        let n_dot_h = max(dot(n, h), 0.0);
+        let h_dot_v = max(dot(h, v), 0.0);
+        let ndf = distribution_ggx(n_dot_h, roughness);
+        let g = geometry_smith(n_dot_v, n_dot_l, roughness);
+        let f = fresnel_schlick(h_dot_v, f0);
+        let kd = (vec3<f32>(1.0, 1.0, 1.0) - f) * (1.0 - metallic);
+        let specular = (ndf * g * f) / (4.0 * n_dot_v * n_dot_l + 0.0001);
+        lo += (kd * albedo / PI + specular) * light.color * n_dot_l * lit;
+    }
+    for (var i: u32 = 0u; i < light.num_point_lights; i++) {
+        let pl = light.point_lights[i];
+        let to_light = pl.position - in.world_pos;
+        let dist = length(to_light);
+        if dist < pl.range {
+            let l = normalize(to_light);
+            let h = normalize(v + l);
+            let n_dot_l = max(dot(n, l), 0.0);
+            let n_dot_h = max(dot(n, h), 0.0);
+            let h_dot_v = max(dot(h, v), 0.0);
+            let t = 1.0 - dist / pl.range;
+            let ndf = distribution_ggx(n_dot_h, roughness);
+            let g = geometry_smith(n_dot_v, n_dot_l, roughness);
+            let f = fresnel_schlick(h_dot_v, f0);
+            let kd = (vec3<f32>(1.0, 1.0, 1.0) - f) * (1.0 - metallic);
+            let specular = (ndf * g * f) / (4.0 * n_dot_v * n_dot_l + 0.0001);
+            let pt_lit = point_shadow_factor(i, -to_light);
+            lo += (kd * albedo / PI + specular) * pl.color * (pl.intensity * t * t) * n_dot_l * pt_lit;
+        }
+    }
+    for (var j: u32 = 0u; j < light.num_spot_lights; j++) {
+        let sl = light.spot_lights[j];
+        let to_light = sl.position - in.world_pos;
+        let dist = length(to_light);
+        if dist < sl.range {
+            let light_dir = normalize(to_light);
+            let cos_angle = dot(-light_dir, sl.direction);
+            let spot_factor = smoothstep(sl.outer_cos, sl.inner_cos, cos_angle);
+            if spot_factor > 0.0 {
+                let l = light_dir;
+                let h = normalize(v + l);
+                let n_dot_l = max(dot(n, l), 0.0);
+                let n_dot_h = max(dot(n, h), 0.0);
+                let h_dot_v = max(dot(h, v), 0.0);
+                let t = 1.0 - dist / sl.range;
+                let ndf = distribution_ggx(n_dot_h, roughness);
+                let g = geometry_smith(n_dot_v, n_dot_l, roughness);
+                let f = fresnel_schlick(h_dot_v, f0);
+                let kd = (vec3<f32>(1.0, 1.0, 1.0) - f) * (1.0 - metallic);
+                let specular = (ndf * g * f) / (4.0 * n_dot_v * n_dot_l + 0.0001);
+                lo += (kd * albedo / PI + specular) * sl.color * (sl.intensity * t * t * spot_factor) * n_dot_l;
+            }
+        }
+    }
+    // The flat ambient term stays -- it is a *direct* constant light in this
+    // engine's model, not a bounce, so it cannot make the bake recursive.
+    // What is deliberately missing is the image-based-lighting branch
+    // MESH_WGSL has at this exact point: see this shader's doc comment.
+    let ambient_term = light.ambient * albedo;
+    let color = ambient_term + lo + model_data.emissive;
+    return vec4<f32>(color, 1.0);
+}
+"#;
+
+/// The skybox, drawn as the background of every probe capture face.
+///
+/// A separate module rather than another entry point in
+/// [`PROBE_CAPTURE_WGSL`]: the sky texture would have to occupy a
+/// `@group @binding` slot that shader already gives a different type, and two
+/// conflicting declarations of one binding is a WGSL validation error whether
+/// or not both entry points use them.
+///
+/// The probe must see the sky, because sky light reaching a wall and bouncing
+/// onto the floor is exactly the effect probes exist to capture. Sampling the
+/// sky here (as *background radiance*) is not the same as sampling IBL: this
+/// is the environment itself, at one texel, not an irradiance convolution fed
+/// back into the shading.
+const PROBE_CAPTURE_SKY_WGSL: &str = r#"
+const PI: f32 = 3.14159265358979323846;
+struct CaptureUniform {
+    view_proj: mat4x4<f32>,
+    light_view_proj: mat4x4<f32>,
+    inv_view_proj: mat4x4<f32>,
+    probe_pos: vec3<f32>,
+    _pad: f32,
+};
+@group(0) @binding(0) var<uniform> capture: CaptureUniform;
+@group(1) @binding(0) var t_sky: texture_2d<f32>;
+@group(1) @binding(1) var s_sky: sampler;
+struct SkyOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) ndc: vec2<f32>,
+};
+@vertex
+fn vs_capture_sky(@builtin(vertex_index) vi: u32) -> SkyOut {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 3.0, -1.0),
+        vec2<f32>(-1.0,  3.0),
+    );
+    let p = positions[vi];
+    var out: SkyOut;
+    // z = w so NDC depth = 1.0; LessEqual passes only where no geometry drew.
+    out.clip_pos = vec4<f32>(p.x, p.y, 1.0, 1.0);
+    out.ndc = p;
+    return out;
+}
+@fragment
+fn fs_capture_sky(in: SkyOut) -> @location(0) vec4<f32> {
+    // Same equirectangular lookup SKYBOX_WGSL does, through this face's own
+    // inverse view-projection instead of the camera's.
+    let world = capture.inv_view_proj * vec4<f32>(in.ndc.x, in.ndc.y, 1.0, 1.0);
+    let dir = normalize(world.xyz);
+    let phi = atan2(dir.z, dir.x);
+    let theta = asin(clamp(dir.y, -1.0, 1.0));
+    let u = phi / (2.0 * PI) + 0.5;
+    let v = 0.5 - theta / PI;
+    return textureSample(t_sky, s_sky, vec2<f32>(u, v));
+}
+"#;
+
 pub(crate) const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 const MAX_OBJECTS: usize = 1024;
 const MODEL_STRIDE: u64 = 256;
@@ -720,6 +1062,28 @@ const POINT_SHADOW_MAP_SIZE: u32 = 512;
 /// `MODEL_STRIDE`'s 256-byte convention (`PointShadowUniformData` is 80 bytes;
 /// 256 satisfies wgpu's minimum uniform buffer offset alignment on every backend).
 const POINT_SHADOW_STRIDE: u64 = 256;
+
+/// Edge length, in texels, of one cube face of a probe capture.
+///
+/// Deliberately tiny. The capture's entire purpose is to be reduced to nine
+/// SH coefficients immediately afterward, and an L2 expansion cannot represent
+/// anything finer than a very broad lobe -- every texel above this resolution
+/// is work whose result is thrown away by the projection. 16x16x6 is already
+/// 1536 samples per probe, far more than nine coefficients need.
+const PROBE_FACE_SIZE: u32 = 16;
+/// Per-face dynamic-offset stride for `probe_capture_uniform_buffer`, same
+/// 256-byte convention as `MODEL_STRIDE` and `POINT_SHADOW_STRIDE`
+/// (`ProbeCaptureUniformData` is 208 bytes).
+const PROBE_CAPTURE_STRIDE: u64 = 256;
+/// Far plane of each probe capture frustum. A probe integrates the whole
+/// sphere around it, so this is "how far away scene geometry still counts",
+/// not a light range -- generous, because a wall that falls outside it simply
+/// vanishes from the probe and its colour never bleeds.
+const PROBE_CAPTURE_RANGE: f32 = 200.0;
+/// Colour format of the probe capture target. HDR, like the main scene buffer:
+/// probe radiance is pre-tonemap and routinely exceeds 1.0, and clipping it to
+/// 8-bit here would quietly cap how much light a probe can carry.
+const PROBE_CAPTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
 
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
@@ -783,6 +1147,28 @@ struct PointShadowUniformData {
     light_pos: [f32; 3],
     _pad: f32,
 }
+
+/// One probe capture face's camera, addressed by dynamic offset. Mirrors
+/// `CaptureUniform` in [`PROBE_CAPTURE_WGSL`] and [`PROBE_CAPTURE_SKY_WGSL`].
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct ProbeCaptureUniformData {
+    view_proj: [[f32; 4]; 4],
+    light_view_proj: [[f32; 4]; 4],
+    /// Rotation-only inverse of `view_proj`, for the sky background.
+    inv_view_proj: [[f32; 4]; 4],
+    /// The probe's world position, which is this capture's eye point.
+    probe_pos: [f32; 3],
+    _pad: f32,
+}
+
+// The dynamic offset of face `n` is `n * PROBE_CAPTURE_STRIDE`, so a struct
+// larger than the stride would have consecutive faces overwriting each other's
+// tails -- silently, and only for the faces after the first.
+const _: () = assert!(
+    std::mem::size_of::<ProbeCaptureUniformData>() as u64 <= PROBE_CAPTURE_STRIDE,
+    "ProbeCaptureUniformData must fit within PROBE_CAPTURE_STRIDE"
+);
 
 /// A single point light entry for the GPU buffer.
 pub struct PointLightEntry {
@@ -1005,22 +1391,132 @@ fn jittered_view_proj(view_proj: Mat4, cam_proj: Mat4, jitter_clip: (f32, f32)) 
     jittered_proj * (cam_proj.inverse() * view_proj)
 }
 
+/// The `(forward, up)` pair of every cube face, in face order.
+///
+/// The standard cubemap face orientation convention (+Y/-Y up-vectors on the
+/// X/Z faces to avoid a degenerate look-at when looking straight up/down).
+///
+/// **This is the single authority for the cube-face convention in this file.**
+/// [`point_light_face_view_projs`] builds its `look_at_rh` matrices from it,
+/// and [`probe_face_texel_direction`] recovers a per-texel direction from it,
+/// so the direction a probe attributes a captured texel to cannot drift from
+/// the matrix that texel was actually rendered with. Writing a second
+/// convention next to this one is how probes end up lit from the wrong side --
+/// a bug whose output still looks like plausible lighting.
+const CUBE_FACE_DIRS: [(Vec3, Vec3); 6] = [
+    (Vec3::X, Vec3::NEG_Y),
+    (Vec3::NEG_X, Vec3::NEG_Y),
+    (Vec3::Y, Vec3::Z),
+    (Vec3::NEG_Y, Vec3::NEG_Z),
+    (Vec3::Z, Vec3::NEG_Y),
+    (Vec3::NEG_Z, Vec3::NEG_Y),
+];
+
+/// The 90-degree square projection every cube face is rendered through.
+fn cube_face_projection(range: f32) -> Mat4 {
+    Mat4::perspective_rh(std::f32::consts::FRAC_PI_2, 1.0, 0.05, range.max(0.5))
+}
+
 /// Computes the 6 face view-projection matrices for a point light's cube shadow
-/// map, one per axis-aligned direction, using the standard cubemap face
-/// orientation convention (+Y/-Y up-vectors on the X/Z faces to avoid a
-/// degenerate look-at when looking straight up/down).
+/// map, one per axis-aligned direction, using [`CUBE_FACE_DIRS`].
 fn point_light_face_view_projs(position: Vec3, range: f32) -> [Mat4; 6] {
-    let far = range.max(0.5);
-    let proj = Mat4::perspective_rh(std::f32::consts::FRAC_PI_2, 1.0, 0.05, far);
-    let dirs: [(Vec3, Vec3); 6] = [
-        (Vec3::X, Vec3::NEG_Y),
-        (Vec3::NEG_X, Vec3::NEG_Y),
-        (Vec3::Y, Vec3::Z),
-        (Vec3::NEG_Y, Vec3::NEG_Z),
-        (Vec3::Z, Vec3::NEG_Y),
-        (Vec3::NEG_Z, Vec3::NEG_Y),
-    ];
-    dirs.map(|(dir, up)| proj * Mat4::look_at_rh(position, position + dir, up))
+    let proj = cube_face_projection(range);
+    CUBE_FACE_DIRS.map(|(dir, up)| proj * Mat4::look_at_rh(position, position + dir, up))
+}
+
+/// The rotation-only inverse view-projection of each cube face, which is what
+/// an equirectangular skybox lookup needs: dropping the translation leaves a
+/// matrix that maps an NDC corner to a *direction*, so the sky stays infinitely
+/// far away instead of sliding past the probe.
+///
+/// Built the same way `bsengine-render`'s `sky_vp_inv` is (strip the
+/// translation column, then invert the product), so a probe's captured sky is
+/// the same image the camera would see looking that way.
+fn probe_face_sky_vp_invs(range: f32) -> [Mat4; 6] {
+    let proj = cube_face_projection(range);
+    CUBE_FACE_DIRS.map(|(dir, up)| {
+        let view = Mat4::look_at_rh(Vec3::ZERO, dir, up);
+        let view_rot = Mat4::from_cols(view.x_axis, view.y_axis, view.z_axis, glam::Vec4::W);
+        (proj * view_rot).inverse()
+    })
+}
+
+/// The world-space direction, as seen from the probe, of texel `(x, y)` on
+/// cube face `face` of a probe capture.
+///
+/// Derived from [`CUBE_FACE_DIRS`] and glam's `look_at_rh`, not from a
+/// hand-written cube convention. `look_at_rh` builds the basis
+/// `f = forward, s = normalize(f x up), u = s x f` and maps a world offset `p`
+/// to view space as `(dot(s, p), dot(u, p), dot(-f, p))`. A 90-degree square
+/// perspective projects view-space `(vx, vy, vz)` to
+/// `ndc = (vx / -vz, vy / -vz)`, so the ray through `ndc` is view-space
+/// `(ndc.x, ndc.y, -1)`, which is world-space `f + ndc.x * s + ndc.y * u`.
+///
+/// `probe_face_texel_direction_matches_the_capture_matrix_ndc` closes that
+/// derivation against the real matrices rather than trusting the algebra.
+fn probe_face_texel_direction(face: usize, x: u32, y: u32) -> Vec3 {
+    let (ndc_x, ndc_y) = probe_face_texel_ndc(x, y);
+    let (forward, up) = CUBE_FACE_DIRS[face];
+    let s = forward.cross(up).normalize();
+    let u = s.cross(forward);
+    (forward + s * ndc_x + u * ndc_y).normalize()
+}
+
+/// The NDC coordinates of the centre of texel `(x, y)` on a probe capture
+/// face. `y` counts down the framebuffer while NDC `y` counts up, hence the
+/// flip.
+fn probe_face_texel_ndc(x: u32, y: u32) -> (f32, f32) {
+    let n = PROBE_FACE_SIZE as f32;
+    (
+        ((x as f32 + 0.5) / n) * 2.0 - 1.0,
+        1.0 - ((y as f32 + 0.5) / n) * 2.0,
+    )
+}
+
+/// Decodes one IEEE-754 binary16 value, the element type of the `Rgba16Float`
+/// probe capture target.
+///
+/// Hand-rolled because this workspace has no `half` dependency and pulling one
+/// in for a dozen lines of bit twiddling is not worth the supply-chain
+/// surface. `f16_round_trips_exact_values` and
+/// `f16_decodes_subnormals_and_specials` pin the three branches.
+fn f16_bits_to_f32(bits: u16) -> f32 {
+    let sign = if bits & 0x8000 != 0 { -1.0f32 } else { 1.0 };
+    let exp = ((bits >> 10) & 0x1f) as i32;
+    let frac = (bits & 0x03ff) as f32;
+    if exp == 0 {
+        // Subnormal (and zero): the value is frac * 2^-24, with no implicit
+        // leading 1.
+        sign * frac * 2.0f32.powi(-24)
+    } else if exp == 0x1f {
+        if frac == 0.0 {
+            sign * f32::INFINITY
+        } else {
+            f32::NAN
+        }
+    } else {
+        sign * (1.0 + frac / 1024.0) * 2.0f32.powi(exp - 15)
+    }
+}
+
+/// The solid angle, in steradians, that texel `(x, y)` of a probe capture face
+/// subtends at the probe.
+///
+/// A cube face is a *flat* square held at unit distance, so its texels do not
+/// all cover the same slice of the sphere: a corner texel is both further away
+/// and seen edge-on. The projected solid angle of the texel at `(u, v)` in
+/// `[-1, 1]` is therefore `dA * (1 + u^2 + v^2)^(-3/2)` with `dA = 4 / n^2`.
+///
+/// The tempting shortcut is a flat `4*PI / (6*n*n)` for every texel. It is
+/// wrong in a way that survives eyeballing: it over-weights the face corners
+/// (by up to `3^(3/2)`, about 5.2x, at the very corner), which biases every
+/// probe's directional terms toward the cube's diagonals.
+/// `probe_face_texel_solid_angles_sum_to_the_full_sphere` and
+/// `a_corner_texel_covers_less_sky_than_a_centre_texel` pin both properties.
+fn probe_face_texel_solid_angle(x: u32, y: u32) -> f32 {
+    let n = PROBE_FACE_SIZE as f32;
+    let (u, v) = probe_face_texel_ndc(x, y);
+    (4.0 / (n * n)) * (1.0 + u * u + v * v).powf(-1.5)
 }
 
 /// Everything group 2 ("light") binds, gathered into one struct.
@@ -1135,6 +1631,33 @@ pub struct WgpuSurface {
     point_shadow_sampler: wgpu::Sampler,
     point_shadow_uniform_buffer: wgpu::Buffer,
     point_shadow_bind_group: wgpu::BindGroup,
+    /// Probe capture target: one cube face per `(probe, face)` as an array
+    /// layer, laid out exactly like `_point_shadow_color_texture`
+    /// (`probe * 6 + face`). Underscore-prefixed only in the sense that
+    /// nothing samples it in a shader -- `project_captures_to_sh` copies out
+    /// of it, which is why it is `COPY_SRC`.
+    probe_capture_texture: crate::profiler::TrackedTexture,
+    /// One shared depth buffer for the capture, cleared per face, exactly as
+    /// the point-shadow pass reuses `point_shadow_depth_view`.
+    _probe_capture_depth_texture: crate::profiler::TrackedTexture,
+    probe_capture_depth_view: wgpu::TextureView,
+    /// Draws scene geometry into a capture face with **direct light only** --
+    /// see [`PROBE_CAPTURE_WGSL`] for why that restriction is load-bearing.
+    probe_capture_pipeline: wgpu::RenderPipeline,
+    /// Fills the rest of a capture face with the skybox, when one is loaded.
+    probe_capture_sky_pipeline: wgpu::RenderPipeline,
+    /// Per-face camera for the capture, one `PROBE_CAPTURE_STRIDE` slot per
+    /// `(probe, face)`. A capture renders every face inside one command
+    /// encoder, and `queue.write_buffer` cannot vary between passes of a
+    /// single submission -- the same constraint that gave the point-shadow
+    /// pass its own per-face uniform buffer.
+    probe_capture_uniform_buffer: wgpu::Buffer,
+    probe_capture_bind_group: wgpu::BindGroup,
+    /// Layout of the skybox's texture+sampler group. Held here rather than
+    /// built inside `set_skybox_from_rgba` because `probe_capture_sky_pipeline`
+    /// is built once at construction and has to bind `SkyboxState::texture_bg`
+    /// against the very same layout object.
+    sky_tex_bgl: wgpu::BindGroupLayout,
     egui_ctx: egui::Context,
     egui_renderer: egui_wgpu::Renderer,
     skybox: Option<SkyboxState>,
@@ -1960,6 +2483,207 @@ impl WgpuSurface {
                 cache: None,
             });
 
+        // --- light probe capture (one cube per probe, MAX_PROBES of them) ---
+        let probe_capture_texture = crate::profiler::create_tracked_texture(
+            &device,
+            &wgpu::TextureDescriptor {
+                label: Some("probe capture array"),
+                size: wgpu::Extent3d {
+                    width: PROBE_FACE_SIZE,
+                    height: PROBE_FACE_SIZE,
+                    depth_or_array_layers: (bsengine_core::MAX_PROBES * 6) as u32,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: PROBE_CAPTURE_FORMAT,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[],
+            },
+        );
+        let probe_capture_depth_texture = crate::profiler::create_tracked_texture(
+            &device,
+            &wgpu::TextureDescriptor {
+                label: Some("probe capture depth"),
+                size: wgpu::Extent3d {
+                    width: PROBE_FACE_SIZE,
+                    height: PROBE_FACE_SIZE,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: DEPTH_FORMAT,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[],
+            },
+        );
+        let probe_capture_depth_view =
+            probe_capture_depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let probe_capture_uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("probe capture uniform"),
+            size: PROBE_CAPTURE_STRIDE * (bsengine_core::MAX_PROBES * 6) as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let probe_capture_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("probe capture bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<
+                        ProbeCaptureUniformData,
+                    >() as u64),
+                },
+                count: None,
+            }],
+        });
+        let probe_capture_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("probe capture bg"),
+            layout: &probe_capture_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &probe_capture_uniform_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(
+                        std::mem::size_of::<ProbeCaptureUniformData>() as u64
+                    ),
+                }),
+            }],
+        });
+
+        let probe_capture_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("probe capture shader"),
+            source: wgpu::ShaderSource::Wgsl(PROBE_CAPTURE_WGSL.into()),
+        });
+        // Groups 1..3 are the scene's own model / light / texture groups, so a
+        // capture draw is the main pass's draw with a different camera. Group 2
+        // carries the IBL bindings the capture shader deliberately never
+        // declares; a bind group layout may expose more than an entry point
+        // uses.
+        let probe_capture_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("probe capture pipeline layout"),
+                bind_group_layouts: &[&probe_capture_bgl, &model_bgl, &light_bgl, &texture_bgl],
+                push_constant_ranges: &[],
+            });
+        let probe_capture_pipeline =
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("probe capture pipeline"),
+                layout: Some(&probe_capture_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &probe_capture_shader,
+                    entry_point: "vs_capture",
+                    buffers: std::slice::from_ref(&vertex_buffer_layout),
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &probe_capture_shader,
+                    entry_point: "fs_capture",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: PROBE_CAPTURE_FORMAT,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                // Same culling and depth rules as the opaque mesh pipeline: a
+                // probe should see the scene the camera sees.
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    cull_mode: Some(wgpu::Face::Back),
+                    front_face: wgpu::FrontFace::Ccw,
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: DEPTH_FORMAT,
+                    depth_write_enabled: true,
+                    depth_compare: wgpu::CompareFunction::Less,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
+        let sky_tex_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("sky tex bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+        let probe_capture_sky_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("probe capture sky shader"),
+            source: wgpu::ShaderSource::Wgsl(PROBE_CAPTURE_SKY_WGSL.into()),
+        });
+        let probe_capture_sky_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("probe capture sky pipeline layout"),
+                bind_group_layouts: &[&probe_capture_bgl, &sky_tex_bgl],
+                push_constant_ranges: &[],
+            });
+        let probe_capture_sky_pipeline =
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("probe capture sky pipeline"),
+                layout: Some(&probe_capture_sky_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &probe_capture_sky_shader,
+                    entry_point: "vs_capture_sky",
+                    buffers: &[],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &probe_capture_sky_shader,
+                    entry_point: "fs_capture_sky",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: PROBE_CAPTURE_FORMAT,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    cull_mode: None,
+                    ..Default::default()
+                },
+                // Depth-test only, at NDC depth 1.0: the sky fills exactly the
+                // texels no geometry claimed, and never overwrites one that did.
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: DEPTH_FORMAT,
+                    depth_write_enabled: false,
+                    depth_compare: wgpu::CompareFunction::LessEqual,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("mesh shader"),
             source: wgpu::ShaderSource::Wgsl(MESH_WGSL.into()),
@@ -2204,6 +2928,14 @@ impl WgpuSurface {
             point_shadow_sampler,
             point_shadow_uniform_buffer,
             point_shadow_bind_group,
+            probe_capture_texture,
+            _probe_capture_depth_texture: probe_capture_depth_texture,
+            probe_capture_depth_view,
+            probe_capture_pipeline,
+            probe_capture_sky_pipeline,
+            probe_capture_uniform_buffer,
+            probe_capture_bind_group,
+            sky_tex_bgl,
             egui_ctx,
             egui_renderer,
             skybox: None,
@@ -2429,32 +3161,13 @@ impl WgpuSurface {
             }],
         });
 
-        let sky_tex_bgl = self
-            .device
-            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("sky tex bgl"),
-                entries: &[
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: None,
-                    },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                        count: None,
-                    },
-                ],
-            });
+        // `self.sky_tex_bgl`, not a fresh layout: `probe_capture_sky_pipeline`
+        // was built against that object at construction and binds the very
+        // `texture_bg` created here.
+        let sky_tex_bgl = &self.sky_tex_bgl;
         let texture_bg = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("sky tex bg"),
-            layout: &sky_tex_bgl,
+            layout: sky_tex_bgl,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
@@ -2477,7 +3190,7 @@ impl WgpuSurface {
             .device
             .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("skybox pipeline layout"),
-                bind_group_layouts: &[&sky_uniform_bgl, &sky_tex_bgl],
+                bind_group_layouts: &[&sky_uniform_bgl, sky_tex_bgl],
                 push_constant_ranges: &[],
             });
         let pipeline = self
@@ -2741,6 +3454,253 @@ impl WgpuSurface {
         };
         readback_buffer.unmap();
         timings
+    }
+
+    /// Renders the scene once per probe per cube face into
+    /// `probe_capture_texture`, ready for [`Self::project_captures_to_sh`].
+    ///
+    /// Structurally the point-light shadow loop with a different target: one
+    /// single-layer `TextureView` per `(probe, face)` at layer
+    /// `probe * 6 + face`, a render pass into it, the capture pipeline, the
+    /// per-face uniform by dynamic offset, then the same `draw_calls` walk with
+    /// the model bind group's own dynamic offset.
+    ///
+    /// **The caller must already have uploaded this frame's `light_buffer` and
+    /// `model_buffer`** -- `render_frame` writes both before it reaches any
+    /// pass, and a capture reuses them rather than duplicating that work.
+    ///
+    /// Terrain chunks are not captured. They take a different group-3 layout
+    /// than the capture pipeline is built for, and terrain is ground: it
+    /// receives bounced light far more than it contributes it.
+    ///
+    /// Probes past [`bsengine_core::MAX_PROBES`] are ignored, matching the
+    /// uniform array's fixed size.
+    // Exercised by this module's tests; `render_frame` starts calling it when
+    // the bake is driven from `bsengine-render` (roadmap item 48, task 5).
+    #[allow(dead_code)]
+    fn capture_probes(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        light_view_proj: Mat4,
+        draw_calls: &[(u64, Mat4, Option<u64>, MaterialParams, Option<String>)],
+        registry: &GpuMeshRegistry,
+        tex_registry: Option<&crate::texture::GpuTextureRegistry>,
+        positions: &[Vec3],
+    ) {
+        let probe_count = positions.len().min(bsengine_core::MAX_PROBES);
+        if probe_count == 0 {
+            return;
+        }
+
+        // Every face's uniform is written up front, before a single pass is
+        // encoded, because `queue.write_buffer` is ordered against *submits*,
+        // not against passes: rewriting one slot between passes of this
+        // encoder would give every face the last value written. The
+        // point-shadow loop stages its faces the same way and for the same
+        // reason.
+        let sky_vp_invs = probe_face_sky_vp_invs(PROBE_CAPTURE_RANGE);
+        for (probe_idx, position) in positions.iter().take(probe_count).enumerate() {
+            let view_projs = point_light_face_view_projs(*position, PROBE_CAPTURE_RANGE);
+            for (face, vp) in view_projs.iter().enumerate() {
+                let slot = probe_idx * 6 + face;
+                let data = ProbeCaptureUniformData {
+                    view_proj: vp.to_cols_array_2d(),
+                    light_view_proj: light_view_proj.to_cols_array_2d(),
+                    inv_view_proj: sky_vp_invs[face].to_cols_array_2d(),
+                    probe_pos: position.to_array(),
+                    _pad: 0.0,
+                };
+                self.queue.write_buffer(
+                    &self.probe_capture_uniform_buffer,
+                    slot as u64 * PROBE_CAPTURE_STRIDE,
+                    bytemuck::cast_slice(&[data]),
+                );
+            }
+        }
+
+        for probe_idx in 0..probe_count {
+            for face in 0..6usize {
+                let slot = probe_idx * 6 + face;
+                let layer_view =
+                    self.probe_capture_texture
+                        .create_view(&wgpu::TextureViewDescriptor {
+                            label: Some("probe capture layer view"),
+                            dimension: Some(wgpu::TextureViewDimension::D2),
+                            base_array_layer: slot as u32,
+                            array_layer_count: Some(1),
+                            ..Default::default()
+                        });
+                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("probe capture pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &layer_view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            // The same background the main pass clears to, so a
+                            // probe in an empty scene records the scene's own
+                            // backdrop rather than black. Overwritten by the sky
+                            // pipeline below wherever a skybox is loaded.
+                            load: wgpu::LoadOp::Clear(wgpu::Color {
+                                r: 0.08,
+                                g: 0.08,
+                                b: 0.08,
+                                a: 1.0,
+                            }),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                        view: &self.probe_capture_depth_view,
+                        depth_ops: Some(wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(1.0),
+                            store: wgpu::StoreOp::Store,
+                        }),
+                        stencil_ops: None,
+                    }),
+                    // A bake is `probes * 6` passes -- up to 192 -- which no
+                    // query set can hold a slot pair for, and it happens once
+                    // rather than every frame, so it is deliberately untimed.
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+                let uniform_offset = (slot as u64 * PROBE_CAPTURE_STRIDE) as u32;
+                pass.set_pipeline(&self.probe_capture_pipeline);
+                pass.set_bind_group(0, &self.probe_capture_bind_group, &[uniform_offset]);
+                pass.set_bind_group(2, &self.light_bind_group, &[]);
+                for (i, (mesh_id, _, tex_id, _, _)) in draw_calls.iter().enumerate() {
+                    if i >= MAX_OBJECTS {
+                        break;
+                    }
+                    let Some(mesh) = registry.get(*mesh_id) else {
+                        continue;
+                    };
+                    // Custom-shader draws are captured with the standard
+                    // capture shader: a custom pipeline binds group 0 as the
+                    // camera uniform, which this pass does not have, and a
+                    // custom shader's output is not decomposable into direct
+                    // light anyway.
+                    let tex_bg = tex_id
+                        .and_then(|id| tex_registry.and_then(|r| r.get_bind_group(id)))
+                        .unwrap_or(&self.default_texture_bind_group);
+                    let offset = (i as u64 * MODEL_STRIDE) as u32;
+                    pass.set_bind_group(1, &self.model_bind_group, &[offset]);
+                    pass.set_bind_group(3, tex_bg, &[]);
+                    pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                    pass.set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+                    pass.draw_indexed(0..mesh.index_count, 0, 0..1);
+                }
+                if let Some(sky) = &self.skybox {
+                    pass.set_pipeline(&self.probe_capture_sky_pipeline);
+                    pass.set_bind_group(0, &self.probe_capture_bind_group, &[uniform_offset]);
+                    pass.set_bind_group(1, &sky.texture_bg, &[]);
+                    pass.draw(0..3, 0..1);
+                }
+            }
+        }
+    }
+
+    /// Reads `probe_capture_texture` back and projects each probe's six faces
+    /// onto L2 spherical harmonics.
+    ///
+    /// Must run after the encoder [`Self::capture_probes`] wrote into has been
+    /// submitted: this copies the texture on its own encoder and blocks on the
+    /// map, so anything still sitting in an unsubmitted encoder would be
+    /// missed.
+    ///
+    /// Every texel contributes `radiance * basis(dir) * solid_angle`, with
+    /// `dir` from [`probe_face_texel_direction`] (the same cube convention the
+    /// capture matrices were built from) and `solid_angle` from
+    /// [`probe_face_texel_solid_angle`] (the real projected solid angle, not a
+    /// flat share of the sphere).
+    // See `capture_probes` for why this is `allow(dead_code)` for now.
+    #[allow(dead_code)]
+    fn project_captures_to_sh(&self, probe_count: usize) -> Vec<crate::sh::ShL2> {
+        let probes = probe_count.min(bsengine_core::MAX_PROBES);
+        if probes == 0 {
+            return Vec::new();
+        }
+        // Rgba16Float.
+        const BYTES_PER_TEXEL: u32 = 8;
+        let layers = (probes * 6) as u32;
+        let unpadded_bytes_per_row = PROBE_FACE_SIZE * BYTES_PER_TEXEL;
+        // `copy_texture_to_buffer` requires every row to start on a 256-byte
+        // boundary. A 16-texel row is 128 bytes, so each row really is padded
+        // here -- reading the buffer as if it were tightly packed would
+        // interleave two rows per face and silently scramble every direction.
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(align) * align;
+        let layer_stride = (padded_bytes_per_row * PROBE_FACE_SIZE) as u64;
+
+        let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("probe capture readback"),
+            size: layer_stride * layers as u64,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("probe capture readback encoder"),
+            });
+        encoder.copy_texture_to_buffer(
+            wgpu::ImageCopyTexture {
+                texture: &self.probe_capture_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::ImageCopyBuffer {
+                buffer: &buffer,
+                layout: wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(PROBE_FACE_SIZE),
+                },
+            },
+            wgpu::Extent3d {
+                width: PROBE_FACE_SIZE,
+                height: PROBE_FACE_SIZE,
+                depth_or_array_layers: layers,
+            },
+        );
+        self.queue.submit(std::iter::once(encoder.finish()));
+
+        let slice = buffer.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        self.device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .expect("map_async never reported a result")
+            .expect("mapping the probe capture readback buffer failed");
+
+        let mapped = slice.get_mapped_range();
+        let mut out = vec![crate::sh::ShL2::default(); probes];
+        for (probe_idx, sh) in out.iter_mut().enumerate() {
+            for face in 0..6usize {
+                let layer_start = (probe_idx * 6 + face) as u64 * layer_stride;
+                for y in 0..PROBE_FACE_SIZE {
+                    let row_start = (layer_start + (y * padded_bytes_per_row) as u64) as usize;
+                    for x in 0..PROBE_FACE_SIZE {
+                        let t = &mapped[row_start + (x * BYTES_PER_TEXEL) as usize..];
+                        let radiance = Vec3::new(
+                            f16_bits_to_f32(u16::from_le_bytes([t[0], t[1]])),
+                            f16_bits_to_f32(u16::from_le_bytes([t[2], t[3]])),
+                            f16_bits_to_f32(u16::from_le_bytes([t[4], t[5]])),
+                        );
+                        sh.accumulate(
+                            probe_face_texel_direction(face, x, y),
+                            radiance,
+                            probe_face_texel_solid_angle(x, y),
+                        );
+                    }
+                }
+            }
+        }
+        drop(mapped);
+        buffer.unmap();
+        out
     }
 
     /// Renders one full frame: shadow map, main scene pass, post-processing,
@@ -4726,5 +5686,405 @@ mod tests {
     fn point_shadow_shader_compiles() {
         let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
         let _module = WgpuSurface::compile_shader(&device, POINT_SHADOW_WGSL);
+    }
+
+    #[test]
+    fn probe_capture_wgsl_is_valid() {
+        assert_eq!(
+            WgpuSurface::validate_wgsl("probe_capture.wgsl", PROBE_CAPTURE_WGSL),
+            Ok(()),
+            "PROBE_CAPTURE_WGSL must pass the same validation MESH_WGSL does"
+        );
+    }
+
+    #[test]
+    fn probe_capture_sky_wgsl_is_valid() {
+        assert_eq!(
+            WgpuSurface::validate_wgsl("probe_capture_sky.wgsl", PROBE_CAPTURE_SKY_WGSL),
+            Ok(()),
+            "PROBE_CAPTURE_SKY_WGSL must pass the same validation SKYBOX_WGSL does"
+        );
+    }
+
+    /// The capture shades **direct light only**, and this is the guard that
+    /// keeps it that way. Sampling IBL (or, later, probes) from the capture
+    /// would make the bake feed on its own output: probes lit by probes, and
+    /// sky light counted twice over -- once as the captured background and
+    /// again as the irradiance convolved from that same sky. The result is
+    /// meant to be exactly one bounce.
+    ///
+    /// A source-level assertion rather than a rendered one because the failure
+    /// it guards against is *plausible-looking*: an IBL-contaminated bake is
+    /// brighter, not obviously broken, and no pixel test would flag it.
+    #[test]
+    fn the_probe_capture_shader_never_reads_the_ibl_resources() {
+        for forbidden in [
+            "irradiance_cube",
+            "prefilter_cube",
+            "brdf_lut",
+            "ibl_sampler",
+            // The branch itself, not the struct field: `ibl_enabled` must
+            // still be *declared*, since this shader shares `light_buffer`
+            // with MESH_WGSL and the layouts have to match byte for byte.
+            "light.ibl_enabled",
+        ] {
+            assert!(
+                !PROBE_CAPTURE_WGSL.contains(forbidden),
+                "the probe capture shader references `{forbidden}`; capturing \
+                 IBL into a probe makes the bake recursive"
+            );
+        }
+        assert!(
+            PROBE_CAPTURE_WGSL.contains("ibl_enabled: u32,"),
+            "LightUniform must still declare ibl_enabled: this shader reads the \
+             same buffer MESH_WGSL does, and a shorter struct would misalign \
+             every field after it"
+        );
+    }
+
+    /// Closes the loop on the per-texel direction: for each face, take the
+    /// direction `probe_face_texel_direction` reports for a texel, project it
+    /// through the **actual** matrix that face was rendered with, and require
+    /// the result to land back on that texel's NDC.
+    ///
+    /// Deliberately uses off-centre texels including the corners. A texel at
+    /// the face centre projects to NDC (0, 0) under any axis swap or sign
+    /// error, so a centre-only check certifies nothing.
+    #[test]
+    fn probe_face_texel_direction_matches_the_capture_matrix_ndc() {
+        let probe_pos = Vec3::new(2.0, -1.0, 4.0);
+        let view_projs = point_light_face_view_projs(probe_pos, PROBE_CAPTURE_RANGE);
+        let n = PROBE_FACE_SIZE;
+        let texels = [
+            (0, 0),
+            (n - 1, 0),
+            (0, n - 1),
+            (n - 1, n - 1),
+            (n / 2, n / 2),
+            (3, n - 4),
+            (n - 2, 5),
+        ];
+        for (face, vp) in view_projs.iter().enumerate() {
+            for (x, y) in texels {
+                let dir = probe_face_texel_direction(face, x, y);
+                assert!(
+                    (dir.length() - 1.0).abs() < 1e-5,
+                    "face {face} texel ({x},{y}): direction must be unit length, got {dir:?}"
+                );
+                // A point out along the ray, from the probe. Any positive
+                // distance inside the frustum projects to the same NDC.
+                let world = probe_pos + dir * 10.0;
+                let clip = *vp * world.extend(1.0);
+                let got = (clip.x / clip.w, clip.y / clip.w);
+                let want = probe_face_texel_ndc(x, y);
+                assert!(
+                    (got.0 - want.0).abs() < 1e-4 && (got.1 - want.1).abs() < 1e-4,
+                    "face {face} texel ({x},{y}): the direction we attribute this \
+                     texel to projects to NDC {got:?}, but the texel sits at \
+                     {want:?} -- the capture and the projection disagree about \
+                     which way this texel looks"
+                );
+            }
+        }
+    }
+
+    /// The six faces' texels must tile the whole sphere exactly once. This is
+    /// what makes the projection an integral over the sphere rather than an
+    /// arbitrarily scaled sum, and it is the assertion a wrong normalisation
+    /// cannot survive.
+    #[test]
+    fn probe_face_texel_solid_angles_sum_to_the_full_sphere() {
+        let mut total = 0.0f64;
+        for _face in 0..6 {
+            for y in 0..PROBE_FACE_SIZE {
+                for x in 0..PROBE_FACE_SIZE {
+                    total += probe_face_texel_solid_angle(x, y) as f64;
+                }
+            }
+        }
+        let four_pi = 4.0 * std::f64::consts::PI;
+        assert!(
+            (total - four_pi).abs() < 0.02,
+            "the six faces must cover 4*pi steradians, got {total} (want {four_pi})"
+        );
+    }
+
+    /// The specific mistake the projected solid angle exists to avoid: a flat
+    /// `4*pi / (6*n*n)` per texel. It sums to 4*pi too, so the test above
+    /// would not catch it -- what distinguishes the two is that a real cube
+    /// face's corner texels are further away and seen edge-on, so they cover
+    /// *less* sky than the centre ones, not the same amount.
+    #[test]
+    fn a_corner_texel_covers_less_sky_than_a_centre_texel() {
+        let n = PROBE_FACE_SIZE;
+        let centre = probe_face_texel_solid_angle(n / 2, n / 2);
+        let corner = probe_face_texel_solid_angle(0, 0);
+        assert!(
+            corner < centre,
+            "a corner texel ({corner}) must subtend less solid angle than a \
+             centre texel ({centre}); equal values mean the flat \
+             4*pi/(6*n*n) shortcut crept back in and the face corners are \
+             being over-weighted"
+        );
+        let flat = 4.0 * std::f32::consts::PI / (6.0 * (n * n) as f32);
+        assert!(
+            corner < flat * 0.75,
+            "the corner texel's real solid angle ({corner}) should be well \
+             below the flat share ({flat}); if it is not, the foreshortening \
+             factor is not being applied"
+        );
+    }
+
+    #[test]
+    fn f16_decodes_normal_subnormal_and_special_values() {
+        assert_eq!(f16_bits_to_f32(0x0000), 0.0);
+        assert_eq!(f16_bits_to_f32(0x3C00), 1.0);
+        assert_eq!(f16_bits_to_f32(0xBC00), -1.0);
+        assert_eq!(f16_bits_to_f32(0x4000), 2.0);
+        assert!((f16_bits_to_f32(0x3555) - 1.0 / 3.0).abs() < 1e-3);
+        // Largest subnormal: 1023 * 2^-24.
+        assert!((f16_bits_to_f32(0x03FF) - 1023.0 * 2.0f32.powi(-24)).abs() < 1e-12);
+        assert!(f16_bits_to_f32(0x7C00).is_infinite());
+        assert!(f16_bits_to_f32(0x7E00).is_nan());
+    }
+
+    /// One emissive quad, standing off-axis, plus a probe at the origin --
+    /// everything a bake needs and nothing else.
+    ///
+    /// The scene is deliberately minimal: the directional light and the
+    /// ambient term are both black, so the *only* radiance in the capture is
+    /// the quad's emissive and the pass's own background clear. That makes
+    /// the l=1 coefficients an almost pure readout of where the quad is.
+    struct ProbeBakeScene {
+        surface: WgpuSurface,
+        registry: crate::mesh::GpuMeshRegistry,
+        draw_calls: Vec<(u64, Mat4, Option<u64>, MaterialParams, Option<String>)>,
+    }
+
+    impl ProbeBakeScene {
+        /// `corners` are the quad's four vertices in counter-clockwise order
+        /// *as seen from the origin*, so the front face points at the probe
+        /// and back-face culling does not swallow it.
+        fn new(corners: [Vec3; 4], emissive: Vec3) -> Self {
+            let surface = pollster::block_on(WgpuSurface::new_offscreen(64, 64, false))
+                .expect("an offscreen surface is what every GPU test here uses");
+            let mut registry = crate::mesh::GpuMeshRegistry::new(surface.device.clone());
+            let normal = (corners[1] - corners[0])
+                .cross(corners[2] - corners[0])
+                .normalize();
+            let vertices: Vec<crate::mesh::Vertex> = corners
+                .iter()
+                .map(|p| crate::mesh::Vertex {
+                    position: p.to_array(),
+                    color: [1.0, 1.0, 1.0],
+                    normal: normal.to_array(),
+                    uv: [0.0, 0.0],
+                })
+                .collect();
+            let mesh_id = registry.register(&vertices, &[0, 1, 2, 0, 2, 3]);
+            let draw_calls = vec![(
+                mesh_id,
+                Mat4::IDENTITY,
+                None,
+                MaterialParams {
+                    metallic: 0.0,
+                    roughness: 1.0,
+                    emissive,
+                    // Black albedo: nothing reflects, so the quad contributes
+                    // its emissive and only its emissive.
+                    base_color: Vec3::ZERO,
+                    opacity: 1.0,
+                },
+                None,
+            )];
+            let scene = Self {
+                surface,
+                registry,
+                draw_calls,
+            };
+            scene.upload_uniforms();
+            scene
+        }
+
+        /// `capture_probes` reads `model_buffer` and `light_buffer` rather
+        /// than writing them -- `render_frame` fills both before any pass runs.
+        /// A test that skips this bakes whatever was left in GPU memory.
+        fn upload_uniforms(&self) {
+            for (i, (_, model, _, mat, _)) in self.draw_calls.iter().enumerate() {
+                let data = ModelUniformData {
+                    model: model.to_cols_array_2d(),
+                    metallic: mat.metallic,
+                    roughness: mat.roughness,
+                    _pad0: 0.0,
+                    _pad1: 0.0,
+                    emissive: mat.emissive.to_array(),
+                    _pad2: 0.0,
+                    base_color: mat.base_color.to_array(),
+                    opacity: mat.opacity,
+                };
+                self.surface.queue.write_buffer(
+                    &self.surface.model_buffer,
+                    i as u64 * MODEL_STRIDE,
+                    bytemuck::cast_slice(&[data]),
+                );
+            }
+            // Zeroed: no point or spot lights, no IBL, black sun, black
+            // ambient. `direction` still has to be a real unit vector because
+            // the shader normalizes it.
+            let mut light_data: LightUniformData = bytemuck::Zeroable::zeroed();
+            light_data.direction = [0.0, -1.0, 0.0];
+            self.surface.queue.write_buffer(
+                &self.surface.light_buffer,
+                0,
+                bytemuck::cast_slice(&[light_data]),
+            );
+        }
+
+        fn bake(&self, positions: &[Vec3]) -> Vec<crate::sh::ShL2> {
+            let mut encoder =
+                self.surface
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                        label: Some("probe bake test encoder"),
+                    });
+            self.surface.capture_probes(
+                &mut encoder,
+                // No shadow map has been rendered, and the directional light
+                // is black anyway; any matrix that keeps `shadow_factor`'s
+                // lookup in range would do.
+                Mat4::orthographic_rh(-20.0, 20.0, -20.0, 20.0, 0.1, 60.0)
+                    * Mat4::look_at_rh(Vec3::new(0.0, 20.0, 0.0), Vec3::ZERO, Vec3::Z),
+                &self.draw_calls,
+                &self.registry,
+                None,
+                positions,
+            );
+            self.surface.queue.submit(std::iter::once(encoder.finish()));
+            self.surface.project_captures_to_sh(positions.len())
+        }
+    }
+
+    /// The direction an L2 expansion attributes its brightest lobe to, read
+    /// out of the l=1 band of one colour channel. `sh_basis` orders l=1 as
+    /// `(y, z, x)`, so this un-permutes it.
+    fn dominant_direction_red(sh: &crate::sh::ShL2) -> Vec3 {
+        Vec3::new(sh.coeffs[3].x, sh.coeffs[1].x, sh.coeffs[2].x).normalize()
+    }
+
+    /// The end-to-end version of `probe_face_texel_direction_matches_...`:
+    /// render a real emissive quad, project the real capture, and require the
+    /// reconstructed lobe to point at where the quad actually is.
+    ///
+    /// Two placements, on two different cube faces, because face 0 (+X, up
+    /// -Y) and face 2 (+Y, up +Z) use different up-vectors -- a bug that
+    /// permutes faces or flips one face's V axis survives a single-face test.
+    /// Both quads are off-axis in two coordinates at once, so no axis swap can
+    /// hide.
+    #[test]
+    fn a_baked_probe_points_its_brightest_lobe_at_the_emissive_quad() {
+        let cases: [([Vec3; 4], &str); 2] = [
+            (
+                [
+                    Vec3::new(3.0, 0.75, 0.0),
+                    Vec3::new(3.0, 0.75, 1.5),
+                    Vec3::new(3.0, 2.25, 1.5),
+                    Vec3::new(3.0, 2.25, 0.0),
+                ],
+                "+X face",
+            ),
+            (
+                [
+                    Vec3::new(0.75, 3.0, 0.0),
+                    Vec3::new(2.25, 3.0, 0.0),
+                    Vec3::new(2.25, 3.0, 1.5),
+                    Vec3::new(0.75, 3.0, 1.5),
+                ],
+                "+Y face",
+            ),
+        ];
+        for (corners, label) in cases {
+            let centre = (corners[0] + corners[1] + corners[2] + corners[3]) / 4.0;
+            let expected = centre.normalize();
+            let scene = ProbeBakeScene::new(corners, Vec3::new(20.0, 0.0, 0.0));
+            let sh = scene.bake(&[Vec3::ZERO]);
+            assert_eq!(sh.len(), 1);
+
+            // The pass's own 0.08 grey background alone integrates to
+            // 0.282095 * 4*pi * 0.08 ~= 0.28 in *every* channel, so "is
+            // anything there?" has to be asked as "is red above grey?", not
+            // as an absolute floor. A capture that drew no geometry leaves
+            // these two equal.
+            assert!(
+                sh[0].coeffs[0].x > sh[0].coeffs[0].y * 2.0 && sh[0].coeffs[0].x > 1.0,
+                "{label}: l=0 is ({}, {}) -- red barely exceeds green, so the \
+                 red quad was never rendered into the probe and all that was \
+                 captured is the grey background",
+                sh[0].coeffs[0].x,
+                sh[0].coeffs[0].y
+            );
+            let got = dominant_direction_red(&sh[0]);
+            assert!(
+                got.dot(expected) > 0.9,
+                "{label}: the probe's brightest red direction is {got:?} but the \
+                 quad is at {expected:?} (dot {}). A probe lit from the wrong \
+                 side still looks like lighting, which is why this is asserted \
+                 rather than eyeballed",
+                got.dot(expected)
+            );
+            // The quad is pure red; the only other radiance is the grey
+            // background clear, which is isotropic and so cancels in l=1.
+            assert!(
+                sh[0].coeffs[3].x.abs() > sh[0].coeffs[3].y.abs() * 3.0,
+                "{label}: the red channel must carry the directional signal, \
+                 not the grey background -- got red {} vs green {}",
+                sh[0].coeffs[3].x,
+                sh[0].coeffs[3].y
+            );
+        }
+    }
+
+    /// CI's headless replays re-render the same scenes and compare pixels, so
+    /// a bake that wobbled between runs would make every downstream test
+    /// flaky rather than failing here.
+    #[test]
+    fn baking_the_same_scene_twice_gives_the_same_coefficients() {
+        let scene = ProbeBakeScene::new(
+            [
+                Vec3::new(3.0, 0.75, 0.0),
+                Vec3::new(3.0, 0.75, 1.5),
+                Vec3::new(3.0, 2.25, 1.5),
+                Vec3::new(3.0, 2.25, 0.0),
+            ],
+            Vec3::new(20.0, 8.0, 2.0),
+        );
+        // More than one probe, and none of them at the origin: a bake that
+        // reused one probe's capture for all of them, or that mixed up the
+        // layer indices, would still pass a single-probe check.
+        let positions = [
+            Vec3::ZERO,
+            Vec3::new(0.5, -0.5, 0.25),
+            Vec3::new(-1.0, 0.75, 1.5),
+        ];
+        let first = scene.bake(&positions);
+        let second = scene.bake(&positions);
+        assert_eq!(first.len(), positions.len());
+        assert_eq!(
+            first, second,
+            "two bakes of one unchanged scene must produce identical \
+             coefficients; CI's replay tests depend on that reproducibility"
+        );
+        // A determinism check passes trivially if both bakes are all zeros.
+        assert!(
+            first.iter().any(|sh| sh.coeffs[0].length() > 0.5),
+            "the bake produced nothing to compare -- every probe's l=0 \
+             coefficient is ~0, so this test would pass on a no-op capture"
+        );
+        // The probes sit at different points and the quad is close, so their
+        // coefficients must actually differ from each other.
+        assert_ne!(
+            first[0], first[1],
+            "two probes at different positions saw identical radiance, which \
+             means the per-probe view-projections are not being applied"
+        );
     }
 }

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -187,6 +187,14 @@ pub struct Scene {
     /// `render` shows almost nothing of TAA even when this is set -- it
     /// accumulates over frames, so use [`Harness::render_converged`].
     pub taa: Option<bsengine_core::Taa>,
+    /// A baked light-probe volume, or `None` for the IBL/flat-ambient path.
+    ///
+    /// The box is **centred on the world origin**. The component itself only
+    /// carries half-extents; in the engine the centre comes from the entity's
+    /// `Transform`, and this harness has no entities, so the origin stands in
+    /// for one. A test that wants a surface outside the volume moves the
+    /// surface, not the box.
+    pub light_probes: Option<bsengine_core::LightProbeVolume>,
     pub hud: HashMap<String, String>,
     pub with_skybox: bool,
     /// Particle batches for the pass that runs after transparency.
@@ -204,6 +212,7 @@ impl Default for Scene {
             tone_map: None,
             ssao: None,
             taa: None,
+            light_probes: None,
             hud: HashMap::new(),
             with_skybox: false,
             particles: Vec::new(),
@@ -491,6 +500,20 @@ struct VertOut {{
             None
         };
 
+        // Exactly the conversion `bsengine-render`'s `render_frame` system
+        // does, minus the entity transform: origin at the box's minimum
+        // corner, extent as the full size, and the resolution already through
+        // `clamped_resolution` so the harness can never ask for more probes
+        // than the GPU uniform holds.
+        let light_probes = scene.light_probes.map(|v| {
+            let half = *v.half_extents;
+            bsengine_rhi_wgpu::ProbeVolumeParams {
+                origin: -half,
+                extent: half * 2.0,
+                resolution: v.clamped_resolution(),
+            }
+        });
+
         let jitter_clip = if scene.taa.map(|t| t.enabled).unwrap_or(false) {
             bsengine_rhi_wgpu::taa_jitter::jitter_clip_offset(frame_index, WIDTH, HEIGHT)
         } else {
@@ -533,10 +556,10 @@ struct VertOut {{
                 // The unjittered matrix, on purpose: reprojection has to track
                 // the camera, not the jitter.
                 view_proj,
-                // No probe volume, so `probes.enabled` stays 0 and every scene
-                // this harness draws keeps rendering exactly as it did before
+                // `None` leaves `probes.enabled` at 0, so every scene that does
+                // not ask for a volume keeps rendering exactly as it did before
                 // light probes existed.
-                None,
+                light_probes,
             )
             .expect("render_frame failed");
 

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -533,6 +533,10 @@ struct VertOut {{
                 // The unjittered matrix, on purpose: reprojection has to track
                 // the camera, not the jitter.
                 view_proj,
+                // No probe volume, so `probes.enabled` stays 0 and every scene
+                // this harness draws keeps rendering exactly as it did before
+                // light probes existed.
+                None,
             )
             .expect("render_frame failed");
 

--- a/crates/bsengine-rhi-wgpu/tests/pixels_light_probe.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_light_probe.rs
@@ -1,0 +1,316 @@
+//! Baked light-probe GI, measured at the pixel.
+//!
+//! The trap this file is written around: **a broken probe implementation also
+//! makes things brighter.** Position-varying ambient light, a mis-scaled
+//! constant, a stuck coefficient -- every one of them raises the floor's luma,
+//! and a test that asserted "brighter with probes on" would pass for all of
+//! them. What only working bounced GI does is make a *white* floor beside a
+//! *red* wall go red, and follow the wall's colour when that colour changes.
+//!
+//! So every measurement here is a per-channel *bias* -- red against the mean of
+//! green and blue -- never a brightness. A uniform brightening leaves the bias
+//! exactly where it was.
+//!
+//! What the floor's centre pixel actually reads, for the record:
+//!
+//! | wall  | probes off        | probes on         |
+//! |-------|-------------------|-------------------|
+//! | red   | `[159, 159, 159]` | `[220, 142, 142]` |
+//! | green | `[159, 159, 159]` | `[157, 228, 157]` |
+//!
+//! The two off-states are the same pixel because with probes off an emissive
+//! surface lights nothing but itself -- the entire bleed is the bake's doing,
+//! and there is no direct-light path for it to be confused with.
+//!
+//! These numbers are post-tonemap: `tone_map: None` in the harness means
+//! `ToneMap::default()`, which is ACES and enabled, so the table is what an eye
+//! would see rather than raw radiance. The thresholds below sit well under the
+//! margins it shows.
+//!
+//! Fixture notes:
+//!
+//! - The wall is **emissive**, not merely brightly lit. Probe capture shades
+//!   direct light only, so a purely diffuse wall reflects at most
+//!   `sun * albedo / PI` -- under a third of the sun's own radiance -- and what
+//!   survives the cosine convolution and the falloff to the floor is a
+//!   correspondingly small fraction of that. `Draw::emissive` at
+//!   [`WALL_RADIANCE`] makes the wall a genuine radiator instead, which is what
+//!   a one-bounce probe bake is built to pick up.
+//! - The wall is a **cube**, the floor a **plane**: the plane is the only mesh
+//!   with white vertex colours (`cube_vertices` paints its faces), so it is the
+//!   one that can carry a truly white albedo for the bleed to land on.
+//! - The wall sits **outside** the volume. Nothing about the effect requires
+//!   that, but it keeps the emitter's own pixels out of the probe branch, so a
+//!   frame difference can only come from surfaces that were lit by the bake.
+//! - No skybox. With none loaded the no-probe ambient is exactly
+//!   `light.ambient * albedo`, a flat grey, which makes the off-state baseline
+//!   achromatic and every asserted colour shift unambiguously the probes'.
+
+mod common;
+
+use bsengine_core::LightProbeVolume;
+use common::{Draw, Harness, Pixels, Scene};
+use glam::Vec3;
+
+/// Height of the floor plane. Comfortably inside [`volume`]'s vertical span,
+/// so the trilinear lookup at the measured pixel blends real probes rather
+/// than clamping at a face.
+const FLOOR_Y: f32 = -0.5;
+
+/// Where the wall stands, just beyond the volume's `x` face.
+const WALL_X: f32 = 3.0;
+
+/// Radiance of the wall, in the same pre-tonemap units the scene shader works
+/// in. High enough that one bounce is worth tens of 8-bit levels on the floor,
+/// low enough that the floor never clips -- a clipped channel cannot show a
+/// rise.
+const WALL_RADIANCE: f32 = 6.0;
+
+/// A volume around the origin covering the middle of the floor.
+///
+/// `[4, 2, 4]` is `LightProbeVolume`'s own default and exactly `MAX_PROBES`.
+/// Two probes on `y` put one just under the floor and one above it, which is
+/// the pair the floor's lookup interpolates between.
+fn volume() -> LightProbeVolume {
+    LightProbeVolume {
+        half_extents: Vec3::new(2.5, 1.5, 2.5).into(),
+        resolution: [4, 2, 4],
+    }
+}
+
+/// A white floor with a coloured emissive wall beside it, and the camera
+/// looking down at the floor so the centre pixel is floor and nothing else.
+///
+/// `shift` displaces the floor, the wall and the camera together. The volume is
+/// pinned to the world origin (see `Scene::light_probes`), so shifting the
+/// scene is how a test puts a surface *outside* the volume while keeping the
+/// framing -- and therefore every other term in the frame -- identical.
+fn wall_and_floor(
+    plane: u64,
+    cube: u64,
+    wall_colour: Vec3,
+    shift: Vec3,
+    probes: Option<LightProbeVolume>,
+) -> Scene {
+    Scene {
+        draws: vec![
+            Draw::new(plane, Vec3::ZERO)
+                .scaled(
+                    Vec3::new(16.0, 1.0, 16.0),
+                    Vec3::new(0.0, FLOOR_Y, 0.0) + shift,
+                )
+                .colour(Vec3::ONE)
+                .roughness(0.9),
+            Draw::new(cube, Vec3::ZERO)
+                .scaled(
+                    Vec3::new(0.3, 4.0, 8.0),
+                    Vec3::new(WALL_X, FLOOR_Y + 2.0, 0.0) + shift,
+                )
+                .colour(wall_colour)
+                .emissive(wall_colour * WALL_RADIANCE),
+        ],
+        camera_pos: Vec3::new(0.0, 2.0, 6.0) + shift,
+        look_at: Vec3::new(0.0, FLOOR_Y, 0.0) + shift,
+        light_probes: probes,
+        ..Scene::default()
+    }
+}
+
+const RED: Vec3 = Vec3::new(1.0, 0.0, 0.0);
+const GREEN: Vec3 = Vec3::new(0.0, 1.0, 0.0);
+
+/// The same scene rendered twice, probes off and then on, with the bake
+/// guaranteed to be this scene's.
+///
+/// `render_frame` re-bakes only when the volume differs from the last one it
+/// baked -- deliberately, so a bake costs one frame on load rather than every
+/// frame. Every test here uses the same box, so two probe scenes rendered back
+/// to back would leave the second lit by the *first* scene's bake, and a
+/// green-wall frame would come out red. Rendering with no volume in between
+/// resets that cache, and an off/on pair is what every measurement below needs
+/// anyway.
+fn probes_off_then_on(
+    h: &mut Harness,
+    scene: impl Fn(Option<LightProbeVolume>) -> Scene,
+) -> (Pixels, Pixels) {
+    let off = h.render(&scene(None));
+    let on = h.render(&scene(Some(volume())));
+    (off, on)
+}
+
+/// The floor pixel every measurement below is taken at: the centre of the
+/// frame, which the camera is aimed at the floor for.
+fn floor_pixel(p: &Pixels) -> [u8; 4] {
+    p.centre()
+}
+
+/// How far channel `c` stands above the mean of the other two, in 8-bit levels.
+///
+/// A *bias*, not a brightness, and that is the whole point: an implementation
+/// that merely made the frame brighter raises all three channels together and
+/// leaves this number where it was. Only light that arrived carrying a colour
+/// moves it.
+fn bias(p: [u8; 4], c: usize) -> f32 {
+    let v = [p[0] as f32, p[1] as f32, p[2] as f32];
+    v[c] - 0.5 * (v[(c + 1) % 3] + v[(c + 2) % 3])
+}
+
+const R: usize = 0;
+const G: usize = 1;
+
+#[test]
+fn a_white_floor_beside_a_red_wall_picks_up_red() {
+    let mut h = Harness::new();
+    let (plane, cube) = (h.plane(), h.cube());
+
+    let (off, on) = probes_off_then_on(&mut h, |p| wall_and_floor(plane, cube, RED, Vec3::ZERO, p));
+
+    let before = floor_pixel(&off);
+    let after = floor_pixel(&on);
+
+    // The baseline has to be neutral for a colour shift to mean anything. With
+    // no skybox and no probes the floor's ambient is `light.ambient * albedo`
+    // on a white albedo, and its direct light is a white sun.
+    assert!(
+        bias(before, R).abs() < 4.0,
+        "the probes-off floor should be achromatic before any bleed, saw {before:?}"
+    );
+
+    // The assertion that matters. Not `after` brighter than `before` -- a
+    // stuck coefficient or a position-varying ambient would pass that. The red
+    // channel has to pull *away from its own green and blue*.
+    assert!(
+        bias(after, R) > bias(before, R) + 12.0,
+        "the floor beside a red wall should go red once probes are baked: \
+         red bias {:.1} -> {:.1} (floor {before:?} -> {after:?}). No rise in \
+         bias means whatever the probes did to this frame was colourless, \
+         which is not bounced light.",
+        bias(before, R),
+        bias(after, R)
+    );
+
+    // And spelled out channel by channel, because a bias can also rise by the
+    // green and blue *falling*. Red must actually gain, and gain more than the
+    // channels the wall emits none of.
+    let d = |i: usize| after[i] as f32 - before[i] as f32;
+    assert!(
+        d(0) > d(1) + 12.0 && d(0) > d(2) + 12.0,
+        "red must gain more than green and blue: dR {:.1}, dG {:.1}, dB {:.1} \
+         ({before:?} -> {after:?})",
+        d(0),
+        d(1),
+        d(2)
+    );
+}
+
+#[test]
+fn a_surface_outside_the_volume_is_unchanged() {
+    let mut h = Harness::new();
+    let (plane, cube) = (h.plane(), h.cube());
+
+    // The same scene as the test above, lowered until floor, wall and camera
+    // are all clear of the volume. The picture is geometrically identical --
+    // only its position relative to the probe box has changed.
+    const BELOW: Vec3 = Vec3::new(0.0, -6.0, 0.0);
+
+    let (off, on) = probes_off_then_on(&mut h, |p| wall_and_floor(plane, cube, RED, BELOW, p));
+
+    // First prove this scene is one probes would visibly change if it were
+    // inside. Without that, "unchanged" could just mean "insensitive", and the
+    // equality below would hold for a probe path that never ran at all.
+    let (inside_off, inside_on) =
+        probes_off_then_on(&mut h, |p| wall_and_floor(plane, cube, RED, Vec3::ZERO, p));
+    assert!(
+        bias(floor_pixel(&inside_on), R) > bias(floor_pixel(&inside_off), R) + 12.0,
+        "the control scene must actually pick up the wall, else this test \
+         proves nothing: {:?} against {:?}",
+        floor_pixel(&inside_off),
+        floor_pixel(&inside_on)
+    );
+
+    assert_eq!(
+        on.data,
+        off.data,
+        "a volume that contains none of the scene must leave every pixel \
+         exactly as it was. It did not -- so `inside_probe_volume` is letting \
+         probe irradiance out of its box, and probe GI is really just a global \
+         ambient with extra steps. probes-off {}, probes-on {}",
+        off.describe(),
+        on.describe()
+    );
+}
+
+#[test]
+fn a_scene_with_no_probe_volume_is_pixel_identical() {
+    let mut h = Harness::new();
+    let (plane, cube) = (h.plane(), h.cube());
+    let scene = |probes| wall_and_floor(plane, cube, RED, Vec3::ZERO, probes);
+
+    let before = h.render(&scene(None));
+
+    // Bake a volume in between, so the probe uniform is provably non-zero and
+    // provably reaching the shader by the time the last frame is drawn. A
+    // "nothing changed" result from a renderer that never baked anything would
+    // be worthless.
+    let baked = h.render(&scene(Some(volume())));
+    assert!(
+        baked.differs_from(&before),
+        "the volume should have changed the frame, saw {}",
+        baked.describe()
+    );
+
+    let after = h.render(&scene(None));
+    assert_eq!(
+        after.data, before.data,
+        "with no volume the frame must be byte-for-byte what it was before \
+         probes existed. It is not -- so the zeroed `enabled: 0` upload is \
+         leaking probe irradiance into every scene that never asked for it, \
+         which is exactly the 'probes just brightened everything' failure this \
+         test exists for."
+    );
+}
+
+#[test]
+fn a_green_wall_bleeds_green_not_red() {
+    let mut h = Harness::new();
+    let (plane, cube) = (h.plane(), h.cube());
+
+    let (off, on) = probes_off_then_on(&mut h, |p| {
+        wall_and_floor(plane, cube, GREEN, Vec3::ZERO, p)
+    });
+    let before = floor_pixel(&off);
+    let after = floor_pixel(&on);
+
+    // The bleed follows the wall. An implementation that read the wrong SH
+    // coefficient, or folded the three channels together, would tint the floor
+    // the same way whatever colour the wall is -- so this is the assertion the
+    // red test cannot make on its own.
+    assert!(
+        bias(after, G) > bias(before, G) + 12.0,
+        "the floor beside a green wall should go green: green bias {:.1} -> \
+         {:.1} ({before:?} -> {after:?})",
+        bias(before, G),
+        bias(after, G)
+    );
+    assert!(
+        bias(after, R) < bias(before, R) + 6.0,
+        "and it must not also go red: red bias {:.1} -> {:.1} \
+         ({before:?} -> {after:?}). Red rising under a green wall means the \
+         bleed is not reading the scene's actual colour.",
+        bias(before, R),
+        bias(after, R)
+    );
+
+    // Cross-checked against the red wall in the same frame geometry: swapping
+    // the emitter's colour must swap which channel gains. This is what
+    // separates "the probes carry colour" from "the probes carry *this*
+    // scene's colour".
+    let (_, red_on) =
+        probes_off_then_on(&mut h, |p| wall_and_floor(plane, cube, RED, Vec3::ZERO, p));
+    let red = floor_pixel(&red_on);
+    assert!(
+        bias(red, R) > bias(after, R) + 12.0 && bias(after, G) > bias(red, G) + 12.0,
+        "red wall and green wall must bleed different channels: red wall \
+         {red:?}, green wall {after:?}"
+    );
+}

--- a/crates/bsengine-rhi-wgpu/tests/terrain_draw.rs
+++ b/crates/bsengine-rhi-wgpu/tests/terrain_draw.rs
@@ -75,6 +75,8 @@ fn a_terrain_draw_call_does_not_panic_alongside_regular_draw_calls() {
         None,
         (0.0, 0.0),
         Mat4::IDENTITY,
+        // No probe volume either; terrain chunks are not captured into probes.
+        None,
     );
 
     assert!(

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -883,6 +883,7 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
     app.register_type::<bsengine_core::Bloom>();
     app.register_type::<bsengine_core::CustomShader>();
     app.register_type::<bsengine_core::Lifetime>();
+    app.register_type::<bsengine_core::LightProbeVolume>();
     app.register_type::<bsengine_core::NetworkId>();
     app.register_type::<bsengine_core::PrefabInstance>();
     app.register_type::<bsengine_core::PrefabInstanceBaseline>();


### PR DESCRIPTION
## Summary
Implements ENGINE_ROADMAP item 48, **sub-step 2/2: light-probe GI** — closing item 48's last open completion condition ("하나 이상의 실시간 또는 베이크드 GI 근사 구현").

This adds **bounced indirect light**: a white floor beside a red wall picks up red. That distinction is the whole point — an implementation that only sampled the skybox per position would be IBL with position variation, not GI.

## How it works
- **`LightProbeVolume { half_extents, resolution }`** defines a box and a probe grid. Probes sit on the grid's **lattice points**, not cell centres — trilinear interpolation is defined by a cell's eight corners, so corner placement is what makes it well-formed. Over-specified resolution is clamped (not rejected) to `MAX_PROBES = 32`.
- **Capture renders the real scene**, six faces per probe, reusing `point_light_face_view_projs` and the point-light shadow pass's exact machinery — probe capture is that existing capability aimed somewhere else. Faces are 16×16 on purpose: the result is immediately reduced to 9 SH coefficients, so higher resolution is discarded work.
- **The capture shader is direct-light-only** — no IBL, no probes. Including them would make the bake recursive; the result is one bounce by design.
- **SH L2 (9 coefficients)**, the format Unity and Unreal ship, with the cosine-lobe convolution constants that turn a radiance expansion into the diffuse irradiance a Lambertian surface actually sees.
- **A uniform buffer with a fixed max, not a storage buffer** — this engine uses no storage buffers anywhere, and fixed-size uniform arrays are its established pattern (`MAX_POINT_LIGHTS`). 4608 bytes at `@group(2) @binding(9)`.
- **Bake runs once**, when a volume appears or its parameters change. 32 probes × 6 faces is a one-time load cost, invisible thereafter.

## Two correctness points worth calling out
**Probe irradiance replaces the IBL irradiance inside a volume; it never adds to it.** The probes captured the scene *including the skybox*, so their SH already carries the sky's contribution — adding would double-count sky light and wash the scene out. The specular half is kept, since probes are diffuse-only and carry no reflection to replace it with.

**The shader blends the eight neighbours' coefficients and evaluates once**, rather than evaluating eight times and blending results. SH evaluation is linear in the coefficients, so this is both cheaper and equivalent.

## Verification
The assertion that matters is **coloured bleed, not brightness** — a broken implementation also makes things brighter:

- `a_white_floor_beside_a_red_wall_picks_up_red` — asserts red gains *more than* green and blue by a real margin, spelled out channel by channel because a red bias can also rise by G and B falling
- `a_green_wall_bleeds_green_not_red` — catches an implementation that mis-indexed a coefficient and tints everything the same way regardless of the scene
- `a_surface_outside_the_volume_is_unchanged` and `a_scene_with_no_probe_volume_is_pixel_identical` — the opposite-direction regressions

Unit tests target the silent-failure modes: SH normalisation (a uniform environment must project onto L0 only, and reconstruct to its own colour — the check that catches a wrong constant, which otherwise just reads as "a bit bright"), trilinear weights summing to 1.0, lattice-corner exactness, cube-face texel solid angles summing to the full sphere, the capture shader provably never reading IBL resources, and bake determinism (replay tests depend on it).

## Test plan
- [x] `cargo test -p bsengine-rhi-wgpu --lib sh` — 6/6
- [x] `cargo test -p bsengine-core --lib light_probe` — 3/3
- [x] `cargo test -p bsengine-rhi-wgpu --test pixels_light_probe` — 4/4
- [x] **All eight pre-existing `pixels_*.rs` files and the four `pixels_ibl.rs` tests pass unchanged** (no probe volume ⇒ `probes.enabled == 0`)
- [x] `cargo test --workspace --exclude bsengine-editor` — zero failures
- [x] `cargo test -p bsengine-editor --lib` — 937/937 (isolated, per CI's split)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` — 61 components, 0 violations
- [x] `cargo clippy --workspace --all-targets` — identical to the pre-existing baseline
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)