### PR TITLE
feat: ragdoll physics (item 52 sub-step 1/2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,9 +1038,11 @@ dependencies = [
  "bsengine-app",
  "bsengine-core",
  "bsengine-ecs",
+ "bsengine-gltf",
  "glam 0.29.3",
  "rapier3d",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/bsengine-gltf/src/loader.rs
+++ b/crates/bsengine-gltf/src/loader.rs
@@ -30,8 +30,18 @@ pub struct GltfImageData {
 /// Per-node local rest-pose transform plus its parent, as decomposed straight
 /// from the glTF document — the "bind pose" a skinned mesh returns to for any
 /// node/joint not overridden by the currently-sampled animation clip.
-#[derive(Debug, Clone, Copy, PartialEq)]
+// Not `Copy`: `name` is a `String`. Nothing relied on the copy — every reader
+// takes `&[NodeTransform]` and looks at fields through the reference.
+#[derive(Debug, Clone, PartialEq)]
 pub struct NodeTransform {
+    /// The node's name, as given in the glTF file, or empty when it has none.
+    ///
+    /// This is the bone name a skeleton is authored against — what
+    /// `Ragdoll::joint_overrides` keys on to mark a knee or an elbow as a
+    /// hinge. glTF node names are optional, so an unnamed node gets `""`
+    /// rather than a synthesised placeholder: a made-up name would look
+    /// authorable and silently never match.
+    pub name: String,
     /// Local-space translation.
     pub position: [f32; 3],
     /// Local-space rotation quaternion, [x, y, z, w].
@@ -45,6 +55,7 @@ pub struct NodeTransform {
 impl Default for NodeTransform {
     fn default() -> Self {
         Self {
+            name: String::new(),
             position: [0.0, 0.0, 0.0],
             rotation: [0.0, 0.0, 0.0, 1.0],
             scale: [1.0, 1.0, 1.0],
@@ -130,6 +141,7 @@ impl GltfLoader {
             for node in doc.nodes() {
                 let (t, r, s) = node.transform().decomposed();
                 out[node.index()] = NodeTransform {
+                    name: node.name().unwrap_or_default().to_string(),
                     position: t,
                     rotation: r,
                     scale: s,

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -231,6 +231,8 @@ fn load_gltf_assets(
                             skin: skin_verts,
                             skin_data,
                             nodes: loaded.nodes.clone(),
+                            pose_override: Vec::new(),
+                            joint_matrices: Vec::new(),
                         },
                         clip_library,
                         AnimationPlayer::new(first_clip_name).with_duration(duration),

--- a/crates/bsengine-gltf/src/skinned_mesh.rs
+++ b/crates/bsengine-gltf/src/skinned_mesh.rs
@@ -634,6 +634,7 @@ mod tests {
     /// A one-node skeleton at the origin, unrotated and unscaled.
     fn one_node() -> Vec<NodeTransform> {
         vec![NodeTransform {
+            name: String::new(),
             position: [0.0, 0.0, 0.0],
             rotation: [0.0, 0.0, 0.0, 1.0],
             scale: [1.0, 1.0, 1.0],
@@ -954,6 +955,7 @@ mod tests {
     #[test]
     fn no_clips_at_all_leaves_the_rest_pose() {
         let nodes = vec![NodeTransform {
+            name: String::new(),
             position: [1.0, 2.0, 3.0],
             rotation: [0.0, 0.0, 0.0, 1.0],
             scale: [1.0, 1.0, 1.0],
@@ -967,6 +969,7 @@ mod tests {
     #[test]
     fn compute_joint_matrices_uses_bind_pose_when_no_channels_animate_a_node() {
         let nodes = vec![NodeTransform {
+            name: String::new(),
             position: [1.0, 0.0, 0.0],
             rotation: [0.0, 0.0, 0.0, 1.0],
             scale: [1.0, 1.0, 1.0],
@@ -985,12 +988,14 @@ mod tests {
     fn compute_joint_matrices_composes_parent_child_hierarchy() {
         let nodes = vec![
             NodeTransform {
+                name: String::new(),
                 position: [1.0, 0.0, 0.0],
                 rotation: [0.0, 0.0, 0.0, 1.0],
                 scale: [1.0, 1.0, 1.0],
                 parent: None,
             },
             NodeTransform {
+                name: String::new(),
                 position: [0.0, 2.0, 0.0],
                 rotation: [0.0, 0.0, 0.0, 1.0],
                 scale: [1.0, 1.0, 1.0],

--- a/crates/bsengine-gltf/src/skinned_mesh.rs
+++ b/crates/bsengine-gltf/src/skinned_mesh.rs
@@ -12,7 +12,7 @@ use glam::{Mat4, Quat, Vec3};
 /// `MeshRenderer` by `GltfPlugin` when the source glTF had a skin.
 /// # What is reflected, and what is not
 ///
-/// `mesh_id` is reflected; the four bulk fields below are `#[reflect(ignore)]`.
+/// `mesh_id` is reflected; every other field below is `#[reflect(ignore)]`.
 /// R1 asks that a public component be *visible* — that the Inspector shows the
 /// entity has a skinned mesh and that MCP can see it is attached — and
 /// `mesh_id` is the whole of what identifies one. The rest is per-vertex data
@@ -52,6 +52,40 @@ pub struct SkinnedMesh {
     /// Not reflected: see the type-level note above.
     #[reflect(ignore)]
     pub nodes: Vec<NodeTransform>,
+    /// Per-node **global** transforms from somewhere other than the animation
+    /// clips, in [`nodes`] order — or empty, which means the clips are the
+    /// source and nothing has been overridden.
+    ///
+    /// This is the whole of how a ragdoll drives a skinned mesh. `bsengine-gltf`
+    /// must not know what physics is, so the physics crate — which already
+    /// depends on this one — writes the pose its bone bodies imply here, and
+    /// [`SkinnedMeshPlugin`]'s system feeds it through the same
+    /// `global * inverse_bind_matrix` step the animated path uses. Skinning
+    /// therefore never asks *why* the pose is what it is, and the ragdoll never
+    /// has to reach into vertex blending.
+    ///
+    /// Whoever fills it is responsible for emptying it again: as long as this
+    /// is non-empty the animation clips are ignored entirely, so a stale
+    /// override leaves the character frozen in whatever pose put it there.
+    ///
+    /// Not reflected: see the type-level note above.
+    ///
+    /// [`nodes`]: SkinnedMesh::nodes
+    #[reflect(ignore)]
+    pub pose_override: Vec<Mat4>,
+    /// The skinning matrix per joint as of the last time [`SkinnedMeshPlugin`]'s
+    /// system ran — `global[joint_node] * inverse_bind_matrix[joint]`, in
+    /// [`SkinData::joint_node_indices`] order.
+    ///
+    /// Output, not input: writing it does nothing, because the next frame
+    /// recomputes it from whichever source is driving the skeleton. It is the
+    /// pose the mesh is actually being deformed by, which nothing outside that
+    /// system could otherwise observe — the matrices used to be computed and
+    /// thrown away inside one loop body.
+    ///
+    /// Not reflected: see the type-level note above.
+    #[reflect(ignore)]
+    pub joint_matrices: Vec<Mat4>,
 }
 
 /// The full set of animation clips available to an entity's `AnimationPlayer`,
@@ -400,15 +434,12 @@ fn push_state_samples<'a>(
 }
 
 /// Walks the node hierarchy to compose each node's GLOBAL transform from its
-/// local transform and its parent chain, then returns one skinning matrix per
-/// joint (`global[joint_node] * inverse_bind_matrix[joint]`) — the matrix
-/// each of that joint's vertices gets blended through. Iterates a fixed
-/// number of passes rather than a proper topological sort, matching the same
-/// pattern `bsengine_core::propagate_global_transforms` already uses for
-/// parent/child Transform hierarchies in this codebase.
-fn compute_joint_matrices_blended(
+/// local transform and its parent chain. Iterates a fixed number of passes
+/// rather than a proper topological sort, matching the same pattern
+/// `bsengine_core::propagate_global_transforms` already uses for parent/child
+/// Transform hierarchies in this codebase.
+fn compute_global_transforms_blended(
     nodes: &[NodeTransform],
-    skin: &SkinData,
     clips: &[ClipSample<'_>],
 ) -> Vec<Mat4> {
     let locals = compute_local_transforms_blended(nodes, clips);
@@ -420,11 +451,41 @@ fn compute_joint_matrices_blended(
             }
         }
     }
+    globals
+}
+
+/// Turns per-node global transforms into one skinning matrix per joint
+/// (`global[joint_node] * inverse_bind_matrix[joint]`) — the matrix each of
+/// that joint's vertices gets blended through.
+///
+/// Split out from the animated path because it is the step the ragdoll shares.
+/// `SkinnedMesh::pose_override` supplies different globals and everything from
+/// here on is identical, which is what keeps "physics drives the bones" from
+/// touching vertex blending or the GPU upload at all.
+///
+/// A joint naming a node the skeleton does not have contributes the identity
+/// rather than panicking: with two sources of globals there are now two ways
+/// for the two to disagree about how many nodes there are, and a malformed
+/// asset should not take the frame down.
+fn joint_matrices_from_globals(globals: &[Mat4], skin: &SkinData) -> Vec<Mat4> {
     skin.joint_node_indices
         .iter()
         .zip(&skin.inverse_bind_matrices)
-        .map(|(&node_index, ibm)| globals[node_index] * Mat4::from_cols_array_2d(ibm))
+        .map(|(&node_index, ibm)| {
+            globals.get(node_index).copied().unwrap_or(Mat4::IDENTITY)
+                * Mat4::from_cols_array_2d(ibm)
+        })
         .collect()
+}
+
+/// The animated path: compose globals from the sampled clips, then turn them
+/// into skinning matrices.
+fn compute_joint_matrices_blended(
+    nodes: &[NodeTransform],
+    skin: &SkinData,
+    clips: &[ClipSample<'_>],
+) -> Vec<Mat4> {
+    joint_matrices_from_globals(&compute_global_transforms_blended(nodes, clips), skin)
 }
 
 /// Blends one rest-pose vertex position through up to 4 joint matrices by
@@ -465,10 +526,17 @@ fn blend_vertex_normal(rest_normal: Vec3, skin: &VertexSkin, joint_matrices: &[M
     result.normalize_or_zero()
 }
 
-/// Drives CPU-side skeletal skinning: each frame, for every entity with
-/// `SkinnedMesh` + `AnimationClipLibrary` + `AnimationPlayer`, samples the
-/// player's current clip, composes joint matrices, blends the rest-pose
-/// vertices, and re-uploads them into the same GPU mesh id. Runs in
+/// Drives CPU-side skeletal skinning: each frame, for every entity with a
+/// `SkinnedMesh`, composes that entity's joint matrices, blends the rest-pose
+/// vertices through them, and re-uploads the result into the same GPU mesh id.
+///
+/// The joint matrices come from one of two sources. Normally the entity's
+/// `AnimationClipLibrary`/`AnimationPlayer` are sampled and the pose is
+/// accumulated down the node hierarchy. When something has filled
+/// [`SkinnedMesh::pose_override`] — the ragdoll, today — those per-node globals
+/// are used instead and the clips are not read at all. Only the *source* of the
+/// globals differs; the `global * inverse_bind_matrix` step, the vertex
+/// blending, and the upload are shared. Runs in
 /// `PostUpdate`, after `bsengine_app::AnimationStateMachinePlugin` (if
 /// present) has already updated which clip/time the player should be
 /// showing this frame -- this plugin has no direct dependency on that one,
@@ -484,53 +552,71 @@ impl Plugin for SkinnedMeshPlugin {
 }
 
 fn update_skinned_meshes(
-    query: Query<(
-        &SkinnedMesh,
-        &AnimationClipLibrary,
-        &bsengine_core::AnimationPlayer,
+    mut query: Query<(
+        &mut SkinnedMesh,
+        Option<&AnimationClipLibrary>,
+        Option<&bsengine_core::AnimationPlayer>,
         Option<&bsengine_core::AnimationStateMachine>,
     )>,
     mesh_registry: Option<ResMut<bsengine_rhi_wgpu::GpuMeshRegistry>>,
     queue: Option<Res<bsengine_rhi_wgpu::GpuQueueResource>>,
 ) {
-    let (Some(mut mesh_registry), Some(queue)) = (mesh_registry, queue) else {
-        return;
-    };
-    for (skinned, library, player, asm) in query.iter() {
-        let Some(clip) = library.clips.get(&player.clip) else {
-            continue;
+    // Deliberately not an early return when there is no GPU. Composing the
+    // joint matrices is a few dozen matrix products over the skeleton and it is
+    // the *pose*, which a headless host still wants to be right; blending the
+    // vertices is tens of thousands of products whose only consumer is the
+    // upload, so that half is what the GPU's absence skips.
+    let mut gpu = mesh_registry.zip(queue);
+
+    for (mut skinned, library, player, asm) in query.iter_mut() {
+        // The one branch this whole feature turns on, and the one that fails
+        // silently: with the bodies built and falling but the clips still
+        // sourcing the pose, the character looks completely normal while a full
+        // ragdoll simulates underneath it.
+        let joint_matrices = if skinned.pose_override.is_empty() {
+            let (Some(library), Some(player)) = (library, player) else {
+                continue;
+            };
+            let Some(clip) = library.clips.get(&player.clip) else {
+                continue;
+            };
+
+            // A state machine mid-transition contributes the state it is
+            // leaving as well as the one it is entering. Until this existed,
+            // `blend_weight` was advanced every frame and read by nothing, so
+            // every "crossfade" was really a hard cut.
+            //
+            // Both clips are sampled at the same `player.time`. For the looping
+            // locomotion clips these transitions are for — idle/walk/run — that
+            // is what keeps the feet in phase across the blend; a clip whose
+            // meaning depends on its own timeline would need its own clock, and
+            // nothing here has one yet.
+            let samples = blend_samples(clip, library, player.time, asm);
+            compute_joint_matrices_blended(&skinned.nodes, &skinned.skin_data, &samples)
+        } else {
+            joint_matrices_from_globals(&skinned.pose_override, &skinned.skin_data)
         };
 
-        // A state machine mid-transition contributes the state it is leaving as
-        // well as the one it is entering. Until this existed, `blend_weight`
-        // was advanced every frame and read by nothing, so every "crossfade"
-        // was really a hard cut.
-        //
-        // Both clips are sampled at the same `player.time`. For the looping
-        // locomotion clips these transitions are for — idle/walk/run — that is
-        // what keeps the feet in phase across the blend; a clip whose meaning
-        // depends on its own timeline would need its own clock, and nothing
-        // here has one yet.
-        let samples = blend_samples(clip, library, player.time, asm);
+        if let Some((mesh_registry, queue)) = gpu.as_mut() {
+            let deformed: Vec<Vertex> = skinned
+                .rest_vertices
+                .iter()
+                .zip(&skinned.skin)
+                .map(|(v, s)| {
+                    let pos = blend_vertex_position(Vec3::from(v.position), s, &joint_matrices);
+                    let normal = blend_vertex_normal(Vec3::from(v.normal), s, &joint_matrices);
+                    Vertex {
+                        position: pos.to_array(),
+                        color: v.color,
+                        normal: normal.to_array(),
+                        uv: v.uv,
+                    }
+                })
+                .collect();
+            mesh_registry.update_vertices(&queue.0, skinned.mesh_id, &deformed);
+        }
 
-        let joint_matrices =
-            compute_joint_matrices_blended(&skinned.nodes, &skinned.skin_data, &samples);
-        let deformed: Vec<Vertex> = skinned
-            .rest_vertices
-            .iter()
-            .zip(&skinned.skin)
-            .map(|(v, s)| {
-                let pos = blend_vertex_position(Vec3::from(v.position), s, &joint_matrices);
-                let normal = blend_vertex_normal(Vec3::from(v.normal), s, &joint_matrices);
-                Vertex {
-                    position: pos.to_array(),
-                    color: v.color,
-                    normal: normal.to_array(),
-                    uv: v.uv,
-                }
-            })
-            .collect();
-        mesh_registry.update_vertices(&queue.0, skinned.mesh_id, &deformed);
+        skinned.joint_matrices = joint_matrices;
     }
 }
 
@@ -1078,6 +1164,8 @@ mod tests {
                 inverse_bind_matrices: vec![Mat4::IDENTITY.to_cols_array_2d()],
             },
             nodes: vec![NodeTransform::default()],
+            pose_override: Vec::new(),
+            joint_matrices: Vec::new(),
         }
     }
 
@@ -1214,6 +1302,8 @@ mod tests {
                     skin,
                     skin_data,
                     nodes,
+                    pose_override: Vec::new(),
+                    joint_matrices: Vec::new(),
                 },
                 AnimationClipLibrary { clips },
                 bsengine_core::AnimationPlayer::new("wiggle").with_duration(1.0),
@@ -1228,10 +1318,141 @@ mod tests {
         app.update();
 
         // No GpuMeshRegistry/GpuQueueResource is present in this headless test
-        // (no RHI plugin added), so the system should compute the deformed
-        // pose without panicking even when it can't upload anywhere -- this
-        // test's job is to prove the math runs end-to-end via the ECS system,
-        // not to assert on GPU state.
-        assert!(app.world().get::<SkinnedMesh>(entity).is_some());
+        // (no RHI plugin added), so the system computes the pose without
+        // uploading it anywhere -- this test's job is to prove the math runs
+        // end-to-end via the ECS system, not to assert on GPU state.
+        let skinned = app
+            .world()
+            .get::<SkinnedMesh>(entity)
+            .expect("the component survives the system");
+        assert_eq!(skinned.joint_matrices.len(), 1);
+        let moved = skinned.joint_matrices[0].transform_point3(Vec3::ZERO);
+        assert!(
+            moved.abs_diff_eq(Vec3::new(0.0, 1.5, 0.0), 0.001),
+            "halfway through a 0 -> 3 translation the one joint should be at \
+             y = 1.5, got {moved:?}"
+        );
+    }
+
+    // ---- ragdoll-sourced poses (roadmap item 52, sub-step 1/2) ------------
+    //
+    // `pose_override` is the whole of what `bsengine-gltf` knows about the
+    // ragdoll: physics writes per-node globals into it and this crate feeds
+    // them through the same `global * inverse_bind_matrix` step the animated
+    // path uses. That the *physics* fills it correctly is asserted in
+    // `bsengine-physics`, which is the only crate that can see both ends; what
+    // belongs here is that the override is honoured at all, and that its
+    // absence changes nothing.
+
+    /// A one-node skeleton, a clip translating that node to (0, 3, 0), and an
+    /// identity inverse bind matrix — so a joint matrix reads back directly as
+    /// where the node ended up.
+    fn one_joint_app() -> (bevy_app::App, bevy_ecs::entity::Entity) {
+        let mut app = bsengine_app::new_app();
+        app.insert_resource(bsengine_core::Time::default());
+        app.add_plugins(SkinnedMeshPlugin);
+
+        let mut clips = std::collections::HashMap::new();
+        clips.insert(
+            "wiggle".to_string(),
+            AnimationClip {
+                name: "wiggle".to_string(),
+                duration: 1.0,
+                channels: vec![AnimationChannel {
+                    node_index: 0,
+                    times: vec![0.0, 1.0],
+                    values: KeyframeValues::Translations(vec![[0.0, 3.0, 0.0], [0.0, 3.0, 0.0]]),
+                    interpolation: Interpolation::Linear,
+                }],
+            },
+        );
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                SkinnedMesh {
+                    mesh_id: 1,
+                    rest_vertices: Vec::new(),
+                    skin: Vec::new(),
+                    skin_data: SkinData {
+                        joint_node_indices: vec![0],
+                        inverse_bind_matrices: vec![Mat4::IDENTITY.to_cols_array_2d()],
+                    },
+                    nodes: one_node(),
+                    pose_override: Vec::new(),
+                    joint_matrices: Vec::new(),
+                },
+                AnimationClipLibrary { clips },
+                bsengine_core::AnimationPlayer::new("wiggle").with_duration(1.0),
+            ))
+            .id();
+        (app, entity)
+    }
+
+    #[test]
+    fn a_pose_override_is_what_the_joint_matrices_come_from() {
+        // The quiet failure this guards: the ragdoll's bodies can be built,
+        // simulating, and perfectly correct while skinning goes on reading the
+        // clip -- and the character then looks completely normal on screen with
+        // a full ragdoll running underneath it. Nothing about the bodies would
+        // show it; only the joint matrices do.
+        let (mut app, entity) = one_joint_app();
+        app.update();
+        let from_clip = app
+            .world()
+            .get::<SkinnedMesh>(entity)
+            .unwrap()
+            .joint_matrices[0]
+            .transform_point3(Vec3::ZERO);
+        assert!(
+            from_clip.abs_diff_eq(Vec3::new(0.0, 3.0, 0.0), 0.001),
+            "sanity: with no override the clip drives the pose, got {from_clip:?}"
+        );
+
+        app.world_mut()
+            .get_mut::<SkinnedMesh>(entity)
+            .unwrap()
+            .pose_override = vec![Mat4::from_translation(Vec3::new(7.0, -2.0, 0.0))];
+        app.update();
+
+        let overridden = app
+            .world()
+            .get::<SkinnedMesh>(entity)
+            .unwrap()
+            .joint_matrices[0]
+            .transform_point3(Vec3::ZERO);
+        assert!(
+            overridden.abs_diff_eq(Vec3::new(7.0, -2.0, 0.0), 0.001),
+            "with a pose override in place the clip must not be read at all; \
+             expected the override's (7, -2, 0), got {overridden:?}"
+        );
+    }
+
+    #[test]
+    fn an_empty_pose_override_leaves_the_animated_path_byte_identical() {
+        // The other direction, and the one a released engine depends on: every
+        // skinned mesh that has never heard of a ragdoll must come out of this
+        // exactly as it did before the feature existed.
+        let (mut app, entity) = one_joint_app();
+        app.update();
+
+        let skinned = app.world().get::<SkinnedMesh>(entity).unwrap();
+        let library = app.world().get::<AnimationClipLibrary>(entity).unwrap();
+        let player = app
+            .world()
+            .get::<bsengine_core::AnimationPlayer>(entity)
+            .unwrap();
+        let samples = blend_samples(&library.clips["wiggle"], library, player.time, None);
+        let expected = compute_joint_matrices_blended(&skinned.nodes, &skinned.skin_data, &samples);
+
+        assert_eq!(skinned.joint_matrices.len(), expected.len());
+        for (i, (got, want)) in skinned.joint_matrices.iter().zip(&expected).enumerate() {
+            assert_eq!(
+                got.to_cols_array(),
+                want.to_cols_array(),
+                "joint {i} must be bit-for-bit what the pre-ragdoll animation \
+                 path produced, not merely close to it"
+            );
+        }
     }
 }

--- a/crates/bsengine-physics/Cargo.toml
+++ b/crates/bsengine-physics/Cargo.toml
@@ -9,6 +9,21 @@ license.workspace = true
 [dependencies]
 bsengine-core    = { workspace = true }
 bsengine-ecs     = { workspace = true }
+# For the ragdoll only: `SkinnedMesh.nodes` (a `Vec<NodeTransform>`) is the
+# rest-pose bone hierarchy the bone bodies and joints are built from, and
+# re-parsing a skeleton out of glTF a second time here would be a second answer
+# to the same question. Acyclic: `bsengine-gltf` depends on `-core`/`-render`/
+# `-rhi-wgpu`/`-asset` and none of those lead back here, and every crate that
+# already depends on this one (`-app`, `-editor`, `-runtime`, `-scene`,
+# `-scripting`) already reaches `bsengine-gltf` too, so this adds no crate to
+# anyone's graph -- only a build-order edge.
+#
+# The edge points this way, and not the other, on purpose. Skinning must not
+# have to know what physics is; when the ragdoll drives the bones (roadmap item
+# 52 sub-step 1/2, task 3) it is this crate that publishes the pose, and
+# `bsengine-gltf` reads it without ever naming a physics type. Reversing the
+# edge would make both directions necessary at once, which is a cycle.
+bsengine-gltf    = { workspace = true }
 bevy_app         = { workspace = true }
 bevy_ecs         = { workspace = true }
 bevy_reflect     = { workspace = true }
@@ -18,3 +33,7 @@ tracing          = { workspace = true }
 
 [dev-dependencies]
 bsengine-app = { workspace = true }
+# Only to capture `tracing` output in tests: a `Ragdoll` on an entity with no
+# skeleton is *meant* to warn and do nothing, so a test that asserted on state
+# alone would pass just as happily on a version that stayed silent.
+tracing-subscriber = { workspace = true }

--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -249,6 +249,14 @@ pub struct Ragdoll {
     /// Per-bone joint overrides, keyed by bone name. Bones absent here get
     /// [`JointKind::Spherical`].
     ///
+    /// The name is the **skeleton node the joint sits on**, which is the one an
+    /// author is thinking of. A bone spans its parent node to itself, so the
+    /// constraint that holds it is at its parent — on a Mixamo-style rig, the
+    /// shin bone runs `LeftLeg`(knee) → `LeftFoot`(ankle) and the hinge that
+    /// stops the knee bending backwards is at `LeftLeg`. So
+    /// `{"LeftLeg": Revolute { .. }}` is a knee hinge, which is what it reads
+    /// like.
+    ///
     /// Spherical is the default because nothing in a skeleton says which bone
     /// is a knee, so a generic answer is required, and spherical is the
     /// physically stable one that needs no configuration at all. This map is
@@ -282,8 +290,12 @@ impl Default for Ragdoll {
 }
 
 impl Ragdoll {
-    /// The joint kind for the bone named `bone`, falling back to
-    /// [`JointKind::Spherical`] when nothing overrides it.
+    /// The joint kind for the bone whose joint sits on the node named `bone`,
+    /// falling back to [`JointKind::Spherical`] when nothing overrides it.
+    ///
+    /// See [`joint_overrides`] for which of a bone's two ends names it.
+    ///
+    /// [`joint_overrides`]: Ragdoll::joint_overrides
     pub fn joint_for_bone(&self, bone: &str) -> JointKind {
         self.joint_overrides
             .get(bone)
@@ -345,6 +357,16 @@ impl Default for PhysicsInput {
         }
     }
 }
+
+/// Internal: marks one of the bone bodies a [`Ragdoll`] spawned.
+///
+/// Deliberately not public, and so not a catalogue entry: these entities are
+/// the simulation's own bookkeeping, created and destroyed by the ragdoll pass
+/// rather than authored, and an engine-wide component catalogue should no more
+/// list them than it lists [`PhysicsHandles`]. The same reasoning `sync_joints`
+/// gives for keeping its `created` map a `Local`.
+#[derive(Component)]
+pub(crate) struct RagdollBone;
 
 /// Internal: Rapier handles stored per entity after body creation.
 #[derive(Component)]

--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -227,6 +227,71 @@ pub enum JointKind {
     Spherical,
 }
 
+/// Turns a skeletal mesh into joint-linked rigid bodies so it collapses
+/// physically.
+///
+/// Requires a `SkinnedMesh` on the same entity: the bone hierarchy comes from
+/// its `nodes`. Activating this on an entity without one warns and does
+/// nothing, rather than panicking — a ragdoll on a non-skeletal entity is an
+/// authoring mistake, not a reason to take the game down.
+///
+/// [`active`] starts **false**. A component that collapsed the character the
+/// moment it was attached would make "give this character a ragdoll" and "kill
+/// this character" the same action; switching it on is a separate, deliberate
+/// step.
+///
+/// [`active`]: Ragdoll::active
+#[derive(Component, Debug, Clone, PartialEq, Reflect)]
+#[reflect(Component, Default)]
+pub struct Ragdoll {
+    /// While true, physics drives the bones instead of animation.
+    pub active: bool,
+    /// Per-bone joint overrides, keyed by bone name. Bones absent here get
+    /// [`JointKind::Spherical`].
+    ///
+    /// Spherical is the default because nothing in a skeleton says which bone
+    /// is a knee, so a generic answer is required, and spherical is the
+    /// physically stable one that needs no configuration at all. This map is
+    /// how an author says otherwise — marking a knee or an elbow `Revolute`
+    /// so it stops bending backwards. Guessing from the bone's *name* was
+    /// rejected: it depends on a rigging naming convention and fails silently
+    /// on a different rig or on non-English bone names.
+    ///
+    /// A `HashMap` rather than a `Vec` of pairs because `bevy_reflect` handles
+    /// it: a `Map`-kind field is structurally recursed by
+    /// `TypedReflectDeserializer`, so a scene can author this directly. (The
+    /// type that does *not* survive that is `HashSet`, which needs an explicit
+    /// `ReflectDeserialize` registration — see `AnimationStateMachine`'s
+    /// `triggers`.)
+    pub joint_overrides: std::collections::HashMap<String, JointKind>,
+    /// Radius of each bone's capsule collider, in world units.
+    pub bone_radius: f32,
+    /// Total mass, distributed across bones in proportion to bone length.
+    pub total_mass: f32,
+}
+
+impl Default for Ragdoll {
+    fn default() -> Self {
+        Self {
+            active: false,
+            joint_overrides: std::collections::HashMap::new(),
+            bone_radius: 0.08,
+            total_mass: 70.0,
+        }
+    }
+}
+
+impl Ragdoll {
+    /// The joint kind for the bone named `bone`, falling back to
+    /// [`JointKind::Spherical`] when nothing overrides it.
+    pub fn joint_for_bone(&self, bone: &str) -> JointKind {
+        self.joint_overrides
+            .get(bone)
+            .copied()
+            .unwrap_or(JointKind::Spherical)
+    }
+}
+
 /// Result of a raycast query.
 #[derive(Debug, Clone)]
 pub struct RaycastHit {
@@ -335,5 +400,71 @@ impl Default for CharacterBody {
             max_slope_deg: 50.0,
             grounded: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_ragdoll_defaults_to_spherical_for_every_bone() {
+        // With an empty override map, every bone must resolve to Spherical.
+        // Spherical is the physically stable default that works with no
+        // configuration at all; the overrides exist so knees and elbows can be
+        // marked Revolute and stop bending backwards. Nothing in a skeleton
+        // says which bone is a knee, so there has to be a generic answer, and
+        // a name-based guess was rejected: it depends on a rigging convention
+        // and fails silently on a rig that names bones differently.
+        let r = Ragdoll::default();
+        assert!(r.joint_overrides.is_empty(), "the default has no overrides");
+        for bone in ["Thigh", "Spine", "LeftForeArm", "허벅지", ""] {
+            assert!(
+                matches!(r.joint_for_bone(bone), JointKind::Spherical),
+                "bone {bone:?} should fall back to Spherical, got {:?}",
+                r.joint_for_bone(bone)
+            );
+        }
+    }
+
+    #[test]
+    fn an_override_replaces_the_default_for_that_bone_only() {
+        // Without this, the override map could be ignored entirely -- read and
+        // then dropped on the floor -- and the test above would still pass.
+        let mut r = Ragdoll::default();
+        r.joint_overrides.insert(
+            "LeftLeg".to_string(),
+            JointKind::Revolute {
+                axis: Vec3::X.into(),
+                limits: Some([0.0, 2.2]),
+            },
+        );
+
+        match r.joint_for_bone("LeftLeg") {
+            JointKind::Revolute { axis, limits } => {
+                assert_eq!(axis.0, Vec3::X, "the override's own axis must come back");
+                assert_eq!(limits, Some([0.0, 2.2]), "and its own limits");
+            }
+            other => panic!("the overridden bone should be Revolute, got {other:?}"),
+        }
+
+        // "for that bone only": an override is not a global switch.
+        assert!(
+            matches!(r.joint_for_bone("RightLeg"), JointKind::Spherical),
+            "a bone with no entry keeps the Spherical default even when a \
+             sibling was overridden"
+        );
+    }
+
+    #[test]
+    fn a_ragdoll_is_inactive_until_something_switches_it_on() {
+        // Attaching the component to a working character must change nothing.
+        // If this defaulted to true, adding a Ragdoll in the Inspector -- or a
+        // scene gaining the component -- would collapse the character on the
+        // spot.
+        assert!(
+            !Ragdoll::default().active,
+            "Ragdoll::default() must be inert"
+        );
     }
 }

--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -358,15 +358,26 @@ impl Default for PhysicsInput {
     }
 }
 
-/// Internal: marks one of the bone bodies a [`Ragdoll`] spawned.
+/// Internal: marks one of the bone bodies a [`Ragdoll`] spawned, and says which
+/// bone of whose skeleton it is.
 ///
 /// Deliberately not public, and so not a catalogue entry: these entities are
 /// the simulation's own bookkeeping, created and destroyed by the ragdoll pass
 /// rather than authored, and an engine-wide component catalogue should no more
 /// list them than it lists [`PhysicsHandles`]. The same reasoning `sync_joints`
 /// gives for keeping its `created` map a `Local`.
+///
+/// The two fields are what lets the pose the bodies imply be published back to
+/// the skeleton by a *different* system from the one that built them — the pass
+/// that reads where the bodies ended up has to run after Rapier has been
+/// stepped, and a `Local` cannot be shared between systems.
 #[derive(Component)]
-pub(crate) struct RagdollBone;
+pub(crate) struct RagdollBone {
+    /// The entity whose [`Ragdoll`] built this bone.
+    pub owner: Entity,
+    /// Index into that entity's `SkinnedMesh.nodes` — the bone's child end.
+    pub node: usize,
+}
 
 /// Internal: Rapier handles stored per entity after body creation.
 #[derive(Component)]

--- a/crates/bsengine-physics/src/lib.rs
+++ b/crates/bsengine-physics/src/lib.rs
@@ -11,6 +11,8 @@
 pub mod components;
 /// The Bevy plugin that drives spawning, stepping, and syncing physics bodies.
 pub mod plugin;
+/// Turning a skeleton's rest pose into the ragdoll's bone bodies and joints.
+pub mod ragdoll;
 /// The Rapier-backed physics world resource and its query/mutation API.
 pub mod world;
 
@@ -19,6 +21,7 @@ pub use components::{
     PhysicsTransform, Ragdoll, RaycastHit, RigidBody, RigidBodyType,
 };
 pub use plugin::PhysicsPlugin;
+pub use ragdoll::{plan_bones, BonePlan};
 pub use world::PhysicsWorld;
 
 #[cfg(test)]

--- a/crates/bsengine-physics/src/lib.rs
+++ b/crates/bsengine-physics/src/lib.rs
@@ -21,7 +21,7 @@ pub use components::{
     PhysicsTransform, Ragdoll, RaycastHit, RigidBody, RigidBodyType,
 };
 pub use plugin::PhysicsPlugin;
-pub use ragdoll::{plan_bones, BonePlan};
+pub use ragdoll::{plan_bones, pose_from_bones, BonePlan};
 pub use world::PhysicsWorld;
 
 #[cfg(test)]

--- a/crates/bsengine-physics/src/lib.rs
+++ b/crates/bsengine-physics/src/lib.rs
@@ -16,7 +16,7 @@ pub mod world;
 
 pub use components::{
     CharacterBody, Collider, ColliderShape, CollisionEvent, Joint, JointKind, PhysicsInput,
-    PhysicsTransform, RaycastHit, RigidBody, RigidBodyType,
+    PhysicsTransform, Ragdoll, RaycastHit, RigidBody, RigidBodyType,
 };
 pub use plugin::PhysicsPlugin;
 pub use world::PhysicsWorld;

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -1,8 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
+use bsengine_gltf::SkinnedMesh;
 use glam::{Quat, Vec3};
 use rapier3d::geometry::{CollisionEvent as RapierCollisionEvent, ContactPair};
 use rapier3d::pipeline::EventHandler;
@@ -11,8 +12,9 @@ use rapier3d::prelude::*;
 use crate::{
     components::{
         CharacterBody, Collider, ColliderShape, CollisionEvent, Joint, PhysicsHandles,
-        PhysicsInput, PhysicsTransform, RigidBody, RigidBodyType,
+        PhysicsInput, PhysicsTransform, Ragdoll, RagdollBone, RigidBody, RigidBodyType,
     },
+    ragdoll::plan_bones,
     world::PhysicsWorld,
 };
 
@@ -43,7 +45,15 @@ impl Plugin for PhysicsPlugin {
             Update,
             (
                 sync_physics_input_from_transform_for_kinematic,
+                // Before `spawn_bodies`, so the bone entities it spawns get
+                // their Rapier bodies on the same frame the ragdoll switched
+                // on, and `sync_joints` below can link them that same frame
+                // rather than leaving the skeleton loose for one step.
+                sync_ragdolls,
                 spawn_bodies,
+                // After `spawn_bodies`, because the collider whose groups this
+                // narrows does not exist until then.
+                isolate_ragdoll_bones,
                 // After `spawn_bodies`, so a joint authored alongside its two
                 // bodies in the same scene is created on the frame those
                 // bodies register rather than the frame after; before
@@ -222,6 +232,193 @@ fn sync_joints(
         ) {
             created.insert(entity, joint.body_b);
         }
+    }
+}
+
+/// The collision group a ragdoll's own bone colliders belong to — and the one
+/// they are filtered *out* of, so a character's bones never collide with each
+/// other.
+///
+/// They have to be. Adjacent bone capsules share an endpoint by construction,
+/// so every joint in the skeleton is also a contact at full penetration depth:
+/// the solver shoves the two bones apart while the joint hauls them back, and
+/// the ragdoll shakes itself to pieces. Self-collision between a character's
+/// own bones is out of scope for this item, and this is what "out of scope"
+/// has to mean mechanically.
+///
+/// Only the bones' *filter* drops the group, not their membership, so a bone
+/// still collides with everything else in the world: Rapier requires both
+/// sides to accept, and an ordinary collider's default filter is `ALL`.
+const RAGDOLL_GROUP: Group = Group::GROUP_32;
+
+/// What [`sync_ragdolls`] built for one ragdoll, so switching it off can take
+/// away exactly what switching it on put there.
+struct BuiltRagdoll {
+    /// `(node index in `SkinnedMesh.nodes`, bone body entity)`.
+    bones: Vec<(usize, Entity)>,
+}
+
+/// Builds a ragdoll's bone bodies and joints when it becomes active, and
+/// removes them when it stops.
+///
+/// Mirrors [`sync_joints`]: the component says what the simulation should
+/// contain and this is the pass that makes it so. The bone entities are
+/// ordinary physics entities — `RigidBody`, `Collider`, `PhysicsInput`, and a
+/// `Joint` naming the bone above — so [`spawn_bodies`] and [`sync_joints`]
+/// bring them into Rapier and take their constraints away again, rather than
+/// this growing a private copy of both.
+///
+/// A `Local` rather than a component holds the bookkeeping, for the reason
+/// `sync_joints` gives for its own: which entities this pass created is its
+/// business alone, and no part of any entity's authored shape.
+fn sync_ragdolls(
+    mut commands: Commands,
+    mut world: ResMut<PhysicsWorld>,
+    mut built: Local<HashMap<Entity, BuiltRagdoll>>,
+    // Warned-about entities, so a misconfigured ragdoll says so once instead
+    // of once per frame forever. Cleared again if it later gets a skeleton.
+    mut warned: Local<HashSet<Entity>>,
+    ragdolls: Query<(Entity, &Ragdoll, Option<&SkinnedMesh>)>,
+) {
+    // Tear down first, so a ragdoll switched off and on again in the same
+    // frame is rebuilt rather than left with the old bodies. A lookup that
+    // misses covers an entity that despawned and one that merely lost its
+    // `Ragdoll`; neither is in `ragdolls` any more.
+    let stale: Vec<Entity> = built
+        .keys()
+        .copied()
+        .filter(|&owner| !ragdolls.get(owner).is_ok_and(|(_, r, _)| r.active))
+        .collect();
+    for owner in stale {
+        for (_, bone) in built.remove(&owner).into_iter().flat_map(|b| b.bones) {
+            // Despawning alone would leave the Rapier body simulating: nothing
+            // removes it, and it would go on falling through the level and
+            // reporting contacts under a collider handle that maps to nothing.
+            world.remove_body(bone);
+            commands.entity(bone).despawn();
+        }
+        warned.remove(&owner);
+    }
+
+    for (owner, ragdoll, skinned) in ragdolls.iter() {
+        if !ragdoll.active || built.contains_key(&owner) {
+            continue;
+        }
+        let Some(skinned) = skinned else {
+            if warned.insert(owner) {
+                tracing::warn!(
+                    "ragdoll: {owner:?} has an active Ragdoll but no SkinnedMesh, so there \
+                     is no skeleton to build bodies from; doing nothing"
+                );
+            }
+            continue;
+        };
+        warned.remove(&owner);
+
+        let radius = ragdoll.bone_radius.max(1.0e-3);
+        let plans = plan_bones(&skinned.nodes, radius, ragdoll.total_mass);
+        if plans.is_empty() {
+            if warned.insert(owner) {
+                tracing::warn!(
+                    "ragdoll: {owner:?} has a SkinnedMesh whose {} node(s) form no bone \
+                     (a bone is a node with a parent), so there is nothing to build",
+                    skinned.nodes.len()
+                );
+            }
+            continue;
+        }
+
+        // Ids first: a bone's `Joint` names its parent's entity, and half the
+        // bones are planned before the bone they hang from.
+        let entities: Vec<Entity> = plans.iter().map(|_| commands.spawn_empty().id()).collect();
+        let by_node: HashMap<usize, usize> = plans
+            .iter()
+            .enumerate()
+            .map(|(i, plan)| (plan.node, i))
+            .collect();
+
+        for (i, plan) in plans.iter().enumerate() {
+            // Rapier takes a density and derives the mass from the shape, so
+            // the mass the plan asked for has to be divided back out by the
+            // capsule's volume. A non-positive result would give the body zero
+            // mass, which Rapier reads as *infinite* -- a bone that anchors the
+            // skeleton in mid-air instead of falling.
+            let volume = plan.volume(radius);
+            let density = if volume > 0.0 && plan.mass > 0.0 {
+                plan.mass / volume
+            } else {
+                1.0
+            };
+
+            commands.entity(entities[i]).insert((
+                RagdollBone,
+                RigidBody::dynamic(),
+                Collider {
+                    shape: ColliderShape::Capsule {
+                        half_height: plan.half_height,
+                        radius,
+                    },
+                    restitution: 0.0,
+                    friction: 0.5,
+                    density,
+                    sensor: false,
+                },
+                PhysicsInput {
+                    position: plan.center.into(),
+                    rotation: plan.rotation.into(),
+                },
+            ));
+
+            let Some(parent_index) = plan.parent.and_then(|node| by_node.get(&node)).copied()
+            else {
+                continue;
+            };
+            let parent = &plans[parent_index];
+            // The two bones meet at the shared node: this bone's head is that
+            // point, and its parent's tail is the same point. Anchoring there
+            // means the joint starts already satisfied instead of the solver
+            // yanking the skeleton into shape on frame one.
+            //
+            // That shared node is also what names the joint. It is the knee,
+            // not either of the two bones the knee connects -- see
+            // `Ragdoll::joint_overrides`.
+            let joint_node = skinned.nodes[plan.node].parent.unwrap_or(plan.node);
+            commands.entity(entities[i]).insert(Joint {
+                body_b: entities[parent_index],
+                kind: ragdoll.joint_for_bone(&skinned.nodes[joint_node].name),
+                anchor_a: plan.local_head().into(),
+                anchor_b: parent.local_tail().into(),
+            });
+        }
+
+        built.insert(
+            owner,
+            BuiltRagdoll {
+                bones: plans
+                    .iter()
+                    .enumerate()
+                    .map(|(i, plan)| (plan.node, entities[i]))
+                    .collect(),
+            },
+        );
+    }
+}
+
+/// Keeps every ragdoll bone collider out of [`RAGDOLL_GROUP`]'s own traffic.
+///
+/// Runs every frame rather than once at creation, for the reason
+/// [`lock_character_rotation`] gives: a body is registered with Rapier by
+/// `spawn_bodies`, so there is no single moment observable from here at which
+/// "the collider now exists". Setting the same groups again is idempotent.
+fn isolate_ragdoll_bones(
+    mut world: ResMut<PhysicsWorld>,
+    query: Query<Entity, (With<RagdollBone>, With<PhysicsHandles>)>,
+) {
+    let groups = InteractionGroups::all()
+        .with_memberships(RAGDOLL_GROUP)
+        .with_filter(Group::ALL.difference(RAGDOLL_GROUP));
+    for entity in query.iter() {
+        world.set_collision_groups(entity, groups);
     }
 }
 
@@ -954,6 +1151,295 @@ mod tests {
                 .resource::<PhysicsWorld>()
                 .has_joint(hanging, bodyless),
             "an entity with no rigid body cannot be one end of a joint"
+        );
+    }
+
+    // ---- Ragdoll (roadmap item 52, sub-step 1/2) -------------------------
+
+    /// A ragdoll-shaped skeleton standing 10 units up: hips at the root, a
+    /// two-bone spine, and a three-bone left leg. Branching on purpose — a
+    /// straight chain would not notice a root that fails to hold its children
+    /// together.
+    fn humanoid_skeleton() -> SkinnedMesh {
+        let node =
+            |name: &str, position: [f32; 3], parent: Option<usize>| bsengine_gltf::NodeTransform {
+                name: name.to_string(),
+                position,
+                rotation: [0.0, 0.0, 0.0, 1.0],
+                scale: [1.0, 1.0, 1.0],
+                parent,
+            };
+        SkinnedMesh {
+            mesh_id: 0,
+            rest_vertices: Vec::new(),
+            skin: Vec::new(),
+            skin_data: Default::default(),
+            nodes: vec![
+                node("Hips", [0.0, 10.0, 0.0], None),
+                node("Spine", [0.0, 0.45, 0.0], Some(0)),
+                node("Head", [0.0, 0.40, 0.0], Some(1)),
+                node("LeftUpLeg", [0.15, -0.10, 0.0], Some(0)),
+                node("LeftLeg", [0.0, -0.45, 0.0], Some(3)),
+                node("LeftFoot", [0.0, -0.42, 0.05], Some(4)),
+            ],
+        }
+    }
+
+    /// Every ragdoll bone body currently in the world, as
+    /// `(entity, PhysicsTransform)`.
+    fn bone_bodies(app: &mut App) -> Vec<(Entity, Vec3)> {
+        let mut query = app
+            .world_mut()
+            .query_filtered::<(Entity, &PhysicsTransform), With<RagdollBone>>();
+        query
+            .iter(app.world())
+            .map(|(e, t)| (e, t.position.0))
+            .collect()
+    }
+
+    #[derive(Clone, Default)]
+    struct LogSink(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for LogSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl tracing_subscriber::fmt::MakeWriter<'_> for LogSink {
+        type Writer = Self;
+        fn make_writer(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// Runs `body` with every `tracing` event on this thread captured.
+    fn capture_logs<T>(body: impl FnOnce() -> T) -> (T, String) {
+        let sink = LogSink::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(sink.clone())
+            .with_ansi(false)
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+        let out = tracing::subscriber::with_default(subscriber, body);
+        let logs = String::from_utf8_lossy(&sink.0.lock().unwrap()).into_owned();
+        (out, logs)
+    }
+
+    #[test]
+    fn an_activated_ragdoll_falls_without_the_skeleton_coming_apart() {
+        // Both halves are needed, for the same reason item 51's chain test
+        // needed both: "it fell" alone passes on a skeleton that scattered to
+        // the four winds, and "it held together" alone passes on one that never
+        // moved at all.
+        //
+        // There is a *floor*, and one bone is kicked, and neither is decoration.
+        // In empty space every body accelerates identically, so the gaps between
+        // them never change and the cohesion half passes with no joints in the
+        // simulation at all -- the assertion would be about gravity, not about
+        // this feature. Landing puts real load through the joints, and the kick
+        // is the item-51 shape: something that would send one bone away on its
+        // own has to drag the rest of the skeleton with it instead.
+        let mut app = new_app();
+        app.add_plugins(PhysicsPlugin);
+        spawn_floor(&mut app);
+        let skeleton = humanoid_skeleton();
+        app.world_mut().spawn((
+            Ragdoll {
+                active: true,
+                ..Default::default()
+            },
+            skeleton.clone(),
+        ));
+
+        app.update();
+        let start: HashMap<Entity, Vec3> = bone_bodies(&mut app).into_iter().collect();
+        assert_eq!(
+            start.len(),
+            skeleton.nodes.len(),
+            "one bone body per node, the root included"
+        );
+
+        // The foot: the extremity furthest from the root, so an unconstrained
+        // one has the whole chain to get away from.
+        let foot = *start
+            .iter()
+            .min_by(|a, b| a.1.y.total_cmp(&b.1.y))
+            .expect("bones exist")
+            .0;
+        app.world_mut()
+            .resource_mut::<PhysicsWorld>()
+            .apply_impulse(foot, Vec3::new(60.0, 0.0, 25.0));
+
+        for _ in 0..300 {
+            app.update();
+        }
+        let end: HashMap<Entity, Vec3> = bone_bodies(&mut app).into_iter().collect();
+
+        // 1. It fell. It started 10 units up and the floor's surface is at 0.
+        let mut min_drop = f32::INFINITY;
+        for (entity, from) in &start {
+            let to = end[entity];
+            min_drop = min_drop.min(from.y - to.y);
+        }
+        println!("ragdoll collapse: smallest drop over 300 steps = {min_drop}");
+        assert!(
+            min_drop > 8.0,
+            "every bone must have fallen to the floor 10 units below; the \
+             least-moved one dropped only {min_drop} units"
+        );
+
+        // 2. It did not explode. A joint holds its two bones at a shared point,
+        //    so the two capsule centres can never be further apart than the sum
+        //    of their half-heights -- whatever angle the joint bends to.
+        //
+        // Which body is which bone is settled by where each one *started*: on
+        // the first frame a bone body sits exactly on its plan's centre. Query
+        // iteration order is an archetype detail and would be the wrong thing
+        // to trust here.
+        let plans = crate::ragdoll::plan_bones(&skeleton.nodes, 0.08, 70.0);
+        let entity_of: HashMap<usize, Entity> = plans
+            .iter()
+            .map(|plan| {
+                let (&entity, _) = start
+                    .iter()
+                    .find(|(_, &at)| at.abs_diff_eq(plan.center, 0.01))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "no bone body spawned at node {}'s planned centre {:?}; \
+                             bodies started at {:?}",
+                            plan.node,
+                            plan.center,
+                            start.values().collect::<Vec<_>>()
+                        )
+                    });
+                (plan.node, entity)
+            })
+            .collect();
+
+        let mut separations: Vec<(usize, f32, f32)> = Vec::new();
+        for plan in &plans {
+            let Some(parent_node) = plan.parent else {
+                continue;
+            };
+            let parent = plans.iter().find(|p| p.node == parent_node).unwrap();
+            separations.push((
+                plan.node,
+                (end[&entity_of[&plan.node]] - end[&entity_of[&parent_node]]).length(),
+                plan.half_height + parent.half_height,
+            ));
+        }
+        println!("ragdoll cohesion (node, separation, joint distance): {separations:?}");
+        let (node, separation, limit) = separations
+            .iter()
+            .copied()
+            .max_by(|a, b| (a.1 - a.2).total_cmp(&(b.1 - b.2)))
+            .expect("a branching skeleton has jointed pairs");
+        assert!(
+            separation <= limit + 0.05,
+            "the skeleton came apart at node {node}: two jointed bones ended up \
+             {separation} apart when the joint can only let them reach {limit}"
+        );
+    }
+
+    #[test]
+    fn an_inactive_ragdoll_creates_no_bodies_at_all() {
+        // `active: false` must be completely inert -- a ragdoll component on a
+        // normal character may not perturb it, and `Ragdoll::default()` is what
+        // the Inspector's Add Component gives you.
+        let mut app = new_app();
+        app.add_plugins(PhysicsPlugin);
+        app.world_mut()
+            .spawn((Ragdoll::default(), humanoid_skeleton()));
+
+        for _ in 0..30 {
+            app.update();
+        }
+
+        assert!(
+            bone_bodies(&mut app).is_empty(),
+            "an inactive ragdoll must build nothing"
+        );
+    }
+
+    #[test]
+    fn switching_a_ragdoll_off_takes_its_bodies_out_of_the_simulation() {
+        // Despawning the bone entities is not enough on its own: nothing
+        // removes their Rapier bodies, so a "torn down" ragdoll would go on
+        // falling through the level and reporting contacts under collider
+        // handles that map to no entity. Nothing fails at the moment that
+        // happens, which is exactly why it needs asserting.
+        let mut app = new_app();
+        app.add_plugins(PhysicsPlugin);
+        let owner = app
+            .world_mut()
+            .spawn((
+                Ragdoll {
+                    active: true,
+                    ..Default::default()
+                },
+                humanoid_skeleton(),
+            ))
+            .id();
+
+        app.update();
+        let bones = bone_bodies(&mut app);
+        assert!(!bones.is_empty(), "the ragdoll should have built bodies");
+        let a_bone = bones[0].0;
+        assert!(app
+            .world()
+            .resource::<PhysicsWorld>()
+            .get_linvel(a_bone)
+            .is_some());
+
+        app.world_mut().get_mut::<Ragdoll>(owner).unwrap().active = false;
+        app.update();
+
+        assert!(
+            bone_bodies(&mut app).is_empty(),
+            "the bone entities must be gone"
+        );
+        assert!(
+            app.world()
+                .resource::<PhysicsWorld>()
+                .get_linvel(a_bone)
+                .is_none(),
+            "and so must their rigid bodies -- an entity-less body keeps simulating"
+        );
+    }
+
+    #[test]
+    fn a_ragdoll_without_a_skinned_mesh_warns_instead_of_panicking() {
+        // The bone hierarchy comes from `SkinnedMesh.nodes`; with no skeleton
+        // there is nothing to build. An authoring mistake is not a reason to
+        // take the game down -- but it is a reason to say so, or it looks
+        // exactly like a ragdoll that ran and did nothing.
+        let (mut app, logs) = capture_logs(|| {
+            let mut app = new_app();
+            app.add_plugins(PhysicsPlugin);
+            app.world_mut().spawn(Ragdoll {
+                active: true,
+                ..Default::default()
+            });
+            for _ in 0..5 {
+                app.update();
+            }
+            app
+        });
+
+        assert!(bone_bodies(&mut app).is_empty(), "no skeleton, no bodies");
+        assert!(
+            logs.contains("SkinnedMesh"),
+            "the warning must name what is missing; captured logs were: {logs:?}"
+        );
+        assert_eq!(
+            logs.matches("no SkinnedMesh").count(),
+            1,
+            "and it must be said once, not once per frame forever: {logs:?}"
         );
     }
 

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -1528,6 +1528,181 @@ mod tests {
         );
     }
 
+    // ---- Per-bone joint overrides reach the simulation --------------------
+
+    /// A root and two collinear bones hanging straight down from it, so that
+    /// consecutive bones share a rest rotation.
+    ///
+    /// That collinearity is not cosmetic. A revolute joint's axis is given in
+    /// *both* bodies' local frames, so two bones that rest at different
+    /// orientations start with the constraint already violated and the solver
+    /// spends the first steps hauling them into agreement — which is motion the
+    /// test would then have to tell apart from the motion it is measuring.
+    fn straight_leg() -> SkinnedMesh {
+        let node =
+            |name: &str, position: [f32; 3], parent: Option<usize>| bsengine_gltf::NodeTransform {
+                name: name.to_string(),
+                position,
+                rotation: [0.0, 0.0, 0.0, 1.0],
+                scale: [1.0, 1.0, 1.0],
+                parent,
+            };
+        SkinnedMesh {
+            mesh_id: 0,
+            rest_vertices: Vec::new(),
+            skin: Vec::new(),
+            skin_data: Default::default(),
+            nodes: vec![
+                node("Hips", [0.0, 5.0, 0.0], None),
+                node("Knee", [0.0, -1.0, 0.0], Some(0)),
+                node("Ankle", [0.0, -1.0, 0.0], Some(1)),
+            ],
+            pose_override: Vec::new(),
+            joint_matrices: Vec::new(),
+        }
+    }
+
+    /// Which entity is which bone, by the node the bone's child end sits on.
+    fn bone_entities_by_node(app: &mut App) -> HashMap<usize, Entity> {
+        let mut query = app.world_mut().query::<(Entity, &RagdollBone)>();
+        query
+            .iter(app.world())
+            .map(|(entity, bone)| (bone.node, entity))
+            .collect()
+    }
+
+    fn rotation_of(app: &App, entity: Entity) -> Quat {
+        app.world()
+            .get::<PhysicsTransform>(entity)
+            .expect("a bone body has a simulated transform")
+            .rotation
+            .0
+    }
+
+    #[test]
+    fn a_bone_overridden_to_revolute_is_constrained_off_axis() {
+        // Task 1 proved `joint_for_bone` RETURNS the override. This proves the
+        // construction path actually USES it: without it the map could be read
+        // and then dropped on the floor, every ragdoll would be spherical
+        // throughout, and everything else in this file would still pass.
+        //
+        // The measurement is the hinge axis as each of the joint's two bodies
+        // sees it. A revolute joint's whole content is that those two stay
+        // pointing the same way; a spherical joint says nothing about them. So
+        // the same off-axis torque, applied to the same bone of the same
+        // skeleton, must open that angle in one and not in the other.
+
+        /// The hinge axis, in each bone body's own local space.
+        const HINGE: Vec3 = Vec3::X;
+
+        use crate::JointKind;
+
+        /// Torques the shin about `local_torque_axis`, expressed in the shin's
+        /// own frame, and reports `(off-axis tilt, total bend)`:
+        ///
+        /// * how far the hinge axis as the shin sees it has drifted from the
+        ///   hinge axis as the thigh sees it — the whole content of a revolute
+        ///   constraint, and the number that must stay at zero;
+        /// * how far the two bones have turned relative to each other at all —
+        ///   which is what separates "a hinge refused an off-axis torque" from
+        ///   "the joint welded the skeleton solid" and from "the torque never
+        ///   landed".
+        fn torque_the_shin(
+            overrides: HashMap<String, JointKind>,
+            local_torque_axis: Vec3,
+        ) -> (f32, f32) {
+            let mut app = new_app();
+            app.add_plugins(PhysicsPlugin);
+            // No gravity and no floor: the only thing that can move a bone is
+            // the test's own torque, so a difference between the runs has one
+            // explanation rather than three.
+            app.world_mut()
+                .resource_mut::<PhysicsWorld>()
+                .set_gravity(0.0);
+            app.world_mut().spawn((
+                Ragdoll {
+                    active: true,
+                    joint_overrides: overrides,
+                    ..Default::default()
+                },
+                straight_leg(),
+            ));
+            app.update();
+
+            let bones = bone_entities_by_node(&mut app);
+            let shin = bones[&2];
+            let thigh = bones[&1];
+
+            let at_rest =
+                (rotation_of(&app, shin) * HINGE).angle_between(rotation_of(&app, thigh) * HINGE);
+            assert!(
+                at_rest < 0.01,
+                "the two bones start collinear, so the hinge axis must start \
+                 agreed; it is already {at_rest} rad apart and the measurement \
+                 below would be of the solver settling, not of the constraint"
+            );
+
+            let torque = rotation_of(&app, shin) * local_torque_axis;
+            app.world_mut()
+                .resource_mut::<PhysicsWorld>()
+                .apply_torque_impulse(shin, torque * 5.0);
+            for _ in 0..60 {
+                app.update();
+            }
+
+            let (shin_rot, thigh_rot) = (rotation_of(&app, shin), rotation_of(&app, thigh));
+            (
+                (shin_rot * HINGE).angle_between(thigh_rot * HINGE),
+                (thigh_rot.inverse() * shin_rot).to_axis_angle().1,
+            )
+        }
+
+        /// The joint sits on the node the two bones share, which is the knee —
+        /// not on either of the bones it joins. See `Ragdoll::joint_overrides`.
+        fn knee_hinge() -> HashMap<String, JointKind> {
+            HashMap::from([(
+                "Knee".to_string(),
+                JointKind::Revolute {
+                    axis: HINGE.into(),
+                    limits: None,
+                },
+            )])
+        }
+
+        // Off the hinge axis: a ball joint allows it, a hinge must not.
+        let (spherical, spherical_bend) = torque_the_shin(HashMap::new(), Vec3::Z);
+        let (revolute, revolute_bend) = torque_the_shin(knee_hinge(), Vec3::Z);
+        // Along it: proves the override produced a *hinge* and not a weld, so
+        // that the zero above is the axis being held and not the whole
+        // skeleton being frozen.
+        let (_, along_axis_bend) = torque_the_shin(knee_hinge(), HINGE);
+        println!(
+            "off-axis torque: spherical tilted {spherical} rad (bend \
+             {spherical_bend}), overridden tilted {revolute} rad (bend \
+             {revolute_bend}); on-axis torque bent the override by \
+             {along_axis_bend} rad"
+        );
+
+        assert!(
+            spherical > 0.3,
+            "the default ball joint must let the bone turn off-axis, or the \
+             comparison is between two motionless skeletons; got {spherical} rad"
+        );
+        assert!(
+            revolute < 0.05,
+            "with the knee overridden to a hinge, the same torque must not tilt \
+             it off its axis -- an override that is read and then discarded \
+             leaves this at the spherical {spherical} rad; got {revolute}"
+        );
+        assert!(
+            along_axis_bend > 0.3,
+            "...and the override has to be a hinge rather than a weld, or the \
+             {revolute} rad above is a skeleton that cannot move at all rather \
+             than one held to its axis; torquing along the axis bent it only \
+             {along_axis_bend} rad"
+        );
+    }
+
     // ---- Skinning follows the ragdoll (item 52 sub-step 1/2, task 3) -----
     //
     // The task the whole feature lives or dies on, and it fails quietly. An

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -14,7 +14,7 @@ use crate::{
         CharacterBody, Collider, ColliderShape, CollisionEvent, Joint, PhysicsHandles,
         PhysicsInput, PhysicsTransform, Ragdoll, RagdollBone, RigidBody, RigidBodyType,
     },
-    ragdoll::plan_bones,
+    ragdoll::{plan_bones, pose_from_bones},
     world::PhysicsWorld,
 };
 
@@ -61,6 +61,10 @@ impl Plugin for PhysicsPlugin {
                 sync_joints,
                 step_world,
                 sync_from_rapier,
+                // After `sync_from_rapier`, which is what puts this step's
+                // simulated pose into `PhysicsTransform`. Read before that and
+                // the skinned mesh would trail the bodies by a frame.
+                publish_ragdoll_pose,
                 sync_transform_from_physics,
                 // After the transform sync, so the ground ray is cast from
                 // where the character actually ended up this step rather than
@@ -351,7 +355,10 @@ fn sync_ragdolls(
             };
 
             commands.entity(entities[i]).insert((
-                RagdollBone,
+                RagdollBone {
+                    owner,
+                    node: plan.node,
+                },
                 RigidBody::dynamic(),
                 Collider {
                     shape: ColliderShape::Capsule {
@@ -401,6 +408,60 @@ fn sync_ragdolls(
                     .collect(),
             },
         );
+    }
+}
+
+/// Publishes the pose the bone bodies imply into the skinned mesh, so the
+/// character on screen follows the simulation instead of its animation clips.
+///
+/// **This is the half of the ragdoll that fails silently.** Everything up to
+/// here can be perfect — capsules in the right places, joints holding, the
+/// skeleton collapsing exactly as it should — and if this pass is missing, the
+/// character goes on playing its walk cycle over the top of it and looks
+/// completely normal. Nothing about the bodies would show it; the only
+/// observable difference is in the joint matrices the skinning ends up with.
+///
+/// The direction of travel is what keeps the two crates apart:
+/// `bsengine-gltf` never names a physics type, it just honours a
+/// `pose_override` written by whoever put one there. See that field, and the
+/// `bsengine-gltf` dependency note in this crate's `Cargo.toml`.
+///
+/// Clearing the override again matters as much as writing it: while one is in
+/// place the clips are not read at all, so a ragdoll switched off without this
+/// leaves the character frozen in the pose it died in.
+fn publish_ragdoll_pose(
+    bones: Query<(&RagdollBone, &PhysicsTransform)>,
+    mut owners: Query<(Entity, &Ragdoll, &mut SkinnedMesh)>,
+) {
+    let mut by_owner: HashMap<Entity, HashMap<usize, (Vec3, Quat)>> = HashMap::new();
+    for (bone, transform) in bones.iter() {
+        by_owner
+            .entry(bone.owner)
+            .or_default()
+            .insert(bone.node, (transform.position.0, transform.rotation.0));
+    }
+
+    for (owner, ragdoll, mut skinned) in owners.iter_mut() {
+        let poses = by_owner.get(&owner).filter(|_| ragdoll.active);
+        let Some(poses) = poses else {
+            // `is_empty` first, not an unconditional `clear`: taking `&mut` out
+            // of the `Mut` marks the component changed, and every skinned mesh
+            // in the level that has a ragdoll it has never used would report a
+            // change every single frame.
+            if !skinned.pose_override.is_empty() {
+                skinned.pose_override.clear();
+            }
+            continue;
+        };
+
+        let radius = ragdoll.bone_radius.max(1.0e-3);
+        let plans = plan_bones(&skinned.nodes, radius, ragdoll.total_mass);
+        let bone_poses: Vec<Option<(Vec3, Quat)>> = plans
+            .iter()
+            .map(|plan| poses.get(&plan.node).copied())
+            .collect();
+        let pose = pose_from_bones(&skinned.nodes, &plans, &bone_poses);
+        skinned.pose_override = pose;
     }
 }
 
@@ -1169,21 +1230,45 @@ mod tests {
                 scale: [1.0, 1.0, 1.0],
                 parent,
             };
+        let nodes = vec![
+            node("Hips", [0.0, 10.0, 0.0], None),
+            node("Spine", [0.0, 0.45, 0.0], Some(0)),
+            node("Head", [0.0, 0.40, 0.0], Some(1)),
+            node("LeftUpLeg", [0.15, -0.10, 0.0], Some(0)),
+            node("LeftLeg", [0.0, -0.45, 0.0], Some(3)),
+            node("LeftFoot", [0.0, -0.42, 0.05], Some(4)),
+        ];
+        // Every node is a joint, and every inverse bind matrix is the identity.
+        // That is not what a real exporter writes, and it is chosen so a joint
+        // matrix reads back as the node's *global transform* with nothing to
+        // undo: `joint_matrices[j].transform_point3(ZERO)` is simply where node
+        // `j` is. `REST_POSITIONS` states independently where that should be.
         SkinnedMesh {
             mesh_id: 0,
             rest_vertices: Vec::new(),
             skin: Vec::new(),
-            skin_data: Default::default(),
-            nodes: vec![
-                node("Hips", [0.0, 10.0, 0.0], None),
-                node("Spine", [0.0, 0.45, 0.0], Some(0)),
-                node("Head", [0.0, 0.40, 0.0], Some(1)),
-                node("LeftUpLeg", [0.15, -0.10, 0.0], Some(0)),
-                node("LeftLeg", [0.0, -0.45, 0.0], Some(3)),
-                node("LeftFoot", [0.0, -0.42, 0.05], Some(4)),
-            ],
+            skin_data: bsengine_gltf::SkinData {
+                joint_node_indices: (0..nodes.len()).collect(),
+                inverse_bind_matrices: vec![glam::Mat4::IDENTITY.to_cols_array_2d(); nodes.len()],
+            },
+            nodes,
+            pose_override: Vec::new(),
+            joint_matrices: Vec::new(),
         }
     }
+
+    /// Where [`humanoid_skeleton`]'s six nodes sit in model space at rest,
+    /// written out rather than accumulated. Re-deriving them with the same
+    /// parent-chain walk the code under test uses would let a broken walk agree
+    /// with itself.
+    const REST_POSITIONS: [Vec3; 6] = [
+        Vec3::new(0.0, 10.0, 0.0),   // Hips
+        Vec3::new(0.0, 10.45, 0.0),  // Spine
+        Vec3::new(0.0, 10.85, 0.0),  // Head
+        Vec3::new(0.15, 9.90, 0.0),  // LeftUpLeg
+        Vec3::new(0.15, 9.45, 0.0),  // LeftLeg
+        Vec3::new(0.15, 9.03, 0.05), // LeftFoot
+    ];
 
     /// Every ragdoll bone body currently in the world, as
     /// `(entity, PhysicsTransform)`.
@@ -1440,6 +1525,224 @@ mod tests {
             logs.matches("no SkinnedMesh").count(),
             1,
             "and it must be said once, not once per frame forever: {logs:?}"
+        );
+    }
+
+    // ---- Skinning follows the ragdoll (item 52 sub-step 1/2, task 3) -----
+    //
+    // The task the whole feature lives or dies on, and it fails quietly. An
+    // implementation that builds the bodies and lets them fall while skinning
+    // goes on reading the animation clips produces a character that looks
+    // completely normal on screen with a full ragdoll simulating underneath it
+    // -- and every test above passes in that state, because they all inspect
+    // the physics bodies, and the bodies are exactly what a broken version also
+    // gets right. So these assert on the JOINT MATRICES, which are the only
+    // place the difference is observable.
+    //
+    // They live in this crate rather than in `bsengine-gltf` because this is
+    // the only one that can see both ends: `bsengine-gltf` must not know what
+    // physics is (see the dependency note in Cargo.toml), so it can be asked
+    // whether it honours a `pose_override` -- which it is, over there -- but
+    // not whether a real ragdoll is what fills one.
+
+    /// Where a clip holds the skeleton's root: 50 units along +X of where it
+    /// rests. Constant over the clip's whole timeline, so nothing here depends
+    /// on how far an `AnimationPlayer` has been ticked.
+    const CLIP_ROOT: Vec3 = Vec3::new(50.0, 10.0, 0.0);
+
+    fn shifted_clip_library() -> bsengine_gltf::AnimationClipLibrary {
+        bsengine_gltf::AnimationClipLibrary::from_clips(vec![bsengine_gltf::AnimationClip {
+            name: "pose".to_string(),
+            duration: 1.0,
+            channels: vec![bsengine_gltf::AnimationChannel {
+                node_index: 0,
+                times: vec![0.0, 1.0],
+                values: bsengine_gltf::KeyframeValues::Translations(vec![
+                    CLIP_ROOT.to_array(),
+                    CLIP_ROOT.to_array(),
+                ]),
+                interpolation: bsengine_gltf::Interpolation::Linear,
+            }],
+        }])
+    }
+
+    /// A skinned character playing [`shifted_clip_library`]'s clip, physics and
+    /// skinning both running, optionally carrying a `Ragdoll`.
+    fn skinned_character(ragdoll: Option<Ragdoll>) -> (App, Entity) {
+        let mut app = new_app();
+        app.add_plugins(PhysicsPlugin);
+        app.add_plugins(bsengine_gltf::SkinnedMeshPlugin);
+        let mut entity = app.world_mut().spawn((
+            humanoid_skeleton(),
+            shifted_clip_library(),
+            bsengine_core::AnimationPlayer::new("pose").with_duration(1.0),
+        ));
+        if let Some(ragdoll) = ragdoll {
+            entity.insert(ragdoll);
+        }
+        let owner = entity.id();
+        (app, owner)
+    }
+
+    /// Where each node currently is, according to the joint matrices the
+    /// skinning system last computed. The inverse bind matrices are the
+    /// identity (see [`humanoid_skeleton`]), so a joint matrix applied to the
+    /// origin is the node's global position and nothing else.
+    fn skinned_node_positions(app: &App, owner: Entity) -> Vec<Vec3> {
+        app.world()
+            .get::<SkinnedMesh>(owner)
+            .expect("the character keeps its skinned mesh")
+            .joint_matrices
+            .iter()
+            .map(|m| m.transform_point3(Vec3::ZERO))
+            .collect()
+    }
+
+    /// Each ragdoll bone body's position, keyed by the node it belongs to.
+    fn bone_positions_by_node(app: &mut App) -> HashMap<usize, Vec3> {
+        let mut query = app.world_mut().query::<(&RagdollBone, &PhysicsTransform)>();
+        query
+            .iter(app.world())
+            .map(|(bone, transform)| (bone.node, transform.position.0))
+            .collect()
+    }
+
+    #[test]
+    fn an_active_ragdoll_makes_the_joint_matrices_follow_physics_not_the_clip() {
+        let (mut app, owner) = skinned_character(Some(Ragdoll {
+            active: true,
+            ..Default::default()
+        }));
+
+        // One frame: the bodies exist and are on their plans' centres, so the
+        // pose is still the rest pose -- which is already the whole assertion
+        // against the quiet failure, because the clip would put the skeleton
+        // 50 units away along +X.
+        app.update();
+        let before = skinned_node_positions(&app, owner);
+        assert_eq!(before.len(), REST_POSITIONS.len(), "one matrix per joint");
+        for (node, rest) in REST_POSITIONS.iter().enumerate() {
+            assert!(
+                before[node].abs_diff_eq(*rest, 0.05),
+                "on the frame the ragdoll switched on, node {node} should still \
+                 be at its rest position {rest:?}; it is at {:?}. The clip puts \
+                 the skeleton at x = {}, so a skinning path still reading the \
+                 clip lands there instead",
+                before[node],
+                rest.x + CLIP_ROOT.x
+            );
+        }
+
+        // No floor: in free fall every bone accelerates identically and the
+        // joints stay satisfied, so the skeleton translates rigidly and "the
+        // mesh followed the bodies" is an exact claim rather than an
+        // approximate one.
+        let bones_before = bone_positions_by_node(&mut app);
+        for _ in 0..120 {
+            app.update();
+        }
+        let bones_after = bone_positions_by_node(&mut app);
+        let travel = bones_after[&0] - bones_before[&0];
+        println!("ragdoll skinning: the bone bodies travelled {travel:?}");
+        assert!(
+            travel.y < -1.0,
+            "the ragdoll has to have actually moved, or 'the mesh followed it' \
+             is a claim about nothing; it travelled {travel:?}"
+        );
+
+        let after = skinned_node_positions(&app, owner);
+        for (node, rest) in REST_POSITIONS.iter().enumerate() {
+            let moved = after[node] - before[node];
+            assert!(
+                moved.abs_diff_eq(travel, 0.05),
+                "node {node} moved {moved:?} while its bone bodies moved \
+                 {travel:?} -- the joint matrices are not following the physics"
+            );
+            assert!(
+                (after[node].x - (rest.x + CLIP_ROOT.x)).abs() > 10.0,
+                "...and they must not be following the clip either: node {node} \
+                 ended at {:?}, and the clip's pose is x = {}",
+                after[node],
+                rest.x + CLIP_ROOT.x
+            );
+        }
+    }
+
+    #[test]
+    fn an_inactive_ragdoll_leaves_the_joint_matrices_byte_identical() {
+        // The opposite direction, and the one every already-shipped character
+        // depends on: attaching a `Ragdoll` and never switching it on must
+        // leave the animation path producing bit-for-bit what it produced
+        // before this feature existed -- which is what an entity with no
+        // `Ragdoll` component at all still gets.
+        let (mut with, with_owner) = skinned_character(Some(Ragdoll::default()));
+        let (mut without, without_owner) = skinned_character(None);
+        for _ in 0..30 {
+            with.update();
+            without.update();
+        }
+
+        let a = with.world().get::<SkinnedMesh>(with_owner).unwrap();
+        let b = without.world().get::<SkinnedMesh>(without_owner).unwrap();
+        assert!(
+            a.pose_override.is_empty(),
+            "an inactive ragdoll must not publish a pose at all"
+        );
+        assert_eq!(a.joint_matrices.len(), REST_POSITIONS.len());
+        assert_eq!(a.joint_matrices.len(), b.joint_matrices.len());
+        for (node, (got, want)) in a.joint_matrices.iter().zip(&b.joint_matrices).enumerate() {
+            assert_eq!(
+                got.to_cols_array(),
+                want.to_cols_array(),
+                "joint {node} of a character carrying an inactive ragdoll must \
+                 be bit-for-bit the same matrix as one carrying no ragdoll"
+            );
+        }
+        // ...and the animation really is what both of them are doing, or the
+        // comparison above is between two copies of the same nothing.
+        let animated = a.joint_matrices[0].transform_point3(Vec3::ZERO);
+        assert!(
+            (animated.x - CLIP_ROOT.x).abs() < 0.001,
+            "the clip should be driving the root to x = {}, got {animated:?}",
+            CLIP_ROOT.x
+        );
+    }
+
+    #[test]
+    fn switching_a_ragdoll_off_hands_the_skeleton_back_to_the_animation() {
+        // While a pose override is in place the clips are not read at all, so a
+        // ragdoll that stops without clearing it leaves the character frozen in
+        // the pose it died in -- forever, and with nothing failing anywhere.
+        let (mut app, owner) = skinned_character(Some(Ragdoll {
+            active: true,
+            ..Default::default()
+        }));
+        for _ in 0..30 {
+            app.update();
+        }
+        let collapsed = skinned_node_positions(&app, owner)[0];
+        assert!(
+            (collapsed.x - CLIP_ROOT.x).abs() > 10.0,
+            "sanity: while active the ragdoll, not the clip, is driving"
+        );
+
+        app.world_mut().get_mut::<Ragdoll>(owner).unwrap().active = false;
+        app.update();
+
+        assert!(
+            app.world()
+                .get::<SkinnedMesh>(owner)
+                .unwrap()
+                .pose_override
+                .is_empty(),
+            "the override must be cleared, not merely stop being updated"
+        );
+        let animated = skinned_node_positions(&app, owner)[0];
+        assert!(
+            (animated.x - CLIP_ROOT.x).abs() < 0.001,
+            "with the ragdoll off the clip drives the root back to x = {}, got \
+             {animated:?}",
+            CLIP_ROOT.x
         );
     }
 

--- a/crates/bsengine-physics/src/ragdoll.rs
+++ b/crates/bsengine-physics/src/ragdoll.rs
@@ -1,0 +1,354 @@
+use bsengine_gltf::NodeTransform;
+use glam::{Mat4, Quat, Vec3};
+
+/// One bone's rigid body, derived from the rest-pose skeleton.
+///
+/// A bone *is* the segment between a node and its parent, and there is one of
+/// these per node — **roots included**. A root spans nothing, so its capsule
+/// collapses to a sphere of `bone_radius`, and that is on purpose rather than
+/// a degenerate case tolerated: a skeleton's root is usually the hips, with
+/// the spine and both legs hanging off it. Skip it and the character comes
+/// apart into three unconnected pieces at the pelvis the instant it is
+/// switched on, each of which falls perfectly convincingly on its own.
+///
+/// What a zero-length bone must not get is zero *mass* — Rapier reads that as
+/// infinite, so the bone would hold the whole skeleton up in mid-air instead
+/// of dropping it. See [`plan_bones`] on how the mass split avoids that.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BonePlan {
+    /// Index into `SkinnedMesh.nodes` — the bone's own (child) end.
+    pub node: usize,
+    /// Parent node index, or `None` for the root bone. The bone is jointed to
+    /// that node's body.
+    pub parent: Option<usize>,
+    /// Capsule midpoint, in model space — halfway between the parent node's
+    /// rest position and this node's.
+    pub center: Vec3,
+    /// Model-space rotation taking `+Y` onto the bone's direction.
+    ///
+    /// Rapier's capsules are Y-aligned, so without this every bone's collider
+    /// would lie along the model's up axis no matter which way the bone
+    /// actually points — and the joint anchors below, which are expressed as
+    /// `±half_height` along local Y, would land nowhere near the joint.
+    pub rotation: Quat,
+    /// Capsule half-height: the bone's rest length / 2.
+    ///
+    /// Rapier measures a capsule's half-height over its *cylindrical* part, so
+    /// the collider overhangs each end of the bone by `bone_radius` — which is
+    /// what gives a joint its rounded shoulder.
+    pub half_height: f32,
+    /// Share of `total_mass`, proportional to bone length.
+    pub mass: f32,
+}
+
+impl BonePlan {
+    /// The bone's head — the end it shares with its parent — in the bone's own
+    /// local space. This is the point a joint holds.
+    pub fn local_head(&self) -> Vec3 {
+        Vec3::new(0.0, -self.half_height, 0.0)
+    }
+
+    /// The bone's tail, in its own local space: where its children attach.
+    pub fn local_tail(&self) -> Vec3 {
+        Vec3::new(0.0, self.half_height, 0.0)
+    }
+
+    /// The capsule's volume, used to turn [`mass`] into the collider density
+    /// Rapier actually takes.
+    ///
+    /// [`mass`]: BonePlan::mass
+    pub fn volume(&self, radius: f32) -> f32 {
+        let r2 = radius * radius;
+        std::f32::consts::PI * r2 * 2.0 * self.half_height
+            + (4.0 / 3.0) * std::f32::consts::PI * r2 * radius
+    }
+}
+
+/// Accumulates each node's rest-pose **global** transform from its local one.
+///
+/// A fixed number of passes rather than a topological sort, because glTF does
+/// not promise a parent's index is lower than its child's — the same shape
+/// `compute_joint_matrices_blended` and `propagate_global_transforms` already
+/// use in this codebase.
+fn rest_globals(nodes: &[NodeTransform]) -> Vec<Mat4> {
+    let locals: Vec<Mat4> = nodes
+        .iter()
+        .map(|n| {
+            Mat4::from_scale_rotation_translation(
+                Vec3::from(n.scale),
+                Quat::from_array(n.rotation),
+                Vec3::from(n.position),
+            )
+        })
+        .collect();
+    let mut globals = locals.clone();
+    for _ in 0..8 {
+        for (i, node) in nodes.iter().enumerate() {
+            if let Some(parent) = node.parent {
+                globals[i] = globals[parent] * locals[i];
+            }
+        }
+    }
+    globals
+}
+
+/// Derives one [`BonePlan`] per bone from the rest-pose node hierarchy.
+///
+/// Pure on purpose: every geometry and mass decision the ragdoll makes is
+/// decided here, where it can be checked without a physics world at all — the
+/// same reasoning that isolated `select_lod_level` and the spherical-harmonics
+/// maths elsewhere in this engine.
+///
+/// # Mass
+///
+/// `total_mass` is split in proportion to each bone's **capsule extent**,
+/// `length + 2 * bone_radius`, rather than its bare length. Long bones are
+/// still heavier, which is the property that matters, and the caps are what
+/// keep a degenerate bone — two joints authored at the same position, which
+/// real rigs do have — from being handed a mass of exactly zero. Rapier reads
+/// zero mass as infinite, so such a bone would not fall; it would hold the
+/// rest of the skeleton up.
+pub fn plan_bones(nodes: &[NodeTransform], bone_radius: f32, total_mass: f32) -> Vec<BonePlan> {
+    let globals = rest_globals(nodes);
+
+    struct Segment {
+        node: usize,
+        parent: Option<usize>,
+        head: Vec3,
+        tail: Vec3,
+    }
+
+    let position_of = |i: usize| globals[i].to_scale_rotation_translation().2;
+    let segments: Vec<Segment> = nodes
+        .iter()
+        .enumerate()
+        .map(|(i, node)| Segment {
+            node: i,
+            parent: node.parent,
+            // A root is its own head: a point, not a segment.
+            head: position_of(node.parent.unwrap_or(i)),
+            tail: position_of(i),
+        })
+        .collect();
+
+    let weights: Vec<f32> = segments
+        .iter()
+        .map(|s| (s.tail - s.head).length() + 2.0 * bone_radius.max(0.0))
+        .collect();
+    let total_weight: f32 = weights.iter().sum();
+
+    segments
+        .iter()
+        .zip(&weights)
+        .map(|(s, &weight)| {
+            let delta = s.tail - s.head;
+            let length = delta.length();
+            BonePlan {
+                node: s.node,
+                parent: s.parent,
+                center: (s.head + s.tail) * 0.5,
+                // `from_rotation_arc` is undefined for a zero vector, and a
+                // zero-length bone has no direction to point at anyway.
+                rotation: if length > f32::EPSILON {
+                    Quat::from_rotation_arc(Vec3::Y, delta / length)
+                } else {
+                    Quat::IDENTITY
+                },
+                half_height: length * 0.5,
+                // An equal split when every weight is zero (a radius of zero
+                // over a skeleton whose joints all coincide) -- anything else
+                // divides by zero and hands back NaN masses.
+                mass: if total_weight > 0.0 {
+                    total_mass * weight / total_weight
+                } else {
+                    total_mass / segments.len().max(1) as f32
+                },
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A node at `position` in its parent's space, unrotated and unscaled.
+    fn node(name: &str, position: [f32; 3], parent: Option<usize>) -> NodeTransform {
+        NodeTransform {
+            name: name.to_string(),
+            position,
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            scale: [1.0, 1.0, 1.0],
+            parent,
+        }
+    }
+
+    /// A root plus two bones of different lengths hanging straight down:
+    /// node 1 is 2 units below the root, node 2 is 1 unit below node 1.
+    fn uneven_chain() -> Vec<NodeTransform> {
+        vec![
+            node("Root", [0.0, 10.0, 0.0], None),
+            node("Long", [0.0, -2.0, 0.0], Some(0)),
+            node("Short", [0.0, -1.0, 0.0], Some(1)),
+        ]
+    }
+
+    #[test]
+    fn bone_masses_sum_to_the_requested_total() {
+        // A mass distribution that does not sum to `total_mass` gives a ragdoll
+        // that falls at the wrong rate -- plausible-looking, and hard to
+        // attribute to this function months later.
+        let plans = plan_bones(&uneven_chain(), 0.08, 70.0);
+        let sum: f32 = plans.iter().map(|p| p.mass).sum();
+        assert!(
+            (sum - 70.0).abs() < 0.001,
+            "the {} bones' masses sum to {sum}, not the requested 70.0: {:?}",
+            plans.len(),
+            plans.iter().map(|p| p.mass).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_longer_bone_gets_more_mass_than_a_shorter_one() {
+        // Guards the "proportional to length" claim. Without it, an equal split
+        // would pass the sum test above without anyone noticing.
+        let nodes = uneven_chain();
+        let plans = plan_bones(&nodes, 0.08, 70.0);
+        let long = plans.iter().find(|p| p.node == 1).expect("bone for node 1");
+        let short = plans.iter().find(|p| p.node == 2).expect("bone for node 2");
+        assert!(
+            long.mass > short.mass,
+            "the 2-unit bone got {} and the 1-unit bone {}; mass must follow length",
+            long.mass,
+            short.mass
+        );
+    }
+
+    #[test]
+    fn each_bone_capsule_spans_from_its_parent_to_itself() {
+        // Not straight down this time: a bone that is not axis-aligned is the
+        // case where a capsule left at its default Y orientation stops covering
+        // the bone at all, and where the joint anchors stop meeting.
+        //
+        // The root is deliberately *not* at the origin either: with it there,
+        // a node's local position and its global one are the same number, and
+        // this test passes just as well on an implementation that never
+        // accumulates the hierarchy at all.
+        let nodes = vec![
+            node("Root", [10.0, 20.0, 30.0], None),
+            node("Arm", [3.0, 4.0, 0.0], Some(0)),
+        ];
+        let plans = plan_bones(&nodes, 0.1, 10.0);
+        let arm = *plans.iter().find(|p| p.node == 1).expect("bone for node 1");
+        let head_pos = Vec3::new(10.0, 20.0, 30.0);
+        let tail_pos = Vec3::new(13.0, 24.0, 30.0);
+
+        assert!(
+            arm.center.abs_diff_eq((head_pos + tail_pos) * 0.5, 0.001),
+            "the capsule centre must sit midway between {head_pos:?} and {tail_pos:?}, got {:?}",
+            arm.center
+        );
+        assert!(
+            (arm.half_height - 2.5).abs() < 0.001,
+            "half-height must be half the 5-unit separation, got {}",
+            arm.half_height
+        );
+        // The two ends, put back into model space, must be the two nodes.
+        let head = arm.center + arm.rotation * arm.local_head();
+        let tail = arm.center + arm.rotation * arm.local_tail();
+        assert!(
+            head.abs_diff_eq(head_pos, 0.001),
+            "the bone's head must land on its parent, got {head:?}"
+        );
+        assert!(
+            tail.abs_diff_eq(tail_pos, 0.001),
+            "the bone's tail must land on the bone's own node, got {tail:?}"
+        );
+    }
+
+    #[test]
+    fn a_skeleton_with_no_bones_plans_nothing_instead_of_panicking() {
+        assert!(
+            plan_bones(&[], 0.08, 70.0).is_empty(),
+            "no nodes at all is no bones"
+        );
+        // A lone root is a degenerate skeleton, not a crash: zero length, and
+        // still a real mass, so nothing downstream divides by zero.
+        let lone = plan_bones(&[node("Lonely", [0.0, 0.0, 0.0], None)], 0.08, 70.0);
+        assert_eq!(lone.len(), 1);
+        assert_eq!(lone[0].half_height, 0.0);
+        assert!(
+            (lone[0].mass - 70.0).abs() < 0.001,
+            "the only bone carries the whole mass, got {}",
+            lone[0].mass
+        );
+    }
+
+    #[test]
+    fn the_root_gets_a_body_so_its_children_are_not_left_as_separate_pieces() {
+        // A skeleton root is the hips, and the spine and both legs hang off it.
+        // If the root spans nothing and is therefore skipped, each of those
+        // three has no parent body to be jointed to -- and the character comes
+        // apart at the pelvis into three pieces that each fall perfectly
+        // convincingly on their own. The collapse test would not notice: every
+        // parent/child pair that *exists* would still be within its joint
+        // distance.
+        let nodes = vec![
+            node("Hips", [0.0, 1.0, 0.0], None),
+            node("Spine", [0.0, 0.3, 0.0], Some(0)),
+            node("LeftUpLeg", [0.1, -0.1, 0.0], Some(0)),
+            node("RightUpLeg", [-0.1, -0.1, 0.0], Some(0)),
+        ];
+        let plans = plan_bones(&nodes, 0.08, 70.0);
+        assert_eq!(plans.len(), 4, "every node is a bone, the root included");
+
+        let hips = plans
+            .iter()
+            .find(|p| p.node == 0)
+            .expect("bone for the root");
+        assert_eq!(hips.parent, None, "the root has nothing above it");
+        assert_eq!(
+            hips.half_height, 0.0,
+            "a root spans nothing, so its capsule is a sphere"
+        );
+        assert!(
+            hips.mass > 0.0,
+            "a zero-mass body reads as infinite mass in Rapier and would hold \
+             the whole ragdoll up in the air; got {}",
+            hips.mass
+        );
+        for child in [1, 2, 3] {
+            assert_eq!(
+                plans.iter().find(|p| p.node == child).expect("bone").parent,
+                Some(0),
+                "node {child} must be jointed to the root's body, not left free"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bone_inherits_its_parents_rotation_when_computing_its_rest_position() {
+        // Bone positions are local, so a rotated parent moves its children.
+        // Reading `nodes[i].position` directly instead of accumulating globals
+        // gives a skeleton that is correct only for an unrotated bind pose --
+        // which most test rigs are, and most real ones are not.
+        let nodes = vec![
+            NodeTransform {
+                name: "Root".to_string(),
+                position: [0.0, 0.0, 0.0],
+                // A quarter turn about Z: the child's local +Y becomes -X.
+                rotation: Quat::from_rotation_z(std::f32::consts::FRAC_PI_2).to_array(),
+                scale: [1.0, 1.0, 1.0],
+                parent: None,
+            },
+            node("Child", [0.0, 2.0, 0.0], Some(0)),
+        ];
+        let plans = plan_bones(&nodes, 0.05, 1.0);
+        let child = *plans.iter().find(|p| p.node == 1).expect("bone for node 1");
+        let tail = child.center + child.rotation * child.local_tail();
+        assert!(
+            tail.abs_diff_eq(Vec3::new(-2.0, 0.0, 0.0), 0.001),
+            "the child sits at its parent's rotated +Y, i.e. (-2, 0, 0), got {tail:?}"
+        );
+    }
+}

--- a/crates/bsengine-physics/src/ragdoll.rs
+++ b/crates/bsengine-physics/src/ragdoll.rs
@@ -168,6 +168,72 @@ pub fn plan_bones(nodes: &[NodeTransform], bone_radius: f32, total_mass: f32) ->
         .collect()
 }
 
+/// The per-node **global** transforms a ragdoll's bone bodies currently imply,
+/// ready to be handed to `SkinnedMesh::pose_override`.
+///
+/// `bone_poses` gives each plan's body's world `(position, rotation)`, in
+/// `plans` order; `None` for a bone whose body does not exist yet leaves that
+/// node in its rest pose rather than snapping it to the origin.
+///
+/// # Which bone drives which node
+///
+/// A [`BonePlan`] spans *from a node's parent to that node*, but the geometry
+/// skinned to a joint is the limb hanging *below* it: the thigh is weighted to
+/// the hip joint, not to the knee. So a node is driven by its **first child
+/// bone** — the capsule whose head sits on that node — and only a leaf, which
+/// has no child, falls back to its own. Driving each node from its own bone
+/// instead is the subtle version of this that looks almost right: every node
+/// would still be in exactly the right *place*, because the two bones meet
+/// there, and every limb would rotate with the segment above it, so the mesh
+/// would slide off its own capsules as the ragdoll bent.
+///
+/// A node with several children (a pelvis, with a spine and two legs) takes the
+/// first. That is not arbitrary in the case that matters: a rig's pelvis
+/// geometry runs from the hips up to the spine, and the spine is the child that
+/// bone belongs to.
+///
+/// # How a body becomes a transform
+///
+/// Each bone body carries a rigid delta from where its plan put it,
+/// `now * rest⁻¹`, and that delta is applied to the node's rest global. Nothing
+/// is decomposed and recomposed on the way through, so a rig with scale in its
+/// bind pose keeps it.
+pub fn pose_from_bones(
+    nodes: &[NodeTransform],
+    plans: &[BonePlan],
+    bone_poses: &[Option<(Vec3, Quat)>],
+) -> Vec<Mat4> {
+    let rest = rest_globals(nodes);
+
+    let mut own: Vec<Option<usize>> = vec![None; nodes.len()];
+    let mut first_child: Vec<Option<usize>> = vec![None; nodes.len()];
+    for (i, plan) in plans.iter().enumerate() {
+        if plan.node < nodes.len() {
+            own[plan.node] = Some(i);
+        }
+        if let Some(parent) = plan.parent {
+            if parent < nodes.len() && first_child[parent].is_none() {
+                first_child[parent] = Some(i);
+            }
+        }
+    }
+
+    (0..nodes.len())
+        .map(|node| {
+            let Some(driver) = first_child[node].or(own[node]) else {
+                return rest[node];
+            };
+            let Some(Some((position, rotation))) = bone_poses.get(driver).copied() else {
+                return rest[node];
+            };
+            let plan = &plans[driver];
+            let now = Mat4::from_rotation_translation(rotation, position);
+            let bone_rest = Mat4::from_rotation_translation(plan.rotation, plan.center);
+            now * bone_rest.inverse() * rest[node]
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -324,6 +390,126 @@ mod tests {
                 "node {child} must be jointed to the root's body, not left free"
             );
         }
+    }
+
+    // ---- the pose the bodies imply -------------------------------------
+
+    /// Every bone still exactly where its plan put it.
+    fn undisturbed(plans: &[BonePlan]) -> Vec<Option<(Vec3, Quat)>> {
+        plans.iter().map(|p| Some((p.center, p.rotation))).collect()
+    }
+
+    #[test]
+    fn bones_left_where_they_were_built_reproduce_the_rest_pose_exactly() {
+        // The frame a ragdoll switches on, before a single step, the bodies are
+        // on their plans' centres and the mesh must not move at all. Any error
+        // in the `now * rest⁻¹` round trip shows up here as a character that
+        // twitches into a different shape the instant it is activated.
+        let nodes = uneven_chain();
+        let plans = plan_bones(&nodes, 0.08, 70.0);
+        let pose = pose_from_bones(&nodes, &plans, &undisturbed(&plans));
+        let rest = rest_globals(&nodes);
+
+        assert_eq!(pose.len(), nodes.len(), "one transform per node");
+        for (i, (got, want)) in pose.iter().zip(&rest).enumerate() {
+            assert!(
+                got.abs_diff_eq(*want, 0.001),
+                "node {i} moved on activation: {got:?} vs the rest pose {want:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn moving_every_bone_carries_every_node_with_it() {
+        let nodes = uneven_chain();
+        let plans = plan_bones(&nodes, 0.08, 70.0);
+        let drop = Vec3::new(1.0, -4.0, 2.0);
+        let moved: Vec<Option<(Vec3, Quat)>> = plans
+            .iter()
+            .map(|p| Some((p.center + drop, p.rotation)))
+            .collect();
+
+        let pose = pose_from_bones(&nodes, &plans, &moved);
+        let rest = rest_globals(&nodes);
+        for (i, (got, want)) in pose.iter().zip(&rest).enumerate() {
+            let got = got.to_scale_rotation_translation().2;
+            let want = want.to_scale_rotation_translation().2 + drop;
+            assert!(
+                got.abs_diff_eq(want, 0.001),
+                "node {i} should have travelled with its bone to {want:?}, got {got:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_node_follows_the_bone_below_it_rather_than_the_one_above_it() {
+        // The decision this function exists to make, and the one whose wrong
+        // answer looks almost right. A bone spans parent -> child, but the
+        // geometry weighted to a joint is the limb *below* it: the thigh is
+        // skinned to the hip, not to the knee. Drive each node from its own
+        // bone instead and every node is still in exactly the right place --
+        // the two bones meet there -- while every limb rotates with the segment
+        // above it, and the mesh slides off its own capsules as the ragdoll
+        // bends.
+        //
+        // Only bone 2 (node 1 -> node 2) moves here: a quarter turn about Z,
+        // pivoting on the node it shares with its parent, so the whole of the
+        // change is a rotation of the segment below node 1.
+        let nodes = uneven_chain();
+        let plans = plan_bones(&nodes, 0.08, 70.0);
+        let shin = plans.iter().position(|p| p.node == 2).expect("bone 2");
+        let pivot = Vec3::new(0.0, 8.0, 0.0); // node 1's rest position
+        let turn = Quat::from_rotation_z(std::f32::consts::FRAC_PI_2);
+
+        let mut poses = undisturbed(&plans);
+        poses[shin] = Some((
+            pivot + turn * (plans[shin].center - pivot),
+            turn * plans[shin].rotation,
+        ));
+        let pose = pose_from_bones(&nodes, &plans, &poses);
+
+        let (_, rotation, translation) = pose[1].to_scale_rotation_translation();
+        assert!(
+            translation.abs_diff_eq(pivot, 0.001),
+            "node 1 is the pivot, so it must not have moved: {translation:?}"
+        );
+        assert!(
+            rotation.abs_diff_eq(turn, 0.001) || (-rotation).abs_diff_eq(turn, 0.001),
+            "node 1 must take its rotation from the bone hanging off it, which \
+             turned by 90 degrees about Z; got {rotation:?}"
+        );
+
+        // And the node below really did swing round to where that puts it.
+        let tip = pose[2].to_scale_rotation_translation().2;
+        assert!(
+            tip.abs_diff_eq(Vec3::new(1.0, 8.0, 0.0), 0.001),
+            "node 2 hangs one unit below node 1 at rest, so a quarter turn \
+             about Z puts it one unit to +X of the pivot; got {tip:?}"
+        );
+
+        // The root is above the bone that moved and must be untouched.
+        let root = pose[0].to_scale_rotation_translation().2;
+        assert!(
+            root.abs_diff_eq(Vec3::new(0.0, 10.0, 0.0), 0.001),
+            "nothing moved the root's own bone, so the root stays put: {root:?}"
+        );
+    }
+
+    #[test]
+    fn a_bone_with_no_body_yet_leaves_its_node_in_the_rest_pose() {
+        // There is one frame between a ragdoll being switched on and its bone
+        // bodies existing in Rapier. Snapping the node to the origin for that
+        // frame would be a visible pop; leaving it in the rest pose is not.
+        let nodes = uneven_chain();
+        let plans = plan_bones(&nodes, 0.08, 70.0);
+        let pose = pose_from_bones(&nodes, &plans, &vec![None; plans.len()]);
+        for (got, want) in pose.iter().zip(&rest_globals(&nodes)) {
+            assert!(got.abs_diff_eq(*want, 0.001));
+        }
+        assert!(
+            pose_from_bones(&[], &[], &[]).is_empty(),
+            "no nodes at all is no pose, not a panic"
+        );
     }
 
     #[test]

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -596,6 +596,63 @@ impl PhysicsWorld {
         self.joint_map.contains_key(&(a, b)) || self.joint_map.contains_key(&(b, a))
     }
 
+    /// Takes `entity`'s rigid body, its colliders, and every joint attached to
+    /// it out of the simulation, returning whether there was one.
+    ///
+    /// Despawning an entity does *not* do this on its own — `spawn_bodies` has
+    /// no despawn-time counterpart — so a body whose entity is gone otherwise
+    /// keeps falling, keeps colliding with the level, and keeps reporting
+    /// contacts against a collider handle that maps to nothing. That is
+    /// tolerable for entities that live as long as the scene; it is not
+    /// tolerable for a ragdoll, whose whole point is to be built and torn down
+    /// while the game runs.
+    ///
+    /// The three maps are cleaned in step with Rapier's sets. A `joint_map`
+    /// entry left behind would make [`Self::has_joint`] claim a constraint
+    /// that no longer exists and hand [`Self::remove_joint`] a dangling
+    /// handle; a `collider_entity_map` entry left behind would attribute a
+    /// later contact to a dead entity.
+    pub fn remove_body(&mut self, entity: Entity) -> bool {
+        let Some(handle) = self.entity_body_map.remove(&entity) else {
+            return false;
+        };
+        self.collider_entity_map.retain(|_, e| *e != entity);
+        self.joint_map
+            .retain(|&(a, b), _| a != entity && b != entity);
+        self.rigid_body_set
+            .remove(
+                handle,
+                &mut self.island_manager,
+                &mut self.collider_set,
+                &mut self.impulse_joint_set,
+                &mut self.multibody_joint_set,
+                true,
+            )
+            .is_some()
+    }
+
+    /// Restricts which other colliders `entity`'s collider interacts with.
+    ///
+    /// Crate-internal: the only caller is the ragdoll, which puts a
+    /// character's own bones in a group that does not collide with itself.
+    /// Exposing collision filtering as an authoring concept is a bigger
+    /// decision than this needs (it would want a `Collider` field, a scene
+    /// syntax, and a name for each group), and nothing outside this crate has
+    /// asked for one yet.
+    pub(crate) fn set_collision_groups(&mut self, entity: Entity, groups: InteractionGroups) {
+        let Some(&body_handle) = self.entity_body_map.get(&entity) else {
+            return;
+        };
+        let Some(body) = self.rigid_body_set.get(body_handle) else {
+            return;
+        };
+        for &collider_handle in body.colliders() {
+            if let Some(collider) = self.collider_set.get_mut(collider_handle) {
+                collider.set_collision_groups(groups);
+            }
+        }
+    }
+
     fn cast_ray_filtered(
         &self,
         origin: Vec3,

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -989,6 +989,14 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
     // types are named below.
     app.register_type::<bsengine_physics::Joint>();
     app.register_type::<bsengine_physics::JointKind>();
+    // `Ragdoll` is `bsengine-physics`'s too, and here for the same reason as
+    // `Joint`. Its `joint_overrides` is a `HashMap<String, JointKind>`, which
+    // needs no extra `register_type_data` the way `AnimationStateMachine`'s
+    // `HashSet<String>` did: a `Map` field *is* structurally recursed by
+    // `TypedReflectDeserializer`, so registering `JointKind` above is enough
+    // for a scene to author an override. There is a test below that fails if
+    // that ever stops being true.
+    app.register_type::<bsengine_physics::Ragdoll>();
     app.register_type::<PhysicsBodyDesc>();
     app.register_type::<crate::types::RigidBodyDesc>();
     app.register_type::<crate::types::ColliderDesc>();
@@ -1187,6 +1195,60 @@ mod tests {
                 "{path} did not survive deserialization -- one of its fields is an                  opaque wrapper with no ReflectDeserialize"
             );
         }
+    }
+
+    #[test]
+    fn a_ragdoll_with_joint_overrides_survives_scene_deserialization() {
+        // `Ragdoll::joint_overrides` is a `HashMap<String, JointKind>`, and
+        // whether that reflects was the one open question about the component's
+        // shape -- the alternative being a `Vec<(String, JointKind)>`. A map
+        // that does not reflect fails the way `ReflectColor` did: the scene
+        // parses, the entity spawns, one warning goes to the log, and the whole
+        // *containing component* is quietly absent.
+        //
+        // A non-empty map with a struct-variant value is the case that decides
+        // it: an empty `{}` would pass even if the value type were opaque.
+        let mut scene: crate::types::SceneDescriptor =
+            ron::from_str(r#"SceneDescriptor(entities: [EntityDescriptor(name: "E")])"#)
+                .expect("the base scene should parse");
+        scene.entities[0].components = vec![(
+            "bsengine_physics::components::Ragdoll".to_string(),
+            r#"(active: true, joint_overrides: {"LeftLeg": Revolute(axis: (1.0, 0.0, 0.0), limits: Some((0.0, 2.2)))}, bone_radius: 0.08, total_mass: 70.0)"#
+                .to_string(),
+        )];
+
+        let mut app = new_app();
+        super::register_gameplay_reflect_types(&mut app);
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+        let entity = app
+            .world()
+            .iter_entities()
+            .next()
+            .expect("the entity should exist")
+            .id();
+        let ragdoll = app.world().get::<bsengine_physics::Ragdoll>(entity).expect(
+            "the Ragdoll component must survive deserialization -- if it is \
+                 absent, HashMap<String, JointKind> is not reflecting and the \
+                 field has to become a Vec of pairs",
+        );
+        assert!(ragdoll.active, "the authored `active: true` must come back");
+        assert!(
+            matches!(
+                ragdoll.joint_for_bone("LeftLeg"),
+                bsengine_physics::JointKind::Revolute { .. }
+            ),
+            "the authored override must come back through the map, not just the \
+             component's presence; got {:?}",
+            ragdoll.joint_for_bone("LeftLeg")
+        );
+        assert!(
+            matches!(
+                ragdoll.joint_for_bone("RightLeg"),
+                bsengine_physics::JointKind::Spherical
+            ),
+            "a bone the scene said nothing about keeps the Spherical default"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Implements ENGINE_ROADMAP item 52, **sub-step 1/2**: the `Ragdoll` component, automatic body/joint construction from the skeleton, and **skinning sourced from physics** while active. Setting `active = true` makes a character collapse.

**ASM integration is sub-step 2/2** — the death trigger and returning to animation. Split so a wrong-looking ragdoll is unambiguously bad construction, bad physics→skin sourcing, or bad transition timing, rather than all three at once.

## What's here
- **`Ragdoll { active, joint_overrides, bone_radius, total_mass }`** — `active` defaults to **false**, so merely attaching the component never perturbs a working character.
- **Spherical by default, per-bone overrides.** Nothing in a skeleton says which bone is a knee, so a generic default is required, and spherical is the physically stable one that works with zero configuration. The override map is what lets an author mark knees and elbows `Revolute` so they don't bend backwards — which also means two of item 51's three joint types get real use. **Bone-name heuristics were rejected**: they depend on a rigging naming convention and fail silently on a different rig or non-English bone names.
- **Bodies built from `SkinnedMesh.nodes`**, which already carries every node's rest transform *and* parent — the bone hierarchy needed no re-parsing. One capsule body per bone (`ColliderShape::Capsule` already existed), joined to its parent, with mass distributed in proportion to bone length.
- **`plan_bones` is a pure function**, so the geometry decisions are testable without a physics world — the same isolation that `select_lod_level` and the SH maths use.

## The part that fails quietly
Bone transforms are **not stored persistently**: `compute_joint_matrices_blended` recomputes them every frame from `nodes` + sampled clips. So this was never a write-conflict between animation and physics — **it's about which source the globals come from**, which is a smaller and safer change than suppressing a writer would have been.

But it still fails silently if done wrong. An implementation that builds the bodies and lets them fall, while skinning keeps reading the clips, produces a character that **looks completely normal on screen** while a full ragdoll simulates underneath — and every body-inspecting test passes. So `an_active_ragdoll_makes_the_joint_matrices_follow_physics_not_the_clip` asserts on the **skinned joint output**, not the body transforms.

## Verification
Paired assertions throughout, since each half alone is passable by a broken implementation:

- `an_activated_ragdoll_falls_without_the_skeleton_coming_apart` — it **fell** *and* every parent/child pair stayed within its joint distance. "It fell" alone passes on a scattered skeleton; "it held together" alone passes on one that never moved
- `an_active_ragdoll_makes_the_joint_matrices_follow_physics_not_the_clip` — the rendered skeleton, not just the bodies
- `an_inactive_ragdoll_creates_no_bodies_at_all` and `an_inactive_ragdoll_leaves_the_joint_matrices_byte_identical` — inactive is completely inert
- `a_bone_overridden_to_revolute_is_constrained_off_axis` — proves the construction path *uses* the override, where the component test only proved `joint_for_bone` *returns* it
- `a_ragdoll_with_joint_overrides_survives_scene_deserialization` — confirms `HashMap<String, JointKind>` genuinely reflects, citing the `ReflectColor` failure mode where a scene parses, the entity spawns, one warning is logged, and the whole containing component is quietly absent
- `a_ragdoll_without_a_skinned_mesh_warns_instead_of_panicking`

`RagdollBone`, the marker on spawned bone bodies, is `pub(crate)` — correctly exempt from catalogue R1, matching the `PendingGltf`/`PendingTerrain` private-marker precedent.

## Test plan
- [x] `cargo test -p bsengine-physics --lib` — 51/51
- [x] `cargo test -p bsengine-gltf --lib` — 52/52
- [x] `cargo test --workspace --exclude bsengine-editor` — zero failures
- [x] `cargo test -p bsengine-editor --lib` — 937/937 (isolated, per CI's split)
- [x] `cargo run -p bsengine-catalog --bin catalog -- --check` — 65 components, 266 ops, **0 violations**
- [x] `cargo clippy --workspace --all-targets` — identical to baseline
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)