### PR TITLE
feat: volumetric fog (froxel), sub-step 1/2

### DIFF
--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -99,6 +99,8 @@ pub mod tween;
 pub mod ui_state;
 /// Visibility toggle component controlling whether an entity is rendered.
 pub mod visible;
+/// Volumetric (froxel) fog post-process settings.
+pub mod volumetric_fog;
 
 pub use ambient_occlusion::AmbientOcclusion;
 pub use animation_player::AnimationPlayer;
@@ -149,6 +151,7 @@ pub use transform::Transform;
 pub use tween::{EasingFn, RepeatMode, Tween, TweenTarget};
 pub use ui_state::{UiState, UiWidget};
 pub use visible::Visible;
+pub use volumetric_fog::VolumetricFog;
 
 /// Recomputes every entity's [`GlobalTransform`] from its local [`Transform`]
 /// and [`Parent`] chain, iterating a fixed number of passes to settle deep hierarchies.

--- a/crates/bsengine-core/src/volumetric_fog.rs
+++ b/crates/bsengine-core/src/volumetric_fog.rs
@@ -1,0 +1,55 @@
+//! Volumetric fog settings for a camera.
+
+use crate::ReflectVec3;
+use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
+
+/// Atmospheric scattering applied by a camera.
+///
+/// Absent means off, leaving rendering exactly as it was -- which is what
+/// keeps every existing pixel test passing unchanged.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Default)]
+pub struct VolumetricFog {
+    /// Whether the effect is applied at all.
+    pub enabled: bool,
+    /// Extinction per world unit. Higher is thicker.
+    pub density: f32,
+    /// Scattering albedo -- the colour the fog scatters.
+    pub color: ReflectVec3,
+    /// Henyey-Greenstein anisotropy in (-1, 1). 0 is isotropic; positive
+    /// scatters forward, giving the bright halo around a light seen
+    /// through haze.
+    pub anisotropy: f32,
+}
+
+impl Default for VolumetricFog {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            density: 0.02,
+            color: glam::Vec3::splat(1.0).into(),
+            anisotropy: 0.3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_enabled_and_physically_sensible() {
+        let f = VolumetricFog::default();
+        assert!(f.enabled);
+        assert!(
+            f.density > 0.0,
+            "a zero default density would render nothing"
+        );
+        assert!(
+            f.anisotropy > -1.0 && f.anisotropy < 1.0,
+            "anisotropy outside (-1, 1) makes the phase function singular"
+        );
+    }
+}

--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -526,6 +526,11 @@ fn render_frame(
     // sub-query needs the same treatment applied one level down (a tuple,
     // or a `#[derive(SystemParam)]` struct), not another entry here.
     mut render_queries: ParamSet<(
+        // `VolumetricFog` rides in this tuple rather than as a seventeenth
+        // top-level parameter for the reason spelled out above: this function
+        // is at Bevy 0.14's 16/16 `SystemParamFunction` ceiling, and going
+        // over it does not say so -- it surfaces as a `.chain()` trait-bound
+        // error in `RenderPlugin::build`.
         Query<(
             &Camera,
             &Transform,
@@ -533,6 +538,7 @@ fn render_frame(
             Option<&ToneMap>,
             Option<&AmbientOcclusion>,
             Option<&Taa>,
+            Option<&bsengine_core::VolumetricFog>,
         )>,
         Query<(
             &MeshRenderer,
@@ -637,12 +643,12 @@ fn render_frame(
         .map(|k| k.is_pressed(&KeyCode::AltLeft) || k.is_pressed(&KeyCode::AltRight))
         .unwrap_or(false);
 
-    let (mut view_proj, mut cam_pos, mut cam_proj, bloom, tone_map, ambient_occlusion, taa) =
+    let (mut view_proj, mut cam_pos, mut cam_proj, bloom, tone_map, ambient_occlusion, taa, fog) =
         render_queries
             .p0()
             .iter()
             .next()
-            .map(|(cam, t, b, tm, ao, taa)| {
+            .map(|(cam, t, b, tm, ao, taa, fog)| {
                 let proj = cam.projection_matrix();
                 (
                     proj * t.view_matrix(),
@@ -652,12 +658,14 @@ fn render_frame(
                     tm.copied(),
                     ao.copied(),
                     taa.copied(),
+                    fog.copied(),
                 )
             })
             .unwrap_or((
                 Mat4::IDENTITY,
                 Vec3::ZERO,
                 Mat4::IDENTITY,
+                None,
                 None,
                 None,
                 None,
@@ -979,6 +987,7 @@ fn render_frame(
         jitter_clip,
         unjittered_view_proj,
         light_probes,
+        fog,
     ) {
         Ok(clicked) => {
             if let Some(ref mut state) = ui_state {

--- a/crates/bsengine-rhi-wgpu/src/froxel.rs
+++ b/crates/bsengine-rhi-wgpu/src/froxel.rs
@@ -1,0 +1,126 @@
+//! Froxel grid geometry and the scattering phase function.
+//!
+//! Deliberately GPU-free so the two things that fail silently -- the phase
+//! function's normalisation and the depth slicing -- can be asserted
+//! exactly instead of eyeballed in a render.
+
+/// Froxel grid dimensions. X/Y are a coarse screen tiling; Z is the depth
+/// axis. 160x90 keeps a 16:9 aspect at 1/8 resolution.
+pub const FROXEL_X: u32 = 160;
+/// See [`FROXEL_X`].
+pub const FROXEL_Y: u32 = 90;
+/// Depth slices. See [`froxel_slice_depth`] for why they are not linear.
+pub const FROXEL_Z: u32 = 64;
+
+/// World-space view depth at the far edge of slice `slice` (0-based) of a
+/// grid spanning `near..far`.
+///
+/// **Exponential, not linear.** Perspective means a near froxel covers far
+/// less world space than a distant one; slicing linearly wastes most of the
+/// volume on distance nobody looks at while under-sampling the near field
+/// where fog gradients are actually visible. Linear slicing produces fog
+/// that looks almost right and bands close to the camera -- the classic
+/// froxel bug, and one that no end-to-end "is it foggy" test catches.
+pub fn froxel_slice_depth(slice: u32, near: f32, far: f32) -> f32 {
+    let t = (slice + 1) as f32 / FROXEL_Z as f32;
+    near * (far / near).powf(t)
+}
+
+/// Henyey-Greenstein phase function: the fraction of light scattered from
+/// direction `cos_theta` (the cosine between the incoming light direction
+/// and the view direction) for anisotropy `g`.
+///
+/// `g` in (-1, 1): 0 is isotropic, positive scatters forward (the bright
+/// halo around a light seen through haze), negative scatters backward.
+///
+/// The `1/(4*pi)` factor is what makes this integrate to 1 over the
+/// sphere. Dropping it -- easy, since many references quote the
+/// unnormalised form -- makes the fog roughly 12x too bright, which reads
+/// as "the density constant needs tuning" rather than as a bug.
+pub fn henyey_greenstein(cos_theta: f32, g: f32) -> f32 {
+    let g = g.clamp(-0.99, 0.99);
+    let g2 = g * g;
+    let denom = 1.0 + g2 - 2.0 * g * cos_theta;
+    (1.0 - g2) / (4.0 * std::f32::consts::PI * denom.max(1e-4).powf(1.5))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_phase_function_integrates_to_one_over_the_sphere() {
+        // The normalisation check. Integrate over theta with the sin(theta)
+        // Jacobian and the 2*pi azimuthal factor.
+        for &g in &[0.0f32, 0.3, -0.3, 0.7] {
+            let steps = 2000;
+            let mut total = 0.0f64;
+            for i in 0..steps {
+                let theta = std::f32::consts::PI * (i as f32 + 0.5) / steps as f32;
+                let d_theta = std::f32::consts::PI / steps as f32;
+                total += (henyey_greenstein(theta.cos(), g)
+                    * theta.sin()
+                    * 2.0
+                    * std::f32::consts::PI
+                    * d_theta) as f64;
+            }
+            assert!(
+                (total - 1.0).abs() < 0.02,
+                "phase function with g={g} integrated to {total}, not 1.0 -- \
+                 a missing 1/(4pi) makes fog ~12x too bright and merely looks \
+                 like a mistuned density"
+            );
+        }
+    }
+
+    #[test]
+    fn positive_g_scatters_forward() {
+        let fwd = henyey_greenstein(1.0, 0.6);
+        let back = henyey_greenstein(-1.0, 0.6);
+        assert!(
+            fwd > back,
+            "positive g must scatter forward: {fwd} vs {back}"
+        );
+    }
+
+    #[test]
+    fn zero_g_is_isotropic() {
+        let a = henyey_greenstein(1.0, 0.0);
+        let b = henyey_greenstein(-1.0, 0.0);
+        let c = henyey_greenstein(0.0, 0.0);
+        assert!((a - b).abs() < 1e-6 && (a - c).abs() < 1e-6);
+        assert!(
+            (a - 1.0 / (4.0 * std::f32::consts::PI)).abs() < 1e-6,
+            "isotropic scattering must equal 1/(4pi), got {a}"
+        );
+    }
+
+    #[test]
+    fn slice_depths_are_monotonic_and_end_on_the_far_plane() {
+        let (near, far) = (0.1f32, 100.0f32);
+        let mut prev = near;
+        for s in 0..FROXEL_Z {
+            let d = froxel_slice_depth(s, near, far);
+            assert!(d > prev, "slice {s} depth {d} did not increase past {prev}");
+            prev = d;
+        }
+        assert!(
+            (prev - far).abs() < 0.01,
+            "the last slice must land on the far plane, got {prev}"
+        );
+    }
+
+    #[test]
+    fn slices_are_denser_near_the_camera_than_far_away() {
+        // The whole point of exponential slicing. If this fails the
+        // distribution is linear and fog will band up close.
+        let (near, far) = (0.1f32, 100.0f32);
+        let first = froxel_slice_depth(0, near, far) - near;
+        let last = froxel_slice_depth(FROXEL_Z - 1, near, far)
+            - froxel_slice_depth(FROXEL_Z - 2, near, far);
+        assert!(
+            last > first * 10.0,
+            "far slices must be much thicker than near ones: near {first}, far {last}"
+        );
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
 
+pub mod froxel;
 /// Screen-space translate/rotate gizmo math and drawing.
 pub mod gizmo;
 /// Image-based lighting: cubemap helpers, the BRDF integration LUT, and the

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -42,6 +42,162 @@ fn fs_fog(in: FullscreenOut) -> @location(0) vec4<f32> {
 }
 "#;
 
+/// Storage/sample format of the two froxel volumes.
+///
+/// `Rgba16Float` carries `all_flags` in wgpu's format capability table, so it
+/// supports `STORAGE_BINDING` with no extra device feature, and it is
+/// filterable, which the Task 5 apply pass needs for its trilinear lookup.
+const FROXEL_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
+
+/// Size of [`FogUniform`], in bytes. See the test of the same name.
+const FOG_UNIFORM_SIZE: u64 = 144;
+
+/// Compute workgroup edge, matching the `@workgroup_size(8, 8, 1)` in both
+/// froxel shaders. The dispatch counts are derived from it.
+const FROXEL_WORKGROUP: u32 = 8;
+
+/// The froxel grid dimensions, emitted as WGSL constants so the two compute
+/// shaders cannot drift from [`crate::froxel`]'s Rust ones.
+///
+/// A disagreement would not fail to compile: it would leave part of the grid
+/// unwritten, or place fog at the wrong depth, which reads as a density bug.
+fn froxel_wgsl_preamble() -> String {
+    format!(
+        "const FROXEL_X: u32 = {}u;\nconst FROXEL_Y: u32 = {}u;\nconst FROXEL_Z: u32 = {}u;\n",
+        crate::froxel::FROXEL_X,
+        crate::froxel::FROXEL_Y,
+        crate::froxel::FROXEL_Z,
+    )
+}
+
+/// Declarations both froxel compute shaders share: the parameter uniform and
+/// the depth slicing.
+///
+/// `froxel_slice_depth` here is a direct port of [`crate::froxel::froxel_slice_depth`]
+/// -- exponential, not linear. The same mapping appears in the Rust, here, and
+/// (inverted) in the apply pass; all three have to agree or the fog sits at the
+/// wrong distance.
+const FROXEL_COMMON_WGSL: &str = r#"
+struct FogUniform {
+    inv_view_proj: mat4x4<f32>,
+    camera_pos: vec3<f32>,
+    near: f32,
+    light_dir: vec3<f32>,
+    far: f32,
+    light_color: vec3<f32>,
+    density: f32,
+    fog_color: vec3<f32>,
+    anisotropy: f32,
+    enabled: u32,
+    pad0: f32,
+    pad1: f32,
+    pad2: f32,
+}
+@group(0) @binding(0) var<uniform> fog: FogUniform;
+
+const PI: f32 = 3.14159265358979;
+
+// Port of `froxel::froxel_slice_depth`: the world-space view depth at the far
+// edge of slice `slice`.
+fn froxel_slice_depth(slice: u32) -> f32 {
+    let t = f32(slice + 1u) / f32(FROXEL_Z);
+    return fog.near * pow(fog.far / fog.near, t);
+}
+"#;
+
+/// Injection: one thread per froxel, writing in-scattered light in RGB and
+/// extinction in A.
+///
+/// **No shadow-map lookup.** Every froxel is treated as lit, so this is fog,
+/// not light shafts; the shadowed variant is roadmap item 49's second
+/// sub-step.
+const FOG_INJECT_WGSL: &str = r#"
+@group(1) @binding(0) var injection_vol: texture_storage_3d<rgba16float, write>;
+
+// Port of `froxel::henyey_greenstein`, 1/(4*PI) included. Dropping that factor
+// -- easy, since many references quote the unnormalised form -- makes the fog
+// roughly 12x too bright and merely reads as a mistuned density.
+fn henyey_greenstein(cos_theta: f32, g_in: f32) -> f32 {
+    let g = clamp(g_in, -0.99, 0.99);
+    let g2 = g * g;
+    let denom = 1.0 + g2 - 2.0 * g * cos_theta;
+    return (1.0 - g2) / (4.0 * PI * pow(max(denom, 1e-4), 1.5));
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn cs_inject(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if gid.x >= FROXEL_X || gid.y >= FROXEL_Y || gid.z >= FROXEL_Z {
+        return;
+    }
+    let uv = (vec2<f32>(f32(gid.x), f32(gid.y)) + vec2<f32>(0.5, 0.5))
+        / vec2<f32>(f32(FROXEL_X), f32(FROXEL_Y));
+    // The far-plane point behind this froxel column. The camera-to-far-plane
+    // vector has a view-space z of exactly `far`, so scaling it by
+    // `depth / far` lands on the slice's view depth -- the same quantity the
+    // apply pass will invert -- without needing the view matrix separately.
+    let ndc = vec4<f32>(uv.x * 2.0 - 1.0, -(uv.y * 2.0 - 1.0), 1.0, 1.0);
+    let far_h = fog.inv_view_proj * ndc;
+    let far_world = far_h.xyz / far_h.w;
+    let depth = froxel_slice_depth(gid.z);
+    let world_pos = fog.camera_pos + (far_world - fog.camera_pos) * (depth / fog.far);
+
+    let scattering = fog.fog_color * fog.density;
+    let extinction = fog.density;
+    let view_dir = normalize(world_pos - fog.camera_pos);
+    let cos_theta = dot(view_dir, fog.light_dir);
+    let phase = henyey_greenstein(cos_theta, fog.anisotropy);
+    let in_scatter = fog.light_color * scattering * phase;
+    textureStore(injection_vol, vec3<i32>(gid), vec4<f32>(in_scatter, extinction));
+}
+"#;
+
+/// Integration: one thread per froxel *column*, marching front to back and
+/// writing the running (in-scattered light, transmittance) at every slice.
+const FOG_INTEGRATE_WGSL: &str = r#"
+@group(1) @binding(0) var injection_vol: texture_3d<f32>;
+@group(2) @binding(0) var integrated_vol: texture_storage_3d<rgba16float, write>;
+
+@compute @workgroup_size(8, 8, 1)
+fn cs_integrate(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if gid.x >= FROXEL_X || gid.y >= FROXEL_Y {
+        return;
+    }
+    var accum = vec3<f32>(0.0, 0.0, 0.0);
+    var transmittance = 1.0;
+    // Slice 0 starts at the near plane; every later slice starts where the
+    // previous one ended.
+    var prev_depth = fog.near;
+    for (var z: u32 = 0u; z < FROXEL_Z; z = z + 1u) {
+        let s = textureLoad(injection_vol, vec3<i32>(i32(gid.x), i32(gid.y), i32(z)), 0);
+        let depth = froxel_slice_depth(z);
+        let slice_thickness = depth - prev_depth;
+        prev_depth = depth;
+        let slice_t = exp(-s.a * slice_thickness);
+        // Analytic integration across the slice, not a point sample at its
+        // centre: a point sample biases thick slices, and the exponential
+        // depth distribution guarantees thick slices at distance.
+        accum += transmittance * s.rgb * (1.0 - slice_t) / max(s.a, 1e-5);
+        transmittance *= slice_t;
+        textureStore(
+            integrated_vol,
+            vec3<i32>(i32(gid.x), i32(gid.y), i32(z)),
+            vec4<f32>(accum, transmittance),
+        );
+    }
+}
+"#;
+
+/// Full source of the injection shader: the generated grid constants, the
+/// shared declarations, then the pass itself.
+fn fog_inject_wgsl() -> String {
+    froxel_wgsl_preamble() + FROXEL_COMMON_WGSL + FOG_INJECT_WGSL
+}
+
+/// Full source of the integration shader. See [`fog_inject_wgsl`].
+fn fog_integrate_wgsl() -> String {
+    froxel_wgsl_preamble() + FROXEL_COMMON_WGSL + FOG_INTEGRATE_WGSL
+}
+
 const BLOOM_WGSL: &str = r#"
 struct FullscreenOut {
     @builtin(position) pos: vec4<f32>,
@@ -474,6 +630,42 @@ pub struct TaaCameraGpu {
     pub prev_view_proj: [[f32; 4]; 4],
 }
 
+/// GPU-uniform layout for the froxel passes.
+///
+/// A buffer of its own rather than more fields on [`PostProcessConfigGpu`]:
+/// that struct is exactly 64 bytes and full, IBL and TAA having taken the last
+/// of its padding.
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct FogUniform {
+    /// Inverse view-projection, to turn a froxel into a world position.
+    pub inv_view_proj: [[f32; 4]; 4],
+    /// Camera position in world space.
+    pub camera_pos: [f32; 3],
+    /// Camera near plane; the front edge of the first depth slice.
+    pub near: f32,
+    /// Direction *toward* the light, matching the scene shader's convention.
+    pub light_dir: [f32; 3],
+    /// Camera far plane; the back edge of the last depth slice.
+    pub far: f32,
+    /// Radiance of the directional light the fog scatters.
+    pub light_color: [f32; 3],
+    /// Uniform participating-media density (both scattering and extinction).
+    pub density: f32,
+    /// Albedo of the medium, multiplied into the scattering coefficient.
+    pub fog_color: [f32; 3],
+    /// Henyey-Greenstein anisotropy `g`; see [`crate::froxel::henyey_greenstein`].
+    pub anisotropy: f32,
+    /// Nonzero to run the fog passes at all.
+    pub enabled: u32,
+    /// Padding to the 16-byte uniform stride. See `fog_uniform_size`.
+    pub _pad0: f32,
+    /// See [`FogUniform::_pad0`].
+    pub _pad1: f32,
+    /// See [`FogUniform::_pad0`].
+    pub _pad2: f32,
+}
+
 struct PostProcessTargets {
     hdr_texture: crate::profiler::TrackedTexture,
     hdr_view: wgpu::TextureView,
@@ -552,6 +744,42 @@ pub struct PostProcessState {
     /// two the other passes use, because the resolve is already at the
     /// four-bind-group WebGPU baseline limit.
     taa_uniform_bg: wgpu::BindGroup,
+    /// The scattering volume: RGB is in-scattered light, A is extinction, one
+    /// texel per froxel. Filled by the injection pass, read by the integration
+    /// pass.
+    ///
+    /// **Deliberately not in `PostProcessTargets`, unlike every other texture
+    /// in this file.** Everything there lives in that struct because a window
+    /// resize has to reallocate it. The froxel grid is a fixed
+    /// `FROXEL_X x FROXEL_Y x FROXEL_Z` resolution, chosen independently of the
+    /// output size, so these two volumes are the only render resources here
+    /// that a resize must leave alone -- putting them in `PostProcessTargets`
+    /// would silently rebuild them on every resize for no reason.
+    _injection_volume: crate::profiler::TrackedTexture,
+    /// The integrated volume: RGB is accumulated in-scattered light up to each
+    /// slice, A is the transmittance to it. Written by the integration pass;
+    /// nothing samples it until the apply pass does.
+    ///
+    /// Not resized -- see [`PostProcessState::_injection_volume`].
+    _integrated_volume: crate::profiler::TrackedTexture,
+    fog_uniform_buffer: wgpu::Buffer,
+    fog_uniform_bg: wgpu::BindGroup,
+    /// The injection volume bound for writing (injection pass).
+    injection_write_bg: wgpu::BindGroup,
+    /// The same volume bound for sampling (integration pass). A second bind
+    /// group rather than a read-write binding, which the WebGPU baseline does
+    /// not offer for storage textures.
+    injection_read_bg: wgpu::BindGroup,
+    integrated_write_bg: wgpu::BindGroup,
+    /// Whether the last [`PostProcessState::update_fog`] enabled the effect.
+    ///
+    /// Mirrored on the CPU because `apply` skips the dispatch entirely when
+    /// fog is off, and it cannot read the flag back out of the uniform buffer.
+    fog_enabled: bool,
+    /// Compute pipeline that fills the scattering volume.
+    fog_inject_pipeline: wgpu::ComputePipeline,
+    /// Compute pipeline that marches each froxel column front to back.
+    fog_integrate_pipeline: wgpu::ComputePipeline,
     /// Pipeline for the volumetric-fog apply shader, the first pass of the
     /// chain. Currently an HDR passthrough; the name is the one the froxel
     /// lookup will keep when it replaces the shader behind it.
@@ -736,6 +964,133 @@ impl PostProcessState {
             ],
         });
 
+        // --- froxel volumes and the two compute pipelines ---
+        //
+        // Created here rather than in `create_targets` on purpose: the froxel
+        // grid has a fixed resolution, so unlike every other texture in this
+        // file these two must survive a window resize untouched.
+        let fog_uniform_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp fog uniform bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(FOG_UNIFORM_SIZE),
+                },
+                count: None,
+            }],
+        });
+        let froxel_write_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp froxel write bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::StorageTexture {
+                    access: wgpu::StorageTextureAccess::WriteOnly,
+                    format: FROXEL_FORMAT,
+                    view_dimension: wgpu::TextureViewDimension::D3,
+                },
+                count: None,
+            }],
+        });
+        let froxel_read_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp froxel read bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D3,
+                    multisampled: false,
+                },
+                count: None,
+            }],
+        });
+
+        let fog_uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pp fog uniform buffer"),
+            size: FOG_UNIFORM_SIZE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let fog_uniform_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pp fog uniform bg"),
+            layout: &fog_uniform_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: fog_uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        let make_volume = |label: &str| {
+            crate::profiler::create_tracked_texture(
+                device,
+                &wgpu::TextureDescriptor {
+                    label: Some(label),
+                    size: wgpu::Extent3d {
+                        width: crate::froxel::FROXEL_X,
+                        height: crate::froxel::FROXEL_Y,
+                        depth_or_array_layers: crate::froxel::FROXEL_Z,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D3,
+                    format: FROXEL_FORMAT,
+                    usage: wgpu::TextureUsages::TEXTURE_BINDING
+                        | wgpu::TextureUsages::STORAGE_BINDING,
+                    view_formats: &[],
+                },
+            )
+        };
+        let volume_view = |tex: &crate::profiler::TrackedTexture| {
+            tex.create_view(&wgpu::TextureViewDescriptor {
+                dimension: Some(wgpu::TextureViewDimension::D3),
+                ..Default::default()
+            })
+        };
+        let injection_volume = make_volume("pp froxel injection");
+        let integrated_volume = make_volume("pp froxel integrated");
+        let injection_view = volume_view(&injection_volume);
+        let integrated_view = volume_view(&integrated_volume);
+
+        let make_volume_bg =
+            |label: &str, bgl: &wgpu::BindGroupLayout, view: &wgpu::TextureView| {
+                device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some(label),
+                    layout: bgl,
+                    entries: &[wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(view),
+                    }],
+                })
+            };
+        let injection_write_bg = make_volume_bg(
+            "pp froxel injection write bg",
+            &froxel_write_bgl,
+            &injection_view,
+        );
+        let injection_read_bg = make_volume_bg(
+            "pp froxel injection read bg",
+            &froxel_read_bgl,
+            &injection_view,
+        );
+        let integrated_write_bg = make_volume_bg(
+            "pp froxel integrated write bg",
+            &froxel_write_bgl,
+            &integrated_view,
+        );
+
+        let fog_inject_pipeline =
+            Self::make_fog_inject_pipeline(device, &fog_uniform_bgl, &froxel_write_bgl);
+        let fog_integrate_pipeline = Self::make_fog_integrate_pipeline(
+            device,
+            &fog_uniform_bgl,
+            &froxel_read_bgl,
+            &froxel_write_bgl,
+        );
+
         let fog_pipeline = Self::make_fog_pipeline(device, &tex2d_bgl);
         let bloom_pipeline = Self::make_bloom_pipeline(device, &tex2d_bgl, &config_bgl);
         let ssao_pipeline =
@@ -790,6 +1145,16 @@ impl PostProcessState {
             ssao_cam_bg,
             taa_cam_buffer,
             taa_uniform_bg,
+            _injection_volume: injection_volume,
+            _integrated_volume: integrated_volume,
+            fog_uniform_buffer,
+            fog_uniform_bg,
+            injection_write_bg,
+            injection_read_bg,
+            integrated_write_bg,
+            fog_enabled: false,
+            fog_inject_pipeline,
+            fog_integrate_pipeline,
             fog_pipeline,
             bloom_pipeline,
             ssao_pipeline,
@@ -918,6 +1283,59 @@ impl PostProcessState {
             history_bgs,
             depth_bg,
         }
+    }
+
+    /// The froxel injection pass: the engine's first compute pipeline.
+    fn make_fog_inject_pipeline(
+        device: &wgpu::Device,
+        fog_uniform_bgl: &wgpu::BindGroupLayout,
+        froxel_write_bgl: &wgpu::BindGroupLayout,
+    ) -> wgpu::ComputePipeline {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("fog inject shader"),
+            source: wgpu::ShaderSource::Wgsl(fog_inject_wgsl().into()),
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("fog inject pll"),
+            bind_group_layouts: &[fog_uniform_bgl, froxel_write_bgl],
+            push_constant_ranges: &[],
+        });
+        device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("fog inject pipeline"),
+            layout: Some(&layout),
+            module: &shader,
+            entry_point: "cs_inject",
+            compilation_options: Default::default(),
+            cache: None,
+        })
+    }
+
+    /// The froxel integration pass. Reads the injection volume as a sampled
+    /// texture and writes the integrated one as storage; the same texture
+    /// cannot be both in one binding on the WebGPU baseline.
+    fn make_fog_integrate_pipeline(
+        device: &wgpu::Device,
+        fog_uniform_bgl: &wgpu::BindGroupLayout,
+        froxel_read_bgl: &wgpu::BindGroupLayout,
+        froxel_write_bgl: &wgpu::BindGroupLayout,
+    ) -> wgpu::ComputePipeline {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("fog integrate shader"),
+            source: wgpu::ShaderSource::Wgsl(fog_integrate_wgsl().into()),
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("fog integrate pll"),
+            bind_group_layouts: &[fog_uniform_bgl, froxel_read_bgl, froxel_write_bgl],
+            push_constant_ranges: &[],
+        });
+        device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("fog integrate pipeline"),
+            layout: Some(&layout),
+            module: &shader,
+            entry_point: "cs_integrate",
+            compilation_options: Default::default(),
+            cache: None,
+        })
     }
 
     /// The fog apply pass renders HDR into HDR, so its colour target is
@@ -1200,6 +1618,18 @@ impl PostProcessState {
         queue.write_buffer(&self.ssao_cam_buffer, 0, bytemuck::cast_slice(&[cam]));
     }
 
+    /// Uploads the froxel passes' parameters, and records whether those passes
+    /// should run at all.
+    ///
+    /// Takes `&mut self`, unlike the uploads either side of it, because the
+    /// enabled flag has to stay readable on the CPU: `apply` skips the whole
+    /// dispatch when fog is off, and it cannot read the flag back out of the
+    /// uniform buffer.
+    pub fn update_fog(&mut self, queue: &wgpu::Queue, fog: FogUniform) {
+        self.fog_enabled = fog.enabled != 0;
+        queue.write_buffer(&self.fog_uniform_buffer, 0, bytemuck::cast_slice(&[fog]));
+    }
+
     /// Uploads the unjittered view-projection matrices the TAA pass reprojects
     /// with: this frame's inverse and the previous frame's forward matrix.
     pub fn update_taa_camera(&self, queue: &wgpu::Queue, cam: TaaCameraGpu) {
@@ -1208,6 +1638,10 @@ impl PostProcessState {
 
     /// Runs the fog, bloom, SSAO, composite, and TAA passes in sequence,
     /// writing the final tonemapped result into `surface_view`.
+    ///
+    /// When the last [`PostProcessState::update_fog`] enabled the effect, a
+    /// compute pass runs first and fills the two froxel volumes. Nothing
+    /// samples them yet.
     ///
     /// The fog pass comes first and copies the scene's HDR image into a second
     /// HDR target that every later pass samples, because a pass cannot sample
@@ -1242,6 +1676,35 @@ impl PostProcessState {
     ) -> (u32, u64) {
         let mut draw_calls = 0u32;
         let mut triangles = 0u64;
+
+        if self.fog_enabled {
+            // The froxel volumes, filled before anything samples them. One
+            // pass with two dispatches: the injection volume's transition from
+            // storage-write to sampled between them is what orders the second
+            // behind the first.
+            //
+            // Compute contributes no draws, so the counters below stay out of
+            // this block.
+            let groups_x = crate::froxel::FROXEL_X.div_ceil(FROXEL_WORKGROUP);
+            let groups_y = crate::froxel::FROXEL_Y.div_ceil(FROXEL_WORKGROUP);
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("froxel fog pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.fog_inject_pipeline);
+            pass.set_bind_group(0, &self.fog_uniform_bg, &[]);
+            pass.set_bind_group(1, &self.injection_write_bg, &[]);
+            // One thread per froxel.
+            pass.dispatch_workgroups(groups_x, groups_y, crate::froxel::FROXEL_Z);
+
+            pass.set_pipeline(&self.fog_integrate_pipeline);
+            pass.set_bind_group(0, &self.fog_uniform_bg, &[]);
+            pass.set_bind_group(1, &self.injection_read_bg, &[]);
+            pass.set_bind_group(2, &self.integrated_write_bg, &[]);
+            // One thread per froxel *column*: each marches the whole Z axis.
+            pass.dispatch_workgroups(groups_x, groups_y, 1);
+        }
+
         {
             // Always drawn, `fast_render` included: every pass below reads
             // `fog_hdr_bg`, so skipping this one would leave them sampling the
@@ -1413,6 +1876,18 @@ mod tests {
     }
 
     #[test]
+    fn fog_uniform_size() {
+        // Must equal the `min_binding_size` the fog bind group layout declares
+        // and the size WGSL computes for `FogUniform`; a mismatch is a
+        // validation error at bind time, not a compile error.
+        assert_eq!(
+            std::mem::size_of::<FogUniform>() as u64,
+            FOG_UNIFORM_SIZE,
+            "FogUniform must stay {FOG_UNIFORM_SIZE} bytes"
+        );
+    }
+
+    #[test]
     fn hdr_format_is_rgba16float() {
         assert_eq!(HDR_FORMAT, wgpu::TextureFormat::Rgba16Float);
     }
@@ -1424,6 +1899,200 @@ mod tests {
             label: None,
             source: wgpu::ShaderSource::Wgsl(FOG_WGSL.into()),
         });
+    }
+
+    /// The two compute shaders are the first in the engine, so nothing else
+    /// would catch a WGSL error in them until it surfaced as a panic deep
+    /// inside a pixel test.
+    #[test]
+    fn fog_inject_shader_compiles() {
+        let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        let _m = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(fog_inject_wgsl().into()),
+        });
+    }
+
+    /// See [`fog_inject_shader_compiles`].
+    #[test]
+    fn fog_integrate_shader_compiles() {
+        let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        let _m = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(fog_integrate_wgsl().into()),
+        });
+    }
+
+    /// Reads `froxel_slice_depth` out of the real shared WGSL and compares it
+    /// against the Rust it was ported from.
+    ///
+    /// The only test-only part is the entry point below: the preamble and
+    /// `FROXEL_COMMON_WGSL` it is appended to are the exact source both compute
+    /// pipelines are built from. Nothing else checks this -- the volumes are
+    /// filled but unread until the apply pass lands -- and a mapping that
+    /// disagrees with the Rust puts the fog at the wrong distance, which reads
+    /// as a mistuned density rather than as a mapping bug.
+    #[test]
+    fn the_wgsl_depth_slicing_matches_froxel_slice_depth() {
+        const PROBE_WGSL: &str = r#"
+@group(1) @binding(0) var<storage, read_write> out_depths: array<f32>;
+
+@compute @workgroup_size(64, 1, 1)
+fn cs_probe(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if gid.x >= FROXEL_Z {
+        return;
+    }
+    out_depths[gid.x] = froxel_slice_depth(gid.x);
+}
+"#;
+        let (near, far) = (0.1f32, 100.0f32);
+        let slices = crate::froxel::FROXEL_Z as usize;
+        let bytes = (slices * std::mem::size_of::<f32>()) as u64;
+
+        let (device, queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("froxel slice depth probe"),
+            source: wgpu::ShaderSource::Wgsl(
+                (froxel_wgsl_preamble() + FROXEL_COMMON_WGSL + PROBE_WGSL).into(),
+            ),
+        });
+
+        let fog_uniform_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: None,
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(FOG_UNIFORM_SIZE),
+                },
+                count: None,
+            }],
+        });
+        let out_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: None,
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(bytes),
+                },
+                count: None,
+            }],
+        });
+
+        use bytemuck::Zeroable as _;
+        let mut fog = FogUniform::zeroed();
+        fog.near = near;
+        fog.far = far;
+        let fog_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: FOG_UNIFORM_SIZE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&fog_buffer, 0, bytemuck::cast_slice(&[fog]));
+        let out_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: bytes,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let readback = device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: bytes,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let fog_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &fog_uniform_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: fog_buffer.as_entire_binding(),
+            }],
+        });
+        let out_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &out_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: out_buffer.as_entire_binding(),
+            }],
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[&fog_uniform_bgl, &out_bgl],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: Some(&layout),
+            module: &shader,
+            entry_point: "cs_probe",
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: None,
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &fog_bg, &[]);
+            pass.set_bind_group(1, &out_bg, &[]);
+            pass.dispatch_workgroups(crate::froxel::FROXEL_Z.div_ceil(64), 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(&out_buffer, 0, &readback, 0, bytes);
+        queue.submit(Some(encoder.finish()));
+
+        let slice = readback.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .expect("map_async never reported a result")
+            .expect("mapping the readback buffer failed");
+        let got: Vec<f32> = bytemuck::cast_slice(&slice.get_mapped_range()).to_vec();
+        readback.unmap();
+
+        for s in 0..crate::froxel::FROXEL_Z {
+            let expected = crate::froxel::froxel_slice_depth(s, near, far);
+            let actual = got[s as usize];
+            assert!(
+                (actual - expected).abs() <= expected * 1e-4,
+                "slice {s}: the WGSL depth mapping gave {actual}, the Rust one \
+                 {expected}. The two must agree exactly, or fog lands at the \
+                 wrong distance and looks like a density problem"
+            );
+        }
+    }
+
+    /// The generated preamble is the only thing keeping the WGSL grid bounds
+    /// tied to the Rust ones, so assert it actually carries them.
+    #[test]
+    fn froxel_preamble_carries_the_rust_grid_dimensions() {
+        let p = froxel_wgsl_preamble();
+        for (name, value) in [
+            ("FROXEL_X", crate::froxel::FROXEL_X),
+            ("FROXEL_Y", crate::froxel::FROXEL_Y),
+            ("FROXEL_Z", crate::froxel::FROXEL_Z),
+        ] {
+            let expected = format!("const {name}: u32 = {value}u;");
+            assert!(
+                p.contains(&expected),
+                "the WGSL preamble must declare `{expected}`, got:\n{p}"
+            );
+        }
     }
 
     #[test]
@@ -1535,6 +2204,87 @@ mod tests {
             "the TAA resolve pass must record cleanly; a validation error here \
              means the pipeline layout, the bind groups, or the two colour \
              attachments disagree with the shader"
+        );
+    }
+
+    /// Compiling the two compute shaders proves nothing about the bindings
+    /// around them: a wrong group index, a storage format the layout does not
+    /// declare, or a dispatch over the device's workgroup limits is a `wgpu`
+    /// validation error, not a WGSL one. No pixel test reaches this code
+    /// either, because none of them enables fog.
+    #[test]
+    fn froxel_compute_passes_record_without_validation_errors() {
+        let (device, queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        let width = 64;
+        let height = 64;
+        let depth_texture = crate::profiler::create_tracked_texture(
+            &device,
+            &wgpu::TextureDescriptor {
+                label: Some("froxel test depth"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: crate::surface::DEPTH_FORMAT,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            },
+        );
+        let depth_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let target = crate::output::create_offscreen_texture(&device, width, height);
+        let target_view = target.create_view(&wgpu::TextureViewDescriptor::default());
+
+        device.push_error_scope(wgpu::ErrorFilter::Validation);
+        let mut pp = PostProcessState::new(
+            &device,
+            width,
+            height,
+            &depth_view,
+            crate::output::OFFSCREEN_FORMAT,
+        );
+        assert!(
+            !pp.fog_enabled,
+            "fog must be off until something uploads a FogUniform, or every \
+             pre-existing pixel test would start dispatching the froxel passes"
+        );
+
+        pp.update_fog(
+            &queue,
+            FogUniform {
+                inv_view_proj: glam::Mat4::perspective_rh(1.0, 1.0, 0.1, 100.0)
+                    .inverse()
+                    .to_cols_array_2d(),
+                camera_pos: [0.0, 0.0, 0.0],
+                near: 0.1,
+                light_dir: [0.0, 1.0, 0.0],
+                far: 100.0,
+                light_color: [1.0, 1.0, 1.0],
+                density: 0.05,
+                fog_color: [0.5, 0.6, 0.7],
+                anisotropy: 0.3,
+                enabled: 1,
+                _pad0: 0.0,
+                _pad1: 0.0,
+                _pad2: 0.0,
+            },
+        );
+        assert!(pp.fog_enabled, "a nonzero `enabled` must arm the dispatch");
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        pp.apply(&mut encoder, &target_view, false);
+        queue.submit(Some(encoder.finish()));
+        device.poll(wgpu::Maintain::Wait);
+        assert!(
+            pollster::block_on(device.pop_error_scope()).is_none(),
+            "the froxel injection and integration passes must record cleanly; \
+             a validation error here means the pipeline layouts, the bind \
+             groups, or the storage-texture formats disagree with the WGSL"
         );
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -9,13 +9,18 @@ const TAA_CAM_SIZE: u64 = 128;
 /// The volumetric-fog apply pass.
 ///
 /// It is the first pass of the post-process chain: the scene renders into
-/// `hdr_texture`, this reads that and writes `fog_hdr_texture`, and every
-/// downstream pass reads the copy. Two HDR targets rather than one because a
-/// pass may not sample the texture it renders into.
+/// `hdr_texture`, this reads that plus the integrated froxel volume and writes
+/// `fog_hdr_texture`, and every downstream pass reads that result. Two HDR
+/// targets rather than one because a pass may not sample the texture it
+/// renders into.
 ///
-/// Today it is an exact passthrough, so the chain produces the same image it
-/// did when bloom and composite sampled the scene target directly. The froxel
-/// lookup replaces the body of `fs_fog` without moving the pass.
+/// Composed by [`fog_apply_wgsl`], which prepends the grid constants and the
+/// shared froxel declarations -- `fog` at group 3, and `depth_to_froxel_w`,
+/// the inverse of the depth slicing the injection pass uses.
+///
+/// With `fog.enabled == 0u` this returns the scene sample untouched, so the
+/// chain produces exactly the image it did before the froxel lookup existed.
+/// Every pixel test relies on that: none of them sets `VolumetricFog`.
 const FOG_WGSL: &str = r#"
 struct FullscreenOut {
     @builtin(position) pos: vec4<f32>,
@@ -23,6 +28,10 @@ struct FullscreenOut {
 }
 @group(0) @binding(0) var hdr_tex: texture_2d<f32>;
 @group(0) @binding(1) var tex_sampler: sampler;
+@group(1) @binding(0) var depth_tex: texture_depth_2d;
+@group(2) @binding(0) var integrated_vol: texture_3d<f32>;
+@group(2) @binding(1) var vol_sampler: sampler;
+// `fog` sits at @group(3) @binding(0); see `fog_uniform_wgsl`.
 
 @vertex
 fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
@@ -36,9 +45,58 @@ fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
     return out;
 }
 
+fn load_depth(uv: vec2<f32>) -> f32 {
+    let dims = vec2<i32>(textureDimensions(depth_tex, 0));
+    let coord = clamp(vec2<i32>(uv * vec2<f32>(dims)), vec2<i32>(0), dims - vec2<i32>(1));
+    return textureLoad(depth_tex, coord, 0);
+}
+
+// The camera-to-far-plane vector through this pixel: the exact ray the
+// injection pass builds this screen column of froxels along.
+fn view_ray(uv: vec2<f32>) -> vec3<f32> {
+    let ndc = vec4<f32>(uv.x * 2.0 - 1.0, -(uv.y * 2.0 - 1.0), 1.0, 1.0);
+    let far_h = fog.inv_view_proj * ndc;
+    return far_h.xyz / far_h.w - fog.camera_pos;
+}
+
+// View depth of whatever was drawn at this pixel, in the same units
+// `froxel_slice_depth` speaks.
+//
+// `ray` spans exactly `fog.far` of view depth and the reconstructed point lies
+// on it, so the fraction along it scales straight to a view depth -- the exact
+// inverse of the injection pass's `world_pos = camera_pos + ray * (depth/far)`.
+// Deriving it from the same `inv_view_proj` is what keeps the two in step; a
+// separately supplied near/far linearisation would not.
+fn surface_view_depth(uv: vec2<f32>, depth: f32, ray: vec3<f32>) -> f32 {
+    let ndc = vec4<f32>(uv.x * 2.0 - 1.0, -(uv.y * 2.0 - 1.0), depth, 1.0);
+    let world_h = fog.inv_view_proj * ndc;
+    let world = world_h.xyz / world_h.w;
+    return fog.far * dot(world - fog.camera_pos, ray) / max(dot(ray, ray), 1e-6);
+}
+
 @fragment
 fn fs_fog(in: FullscreenOut) -> @location(0) vec4<f32> {
-    return textureSample(hdr_tex, tex_sampler, in.uv);
+    let scene = textureSample(hdr_tex, tex_sampler, in.uv);
+    // The whole pass is a passthrough with fog off, and this is the branch
+    // that makes it one. It is also the only reason the pre-existing pixel
+    // tests still produce their reference images.
+    if fog.enabled == 0u {
+        return scene;
+    }
+    let depth = load_depth(in.uv);
+    let ray = view_ray(in.uv);
+    // Background pixels (nothing drawn) take the volume's last slice, so the
+    // sky is fogged too. Skipping them -- the tempting shortcut, since the
+    // SSAO pass in this same file does skip them -- would leave a crisp
+    // horizon standing behind thick fog.
+    let view_z = select(surface_view_depth(in.uv, depth, ray), fog.far, depth >= 1.0);
+    let vol = textureSampleLevel(
+        integrated_vol, vol_sampler,
+        vec3<f32>(in.uv, depth_to_froxel_w(view_z)), 0.0,
+    );
+    // RGB is the light in-scattered between the camera and this pixel; A is
+    // the transmittance across that same stretch.
+    return vec4<f32>(scene.rgb * vol.a + vol.rgb, scene.a);
 }
 "#;
 
@@ -70,14 +128,11 @@ fn froxel_wgsl_preamble() -> String {
     )
 }
 
-/// Declarations both froxel compute shaders share: the parameter uniform and
-/// the depth slicing.
+/// The `FogUniform` declaration, matching the Rust [`FogUniform`].
 ///
-/// `froxel_slice_depth` here is a direct port of [`crate::froxel::froxel_slice_depth`]
-/// -- exponential, not linear. The same mapping appears in the Rust, here, and
-/// (inverted) in the apply pass; all three have to agree or the fog sits at the
-/// wrong distance.
-const FROXEL_COMMON_WGSL: &str = r#"
+/// Split from [`FROXEL_COMMON_WGSL`] only so the binding line can name a
+/// different group per shader; see [`fog_uniform_wgsl`].
+const FOG_UNIFORM_STRUCT_WGSL: &str = r#"
 struct FogUniform {
     inv_view_proj: mat4x4<f32>,
     camera_pos: vec3<f32>,
@@ -93,8 +148,27 @@ struct FogUniform {
     pad1: f32,
     pad2: f32,
 }
-@group(0) @binding(0) var<uniform> fog: FogUniform;
+"#;
 
+/// The `FogUniform` struct plus its binding at `group`.
+///
+/// The two compute passes take it at group 0, where it is their first group.
+/// The apply pass takes it at group 3, its first three being the scene colour,
+/// the depth buffer, and the integrated volume.
+fn fog_uniform_wgsl(group: u32) -> String {
+    format!("{FOG_UNIFORM_STRUCT_WGSL}@group({group}) @binding(0) var<uniform> fog: FogUniform;\n")
+}
+
+/// Declarations every froxel shader shares: the depth slicing and its inverse.
+///
+/// `froxel_slice_depth` here is a direct port of [`crate::froxel::froxel_slice_depth`]
+/// -- exponential, not linear -- and `depth_to_froxel_w` inverts it. The
+/// mapping exists in the Rust, in this forward function, and in that inverse;
+/// all three have to agree or the fog sits at the wrong distance, which reads
+/// as a density problem rather than a mapping one. `depth_to_froxel_w` lives
+/// here, beside the mapping it inverts, rather than in the apply shader that
+/// is its only caller, so the pair cannot drift apart unnoticed.
+const FROXEL_COMMON_WGSL: &str = r#"
 const PI: f32 = 3.14159265358979;
 
 // Port of `froxel::froxel_slice_depth`: the world-space view depth at the far
@@ -102,6 +176,17 @@ const PI: f32 = 3.14159265358979;
 fn froxel_slice_depth(slice: u32) -> f32 {
     let t = f32(slice + 1u) / f32(FROXEL_Z);
     return fog.near * pow(fog.far / fog.near, t);
+}
+
+// Inverse of `froxel_slice_depth`, as a 0..1 coordinate down the volume's W
+// axis. Solving `view_z = near * pow(far/near, t)` for `t` gives
+// `log(view_z/near) / log(far/near)`.
+//
+// Clamped at both ends: nothing nearer than the near plane or beyond the far
+// plane has a slice, and the volume's edge texels are what those should read.
+fn depth_to_froxel_w(view_z: f32) -> f32 {
+    let z = clamp(view_z, fog.near, fog.far);
+    return clamp(log(z / fog.near) / log(fog.far / fog.near), 0.0, 1.0);
 }
 "#;
 
@@ -187,15 +272,23 @@ fn cs_integrate(@builtin(global_invocation_id) gid: vec3<u32>) {
 }
 "#;
 
-/// Full source of the injection shader: the generated grid constants, the
-/// shared declarations, then the pass itself.
+/// Full source of the injection shader: the generated grid constants, the fog
+/// uniform at group 0, the shared declarations, then the pass itself.
 fn fog_inject_wgsl() -> String {
-    froxel_wgsl_preamble() + FROXEL_COMMON_WGSL + FOG_INJECT_WGSL
+    froxel_wgsl_preamble() + &fog_uniform_wgsl(0) + FROXEL_COMMON_WGSL + FOG_INJECT_WGSL
 }
 
 /// Full source of the integration shader. See [`fog_inject_wgsl`].
 fn fog_integrate_wgsl() -> String {
-    froxel_wgsl_preamble() + FROXEL_COMMON_WGSL + FOG_INTEGRATE_WGSL
+    froxel_wgsl_preamble() + &fog_uniform_wgsl(0) + FROXEL_COMMON_WGSL + FOG_INTEGRATE_WGSL
+}
+
+/// Full source of the apply shader. Same shared declarations as the compute
+/// passes -- which is what makes its `depth_to_froxel_w` the genuine inverse of
+/// their `froxel_slice_depth` rather than a re-derivation -- with the uniform
+/// at group 3 instead of group 0.
+fn fog_apply_wgsl() -> String {
+    froxel_wgsl_preamble() + &fog_uniform_wgsl(3) + FROXEL_COMMON_WGSL + FOG_WGSL
 }
 
 const BLOOM_WGSL: &str = r#"
@@ -757,8 +850,8 @@ pub struct PostProcessState {
     /// would silently rebuild them on every resize for no reason.
     _injection_volume: crate::profiler::TrackedTexture,
     /// The integrated volume: RGB is accumulated in-scattered light up to each
-    /// slice, A is the transmittance to it. Written by the integration pass;
-    /// nothing samples it until the apply pass does.
+    /// slice, A is the transmittance to it. Written by the integration pass and
+    /// sampled by the apply pass.
     ///
     /// Not resized -- see [`PostProcessState::_injection_volume`].
     _integrated_volume: crate::profiler::TrackedTexture,
@@ -771,6 +864,10 @@ pub struct PostProcessState {
     /// not offer for storage textures.
     injection_read_bg: wgpu::BindGroup,
     integrated_write_bg: wgpu::BindGroup,
+    /// The integrated volume bound for the apply pass to sample: a filtering
+    /// sampler and a `texture_3d<f32>`, not the storage binding the
+    /// integration pass writes it through.
+    integrated_read_bg: wgpu::BindGroup,
     /// Whether the last [`PostProcessState::update_fog`] enabled the effect.
     ///
     /// Mirrored on the CPU because `apply` skips the dispatch entirely when
@@ -781,8 +878,8 @@ pub struct PostProcessState {
     /// Compute pipeline that marches each froxel column front to back.
     fog_integrate_pipeline: wgpu::ComputePipeline,
     /// Pipeline for the volumetric-fog apply shader, the first pass of the
-    /// chain. Currently an HDR passthrough; the name is the one the froxel
-    /// lookup will keep when it replaces the shader behind it.
+    /// chain: it composites the integrated volume onto the scene's HDR image.
+    /// An exact passthrough while `fog.enabled` is zero.
     pub fog_pipeline: wgpu::RenderPipeline,
     /// Pipeline for the bright-pass bloom extraction shader.
     pub bloom_pipeline: wgpu::RenderPipeline,
@@ -815,6 +912,10 @@ impl PostProcessState {
             label: Some("pp sampler"),
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
+            // W matters only to the fog apply pass, the one user of a 3D
+            // texture here: clamping is what makes a lookup past the far slice
+            // hold at that slice instead of wrapping back to the near one.
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
             ..Default::default()
@@ -969,11 +1070,14 @@ impl PostProcessState {
         // Created here rather than in `create_targets` on purpose: the froxel
         // grid has a fixed resolution, so unlike every other texture in this
         // file these two must survive a window resize untouched.
+        // Visible to both stages: the two compute passes read these parameters
+        // to fill the volumes, and the apply pass reads the same buffer for
+        // `enabled`, the near/far mapping, and the camera matrix.
         let fog_uniform_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("pp fog uniform bgl"),
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStages::COMPUTE,
+                visibility: wgpu::ShaderStages::COMPUTE | wgpu::ShaderStages::FRAGMENT,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: false,
@@ -1007,6 +1111,32 @@ impl PostProcessState {
                 },
                 count: None,
             }],
+        });
+        // The apply pass reads the integrated volume as a *sampled* texture --
+        // it wants the trilinear filter between froxels, which a storage
+        // binding cannot give it -- so its layout is a `Texture` entry with a
+        // `D3` view dimension plus a filtering sampler, not the storage entry
+        // the integration pass writes through.
+        let froxel_apply_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("pp froxel apply bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D3,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
         });
 
         let fog_uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -1081,6 +1211,24 @@ impl PostProcessState {
             &froxel_write_bgl,
             &integrated_view,
         );
+        // The same volume the integration pass writes, bound for the apply
+        // pass to sample. `sampler` clamps on every axis, W included, so the
+        // near and far ends of the volume hold at their edge slices instead of
+        // wrapping around to each other.
+        let integrated_read_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pp froxel integrated read bg"),
+            layout: &froxel_apply_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&integrated_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+            ],
+        });
 
         let fog_inject_pipeline =
             Self::make_fog_inject_pipeline(device, &fog_uniform_bgl, &froxel_write_bgl);
@@ -1091,7 +1239,13 @@ impl PostProcessState {
             &froxel_write_bgl,
         );
 
-        let fog_pipeline = Self::make_fog_pipeline(device, &tex2d_bgl);
+        let fog_pipeline = Self::make_fog_pipeline(
+            device,
+            &tex2d_bgl,
+            &depth_bgl,
+            &froxel_apply_bgl,
+            &fog_uniform_bgl,
+        );
         let bloom_pipeline = Self::make_bloom_pipeline(device, &tex2d_bgl, &config_bgl);
         let ssao_pipeline =
             Self::make_ssao_pipeline(device, &depth_bgl, &config_bgl, &ssao_cam_bgl);
@@ -1152,6 +1306,7 @@ impl PostProcessState {
             injection_write_bg,
             injection_read_bg,
             integrated_write_bg,
+            integrated_read_bg,
             fog_enabled: false,
             fog_inject_pipeline,
             fog_integrate_pipeline,
@@ -1340,17 +1495,24 @@ impl PostProcessState {
 
     /// The fog apply pass renders HDR into HDR, so its colour target is
     /// `HDR_FORMAT` rather than the swapchain format the later passes use.
+    ///
+    /// Four bind groups -- scene colour, depth, the integrated volume, the fog
+    /// parameters -- which is the WebGPU baseline `max_bind_groups`, the same
+    /// ceiling the TAA resolve sits at.
     fn make_fog_pipeline(
         device: &wgpu::Device,
         tex2d_bgl: &wgpu::BindGroupLayout,
+        depth_bgl: &wgpu::BindGroupLayout,
+        froxel_apply_bgl: &wgpu::BindGroupLayout,
+        fog_uniform_bgl: &wgpu::BindGroupLayout,
     ) -> wgpu::RenderPipeline {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("fog shader"),
-            source: wgpu::ShaderSource::Wgsl(FOG_WGSL.into()),
+            source: wgpu::ShaderSource::Wgsl(fog_apply_wgsl().into()),
         });
         let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("fog pll"),
-            bind_group_layouts: &[tex2d_bgl],
+            bind_group_layouts: &[tex2d_bgl, depth_bgl, froxel_apply_bgl, fog_uniform_bgl],
             push_constant_ranges: &[],
         });
         device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -1640,14 +1802,14 @@ impl PostProcessState {
     /// writing the final tonemapped result into `surface_view`.
     ///
     /// When the last [`PostProcessState::update_fog`] enabled the effect, a
-    /// compute pass runs first and fills the two froxel volumes. Nothing
-    /// samples them yet.
+    /// compute pass runs first and fills the two froxel volumes; the apply
+    /// pass then samples the integrated one.
     ///
-    /// The fog pass comes first and copies the scene's HDR image into a second
+    /// The fog pass comes first and writes the scene's HDR image into a second
     /// HDR target that every later pass samples, because a pass cannot sample
-    /// the texture it renders into. It is an exact passthrough for now, so the
-    /// image reaching `surface_view` is the one the chain produced when bloom
-    /// and composite read the scene target directly.
+    /// the texture it renders into. With fog disabled it is an exact
+    /// passthrough, so the image reaching `surface_view` is the one the chain
+    /// produced when bloom and composite read the scene target directly.
     ///
     /// Composite writes into an intermediate LDR target rather than straight
     /// into `surface_view`; the TAA pass then reads that target and writes both
@@ -1724,6 +1886,12 @@ impl PostProcessState {
             });
             pass.set_pipeline(&self.fog_pipeline);
             pass.set_bind_group(0, &self.hdr_bg, &[]);
+            pass.set_bind_group(1, &self.depth_bg, &[]);
+            // Bound even with fog off: the pipeline layout demands all four
+            // groups, and the shader's `enabled == 0` early-out is what stops
+            // the volume from being read.
+            pass.set_bind_group(2, &self.integrated_read_bg, &[]);
+            pass.set_bind_group(3, &self.fog_uniform_bg, &[]);
             pass.draw(0..3, 0..1);
             draw_calls += 1;
             triangles += 1;
@@ -1897,7 +2065,7 @@ mod tests {
         let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
         let _m = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: None,
-            source: wgpu::ShaderSource::Wgsl(FOG_WGSL.into()),
+            source: wgpu::ShaderSource::Wgsl(fog_apply_wgsl().into()),
         });
     }
 
@@ -1923,37 +2091,24 @@ mod tests {
         });
     }
 
-    /// Reads `froxel_slice_depth` out of the real shared WGSL and compares it
-    /// against the Rust it was ported from.
+    /// Runs a test-only compute entry point named `cs_probe`, appended to the
+    /// real shared froxel WGSL, and returns the `out_floats` values it wrote
+    /// to `out_values` at `@group(1) @binding(0)`.
     ///
-    /// The only test-only part is the entry point below: the preamble and
-    /// `FROXEL_COMMON_WGSL` it is appended to are the exact source both compute
-    /// pipelines are built from. Nothing else checks this -- the volumes are
-    /// filled but unread until the apply pass lands -- and a mapping that
-    /// disagrees with the Rust puts the fog at the wrong distance, which reads
-    /// as a mistuned density rather than as a mapping bug.
-    #[test]
-    fn the_wgsl_depth_slicing_matches_froxel_slice_depth() {
-        const PROBE_WGSL: &str = r#"
-@group(1) @binding(0) var<storage, read_write> out_depths: array<f32>;
-
-@compute @workgroup_size(64, 1, 1)
-fn cs_probe(@builtin(global_invocation_id) gid: vec3<u32>) {
-    if gid.x >= FROXEL_Z {
-        return;
-    }
-    out_depths[gid.x] = froxel_slice_depth(gid.x);
-}
-"#;
-        let (near, far) = (0.1f32, 100.0f32);
-        let slices = crate::froxel::FROXEL_Z as usize;
-        let bytes = (slices * std::mem::size_of::<f32>()) as u64;
+    /// Only the entry point a caller supplies is test-only. The preamble, the
+    /// `FogUniform`, and `FROXEL_COMMON_WGSL` around it are the exact source
+    /// the two compute pipelines are built from, and `depth_to_froxel_w` in
+    /// there is the exact function the apply shader calls -- so what these
+    /// probes measure is the shipping mapping, not a copy of it.
+    fn run_froxel_probe(near: f32, far: f32, probe_wgsl: &str, out_floats: usize) -> Vec<f32> {
+        let bytes = (out_floats * std::mem::size_of::<f32>()) as u64;
 
         let (device, queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("froxel slice depth probe"),
+            label: Some("froxel probe"),
             source: wgpu::ShaderSource::Wgsl(
-                (froxel_wgsl_preamble() + FROXEL_COMMON_WGSL + PROBE_WGSL).into(),
+                (froxel_wgsl_preamble() + &fog_uniform_wgsl(0) + FROXEL_COMMON_WGSL + probe_wgsl)
+                    .into(),
             ),
         });
 
@@ -2064,6 +2219,31 @@ fn cs_probe(@builtin(global_invocation_id) gid: vec3<u32>) {
             .expect("mapping the readback buffer failed");
         let got: Vec<f32> = bytemuck::cast_slice(&slice.get_mapped_range()).to_vec();
         readback.unmap();
+        got
+    }
+
+    /// Reads `froxel_slice_depth` out of the real shared WGSL and compares it
+    /// against the Rust it was ported from.
+    ///
+    /// A mapping that disagrees with the Rust puts the fog at the wrong
+    /// distance, which reads as a mistuned density rather than as a mapping
+    /// bug. See [`run_froxel_probe`] for what is and is not test-only here.
+    #[test]
+    fn the_wgsl_depth_slicing_matches_froxel_slice_depth() {
+        const PROBE_WGSL: &str = r#"
+@group(1) @binding(0) var<storage, read_write> out_values: array<f32>;
+
+@compute @workgroup_size(64, 1, 1)
+fn cs_probe(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if gid.x >= FROXEL_Z {
+        return;
+    }
+    out_values[gid.x] = froxel_slice_depth(gid.x);
+}
+"#;
+        let (near, far) = (0.1f32, 100.0f32);
+        let slices = crate::froxel::FROXEL_Z as usize;
+        let got = run_froxel_probe(near, far, PROBE_WGSL, slices);
 
         for s in 0..crate::froxel::FROXEL_Z {
             let expected = crate::froxel::froxel_slice_depth(s, near, far);
@@ -2075,6 +2255,61 @@ fn cs_probe(@builtin(global_invocation_id) gid: vec3<u32>) {
                  wrong distance and looks like a density problem"
             );
         }
+    }
+
+    /// `depth_to_froxel_w`, the function the apply pass turns a pixel's view
+    /// depth into a volume coordinate with, must be the exact inverse of the
+    /// slicing the injection pass placed that light at.
+    ///
+    /// Slice `s` holds what was integrated up to its far edge, at
+    /// `froxel_slice_depth(s)`, which is `(s+1)/FROXEL_Z` of the way down the
+    /// volume -- so feeding that depth back in has to return `(s+1)/FROXEL_Z`.
+    /// An inverse that disagrees samples a neighbouring slice's light and
+    /// again reads as a density problem, not a mapping one.
+    ///
+    /// The two entries past the grid check the clamp the background path
+    /// depends on: a depth outside `near..far` must land on an edge slice.
+    #[test]
+    fn the_wgsl_depth_to_froxel_w_inverts_the_slice_mapping() {
+        const PROBE_WGSL: &str = r#"
+@group(1) @binding(0) var<storage, read_write> out_values: array<f32>;
+
+@compute @workgroup_size(64, 1, 1)
+fn cs_probe(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if gid.x >= FROXEL_Z {
+        return;
+    }
+    out_values[gid.x] = depth_to_froxel_w(froxel_slice_depth(gid.x));
+    if gid.x == 0u {
+        out_values[FROXEL_Z] = depth_to_froxel_w(fog.near * 0.5);
+        out_values[FROXEL_Z + 1u] = depth_to_froxel_w(fog.far * 2.0);
+    }
+}
+"#;
+        let (near, far) = (0.1f32, 100.0f32);
+        let slices = crate::froxel::FROXEL_Z as usize;
+        let got = run_froxel_probe(near, far, PROBE_WGSL, slices + 2);
+
+        for s in 0..crate::froxel::FROXEL_Z {
+            let expected = (s + 1) as f32 / crate::froxel::FROXEL_Z as f32;
+            let actual = got[s as usize];
+            assert!(
+                (actual - expected).abs() <= 1e-4,
+                "slice {s}: depth_to_froxel_w(froxel_slice_depth({s})) gave \
+                 {actual}, not {expected}. The apply pass would sample the \
+                 wrong slice, which looks like mistuned density"
+            );
+        }
+        assert_eq!(
+            got[slices], 0.0,
+            "a depth nearer than the near plane must clamp onto the first slice"
+        );
+        assert_eq!(
+            got[slices + 1],
+            1.0,
+            "a depth past the far plane must clamp onto the last slice -- this \
+             is the path every background pixel takes"
+        );
     }
 
     /// The generated preamble is the only thing keeping the WGSL grid bounds

--- a/crates/bsengine-rhi-wgpu/src/post_process.rs
+++ b/crates/bsengine-rhi-wgpu/src/post_process.rs
@@ -6,6 +6,42 @@ const CONFIG_SIZE: u64 = 64;
 const SSAO_CAM_SIZE: u64 = 128;
 const TAA_CAM_SIZE: u64 = 128;
 
+/// The volumetric-fog apply pass.
+///
+/// It is the first pass of the post-process chain: the scene renders into
+/// `hdr_texture`, this reads that and writes `fog_hdr_texture`, and every
+/// downstream pass reads the copy. Two HDR targets rather than one because a
+/// pass may not sample the texture it renders into.
+///
+/// Today it is an exact passthrough, so the chain produces the same image it
+/// did when bloom and composite sampled the scene target directly. The froxel
+/// lookup replaces the body of `fs_fog` without moving the pass.
+const FOG_WGSL: &str = r#"
+struct FullscreenOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+@group(0) @binding(0) var hdr_tex: texture_2d<f32>;
+@group(0) @binding(1) var tex_sampler: sampler;
+
+@vertex
+fn vs_fullscreen(@builtin(vertex_index) vi: u32) -> FullscreenOut {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0), vec2<f32>(-1.0, 1.0), vec2<f32>(3.0, 1.0),
+    );
+    let p = positions[vi];
+    var out: FullscreenOut;
+    out.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+    out.uv = vec2<f32>(p.x * 0.5 + 0.5, -p.y * 0.5 + 0.5);
+    return out;
+}
+
+@fragment
+fn fs_fog(in: FullscreenOut) -> @location(0) vec4<f32> {
+    return textureSample(hdr_tex, tex_sampler, in.uv);
+}
+"#;
+
 const BLOOM_WGSL: &str = r#"
 struct FullscreenOut {
     @builtin(position) pos: vec4<f32>,
@@ -442,6 +478,12 @@ struct PostProcessTargets {
     hdr_texture: crate::profiler::TrackedTexture,
     hdr_view: wgpu::TextureView,
     hdr_bg: wgpu::BindGroup,
+    /// Second HDR target. The scene renders into `hdr_texture`; the fog pass
+    /// reads that and writes here, and bloom/composite read this one. Two
+    /// targets because a pass may not sample the texture it renders to.
+    fog_hdr_texture: crate::profiler::TrackedTexture,
+    fog_hdr_view: wgpu::TextureView,
+    fog_hdr_bg: wgpu::BindGroup,
     bloom_texture: crate::profiler::TrackedTexture,
     bloom_view: wgpu::TextureView,
     bloom_bg: wgpu::BindGroup,
@@ -458,11 +500,18 @@ struct PostProcessTargets {
 }
 
 /// Owns the render targets, bind groups, and pipelines for the post-process
-/// chain (bloom -> SSAO -> tonemapped composite onto the swapchain).
+/// chain (fog -> bloom -> SSAO -> tonemapped composite -> TAA resolve onto the
+/// swapchain).
 pub struct PostProcessState {
     /// View of the HDR scene-color render target the main pass writes into.
     pub hdr_view: wgpu::TextureView,
     _hdr_texture: crate::profiler::TrackedTexture,
+    /// The fog pass's HDR output, and the image the rest of the chain reads.
+    /// `hdr_view` above is what the scene rendered; this is that image with
+    /// fog applied, and it exists as a second target because the fog pass
+    /// cannot sample the texture it renders into.
+    fog_hdr_view: wgpu::TextureView,
+    _fog_hdr_texture: crate::profiler::TrackedTexture,
     bloom_view: wgpu::TextureView,
     _bloom_texture: crate::profiler::TrackedTexture,
     ao_view: wgpu::TextureView,
@@ -487,6 +536,7 @@ pub struct PostProcessState {
     /// than blending against an uninitialised texture.
     history_valid: bool,
     hdr_bg: wgpu::BindGroup,
+    fog_hdr_bg: wgpu::BindGroup,
     bloom_bg: wgpu::BindGroup,
     ao_bg: wgpu::BindGroup,
     ldr_bg: wgpu::BindGroup,
@@ -502,6 +552,10 @@ pub struct PostProcessState {
     /// two the other passes use, because the resolve is already at the
     /// four-bind-group WebGPU baseline limit.
     taa_uniform_bg: wgpu::BindGroup,
+    /// Pipeline for the volumetric-fog apply shader, the first pass of the
+    /// chain. Currently an HDR passthrough; the name is the one the froxel
+    /// lookup will keep when it replaces the shader behind it.
+    pub fog_pipeline: wgpu::RenderPipeline,
     /// Pipeline for the bright-pass bloom extraction shader.
     pub bloom_pipeline: wgpu::RenderPipeline,
     /// Pipeline for the SSAO occlusion shader.
@@ -682,6 +736,7 @@ impl PostProcessState {
             ],
         });
 
+        let fog_pipeline = Self::make_fog_pipeline(device, &tex2d_bgl);
         let bloom_pipeline = Self::make_bloom_pipeline(device, &tex2d_bgl, &config_bgl);
         let ssao_pipeline =
             Self::make_ssao_pipeline(device, &depth_bgl, &config_bgl, &ssao_cam_bgl);
@@ -709,6 +764,8 @@ impl PostProcessState {
         Self {
             hdr_view: targets.hdr_view,
             _hdr_texture: targets.hdr_texture,
+            fog_hdr_view: targets.fog_hdr_view,
+            _fog_hdr_texture: targets.fog_hdr_texture,
             bloom_view: targets.bloom_view,
             _bloom_texture: targets.bloom_texture,
             ao_view: targets.ao_view,
@@ -721,6 +778,7 @@ impl PostProcessState {
             history_read: 0,
             history_valid: false,
             hdr_bg: targets.hdr_bg,
+            fog_hdr_bg: targets.fog_hdr_bg,
             bloom_bg: targets.bloom_bg,
             ao_bg: targets.ao_bg,
             ldr_bg: targets.ldr_bg,
@@ -732,6 +790,7 @@ impl PostProcessState {
             ssao_cam_bg,
             taa_cam_buffer,
             taa_uniform_bg,
+            fog_pipeline,
             bloom_pipeline,
             ssao_pipeline,
             composite_pipeline,
@@ -776,6 +835,10 @@ impl PostProcessState {
 
         let hdr_texture = make_tex("pp hdr", HDR_FORMAT);
         let hdr_view = hdr_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        // Same format and size as `hdr_texture`: the fog pass copies the scene
+        // image through it, so anything narrower would requantize the frame.
+        let fog_hdr_texture = make_tex("pp fog hdr", HDR_FORMAT);
+        let fog_hdr_view = fog_hdr_texture.create_view(&wgpu::TextureViewDescriptor::default());
         let bloom_texture = make_tex("pp bloom", BLOOM_FORMAT);
         let bloom_view = bloom_texture.create_view(&wgpu::TextureViewDescriptor::default());
         let ao_texture = make_tex("pp ao", AO_FORMAT);
@@ -816,6 +879,7 @@ impl PostProcessState {
         };
 
         let hdr_bg = make_tex2d_bg("pp hdr bg", &hdr_view);
+        let fog_hdr_bg = make_tex2d_bg("pp fog hdr bg", &fog_hdr_view);
         let bloom_bg = make_tex2d_bg("pp bloom bg", &bloom_view);
         let ao_bg = make_tex2d_bg("pp ao bg", &ao_view);
         let ldr_bg = make_tex2d_bg("pp ldr bg", &ldr_view);
@@ -837,6 +901,9 @@ impl PostProcessState {
             hdr_texture,
             hdr_view,
             hdr_bg,
+            fog_hdr_texture,
+            fog_hdr_view,
+            fog_hdr_bg,
             bloom_texture,
             bloom_view,
             bloom_bg,
@@ -851,6 +918,48 @@ impl PostProcessState {
             history_bgs,
             depth_bg,
         }
+    }
+
+    /// The fog apply pass renders HDR into HDR, so its colour target is
+    /// `HDR_FORMAT` rather than the swapchain format the later passes use.
+    fn make_fog_pipeline(
+        device: &wgpu::Device,
+        tex2d_bgl: &wgpu::BindGroupLayout,
+    ) -> wgpu::RenderPipeline {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("fog shader"),
+            source: wgpu::ShaderSource::Wgsl(FOG_WGSL.into()),
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("fog pll"),
+            bind_group_layouts: &[tex2d_bgl],
+            push_constant_ranges: &[],
+        });
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("fog pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_fullscreen",
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_fog",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: HDR_FORMAT,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        })
     }
 
     fn make_bloom_pipeline(
@@ -1026,8 +1135,9 @@ impl PostProcessState {
         })
     }
 
-    /// Recreates the sized render targets (HDR/bloom/AO/LDR/depth bind group)
-    /// for a new surface resolution, leaving pipelines and samplers untouched.
+    /// Recreates the sized render targets (HDR/fog HDR/bloom/AO/LDR/history and
+    /// the depth bind group) for a new surface resolution, leaving pipelines and
+    /// samplers untouched.
     pub fn resize_targets(
         &mut self,
         device: &wgpu::Device,
@@ -1047,6 +1157,8 @@ impl PostProcessState {
         );
         self.hdr_view = t.hdr_view;
         self._hdr_texture = t.hdr_texture;
+        self.fog_hdr_view = t.fog_hdr_view;
+        self._fog_hdr_texture = t.fog_hdr_texture;
         self.bloom_view = t.bloom_view;
         self._bloom_texture = t.bloom_texture;
         self.ao_view = t.ao_view;
@@ -1060,6 +1172,7 @@ impl PostProcessState {
         // resolution, so nothing in it may be blended against.
         self.invalidate_history();
         self.hdr_bg = t.hdr_bg;
+        self.fog_hdr_bg = t.fog_hdr_bg;
         self.bloom_bg = t.bloom_bg;
         self.ao_bg = t.ao_bg;
         self.ldr_bg = t.ldr_bg;
@@ -1093,8 +1206,14 @@ impl PostProcessState {
         queue.write_buffer(&self.taa_cam_buffer, 0, bytemuck::cast_slice(&[cam]));
     }
 
-    /// Runs the bloom, SSAO, composite, and TAA passes in sequence, writing
-    /// the final tonemapped result into `surface_view`.
+    /// Runs the fog, bloom, SSAO, composite, and TAA passes in sequence,
+    /// writing the final tonemapped result into `surface_view`.
+    ///
+    /// The fog pass comes first and copies the scene's HDR image into a second
+    /// HDR target that every later pass samples, because a pass cannot sample
+    /// the texture it renders into. It is an exact passthrough for now, so the
+    /// image reaching `surface_view` is the one the chain produced when bloom
+    /// and composite read the scene target directly.
     ///
     /// Composite writes into an intermediate LDR target rather than straight
     /// into `surface_view`; the TAA pass then reads that target and writes both
@@ -1124,6 +1243,30 @@ impl PostProcessState {
         let mut draw_calls = 0u32;
         let mut triangles = 0u64;
         {
+            // Always drawn, `fast_render` included: every pass below reads
+            // `fog_hdr_bg`, so skipping this one would leave them sampling the
+            // clear colour instead of the scene.
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("fog apply pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.fog_hdr_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(&self.fog_pipeline);
+            pass.set_bind_group(0, &self.hdr_bg, &[]);
+            pass.draw(0..3, 0..1);
+            draw_calls += 1;
+            triangles += 1;
+        }
+
+        {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("bloom pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -1139,7 +1282,7 @@ impl PostProcessState {
             });
             if !fast_render {
                 pass.set_pipeline(&self.bloom_pipeline);
-                pass.set_bind_group(0, &self.hdr_bg, &[]);
+                pass.set_bind_group(0, &self.fog_hdr_bg, &[]);
                 pass.set_bind_group(1, &self.config_bg, &[]);
                 pass.draw(0..3, 0..1);
                 draw_calls += 1;
@@ -1187,7 +1330,7 @@ impl PostProcessState {
                 ..Default::default()
             });
             pass.set_pipeline(&self.composite_pipeline);
-            pass.set_bind_group(0, &self.hdr_bg, &[]);
+            pass.set_bind_group(0, &self.fog_hdr_bg, &[]);
             pass.set_bind_group(1, &self.bloom_bg, &[]);
             pass.set_bind_group(2, &self.ao_bg, &[]);
             pass.set_bind_group(3, &self.config_bg, &[]);
@@ -1272,6 +1415,15 @@ mod tests {
     #[test]
     fn hdr_format_is_rgba16float() {
         assert_eq!(HDR_FORMAT, wgpu::TextureFormat::Rgba16Float);
+    }
+
+    #[test]
+    fn fog_shader_compiles() {
+        let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
+        let _m = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(FOG_WGSL.into()),
+        });
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -4397,10 +4397,7 @@ impl WgpuSurface {
                     far: fog_far,
                     light_color: light.color.to_array(),
                     density: active_fog.map(|f| f.density).unwrap_or(0.0),
-                    fog_color: active_fog
-                        .map(|f| *f.color)
-                        .unwrap_or(Vec3::ONE)
-                        .to_array(),
+                    fog_color: active_fog.map(|f| *f.color).unwrap_or(Vec3::ONE).to_array(),
                     anisotropy: active_fog.map(|f| f.anisotropy).unwrap_or(0.0),
                     enabled: u32::from(active_fog.is_some()),
                     _pad0: 0.0,
@@ -5847,7 +5844,10 @@ mod tests {
                 (n - near).abs() < near * 1e-3,
                 "near {n} should have been {near}"
             );
-            assert!((f - far).abs() < far * 1e-3, "far {f} should have been {far}");
+            assert!(
+                (f - far).abs() < far * 1e-3,
+                "far {f} should have been {far}"
+            );
         }
     }
 

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1608,6 +1608,40 @@ fn jittered_view_proj(view_proj: Mat4, cam_proj: Mat4, jitter_clip: (f32, f32)) 
     jittered_proj * (cam_proj.inverse() * view_proj)
 }
 
+/// The camera's near and far clip distances, recovered from its projection.
+///
+/// The froxel grid slices the range between them, and the apply pass inverts
+/// that slicing, so both need the two numbers as scalars. Reading them back out
+/// of the same matrix the frame rasterises with -- rather than plumbing
+/// `Camera::near`/`far` down as two more parameters -- is what keeps them from
+/// ever disagreeing with the depth buffer the apply pass unprojects, including
+/// on the editor path where the projection comes from the orbit camera and no
+/// `Camera` component is involved at all.
+///
+/// Unprojecting NDC z of 0 and 1 down the view axis gives them directly: glam's
+/// `perspective_rh` writes wgpu's 0..1 depth range, so those are the two clip
+/// planes. A degenerate or reversed projection falls back to
+/// `Camera::default()`'s planes rather than returning zeros -- the slicing
+/// divides by `log(far/near)`, and a zero near would put NaN in every froxel.
+fn camera_near_far(cam_proj: Mat4) -> (f32, f32) {
+    let fallback = (0.1, 1000.0);
+    if cam_proj.determinant().abs() < f32::EPSILON {
+        return fallback;
+    }
+    let inv = cam_proj.inverse();
+    let view_depth_at = |ndc_z: f32| {
+        let p = inv * glam::Vec4::new(0.0, 0.0, ndc_z, 1.0);
+        // View space looks down -Z, so the positive depth is the negated z.
+        -(p.z / p.w)
+    };
+    let near = view_depth_at(0.0);
+    let far = view_depth_at(1.0);
+    if !near.is_finite() || !far.is_finite() || near <= 0.0 || far <= near {
+        return fallback;
+    }
+    (near, far)
+}
+
 /// The `(forward, up)` pair of every cube face, in face order.
 ///
 /// The standard cubemap face orientation convention (+Y/-Y up-vectors on the
@@ -4111,6 +4145,7 @@ impl WgpuSurface {
         jitter_clip: (f32, f32),
         unjittered_view_proj: Mat4,
         light_probes: Option<ProbeVolumeParams>,
+        fog: Option<bsengine_core::VolumetricFog>,
     ) -> Result<std::collections::HashSet<String>, String> {
         // Wall-clock CPU time for this call, for `FrameStats::cpu_frame_time_ms`.
         let frame_start = std::time::Instant::now();
@@ -4332,6 +4367,45 @@ impl WgpuSurface {
                 crate::post_process::TaaCameraGpu {
                     inv_view_proj: unjittered_view_proj.inverse().to_cols_array_2d(),
                     prev_view_proj: self.prev_unjittered_view_proj.to_cols_array_2d(),
+                },
+            );
+
+            // Volumetric fog. An absent component -- and a present but
+            // disabled one -- uploads `enabled: 0`, which makes the apply
+            // pass an exact passthrough. That is what leaves every scene
+            // that never asks for fog rendering as it did before the froxel
+            // volumes existed.
+            let active_fog = fog.filter(|f| f.enabled);
+            let (fog_near, fog_far) = camera_near_far(cam_proj);
+            self.post_process.update_fog(
+                &self.queue,
+                crate::post_process::FogUniform {
+                    // The *jittered* matrix, matching what actually
+                    // rasterised the depth buffer the apply pass unprojects.
+                    // With TAA off the two are identical; with it on, the
+                    // unjittered one would read depth a fraction of a pixel
+                    // off its own reconstruction.
+                    inv_view_proj: raster_view_proj.inverse().to_cols_array_2d(),
+                    camera_pos: cam_pos.to_array(),
+                    near: fog_near,
+                    // Toward the light, which is the convention the scene
+                    // shader's `let l = normalize(-light.direction)` uses.
+                    // Handing over the travel direction instead would flip
+                    // the phase function and darken exactly the view that
+                    // should be brightest.
+                    light_dir: (-light.direction.normalize_or_zero()).to_array(),
+                    far: fog_far,
+                    light_color: light.color.to_array(),
+                    density: active_fog.map(|f| f.density).unwrap_or(0.0),
+                    fog_color: active_fog
+                        .map(|f| *f.color)
+                        .unwrap_or(Vec3::ONE)
+                        .to_array(),
+                    anisotropy: active_fog.map(|f| f.anisotropy).unwrap_or(0.0),
+                    enabled: u32::from(active_fog.is_some()),
+                    _pad0: 0.0,
+                    _pad1: 0.0,
+                    _pad2: 0.0,
                 },
             );
         }
@@ -5762,6 +5836,34 @@ mod tests {
     }
 
     #[test]
+    fn near_and_far_come_back_out_of_the_projection_they_went_into() {
+        // The froxel slicing spans exactly this range and the apply pass
+        // inverts that span, so a wrong pair puts the fog at the wrong
+        // distance -- which reads as a density problem, not a mapping one.
+        for (near, far) in [(0.1_f32, 100.0_f32), (0.05, 500.0), (1.0, 20.0)] {
+            let proj = Mat4::perspective_rh(60.0_f32.to_radians(), 16.0 / 9.0, near, far);
+            let (n, f) = camera_near_far(proj);
+            assert!(
+                (n - near).abs() < near * 1e-3,
+                "near {n} should have been {near}"
+            );
+            assert!((f - far).abs() < far * 1e-3, "far {f} should have been {far}");
+        }
+    }
+
+    #[test]
+    fn a_degenerate_projection_yields_usable_near_and_far() {
+        // Same all-zero `editor_proj` as the jitter fallback above. A zero
+        // near would divide by `log(far/0)` in the froxel mapping and fill
+        // every slice with NaN.
+        let (near, far) = camera_near_far(Mat4::ZERO);
+        assert!(
+            near > 0.0 && far > near && near.is_finite() && far.is_finite(),
+            "expected a usable range, got near {near}, far {far}"
+        );
+    }
+
+    #[test]
     fn point_light_face_view_projs_all_invertible() {
         let vps = point_light_face_view_projs(Vec3::new(1.0, 2.0, 3.0), 10.0);
         for (i, vp) in vps.iter().enumerate() {
@@ -6458,6 +6560,7 @@ mod tests {
                 (0.0, 0.0),
                 Mat4::IDENTITY,
                 volume,
+                None,
             )
         }
 

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -560,6 +560,7 @@ struct VertOut {{
                 // not ask for a volume keeps rendering exactly as it did before
                 // light probes existed.
                 light_probes,
+                None,
             )
             .expect("render_frame failed");
 

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -195,6 +195,10 @@ pub struct Scene {
     /// for one. A test that wants a surface outside the volume moves the
     /// surface, not the box.
     pub light_probes: Option<bsengine_core::LightProbeVolume>,
+    /// Volumetric fog for this camera, or `None` for no fog at all -- which is
+    /// exactly what an absent component means on a real camera, and what every
+    /// other test file in this directory leaves it as.
+    pub fog: Option<bsengine_core::VolumetricFog>,
     pub hud: HashMap<String, String>,
     pub with_skybox: bool,
     /// Particle batches for the pass that runs after transparency.
@@ -213,6 +217,7 @@ impl Default for Scene {
             ssao: None,
             taa: None,
             light_probes: None,
+            fog: None,
             hud: HashMap::new(),
             with_skybox: false,
             particles: Vec::new(),
@@ -560,7 +565,10 @@ struct VertOut {{
                 // not ask for a volume keeps rendering exactly as it did before
                 // light probes existed.
                 light_probes,
-                None,
+                // `None` uploads `enabled: 0`, so the fog apply pass is an
+                // exact passthrough and every scene that does not ask for fog
+                // renders as it did before the froxel volumes existed.
+                scene.fog,
             )
             .expect("render_frame failed");
 

--- a/crates/bsengine-rhi-wgpu/tests/pixels_fog.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_fog.rs
@@ -1,0 +1,363 @@
+//! Volumetric fog: is it actually *volumetric*?
+//!
+//! The assertion that matters here is depth dependence, not haze. An
+//! implementation that added a constant everywhere -- no froxel volume, no
+//! integration, a single `mix` against a fog colour -- would satisfy "the
+//! screen got foggier" and every casual eyeball check. Only a working froxel
+//! volume makes a far surface shift several times further than a near one, so
+//! that ratio is what the first test measures and the only thing that proves
+//! the depth axis works.
+//!
+//! Every scene here turns bloom, SSAO and tone mapping **off**. All three sit
+//! downstream of the fog pass and all three are on by default, and each one
+//! would fold its own depth- or brightness-dependent term into a measurement
+//! meant to isolate a single pass. With them off, what reaches a pixel is the
+//! scene colour, the fog, and the sRGB encode.
+
+mod common;
+
+use common::{Draw, Harness, Light, Pixels, Scene};
+use glam::{Mat4, Vec3};
+
+/// The cubes' constant colour, straight into the HDR target.
+///
+/// A *custom shader* rather than a lit material, deliberately: a lit cube's
+/// colour depends on its distance to the light, its normals and the shadow
+/// map, so a near and a far cube would start from different colours and the
+/// near/far shift comparison would be measuring that difference as much as the
+/// fog. A constant-colour shader makes the two cubes' unfogged pixels
+/// identical, which leaves depth as the only thing that can separate them.
+const CUBE_LINEAR: f32 = 0.6;
+
+/// Cube centres. The near one is two world units in front of the camera, the
+/// far one twenty-five -- both inside the frustum, neither overlapping the
+/// other on screen.
+const NEAR_CENTRE: Vec3 = Vec3::new(-1.0, 0.0, 3.0);
+const FAR_CENTRE: Vec3 = Vec3::new(8.0, 0.0, -20.0);
+
+/// The far cube is scaled up so it covers a comparable number of pixels: at
+/// twenty-five units a unit cube is about six pixels across, and a sample
+/// point on something that small is one bad rounding away from the background.
+/// Scale changes nothing about the comparison, because the constant-colour
+/// shader makes both cubes render the same value at any size.
+const FAR_SCALE: f32 = 8.0;
+
+/// A camera looking at the origin from `+Z`, the harness's default.
+const CAMERA: Vec3 = Vec3::new(0.0, 0.0, 5.0);
+
+/// Where a world-space point lands, in pixels.
+///
+/// Mirrors the harness's own projection (60 degrees, 0.1 to 100) so the sample
+/// points are derived from the camera rather than read off a screenshot and
+/// pasted in. `cube_sample_is_really_on_the_cube` below is what catches this
+/// drifting out of step with `render_frame_at`.
+fn screen_of(world: Vec3, camera_pos: Vec3) -> (u32, u32) {
+    let proj = Mat4::perspective_rh(
+        60.0_f32.to_radians(),
+        common::WIDTH as f32 / common::HEIGHT as f32,
+        0.1,
+        100.0,
+    );
+    let clip = proj * Mat4::look_at_rh(camera_pos, Vec3::ZERO, Vec3::Y) * world.extend(1.0);
+    let ndc = clip.truncate() / clip.w;
+    (
+        ((ndc.x * 0.5 + 0.5) * common::WIDTH as f32) as u32,
+        ((-ndc.y * 0.5 + 0.5) * common::HEIGHT as f32) as u32,
+    )
+}
+
+/// How far a pixel moved between two frames: the sum of the per-channel
+/// differences, in 0-255 units.
+///
+/// Summed across channels rather than compared per channel because the fog
+/// colour is not grey -- a coloured fog moves the three channels by different
+/// amounts, and the question here is how far the pixel travelled, not which
+/// way.
+fn shift(a: &Pixels, b: &Pixels, at: (u32, u32)) -> f32 {
+    let (p, q) = (a.at(at.0, at.1), b.at(at.0, at.1));
+    (0..3).map(|i| (p[i] as f32 - q[i] as f32).abs()).sum()
+}
+
+/// The mesh and the flat shader every scene in this file draws with.
+fn fixtures(h: &mut Harness) -> (u64, String) {
+    let cube = h.cube();
+    let shader = h.constant_colour_shader([CUBE_LINEAR; 3], "fog-flat");
+    (cube, shader)
+}
+
+/// The two cubes, with everything downstream of the fog pass switched off.
+fn two_cubes(
+    cube: u64,
+    shader: &str,
+    fog: Option<bsengine_core::VolumetricFog>,
+) -> Scene {
+    Scene {
+        draws: vec![
+            Draw::new(cube, NEAR_CENTRE).shader(shader),
+            Draw::new(cube, FAR_CENTRE)
+                .scaled(Vec3::splat(FAR_SCALE), FAR_CENTRE)
+                .shader(shader),
+        ],
+        bloom: Some(bsengine_core::Bloom::default().disabled()),
+        ssao: Some(bsengine_core::AmbientOcclusion::default().disabled()),
+        tone_map: Some(bsengine_core::ToneMap::default().disabled()),
+        fog,
+        ..Scene::default()
+    }
+}
+
+/// Moderate fog: thick enough that twenty-five units is most of the way to
+/// opaque, thin enough that two units is nearly clear. Isotropic, so the phase
+/// function contributes the same constant everywhere and cannot be what makes
+/// the near and far samples differ.
+fn moderate_fog() -> bsengine_core::VolumetricFog {
+    bsengine_core::VolumetricFog {
+        enabled: true,
+        density: 0.05,
+        // Distinctly red, so "shifted toward the fog colour" is a direction on
+        // screen and not just a magnitude.
+        color: Vec3::new(1.0, 0.2, 0.2).into(),
+        anisotropy: 0.0,
+    }
+}
+
+#[test]
+fn cube_sample_is_really_on_the_cube() {
+    // `screen_of` reproduces the harness's projection rather than asking it,
+    // so it can silently drift. Sampling the background instead of the cube
+    // would make the near/far comparison below meaningless while still
+    // producing two numbers to divide, so this pins both sample points to the
+    // flat colour the cubes actually render.
+    let mut h = Harness::new();
+    let (cube, shader) = fixtures(&mut h);
+    let plain = h.render(&two_cubes(cube, &shader, None));
+
+    // 0.6 linear through the sRGB encode the offscreen target applies.
+    let expected = (1.055 * CUBE_LINEAR.powf(1.0 / 2.4) - 0.055) * 255.0;
+    for (label, centre) in [("near", NEAR_CENTRE), ("far", FAR_CENTRE)] {
+        let at = screen_of(centre, CAMERA);
+        let p = plain.at(at.0, at.1);
+        assert!(
+            (p[0] as f32 - expected).abs() < 12.0,
+            "the {label} cube's sample point {at:?} reads {p:?}, not the flat \
+             {expected:.0} the constant-colour shader writes -- the sample is \
+             off the cube, so every fog measurement taken there is measuring \
+             the background"
+        );
+    }
+}
+
+#[test]
+fn fog_affects_distant_surfaces_much_more_than_near_ones() {
+    // THE test. Two cubes that render the identical colour when unfogged, one
+    // two units away and one twenty-five. A constant haze added everywhere
+    // moves both by the same amount; a real froxel volume, integrated front to
+    // back along Z, moves the far one far further. The ratio is the proof the
+    // depth axis exists.
+    let mut h = Harness::new();
+    let (cube, shader) = fixtures(&mut h);
+    let plain = h.render(&two_cubes(cube, &shader, None));
+    let fogged = h.render(&two_cubes(cube, &shader, Some(moderate_fog())));
+
+    let near_at = screen_of(NEAR_CENTRE, CAMERA);
+    let far_at = screen_of(FAR_CENTRE, CAMERA);
+    let near = shift(&plain, &fogged, near_at);
+    let far = shift(&plain, &fogged, far_at);
+
+    // Reported unconditionally: the numbers are the finding, and a test that
+    // only prints them on failure hides the margin it is passing by.
+    println!(
+        "near cube {near_at:?}: {:?} -> {:?}  (shift {near:.1})\n\
+         far  cube {far_at:?}: {:?} -> {:?}  (shift {far:.1})\n\
+         ratio far/near = {:.2}",
+        plain.at(near_at.0, near_at.1),
+        fogged.at(near_at.0, near_at.1),
+        plain.at(far_at.0, far_at.1),
+        fogged.at(far_at.0, far_at.1),
+        far / near.max(1e-6),
+    );
+
+    assert!(
+        near > 2.0,
+        "the near cube should still be fogged a little -- a shift of {near} \
+         means the fog is not reaching the near field at all, which is a \
+         different bug from the one this test is about"
+    );
+    assert!(
+        far > 4.0 * near,
+        "the far cube must shift several times further than the near one; got \
+         far {far:.1} vs near {near:.1} (ratio {:.2}). Equal shifts mean the \
+         fog is a constant added to every pixel and the froxel volume's depth \
+         axis is not doing anything: check that the exponential Z mapping \
+         agrees between froxel_slice_depth, the injection shader and \
+         depth_to_froxel_w, that the integration accumulates along Z, and that \
+         fog.enabled reaches the shader",
+        far / near.max(1e-6),
+    );
+
+    // ...and it moved *toward the fog colour*, not merely somewhere. The fog
+    // is red, so the far cube's red channel must end up ahead of its green by
+    // more than the near cube's does.
+    let redness = |p: &Pixels, at: (u32, u32)| {
+        let c = p.at(at.0, at.1);
+        c[0] as f32 - c[1] as f32
+    };
+    let near_red = redness(&fogged, near_at) - redness(&plain, near_at);
+    let far_red = redness(&fogged, far_at) - redness(&plain, far_at);
+    assert!(
+        far_red > near_red + 5.0,
+        "the far cube must take on more of the red fog colour than the near \
+         one: far gained {far_red:.1} of red-over-green, near gained {near_red:.1}"
+    );
+}
+
+#[test]
+fn zero_density_leaves_the_image_unchanged() {
+    // Zero extinction means zero scattering *and* full transmittance, so the
+    // apply pass must hand back the scene byte for byte -- not "close enough".
+    // A shader that mixed toward the fog colour by a density-independent
+    // amount, or an integration that divided by a density it had clamped away
+    // from zero, fails exactly here.
+    let mut h = Harness::new();
+    let (cube, shader) = fixtures(&mut h);
+    let off = h.render(&two_cubes(cube, &shader, None));
+    let zero = h.render(&two_cubes(
+        cube,
+        &shader,
+        Some(bsengine_core::VolumetricFog {
+            enabled: true,
+            density: 0.0,
+            ..moderate_fog()
+        }),
+    ));
+    assert!(
+        !zero.differs_from(&off),
+        "density 0 must be pixel-identical to no fog at all; fog-off reads {}, \
+         zero-density reads {}",
+        off.describe(),
+        zero.describe()
+    );
+
+    // Non-vacuity: the same harness, the same scene, a real density -- if this
+    // did not differ, the equality above would be measuring nothing.
+    let real = h.render(&two_cubes(cube, &shader, Some(moderate_fog())));
+    assert!(
+        real.differs_from(&off),
+        "a non-zero density must change the image, or the test above proves \
+         nothing about density"
+    );
+}
+
+#[test]
+fn a_scene_with_no_fog_component_is_pixel_identical() {
+    // The strongest regression this branch has. Every one of the pre-existing
+    // pixel tests renders with no `VolumetricFog` at all, and their reference
+    // behaviour is only preserved while the disabled path is an exact
+    // passthrough -- not a passthrough through an extra sampler, an extra
+    // format conversion, or a `mix` by zero.
+    let mut h = Harness::new();
+    let (cube, shader) = fixtures(&mut h);
+    let absent = h.render(&two_cubes(cube, &shader, None));
+
+    // A component that is present but disabled, carrying deliberately violent
+    // parameters. If `enabled` were ignored anywhere -- in the CPU-side guard
+    // that skips the dispatch, or in the shader's early return -- this frame
+    // would be unmistakable.
+    let present_but_off = h.render(&two_cubes(
+        cube,
+        &shader,
+        Some(bsengine_core::VolumetricFog {
+            enabled: false,
+            density: 0.9,
+            color: Vec3::new(0.0, 1.0, 0.0).into(),
+            anisotropy: 0.9,
+        }),
+    ));
+    assert!(
+        !present_but_off.differs_from(&absent),
+        "a disabled VolumetricFog must render exactly as no component at all; \
+         absent reads {}, disabled reads {}",
+        absent.describe(),
+        present_but_off.describe()
+    );
+
+    // Non-vacuity again: the same violent parameters, enabled.
+    let enabled = h.render(&two_cubes(
+        cube,
+        &shader,
+        Some(bsengine_core::VolumetricFog {
+            enabled: true,
+            density: 0.9,
+            color: Vec3::new(0.0, 1.0, 0.0).into(),
+            anisotropy: 0.9,
+        }),
+    ));
+    assert!(
+        enabled.differs_from(&absent),
+        "enabling that same fog must change the image, or the two equality \
+         assertions above are comparing a pass that never runs"
+    );
+}
+
+#[test]
+fn positive_anisotropy_brightens_the_view_toward_the_light() {
+    // The phase function, end to end. An empty scene, so every pixel is pure
+    // in-scattered light and nothing else, viewed twice: once looking into the
+    // directional light and once with it behind the camera. Only the phase
+    // function can separate those two frames -- the medium, the density, the
+    // colour and the depth range are identical.
+    let mut h = Harness::new();
+
+    // The light travels along -Z, so it comes *from* +Z: a camera at +Z looks
+    // away from it, and one at -Z looks into it.
+    let sun = Light {
+        direction: Vec3::new(0.0, 0.0, -1.0),
+        ..Light::default()
+    };
+    let view = |camera_pos: Vec3, anisotropy: f32| Scene {
+        draws: Vec::new(),
+        light: sun.clone(),
+        camera_pos,
+        bloom: Some(bsengine_core::Bloom::default().disabled()),
+        ssao: Some(bsengine_core::AmbientOcclusion::default().disabled()),
+        tone_map: Some(bsengine_core::ToneMap::default().disabled()),
+        fog: Some(bsengine_core::VolumetricFog {
+            enabled: true,
+            density: 0.05,
+            color: Vec3::ONE.into(),
+            anisotropy,
+        }),
+        ..Scene::default()
+    };
+    let toward = Vec3::new(0.0, 0.0, -5.0);
+    let away = Vec3::new(0.0, 0.0, 5.0);
+
+    // The control. With g = 0 the phase function is the constant 1/(4*pi), so
+    // the two views must read the same. Without this, a renderer that simply
+    // made the -Z camera brighter for some unrelated reason would pass the
+    // real assertion below.
+    let iso_toward = h.render(&view(toward, 0.0)).centre_luma();
+    let iso_away = h.render(&view(away, 0.0)).centre_luma();
+    assert!(
+        (iso_toward - iso_away).abs() < 2.0,
+        "isotropic fog must look the same in both directions, got {iso_toward:.1} \
+         toward the light and {iso_away:.1} away from it -- something other than \
+         the phase function is separating these two views, and the assertion \
+         below would inherit it"
+    );
+
+    let fwd_toward = h.render(&view(toward, 0.7)).centre_luma();
+    let fwd_away = h.render(&view(away, 0.7)).centre_luma();
+    println!(
+        "anisotropy 0.0: toward {iso_toward:.1}, away {iso_away:.1}\n\
+         anisotropy 0.7: toward {fwd_toward:.1}, away {fwd_away:.1}"
+    );
+    assert!(
+        fwd_toward > fwd_away + 10.0,
+        "forward scattering (g = 0.7) must brighten the view into the light \
+         relative to the view away from it: toward {fwd_toward:.1}, away \
+         {fwd_away:.1}. Equal readings mean the Henyey-Greenstein term is not \
+         reaching the injection pass, so the fog is uniform grey rather than \
+         scattering"
+    );
+}

--- a/crates/bsengine-rhi-wgpu/tests/pixels_fog.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_fog.rs
@@ -86,11 +86,7 @@ fn fixtures(h: &mut Harness) -> (u64, String) {
 }
 
 /// The two cubes, with everything downstream of the fog pass switched off.
-fn two_cubes(
-    cube: u64,
-    shader: &str,
-    fog: Option<bsengine_core::VolumetricFog>,
-) -> Scene {
+fn two_cubes(cube: u64, shader: &str, fog: Option<bsengine_core::VolumetricFog>) -> Scene {
     Scene {
         draws: vec![
             Draw::new(cube, NEAR_CENTRE).shader(shader),

--- a/crates/bsengine-rhi-wgpu/tests/terrain_draw.rs
+++ b/crates/bsengine-rhi-wgpu/tests/terrain_draw.rs
@@ -77,6 +77,8 @@ fn a_terrain_draw_call_does_not_panic_alongside_regular_draw_calls() {
         Mat4::IDENTITY,
         // No probe volume either; terrain chunks are not captured into probes.
         None,
+        // No fog, so the apply pass stays a passthrough.
+        None,
     );
 
     assert!(

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -894,6 +894,7 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
     app.register_type::<bsengine_core::Timer>();
     app.register_type::<bsengine_core::ToneMap>();
     app.register_type::<bsengine_core::Visible>();
+    app.register_type::<bsengine_core::VolumetricFog>();
     app.register_type::<bsengine_core::Follow>();
     app.register_type::<bsengine_core::LookAt>();
     app.register_type::<bsengine_core::NavMeshAgent>();

--- a/crates/bsengine-scripting/src/js/prelude.js
+++ b/crates/bsengine-scripting/src/js/prelude.js
@@ -296,6 +296,12 @@ var Bsengine = {
     getToneMapMode:     (name)             => Deno.core.ops.bsengine_get_tone_map_mode(name),
     getToneMapExposure: (name)             => Deno.core.ops.bsengine_get_tone_map_exposure(name),
     isToneMapEnabled:   (name)             => Deno.core.ops.bsengine_is_tone_map_enabled(name),
+    setFogEnabled:      (name, v)          => Deno.core.ops.bsengine_set_fog_enabled(name, v),
+    setFogDensity:      (name, v)          => Deno.core.ops.bsengine_set_fog_density(name, v),
+    // All three channels in one call. A setFogColorR/G/B trio is exactly the
+    // per-axis shape the component catalogue's R2 ratchet forbids.
+    setFogColor:        (name, r, g, b)    => Deno.core.ops.bsengine_set_fog_color(name, r, g, b),
+    setFogAnisotropy:   (name, v)          => Deno.core.ops.bsengine_set_fog_anisotropy(name, v),
     setTweenDuration:(name, duration)      => Deno.core.ops.bsengine_set_tween_duration(name, duration),
     setTweenEasing: (name, easing)         => Deno.core.ops.bsengine_set_tween_easing(name, easing),
     setTweenRepeat: (name, repeat)         => Deno.core.ops.bsengine_set_tween_repeat(name, repeat),

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -522,6 +522,43 @@ pub enum ScriptCommand {
         /// Whether the effect is enabled.
         enabled: bool,
     },
+    /// Enable or disable volumetric fog on a camera.
+    SetFogEnabled {
+        /// Name of the entity to modify.
+        name: String,
+        /// Whether the effect is enabled.
+        enabled: bool,
+    },
+    /// Set the volumetric fog's extinction per world unit.
+    SetFogDensity {
+        /// Name of the entity to modify.
+        name: String,
+        /// New density. Higher is thicker.
+        density: f32,
+    },
+    /// Set the colour the volumetric fog scatters.
+    ///
+    /// All three channels in one command, deliberately: the component
+    /// catalogue's R2 ratchet exists to stop `setFogColorR`/`G`/`B` triples
+    /// from accumulating the way the workspace's 45 grandfathered per-axis ops
+    /// did.
+    SetFogColor {
+        /// Name of the entity to modify.
+        name: String,
+        /// Red channel of the scattering albedo.
+        r: f32,
+        /// Green channel of the scattering albedo.
+        g: f32,
+        /// Blue channel of the scattering albedo.
+        b: f32,
+    },
+    /// Set the volumetric fog's Henyey-Greenstein anisotropy.
+    SetFogAnisotropy {
+        /// Name of the entity to modify.
+        name: String,
+        /// New anisotropy `g`; 0 is isotropic, positive scatters forward.
+        anisotropy: f32,
+    },
     /// Set the duration of a running tween.
     SetTweenDuration {
         /// Name of the entity to modify.
@@ -3969,6 +4006,45 @@ pub fn bsengine_set_tone_map_enabled(#[string] name: String, enabled: bool) {
     });
 }
 
+/// Queue enabling or disabling volumetric fog on a camera.
+#[op2(fast)]
+pub fn bsengine_set_fog_enabled(#[string] name: String, enabled: bool) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetFogEnabled { name, enabled })
+    });
+}
+
+/// Queue setting the volumetric fog's extinction per world unit.
+#[op2(fast)]
+pub fn bsengine_set_fog_density(#[string] name: String, density: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetFogDensity { name, density })
+    });
+}
+
+/// Queue setting the colour the volumetric fog scatters.
+///
+/// One op for all three channels rather than a `setFogColorR`/`G`/`B` trio:
+/// that shape is exactly what the component catalogue's R2 ratchet forbids.
+#[op2(fast)]
+pub fn bsengine_set_fog_color(#[string] name: String, r: f32, g: f32, b: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetFogColor { name, r, g, b })
+    });
+}
+
+/// Queue setting the volumetric fog's Henyey-Greenstein anisotropy.
+#[op2(fast)]
+pub fn bsengine_set_fog_anisotropy(#[string] name: String, anisotropy: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetFogAnisotropy { name, anisotropy })
+    });
+}
+
 /// Get the current tone-mapping operator, encoded as an integer.
 #[op2(fast)]
 pub fn bsengine_get_tone_map_mode(#[string] name: String) -> u32 {
@@ -5833,6 +5909,10 @@ deno_core::extension!(
         bsengine_get_tone_map_mode,
         bsengine_get_tone_map_exposure,
         bsengine_is_tone_map_enabled,
+        bsengine_set_fog_enabled,
+        bsengine_set_fog_density,
+        bsengine_set_fog_color,
+        bsengine_set_fog_anisotropy,
     ],
 );
 
@@ -9859,6 +9939,51 @@ JSON.stringify(received)
                 cmd,
                 super::ScriptCommand::SetToneMapEnabled { name, enabled }
                 if name == "Cam" && !*enabled
+            )));
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn fog_write_ops_queue_commands() {
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setFogEnabled("Cam", true);"#).unwrap();
+        rt.eval(r#"Bsengine.setFogDensity("Cam", 0.05);"#).unwrap();
+        // One call, three channels. A `setFogColorR`/`G`/`B` trio here would
+        // trip the component catalogue's R2 ratchet.
+        rt.eval(r#"Bsengine.setFogColor("Cam", 0.2, 0.4, 0.6);"#)
+            .unwrap();
+        rt.eval(r#"Bsengine.setFogAnisotropy("Cam", 0.7);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetFogEnabled { name, enabled }
+                if name == "Cam" && *enabled
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetFogDensity { name, density }
+                if name == "Cam" && (*density - 0.05).abs() < 0.001
+            )));
+            // All three channels asserted separately: a binding that passed
+            // the same argument three times, or dropped the last one, would
+            // still satisfy a check on `r` alone.
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetFogColor { name, r, g, b }
+                if name == "Cam"
+                    && (*r - 0.2).abs() < 0.001
+                    && (*g - 0.4).abs() < 0.001
+                    && (*b - 0.6).abs() < 0.001
+            )));
+            assert!(buf.iter().any(|cmd| matches!(
+                cmd,
+                super::ScriptCommand::SetFogAnisotropy { name, anisotropy }
+                if name == "Cam" && (*anisotropy - 0.7).abs() < 0.001
             )));
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -1681,6 +1681,64 @@ fn run_scripts(world: &mut World) {
                     }
                 }
             }
+            // The four fog commands all modify a `VolumetricFog` already on
+            // the entity and never insert one, matching every other
+            // post-process setter here: a script that could conjure the
+            // component into existence would turn a typo'd camera name into a
+            // fogged scene rather than a no-op.
+            ScriptCommand::SetFogEnabled { name, enabled } => {
+                use bsengine_core::VolumetricFog;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut f) = world.get_mut::<VolumetricFog>(e) {
+                        f.enabled = enabled;
+                    }
+                }
+            }
+            ScriptCommand::SetFogDensity { name, density } => {
+                use bsengine_core::VolumetricFog;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut f) = world.get_mut::<VolumetricFog>(e) {
+                        // Negative extinction would make `exp(-density * dz)`
+                        // grow without bound down the froxel column.
+                        f.density = density.max(0.0);
+                    }
+                }
+            }
+            ScriptCommand::SetFogColor { name, r, g, b } => {
+                use bsengine_core::VolumetricFog;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut f) = world.get_mut::<VolumetricFog>(e) {
+                        f.color = glam::Vec3::new(r.max(0.0), g.max(0.0), b.max(0.0)).into();
+                    }
+                }
+            }
+            ScriptCommand::SetFogAnisotropy { name, anisotropy } => {
+                use bsengine_core::VolumetricFog;
+                let entity = {
+                    let mut q = world.query::<(Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                if let Some(e) = entity {
+                    if let Some(mut f) = world.get_mut::<VolumetricFog>(e) {
+                        // The phase function is singular at exactly +/-1; the
+                        // shader clamps too, but a component holding 1.0 would
+                        // read back as a value the renderer never uses.
+                        f.anisotropy = anisotropy.clamp(-0.99, 0.99);
+                    }
+                }
+            }
             ScriptCommand::SetTweenDuration { name, duration } => {
                 use bsengine_core::Tween;
                 let entity = {
@@ -5363,6 +5421,138 @@ mod tests {
             (pos["x"].as_f64().unwrap() - 3.0).abs() < 1e-4,
             "the spawned entity must be at the position instantiatePrefab was \
              called with, not the origin: {tick2}"
+        );
+    }
+
+    /// The four fog ops, driven through a real script on a real `App`, land on
+    /// the real `VolumetricFog` component.
+    ///
+    /// `fog_write_ops_queue_commands` in `ops.rs` proves the JS binding reaches
+    /// the command buffer; it says nothing about whether anything ever drains
+    /// that buffer into the world. A `ScriptCommand` variant with no match arm
+    /// would pass it and change nothing on screen. This is the half that
+    /// notices.
+    ///
+    /// Every starting value is deliberately the opposite of its target -- the
+    /// component starts disabled, black, and at zero density and zero
+    /// anisotropy -- so no assertion here can be satisfied by a field the
+    /// script never touched.
+    #[test]
+    fn fog_ops_reach_the_volumetric_fog_component() {
+        let (project, root, _guard) = script_probe("fog-ops-roundtrip");
+        std::fs::write(
+            root.join("assets").join("scripts").join("cam.js"),
+            "let done = false;\n\
+             function onUpdate(name) {\n\
+                 if (done) { return; }\n\
+                 done = true;\n\
+                 Bsengine.setFogEnabled(name, true);\n\
+                 Bsengine.setFogDensity(name, 0.05);\n\
+                 Bsengine.setFogColor(name, 0.2, 0.4, 0.6);\n\
+                 Bsengine.setFogAnisotropy(name, 0.7);\n\
+             }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: project.clone(),
+        });
+        app.world_mut().spawn((
+            Name("Cam".to_string()),
+            ScriptPath("assets/scripts/cam.js".to_string()),
+            bsengine_core::VolumetricFog {
+                enabled: false,
+                density: 0.0,
+                color: glam::Vec3::ZERO.into(),
+                anisotropy: 0.0,
+            },
+        ));
+
+        // Two ticks, for the reason
+        // `instantiated_prefab_position_is_not_available_until_the_next_tick`
+        // documents: the first loads the script and runs `onUpdate`, and the
+        // commands it queued are only drained into the world afterwards.
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let mut q = world.query::<(&Name, &bsengine_core::VolumetricFog)>();
+        let (_, fog) = q
+            .iter(world)
+            .find(|(n, _)| n.0 == "Cam")
+            .expect("the Cam entity still carries a VolumetricFog");
+
+        assert!(fog.enabled, "setFogEnabled did not reach the component");
+        assert!(
+            (fog.density - 0.05).abs() < 1e-6,
+            "setFogDensity did not reach the component: {}",
+            fog.density
+        );
+        assert!(
+            (fog.color.x - 0.2).abs() < 1e-6
+                && (fog.color.y - 0.4).abs() < 1e-6
+                && (fog.color.z - 0.6).abs() < 1e-6,
+            "setFogColor did not reach all three channels: {:?}",
+            *fog.color
+        );
+        assert!(
+            (fog.anisotropy - 0.7).abs() < 1e-6,
+            "setFogAnisotropy did not reach the component: {}",
+            fog.anisotropy
+        );
+    }
+
+    /// The clamps in the fog command arms, which exist because the values they
+    /// guard are not merely ugly but divergent: a negative density turns the
+    /// integration's `exp(-density * dz)` into unbounded growth down the
+    /// froxel column, and an anisotropy of exactly 1 makes the
+    /// Henyey-Greenstein denominator zero.
+    ///
+    /// Asserted through a script rather than by calling the arms directly, so
+    /// this measures what a game can actually do to the renderer.
+    #[test]
+    fn fog_ops_clamp_values_that_would_make_the_shader_diverge() {
+        let (project, root, _guard) = script_probe("fog-ops-clamping");
+        std::fs::write(
+            root.join("assets").join("scripts").join("cam.js"),
+            "let done = false;\n\
+             function onUpdate(name) {\n\
+                 if (done) { return; }\n\
+                 done = true;\n\
+                 Bsengine.setFogDensity(name, -5.0);\n\
+                 Bsengine.setFogAnisotropy(name, 1.0);\n\
+             }",
+        )
+        .unwrap();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(ScriptingPlugin {
+            project_dir: project.clone(),
+        });
+        app.world_mut().spawn((
+            Name("Cam".to_string()),
+            ScriptPath("assets/scripts/cam.js".to_string()),
+            bsengine_core::VolumetricFog::default(),
+        ));
+
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let mut q = world.query::<(&Name, &bsengine_core::VolumetricFog)>();
+        let (_, fog) = q
+            .iter(world)
+            .find(|(n, _)| n.0 == "Cam")
+            .expect("the Cam entity still carries a VolumetricFog");
+
+        assert_eq!(fog.density, 0.0, "a negative density must clamp to zero");
+        assert!(
+            fog.anisotropy < 1.0,
+            "anisotropy must stay strictly inside (-1, 1), got {}",
+            fog.anisotropy
         );
     }
 }


### PR DESCRIPTION
## Summary
Implements ENGINE_ROADMAP item 49, **sub-step 1/2: froxel infrastructure and directional-light scattering**. Satisfies completion conditions 1 (frustum-based volumetric fog pass) and 3 (scene/scripting parameters).

**Light shafts are sub-step 2/2** — shadow-map sampling in the injection pass, plus point/spot contribution. Deliberately excluded so that if fog looks wrong, it's unambiguous whether the new compute infrastructure or the shaft maths is at fault.

## This is the engine's first compute pipeline and first 3D texture
Before this branch, `ComputePipeline`, `@compute`, and `TextureDimension::D3` had **zero hits** anywhere in the codebase. Like the cubemap work in item 48, the froxel approach was chosen knowing it costs new infrastructure — and the engine comes away with reusable compute and volume-texture support rather than fog-shaped plumbing.

## How it works
- **`VolumetricFog { enabled, density, color, anisotropy }`** on the camera, matching `Bloom`/`ToneMap`/`AmbientOcclusion`/`Taa`. **Absent means off**, which is what keeps all sixteen existing pixel tests passing untouched.
- **Two compute passes over a 160×90×64 `Rgba16Float` volume pair.** Injection writes per-froxel scattering, extinction, and in-scattered sunlight weighted by the Henyey-Greenstein phase function; integration marches each screen column front-to-back accumulating scattering and transmittance, so the apply pass is a single lookup rather than a march.
- **Z is distributed exponentially, not linearly.** Perspective means near froxels cover far less world space; linear slicing wastes the volume on distance nobody notices and bands up close. This mapping appears in three places (Rust, injection WGSL, `depth_to_froxel_w`) and all three agree.
- **Integration is analytic per slice**, not a point sample — a point sample biases thick slices, which the exponential distribution guarantees you have at distance.
- **Applied in HDR, before bloom reads the scene**, so thick fog around a bright light blooms. That required routing HDR through a second target (a pass may not sample the texture it renders to), shipped as **its own behaviour-preserving commit** so any later pixel-test failure is attributable.
- **Background pixels are fogged too** — SSAO skips them, and copying that instinct would leave a crisp horizon behind thick fog.
- **Scripting** (condition 3): `setFogEnabled` / `setFogDensity` / `setFogColor(cam, r, g, b)` / `setFogAnisotropy`. Colour is one op deliberately — splitting into `setFogColorR/G/B` would trip the catalogue's R2 ratchet.

## Measured effect
The assertion that matters is **depth dependence, not haze** — an implementation adding a constant everywhere would satisfy "the screen got foggier". Two identical cubes, near and far:

| | colour shift with fog |
|---|---|
| near cube | 17.0 |
| far cube | **219.0** |
| ratio | **12.9×** |

Paired with the opposite-direction regressions: `zero_density_leaves_the_image_unchanged` and `a_scene_with_no_fog_component_is_pixel_identical`. `positive_anisotropy_brightens_the_view_toward_the_light` proves the phase function is actually applied rather than the fog being uniform grey.

Unit tests target the silent failures: the phase function integrates to 1 over the sphere (dropping the `1/(4π)` makes fog ~12× too bright, which reads as a mistuned density rather than a bug), and the Z slices are monotonic, end exactly on the far plane, and are >10× thicker far than near.

## Test plan
- [x] `cargo test -p bsengine-rhi-wgpu --lib froxel` — 5/5
- [x] `cargo test -p bsengine-core --lib volumetric_fog` — 1/1
- [x] `cargo test -p bsengine-rhi-wgpu --test pixels_fog` — 5/5
- [x] Scripting round-trip tests for all four ops
- [x] **All sixteen pre-existing pixel tests pass unchanged** (eight `pixels_*.rs`, four `pixels_ibl.rs`, four `pixels_light_probe.rs`)
- [x] `cargo test --workspace --exclude bsengine-editor` — zero failures
- [x] `cargo test -p bsengine-editor --lib` — 937/937 (isolated, per CI's split)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` — 62 components, 262 ops, 0 violations (no R2 violation from the new ops)
- [x] `cargo clippy --workspace --all-targets` — identical to the pre-existing baseline
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)