### PR TITLE
feat: vehicle physics — driveable cars (item 53 sub-step 1/2)

### DIFF
--- a/crates/bsengine-physics/src/components.rs
+++ b/crates/bsengine-physics/src/components.rs
@@ -401,6 +401,75 @@ pub(crate) struct PhysicsHandles {
     pub collider_handle: ColliderHandle,
 }
 
+/// A raycast-wheel vehicle. Attach to the chassis entity, which must also have
+/// a dynamic [`RigidBody`] and a [`Collider`].
+///
+/// The wheels are raycasts, not bodies: each casts downward from its mount
+/// point and pushes the chassis up along a suspension spring. Nothing is
+/// spawned per wheel.
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component, Default)]
+pub struct Vehicle {
+    /// The authored wheel layout. A vehicle with no wheels never moves.
+    pub wheels: Vec<WheelConfig>,
+    /// Drive input, `-1.0..=1.0`. Negative reverses.
+    pub throttle: f32,
+    /// Steering input, `-1.0..=1.0`.
+    pub steering: f32,
+    /// Brake input, `0.0..=1.0`.
+    pub brake: f32,
+}
+
+/// One wheel's mount point and tuning.
+#[derive(Debug, Clone, Default, Reflect)]
+pub struct WheelConfig {
+    /// Mount point on the chassis, in chassis space.
+    ///
+    /// A [`ReflectVec3`] rather than a bare `glam::Vec3` for the same reason
+    /// the other reflected vectors in this file are.
+    pub connection: ReflectVec3,
+    /// Wheel radius, in metres.
+    pub radius: f32,
+    /// Suspension length at rest, in metres.
+    pub suspension_rest_length: f32,
+    /// Whether this wheel turns with the steering input.
+    pub steers: bool,
+    /// Whether this wheel receives engine force.
+    pub drives: bool,
+    /// Suspension spring stiffness.
+    pub suspension_stiffness: f32,
+    /// Damping while the suspension compresses.
+    pub damping_compression: f32,
+    /// Damping while the suspension extends.
+    pub damping_relaxation: f32,
+    /// Tire grip. Higher resists sliding.
+    pub friction_slip: f32,
+    /// Maximum suspension travel, in metres.
+    pub max_suspension_travel: f32,
+}
+
+impl WheelConfig {
+    /// A wheel at `connection` with defaults that actually drive.
+    ///
+    /// Deriving `Default` gives a zero radius and zero stiffness -- a wheel
+    /// that cannot hold a car up. These values are the starting point tuning
+    /// should move away from, not zeros.
+    pub fn new(connection: ReflectVec3, radius: f32) -> Self {
+        Self {
+            connection,
+            radius,
+            suspension_rest_length: 0.3,
+            steers: false,
+            drives: false,
+            suspension_stiffness: 30.0,
+            damping_compression: 0.4,
+            damping_relaxation: 0.6,
+            friction_slip: 2.0,
+            max_suspension_travel: 0.4,
+        }
+    }
+}
+
 /// Marks a [`RigidBody`] as a walking character, and carries what the physics
 /// engine cannot infer on its own.
 ///

--- a/crates/bsengine-physics/src/lib.rs
+++ b/crates/bsengine-physics/src/lib.rs
@@ -18,7 +18,7 @@ pub mod world;
 
 pub use components::{
     CharacterBody, Collider, ColliderShape, CollisionEvent, Joint, JointKind, PhysicsInput,
-    PhysicsTransform, Ragdoll, RaycastHit, RigidBody, RigidBodyType,
+    PhysicsTransform, Ragdoll, RaycastHit, RigidBody, RigidBodyType, Vehicle, WheelConfig,
 };
 pub use plugin::PhysicsPlugin;
 pub use ragdoll::{plan_bones, pose_from_bones, BonePlan};

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -310,12 +310,17 @@ fn sync_vehicles(
         let controller = controllers.entry(entity).or_insert_with(|| {
             let mut c = rapier3d::control::DynamicRayCastVehicleController::new(chassis);
             for wheel in &vehicle.wheels {
-                let mut tuning = rapier3d::control::WheelTuning::default();
-                tuning.suspension_stiffness = wheel.suspension_stiffness;
-                tuning.suspension_compression = wheel.damping_compression;
-                tuning.suspension_damping = wheel.damping_relaxation;
-                tuning.friction_slip = wheel.friction_slip;
-                tuning.max_suspension_travel = wheel.max_suspension_travel;
+                // `..Default::default()` for the fields `WheelConfig` does not
+                // expose (max suspension force, side friction stiffness),
+                // rather than assigning field by field after a `default()`.
+                let tuning = rapier3d::control::WheelTuning {
+                    suspension_stiffness: wheel.suspension_stiffness,
+                    suspension_compression: wheel.damping_compression,
+                    suspension_damping: wheel.damping_relaxation,
+                    friction_slip: wheel.friction_slip,
+                    max_suspension_travel: wheel.max_suspension_travel,
+                    ..Default::default()
+                };
                 let c_ws = wheel.connection.0;
                 c.add_wheel(
                     Vector::new(c_ws.x, c_ws.y, c_ws.z),

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -283,14 +283,8 @@ const WHEEL_AXLE: Vector = Vector::new(-1.0, 0.0, 0.0);
 fn sync_vehicles(
     mut world: ResMut<PhysicsWorld>,
     mut controllers: Local<HashMap<Entity, rapier3d::control::DynamicRayCastVehicleController>>,
-    // `Option<Res<_>>` rather than `Res<_>`, matching `publish_ragdoll_pose`:
-    // a bare `Res` panics when the resource is absent, and this crate's own
-    // `new_app` test helper inserts no `Time`. Requiring it here would fail
-    // every existing physics test, none of which has a vehicle in it.
-    time: Option<Res<bsengine_core::Time>>,
     vehicles: Query<(Entity, &Vehicle)>,
 ) {
-    let dt = time.as_ref().map(|t| t.delta_seconds).unwrap_or(0.0);
     // Tear down first, matching `sync_ragdolls`. A lookup that misses covers an
     // entity that despawned and one that merely lost its `Vehicle`; neither is
     // in `vehicles` any more, and without this the table grows forever and a
@@ -348,7 +342,7 @@ fn sync_vehicles(
             w.brake = vehicle.brake;
         }
 
-        world.update_vehicle(controller, dt);
+        world.update_vehicle(controller);
     }
 }
 

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -12,7 +12,7 @@ use rapier3d::prelude::*;
 use crate::{
     components::{
         CharacterBody, Collider, ColliderShape, CollisionEvent, Joint, PhysicsHandles,
-        PhysicsInput, PhysicsTransform, Ragdoll, RagdollBone, RigidBody, RigidBodyType,
+        PhysicsInput, PhysicsTransform, Ragdoll, RagdollBone, RigidBody, RigidBodyType, Vehicle,
     },
     ragdoll::{plan_bones, pose_from_bones},
     world::PhysicsWorld,
@@ -59,6 +59,13 @@ impl Plugin for PhysicsPlugin {
                 // bodies register rather than the frame after; before
                 // `step_world`, so it constrains that very step.
                 sync_joints,
+                // After `spawn_bodies`, because the chassis body it looks up
+                // does not exist until then; before `step_world`, because
+                // `update_vehicle` applies impulses and an impulse added after
+                // the step has integrated does not move the car until the next
+                // frame. That failure is quiet -- the car still drives, just a
+                // frame behind, which reads as sluggish handling.
+                sync_vehicles,
                 step_world,
                 sync_from_rapier,
                 // After `sync_from_rapier`, which is what puts this step's
@@ -254,6 +261,96 @@ fn sync_joints(
 /// still collides with everything else in the world: Rapier requires both
 /// sides to accept, and an ordinary collider's default filter is `ALL`.
 const RAGDOLL_GROUP: Group = Group::GROUP_32;
+
+/// The chassis-space direction a wheel ray is cast along: straight down.
+///
+/// Not authored. `add_wheel` wants a basis vector, but it follows from the
+/// chassis convention (+Y up, -Z forward) rather than being a per-wheel choice,
+/// so a scene author writes a mount point and a radius instead.
+const WHEEL_RAY_DIRECTION: Vector = Vector::new(0.0, -1.0, 0.0);
+
+/// The chassis-space axle a wheel spins about: the lateral axis.
+///
+/// Not authored, for the same reason as [`WHEEL_RAY_DIRECTION`].
+const WHEEL_AXLE: Vector = Vector::new(-1.0, 0.0, 0.0);
+
+/// Builds a Rapier vehicle controller for each [`Vehicle`], pushes this frame's
+/// throttle/steering/brake into it, and steps it.
+///
+/// The controller holds its wheel state outside the ECS, so it lives in a
+/// `Local` side table keyed by entity — the same shape [`sync_ragdolls`] uses
+/// for the bodies it builds, and for the same reason.
+fn sync_vehicles(
+    mut world: ResMut<PhysicsWorld>,
+    mut controllers: Local<HashMap<Entity, rapier3d::control::DynamicRayCastVehicleController>>,
+    // `Option<Res<_>>` rather than `Res<_>`, matching `publish_ragdoll_pose`:
+    // a bare `Res` panics when the resource is absent, and this crate's own
+    // `new_app` test helper inserts no `Time`. Requiring it here would fail
+    // every existing physics test, none of which has a vehicle in it.
+    time: Option<Res<bsengine_core::Time>>,
+    vehicles: Query<(Entity, &Vehicle)>,
+) {
+    let dt = time.as_ref().map(|t| t.delta_seconds).unwrap_or(0.0);
+    // Tear down first, matching `sync_ragdolls`. A lookup that misses covers an
+    // entity that despawned and one that merely lost its `Vehicle`; neither is
+    // in `vehicles` any more, and without this the table grows forever and a
+    // re-added `Vehicle` would inherit the old controller's wheels.
+    let stale: Vec<Entity> = controllers
+        .keys()
+        .copied()
+        .filter(|e| vehicles.get(*e).is_err())
+        .collect();
+    for entity in stale {
+        controllers.remove(&entity);
+    }
+
+    for (entity, vehicle) in vehicles.iter() {
+        let Some(&chassis) = world.entity_body_map.get(&entity) else {
+            // No body yet. `spawn_bodies` runs before this, so this is a
+            // vehicle whose `RigidBody`/`Collider` are missing rather than a
+            // one-frame lag; leaving it alone is what lets it start working if
+            // they arrive later.
+            continue;
+        };
+
+        let controller = controllers.entry(entity).or_insert_with(|| {
+            let mut c = rapier3d::control::DynamicRayCastVehicleController::new(chassis);
+            for wheel in &vehicle.wheels {
+                let mut tuning = rapier3d::control::WheelTuning::default();
+                tuning.suspension_stiffness = wheel.suspension_stiffness;
+                tuning.suspension_compression = wheel.damping_compression;
+                tuning.suspension_damping = wheel.damping_relaxation;
+                tuning.friction_slip = wheel.friction_slip;
+                tuning.max_suspension_travel = wheel.max_suspension_travel;
+                let c_ws = wheel.connection.0;
+                c.add_wheel(
+                    Vector::new(c_ws.x, c_ws.y, c_ws.z),
+                    WHEEL_RAY_DIRECTION,
+                    WHEEL_AXLE,
+                    wheel.suspension_rest_length,
+                    wheel.radius,
+                    &tuning,
+                );
+            }
+            c
+        });
+
+        // Push this frame's inputs in. Engine force reaches only `drives`
+        // wheels and steering only `steers` wheels, so a rear-wheel-drive,
+        // front-steering car falls out of the authored layout rather than
+        // needing a drivetrain enum.
+        for (i, cfg) in vehicle.wheels.iter().enumerate() {
+            let Some(w) = controller.wheels_mut().get_mut(i) else {
+                break;
+            };
+            w.engine_force = if cfg.drives { vehicle.throttle } else { 0.0 };
+            w.steering = if cfg.steers { vehicle.steering } else { 0.0 };
+            w.brake = vehicle.brake;
+        }
+
+        world.update_vehicle(controller, dt);
+    }
+}
 
 /// What [`sync_ragdolls`] built for one ragdoll, so switching it off can take
 /// away exactly what switching it on put there.
@@ -2171,5 +2268,217 @@ mod tests {
              either it fell through the collider entirely or the shape is not \
              where the height data says it should be"
         );
+    }
+
+    // ---- Vehicle physics (roadmap item 53, sub-step 1/2) -----------------
+
+    /// A car on flat ground, with `Time` inserted so the controller advances by
+    /// a fixed step and the numbers below are reproducible.
+    ///
+    /// The wheels mount at local y = -0.2, INSIDE the chassis box (local y
+    /// spans -0.4..0.4), which is where real wheels sit and what makes the
+    /// chassis exclusion in `PhysicsWorld::update_vehicle` load-bearing. The
+    /// suspension reaches 0.5 + 0.35 = 0.85 from a mount at world y = 0.8, so
+    /// it touches the ground at y = 0 with a little compression.
+    fn car_on_flat_ground(throttle: f32, steering: f32, brake: f32) -> (App, Entity) {
+        let mut app = App::new();
+        app.add_plugins(PhysicsPlugin);
+        let mut t = bsengine_core::Time::default();
+        t.set_delta_for_test(1.0 / 60.0);
+        app.insert_resource(t);
+
+        // Ground: top face at y = 0.
+        app.world_mut().spawn((
+            RigidBody::fixed(),
+            Collider::cuboid(100.0, 0.5, 100.0),
+            PhysicsInput {
+                position: Vec3::new(0.0, -0.5, 0.0).into(),
+                rotation: Default::default(),
+            },
+        ));
+
+        let wheels = vec![
+            wheel_at(Vec3::new(0.8, -0.2, 1.4), true, false),
+            wheel_at(Vec3::new(-0.8, -0.2, 1.4), true, false),
+            wheel_at(Vec3::new(0.8, -0.2, -1.4), false, true),
+            wheel_at(Vec3::new(-0.8, -0.2, -1.4), false, true),
+        ];
+        let car = app
+            .world_mut()
+            .spawn((
+                RigidBody::dynamic(),
+                Collider::cuboid(0.9, 0.4, 2.0),
+                PhysicsInput {
+                    position: Vec3::new(0.0, 1.0, 0.0).into(),
+                    rotation: Default::default(),
+                },
+                Vehicle {
+                    wheels,
+                    throttle,
+                    steering,
+                    brake,
+                },
+            ))
+            .id();
+        (app, car)
+    }
+
+    fn wheel_at(at: Vec3, steers: bool, drives: bool) -> crate::components::WheelConfig {
+        let mut w = crate::components::WheelConfig::new(at.into(), 0.35);
+        w.suspension_rest_length = 0.5;
+        w.steers = steers;
+        w.drives = drives;
+        w
+    }
+
+    fn car_position(app: &App, car: Entity) -> Vec3 {
+        app.world()
+            .get::<PhysicsTransform>(car)
+            .expect("the car keeps its physics transform")
+            .position
+            .0
+    }
+
+    fn car_rotation(app: &App, car: Entity) -> Quat {
+        app.world()
+            .get::<PhysicsTransform>(car)
+            .expect("the car keeps its physics transform")
+            .rotation
+            .0
+    }
+
+    fn drive_for(app: &mut App, frames: usize) {
+        for _ in 0..frames {
+            app.update();
+        }
+    }
+
+    #[test]
+    fn throttle_drives_the_car_forward() {
+        // The headline assertion of the whole feature.
+        //
+        // The bound is METRES, deliberately. An earlier feature in this repo
+        // shipped a test whose bound was satisfied by ~2e-12 of solver settling
+        // noise and passed with the feature disabled; "it moved" has to mean
+        // moved.
+        //
+        // Measured: 14.0 m against a 1.0 m bound, versus 0.034 m for the
+        // no-throttle pair -- a ~400x separation, so neither test is anywhere
+        // near its threshold. Cutting the `engine_force` assignment in
+        // `sync_vehicles` drops this to 0.03444338 m, byte-identical to the
+        // idle run, which is what proves the distance comes from the throttle
+        // path and not from rolling or settling.
+        let (mut app, car) = car_on_flat_ground(20.0, 0.0, 0.0);
+        drive_for(&mut app, 1);
+        let start = car_position(&app, car);
+        drive_for(&mut app, 120);
+        let travelled = (car_position(&app, car) - start).length();
+        println!("throttle run travelled {travelled} m in 120 frames");
+        assert!(
+            travelled > 1.0,
+            "a car under throttle must cover real ground in two seconds; it \
+             moved {travelled} m, which is settling, not driving"
+        );
+    }
+
+    #[test]
+    fn a_car_with_no_throttle_stays_put() {
+        // The pair. Without it, an implementation that applies engine force
+        // unconditionally -- or one that ignores `drives` -- passes the test
+        // above. The tolerance covers the suspension settling onto its springs
+        // and is far below the metre the driving test demands.
+        let (mut app, car) = car_on_flat_ground(0.0, 0.0, 0.0);
+        drive_for(&mut app, 1);
+        let start = car_position(&app, car);
+        drive_for(&mut app, 120);
+        let drift = (car_position(&app, car) - start).length();
+        println!("idle run drifted {drift} m in 120 frames");
+        assert!(
+            drift < 0.25,
+            "a car with no throttle must stay where it is; it moved {drift} m"
+        );
+    }
+
+    #[test]
+    fn braking_slows_a_rolling_car() {
+        // Two runs from the same rolling start, one braking and one not. A
+        // single-run "the speed went down" test also passes on plain friction,
+        // which is why the control run is the assertion.
+        let roll = |brake: f32| {
+            let (mut app, car) = car_on_flat_ground(20.0, 0.0, 0.0);
+            drive_for(&mut app, 60);
+            {
+                let mut v = app.world_mut().get_mut::<Vehicle>(car).unwrap();
+                v.throttle = 0.0;
+                v.brake = brake;
+            }
+            drive_for(&mut app, 60);
+            let world = app.world().resource::<PhysicsWorld>();
+            world.get_linvel(car).unwrap_or(Vec3::ZERO).length()
+        };
+        let coasting = roll(0.0);
+        let braking = roll(50.0);
+        println!("coasting ended at {coasting} m/s, braking at {braking} m/s");
+        assert!(
+            braking < coasting * 0.75,
+            "braking must slow the car materially more than coasting does: \
+             coasting ended at {coasting} m/s, braking at {braking} m/s"
+        );
+    }
+
+    #[test]
+    fn steering_changes_the_heading_not_just_the_position() {
+        // Asserts on ROTATION. A car shoved sideways also changes position, so
+        // position alone does not show that steering works.
+        let (mut app, car) = car_on_flat_ground(20.0, 0.5, 0.0);
+        drive_for(&mut app, 1);
+        let start = car_rotation(&app, car);
+        drive_for(&mut app, 120);
+        let ended = car_rotation(&app, car);
+        let turned = start.angle_between(ended).to_degrees();
+        println!("steered run turned {turned} degrees");
+        assert!(
+            turned > 5.0,
+            "a steering car must actually change heading; it turned {turned} \
+             degrees, which is body roll, not steering"
+        );
+    }
+
+    #[test]
+    fn suspension_holds_the_chassis_off_the_ground() {
+        // What distinguishes working suspension from a box lying on the floor.
+        // The chassis half-height is 0.4, so resting directly on the ground
+        // would put its centre at y = 0.4; the suspension should hold it
+        // meaningfully higher.
+        let (mut app, car) = car_on_flat_ground(0.0, 0.0, 0.0);
+        drive_for(&mut app, 180);
+        let y = car_position(&app, car).y;
+        println!("chassis settled at y = {y}");
+        assert!(
+            y > 0.55,
+            "the suspension must hold the chassis clear of the ground; its \
+             centre settled at y = {y}, and 0.4 is the collider resting flat"
+        );
+    }
+
+    #[test]
+    fn a_vehicle_whose_component_is_removed_loses_its_controller() {
+        // Mirrors `sync_ragdolls`' stale sweep: without it the side table grows
+        // forever, and a re-added `Vehicle` inherits the old wheels.
+        let (mut app, car) = car_on_flat_ground(0.0, 0.0, 0.0);
+        drive_for(&mut app, 2);
+        app.world_mut().entity_mut(car).remove::<Vehicle>();
+        drive_for(&mut app, 2);
+        // Re-adding must give a fresh controller rather than reviving the old
+        // one: a stale controller holding four wheels indexed against this
+        // one-wheel config is the bug this guards.
+        app.world_mut().entity_mut(car).insert(Vehicle {
+            wheels: vec![wheel_at(Vec3::new(0.0, -0.2, 0.0), false, true)],
+            throttle: 0.0,
+            steering: 0.0,
+            brake: 0.0,
+        });
+        drive_for(&mut app, 2);
+        assert!(app.world().get::<Vehicle>(car).is_some());
     }
 }

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -478,6 +478,42 @@ impl PhysicsWorld {
         self.cast_ray_filtered(origin, dir, max_dist, QueryFilter::default())
     }
 
+    /// Advances one vehicle controller against the current world, casting its
+    /// wheel rays and applying the resulting suspension, engine and brake
+    /// impulses to the chassis.
+    ///
+    /// The controller is passed in rather than stored here because it belongs
+    /// to the entity, not the world — `sync_vehicles` keeps one per vehicle.
+    /// That is also what makes the borrows compose: the query pipeline needs
+    /// the two sets mutably while the two phases are borrowed shared, which
+    /// Rust allows across *disjoint fields* but would not if the controller
+    /// were a field of `self` being borrowed mutably at the same time.
+    ///
+    /// **Call this before [`step`](Self::step).** `update_vehicle` applies
+    /// impulses, which change velocity directly, so an impulse applied after
+    /// the step has integrated does not take effect until the next frame. That
+    /// failure is quiet: the car still drives, just a frame behind, which reads
+    /// as sluggish handling rather than as a bug.
+    ///
+    /// The chassis is excluded from the wheel rays for the same reason
+    /// [`cast_ray_excluding`](Self::cast_ray_excluding) exists: the rays start
+    /// inside the chassis collider, so without the exclusion every wheel
+    /// reports the chassis itself as the ground, at zero distance.
+    pub fn update_vehicle(
+        &mut self,
+        controller: &mut rapier3d::control::DynamicRayCastVehicleController,
+        dt: f32,
+    ) {
+        let filter = QueryFilter::default().exclude_rigid_body(controller.chassis);
+        let queries = self.broad_phase.as_query_pipeline_mut(
+            self.narrow_phase.query_dispatcher(),
+            &mut self.rigid_body_set,
+            &mut self.collider_set,
+            filter,
+        );
+        controller.update_vehicle(dt, queries);
+    }
+
     /// Rebuilds `entity`'s collider shape in place, keeping the same
     /// `ColliderHandle` (so nothing referencing it, e.g. `PhysicsHandles`,
     /// needs to change) -- the first place in this engine that mutates a
@@ -689,6 +725,85 @@ impl PhysicsWorld {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_vehicle_controller_can_be_stepped_against_the_world() {
+        // Deliberately narrow: this proves the borrows compose and that a
+        // wheel ray finds the ground. Driving behaviour is `plugin.rs`'s to
+        // test, once a system is pushing inputs in.
+        let mut world = PhysicsWorld::new(9.81);
+
+        // Ground: a wide fixed box whose top face is at y = 0.
+        let ground = rapier3d::prelude::RigidBodyBuilder::fixed().build();
+        let ground_body = world.rigid_body_set.insert(ground);
+        let ground_shape = crate::plugin::make_shape(&crate::components::ColliderShape::Box {
+            half_extents: Vec3::new(50.0, 0.5, 50.0).into(),
+        });
+        let ground_collider = rapier3d::prelude::ColliderBuilder::new(ground_shape)
+            .translation(Vector::new(0.0, -0.5, 0.0))
+            .build();
+        world.add_collider(ground_collider, ground_body);
+
+        // Chassis: a dynamic box sitting a little above the ground.
+        let chassis = rapier3d::prelude::RigidBodyBuilder::dynamic()
+            .translation(Vector::new(0.0, 1.0, 0.0))
+            .build();
+        let chassis_body = world.rigid_body_set.insert(chassis);
+        let chassis_shape = crate::plugin::make_shape(&crate::components::ColliderShape::Box {
+            half_extents: Vec3::new(0.9, 0.4, 2.0).into(),
+        });
+        let chassis_collider = rapier3d::prelude::ColliderBuilder::new(chassis_shape).build();
+        world.add_collider(chassis_collider, chassis_body);
+
+        // The broad-phase BVH the wheel rays query is only rebuilt inside
+        // `step()`; colliders inserted directly are not in the tree until then.
+        // Without this the raycast finds nothing and the wheel reports no
+        // contact for a reason that has nothing to do with the vehicle code.
+        world.step(&());
+
+        let mut controller =
+            rapier3d::control::DynamicRayCastVehicleController::new(chassis_body);
+        let tuning = rapier3d::control::WheelTuning::default();
+        controller.add_wheel(
+            Vector::new(0.0, -0.2, 1.5),
+            Vector::new(0.0, -1.0, 0.0),
+            Vector::new(-1.0, 0.0, 0.0),
+            0.5,
+            0.35,
+            &tuning,
+        );
+
+        world.update_vehicle(&mut controller, 1.0 / 60.0);
+
+        let info = *controller.wheels()[0].raycast_info();
+        assert!(
+            info.is_in_contact,
+            "the wheel ray must find something beneath the chassis"
+        );
+        // `is_in_contact` alone is not enough, and that is the whole point of
+        // this assertion: with the chassis NOT excluded the ray hits the
+        // chassis from the inside and still reports contact, just at the wrong
+        // height. Checking only the flag passes either way and would certify an
+        // exclusion that is not there -- the same failure `cast_ray_excluding`
+        // describes for characters ("every character reports standing on
+        // something forever").
+        //
+        // The wheel is mounted at local y = -0.2, INSIDE the chassis box (local
+        // y spans -0.4..0.4), which is where a real wheel sits. That placement
+        // is what makes the exclusion load-bearing and is not incidental: with
+        // the wheel at exactly -0.4 the ray starts on the bottom face pointing
+        // outward, never hits the chassis, and removing the exclusion changes
+        // nothing. Measured -- the first version of this test sat at -0.4 and
+        // passed with the exclusion deleted.
+        assert!(
+            info.contact_point_ws.y.abs() < 0.05,
+            "the wheel must contact the GROUND at y = 0, not the chassis it is \
+             mounted inside; contact was at y = {} (~0.8 is the \
+             ray's own start point, meaning it hit the chassis at zero \
+             distance because the exclusion is missing)",
+            info.contact_point_ws.y
+        );
+    }
 
     #[test]
     fn set_collider_shape_changes_where_a_raycast_hits() {

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -769,8 +769,7 @@ mod tests {
         // contact for a reason that has nothing to do with the vehicle code.
         world.step(&());
 
-        let mut controller =
-            rapier3d::control::DynamicRayCastVehicleController::new(chassis_body);
+        let mut controller = rapier3d::control::DynamicRayCastVehicleController::new(chassis_body);
         let tuning = rapier3d::control::WheelTuning::default();
         controller.add_wheel(
             Vector::new(0.0, -0.2, 1.5),

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -499,11 +499,19 @@ impl PhysicsWorld {
     /// [`cast_ray_excluding`](Self::cast_ray_excluding) exists: the rays start
     /// inside the chassis collider, so without the exclusion every wheel
     /// reports the chassis itself as the ground, at zero distance.
+    /// The timestep comes from this world's own integration parameters rather
+    /// than from the caller, because it MUST be the one [`step`](Self::step)
+    /// integrates with. `step` uses `integration_parameters.dt` (a fixed 1/60)
+    /// and ignores wall-clock time entirely, so feeding this a frame delta
+    /// computes the wheel forces for one interval while the simulation advances
+    /// by another. Measured: passing a headless app's real frame delta drove
+    /// the demo car 0.23 m where the fixed step drives it 14 m. Taking no `dt`
+    /// argument is what makes the two impossible to disagree.
     pub fn update_vehicle(
         &mut self,
         controller: &mut rapier3d::control::DynamicRayCastVehicleController,
-        dt: f32,
     ) {
+        let dt = self.integration_parameters.dt;
         let filter = QueryFilter::default().exclude_rigid_body(controller.chassis);
         let queries = self.broad_phase.as_query_pipeline_mut(
             self.narrow_phase.query_dispatcher(),
@@ -773,7 +781,7 @@ mod tests {
             &tuning,
         );
 
-        world.update_vehicle(&mut controller, 1.0 / 60.0);
+        world.update_vehicle(&mut controller);
 
         let info = *controller.wheels()[0].raycast_info();
         assert!(

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -3074,4 +3074,90 @@ mod tests {
              playing its animation"
         );
     }
+
+    #[test]
+    fn the_demo_car_drives_when_its_throttle_key_is_held() {
+        // Drives the whole real path end-to-end: a held key reaches
+        // `drive.js`, which calls `Bsengine.vehicle.setThrottle`, which queues
+        // a `SetVehicleInput`, which writes the `Vehicle` component, which
+        // `sync_vehicles` feeds to the Rapier controller, whose wheel rays have
+        // to reach the ground. No crate-level test covers that chain.
+        //
+        // Pressing the key rather than writing `Vehicle.throttle` directly is
+        // load-bearing, not stylistic. The first version of this test set the
+        // field and measured 0.23 m: `drive.js` runs every frame and set the
+        // throttle straight back to 0.0, because no key was held. Writing the
+        // component fights the script that a real player drives through.
+        let run = |hold_throttle: bool| -> f32 {
+            let project_dir = format!("{}/../../games/vehicle-demo", env!("CARGO_MANIFEST_DIR"));
+            let mut app = build_test_app(&project_dir, None, false);
+            let mut frame: u64 = 0;
+
+            let car = |app: &mut App| {
+                let mut q = app
+                    .world_mut()
+                    .query::<(&bsengine_scene::Name, bevy_ecs::prelude::Entity)>();
+                q.iter(app.world())
+                    .find(|(n, _)| n.0 == "Car")
+                    .map(|(_, e)| e)
+                    .expect("the demo scene must contain a Car")
+            };
+
+            // Settle onto the suspension first, so what is measured below is
+            // driving rather than the initial drop.
+            execute_command(&mut app, &mut frame, Command::Step { frames: 30 });
+
+            let e = car(&mut app);
+            // An unregistered element type yields an empty `Vec` rather than an
+            // error, and a car with no wheels reads as "the throttle does not
+            // work" instead of as a load failure. Worth separating.
+            let wheels = app
+                .world()
+                .get::<bsengine_physics::Vehicle>(e)
+                .expect("the Car must have a Vehicle component")
+                .wheels
+                .len();
+            assert_eq!(wheels, 4, "all four authored wheels must survive the load");
+
+            if hold_throttle {
+                let (resp, _) = execute_command(
+                    &mut app,
+                    &mut frame,
+                    Command::PressKey {
+                        key: "W".to_string(),
+                    },
+                );
+                assert!(resp.ok, "PressKey should succeed: {:?}", resp.error);
+            }
+
+            let start = app
+                .world()
+                .get::<bsengine_physics::PhysicsTransform>(e)
+                .unwrap()
+                .position
+                .0;
+            execute_command(&mut app, &mut frame, Command::Step { frames: 120 });
+            let end = app
+                .world()
+                .get::<bsengine_physics::PhysicsTransform>(e)
+                .unwrap()
+                .position
+                .0;
+            (end - start).length()
+        };
+
+        let driven = run(true);
+        let coasted = run(false);
+        println!("demo car: {driven} m holding W, {coasted} m without");
+        assert!(
+            driven > 1.0,
+            "the demo car must cover real ground with the throttle key held; \
+             it moved {driven} m, which is settling, not driving"
+        );
+        assert!(
+            coasted < driven * 0.25,
+            "the distance must come from the throttle: with no key held the \
+             car moved {coasted} m against {driven} m driven"
+        );
+    }
 }

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -1022,6 +1022,24 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
     // for a scene to author an override. There is a test below that fails if
     // that ever stops being true.
     app.register_type::<bsengine_physics::Ragdoll>();
+    // `Vehicle` is `bsengine-physics`'s, and here for the same reason as
+    // `Joint`/`Ragdoll`.
+    //
+    // `WheelConfig` is named for the same reason `RigidBodyType` is, and with
+    // the same caveat: `register_type` already walks type dependencies, so
+    // registering `Vehicle` brings its `Vec<WheelConfig>` element type along.
+    // Naming it is what keeps that true if `Vehicle` ever stops being the only
+    // thing referring to it -- it is NOT what makes the wheel list survive
+    // today. That was measured, not assumed: deleting the `WheelConfig` line
+    // alone leaves `a_vehicle_with_wheels_survives_scene_deserialization`
+    // passing, while deleting the `Vehicle` line makes it fail.
+    //
+    // The failure that test really guards is the unregistered-component one:
+    // the scene parses, the entity spawns, and the component is silently
+    // absent. It authors two wheels rather than `[]` because an empty Vec
+    // round-trips even when nothing about the element type is known.
+    app.register_type::<bsengine_physics::Vehicle>();
+    app.register_type::<bsengine_physics::WheelConfig>();
     app.register_type::<PhysicsBodyDesc>();
     app.register_type::<crate::types::RigidBodyDesc>();
     app.register_type::<crate::types::ColliderDesc>();
@@ -1273,6 +1291,72 @@ mod tests {
                 bsengine_physics::JointKind::Spherical
             ),
             "a bone the scene said nothing about keeps the Spherical default"
+        );
+    }
+
+    #[test]
+    fn a_vehicle_with_wheels_survives_scene_deserialization() {
+        // The wheel list must be NON-EMPTY. An empty `Vec` round-trips
+        // successfully even when nothing is known about its element type, so a
+        // test authoring `wheels: []` proves nothing about the wheels.
+        //
+        // What this actually catches, measured by deleting each registration in
+        // turn: dropping `register_type::<Vehicle>()` makes it fail, and that
+        // failure is the silent one -- the scene parses, the entity spawns, and
+        // the component is simply absent. Dropping the `WheelConfig` line alone
+        // does not, because `register_type` walks type dependencies.
+        let mut scene: crate::types::SceneDescriptor =
+            ron::from_str(r#"SceneDescriptor(entities: [EntityDescriptor(name: "Car")])"#)
+                .expect("the base scene should parse");
+        scene.entities[0].components = vec![(
+            "bsengine_physics::components::Vehicle".to_string(),
+            concat!(
+                "(wheels: [",
+                "(connection: (1.0, -0.5, 1.5), radius: 0.35, suspension_rest_length: 0.3,",
+                " steers: true, drives: true, suspension_stiffness: 30.0,",
+                " damping_compression: 0.4, damping_relaxation: 0.6,",
+                " friction_slip: 2.0, max_suspension_travel: 0.4),",
+                "(connection: (-1.0, -0.5, 1.5), radius: 0.4, suspension_rest_length: 0.3,",
+                " steers: false, drives: true, suspension_stiffness: 30.0,",
+                " damping_compression: 0.4, damping_relaxation: 0.6,",
+                " friction_slip: 2.0, max_suspension_travel: 0.4)",
+                "], throttle: 0.0, steering: 0.0, brake: 0.0)"
+            )
+            .to_string(),
+        )];
+
+        let mut app = new_app();
+        super::register_gameplay_reflect_types(&mut app);
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+        let entity = app
+            .world()
+            .iter_entities()
+            .next()
+            .expect("the entity should exist")
+            .id();
+        let vehicle = app
+            .world()
+            .get::<bsengine_physics::Vehicle>(entity)
+            .expect(
+                "the Vehicle component must survive deserialization -- if it is \
+                 absent, Vehicle is not registered for reflection",
+            );
+        assert_eq!(
+            vehicle.wheels.len(),
+            2,
+            "both authored wheels must come back; a 0 here means the element \
+             type could not be deserialized and TypedReflectDeserializer \
+             silently emptied the Vec rather than erroring"
+        );
+        assert!(
+            (vehicle.wheels[0].radius - 0.35).abs() < 1e-6,
+            "the first wheel's radius must survive round-trip, got {}",
+            vehicle.wheels[0].radius
+        );
+        assert!(
+            vehicle.wheels[0].steers,
+            "the first wheel's steers flag must survive round-trip"
         );
     }
 

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -1335,13 +1335,10 @@ mod tests {
             .next()
             .expect("the entity should exist")
             .id();
-        let vehicle = app
-            .world()
-            .get::<bsengine_physics::Vehicle>(entity)
-            .expect(
-                "the Vehicle component must survive deserialization -- if it is \
+        let vehicle = app.world().get::<bsengine_physics::Vehicle>(entity).expect(
+            "the Vehicle component must survive deserialization -- if it is \
                  absent, Vehicle is not registered for reflection",
-            );
+        );
         assert_eq!(
             vehicle.wheels.len(),
             2,

--- a/crates/bsengine-scripting/src/js/prelude.js
+++ b/crates/bsengine-scripting/src/js/prelude.js
@@ -583,6 +583,15 @@ var Bsengine = {
         detach:          (a, b)             => Deno.core.ops.bsengine_joint_detach(a, b),
     },
 
+    // Vehicle driver input. Three setters rather than one combined call so a
+    // script can change throttle without restating steering and brake, and so
+    // a value cannot land in the wrong input by argument order.
+    vehicle: {
+        setThrottle: (name, v) => Deno.core.ops.bsengine_vehicle_set_throttle(name, v),
+        setSteering: (name, v) => Deno.core.ops.bsengine_vehicle_set_steering(name, v),
+        setBrake:    (name, v) => Deno.core.ops.bsengine_vehicle_set_brake(name, v),
+    },
+
     loadScene:      (path)                 => Deno.core.ops.bsengine_load_scene(path),
 
     save:           (path)                 => Deno.core.ops.bsengine_save_game(path ?? 'save.json'),

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -1185,6 +1185,20 @@ pub enum ScriptCommand {
         /// rather than one command each.
         kind: bsengine_physics::JointKind,
     },
+    /// Set one of a [`Vehicle`](bsengine_physics::Vehicle)'s three driver
+    /// inputs.
+    ///
+    /// One variant for all three setters, for the same reason
+    /// [`AttachJoint`](ScriptCommand::AttachJoint) is one variant for all three
+    /// joint kinds: the ops differ only in which field they write.
+    SetVehicleInput {
+        /// Name of the entity carrying the `Vehicle`.
+        name: String,
+        /// Which of the three inputs to write.
+        input: VehicleInput,
+        /// The value to write.
+        value: f32,
+    },
     /// Remove the joint linking two rigid bodies, if there is one.
     DetachJoint {
         /// Name of one end. Either order finds the joint.
@@ -4834,6 +4848,48 @@ fn queue_attach_joint(a: String, b: String, kind: bsengine_physics::JointKind) {
     });
 }
 
+/// Which of a vehicle's three driver inputs a
+/// [`SetVehicleInput`](ScriptCommand::SetVehicleInput) writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VehicleInput {
+    /// Drive force, `-1.0..=1.0` scaled by the vehicle's engine force.
+    Throttle,
+    /// Steering angle, `-1.0..=1.0`.
+    Steering,
+    /// Brake force, `0.0..=1.0`.
+    Brake,
+}
+
+/// Queues one `SetVehicleInput`. Shared by the three `vehicle.set*` ops.
+fn queue_vehicle_input(name: String, input: VehicleInput, value: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut()
+            .push(ScriptCommand::SetVehicleInput { name, input, value });
+    });
+}
+
+/// Queue setting a vehicle's throttle.
+///
+/// Three separate setters rather than one combined call so a script can change
+/// throttle without restating steering and brake, and so a value cannot land in
+/// the wrong input by argument order.
+#[op2(fast)]
+pub fn bsengine_vehicle_set_throttle(#[string] name: String, value: f32) {
+    queue_vehicle_input(name, VehicleInput::Throttle, value);
+}
+
+/// Queue setting a vehicle's steering.
+#[op2(fast)]
+pub fn bsengine_vehicle_set_steering(#[string] name: String, value: f32) {
+    queue_vehicle_input(name, VehicleInput::Steering, value);
+}
+
+/// Queue setting a vehicle's brake.
+#[op2(fast)]
+pub fn bsengine_vehicle_set_brake(#[string] name: String, value: f32) {
+    queue_vehicle_input(name, VehicleInput::Brake, value);
+}
+
 /// Queue welding two rigid bodies together, leaving no relative motion at all.
 ///
 /// Both anchors sit at their own body's origin, which is Rapier's own default:
@@ -5876,6 +5932,9 @@ deno_core::extension!(
         bsengine_add_force,
         bsengine_add_force_at_point,
         bsengine_reset_forces,
+        bsengine_vehicle_set_throttle,
+        bsengine_vehicle_set_steering,
+        bsengine_vehicle_set_brake,
         bsengine_joint_attach_fixed,
         bsengine_joint_attach_revolute,
         bsengine_joint_attach_spherical,
@@ -9795,6 +9854,61 @@ JSON.stringify(received)
             "object,function,function,function,function,undefined",
             "the four ops must hang off Bsengine.joint, and nothing flat should \
              exist alongside them"
+        );
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn the_three_vehicle_setters_each_queue_their_own_input() {
+        // All three in one test because the thing worth asserting is that they
+        // are DISTINCT: a copy-paste slip that pointed `setBrake` at the
+        // throttle field would still queue a command and still pass a test
+        // that only checked "something was queued".
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(
+            r#"Bsengine.vehicle.setThrottle("Car", 0.75);
+               Bsengine.vehicle.setSteering("Car", -0.25);
+               Bsengine.vehicle.setBrake("Car", 0.5);"#,
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            for (input, value) in [
+                (super::VehicleInput::Throttle, 0.75_f32),
+                (super::VehicleInput::Steering, -0.25),
+                (super::VehicleInput::Brake, 0.5),
+            ] {
+                let found = buf.iter().any(|cmd| {
+                    matches!(cmd, super::ScriptCommand::SetVehicleInput { name, input: i, value: v }
+                        if name == "Car" && *i == input && (*v - value).abs() < 1e-6)
+                });
+                assert!(found, "{input:?} = {value} not in buffer: {buf:?}");
+            }
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn the_vehicle_setters_hang_off_bsengine_vehicle() {
+        // Mirrors the joint namespace test: the three ops must live under
+        // `Bsengine.vehicle`, with nothing flat alongside them.
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let shape = rt
+            .eval(
+                r#"[typeof Bsengine.vehicle,
+                    typeof Bsengine.vehicle.setThrottle,
+                    typeof Bsengine.vehicle.setSteering,
+                    typeof Bsengine.vehicle.setBrake,
+                    typeof Bsengine.setThrottle].join(",")"#,
+            )
+            .unwrap();
+        assert_eq!(
+            shape.trim(),
+            "object,function,function,function,undefined",
+            "the three setters must hang off Bsengine.vehicle, and nothing \
+             flat should exist alongside them"
         );
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -2339,6 +2339,28 @@ fn run_scripts(world: &mut World) {
                     pw.reset_forces(e);
                 }
             }
+            ScriptCommand::SetVehicleInput { name, input, value } => {
+                let entity = {
+                    let mut q = world.query::<(bevy_ecs::prelude::Entity, &Name)>();
+                    q.iter(world).find(|(_, n)| n.0 == name).map(|(e, _)| e)
+                };
+                match entity.and_then(|e| world.get_mut::<bsengine_physics::Vehicle>(e)) {
+                    Some(mut v) => match input {
+                        crate::ops::VehicleInput::Throttle => v.throttle = value,
+                        crate::ops::VehicleInput::Steering => v.steering = value,
+                        crate::ops::VehicleInput::Brake => v.brake = value,
+                    },
+                    None => {
+                        // Worth a line: an input set on a name that is not a
+                        // vehicle looks exactly like a car that will not drive,
+                        // and nothing else about the call reports a problem.
+                        tracing::warn!(
+                            "[scripting] vehicle.set*('{name}'): no entity by that name has a \
+                             Vehicle, so the input was dropped"
+                        );
+                    }
+                }
+            }
             ScriptCommand::AttachJoint { a, b, kind: _ } if a == b => {
                 // A body jointed to itself is not a constraint Rapier can
                 // solve; it is always a typo.

--- a/games/vehicle-demo/assets/scenes/main.ron
+++ b/games/vehicle-demo/assets/scenes/main.ron
@@ -1,0 +1,56 @@
+// Roadmap item 53 sub-step 1/2: a driveable car on flat ground.
+//
+// Flat deliberately. This sub-step's assertions are exact distances and
+// headings, and a slope makes "how far should it have gone" unanswerable --
+// a failure would then need splitting between the vehicle and the terrain
+// before it could be read at all. Sub-step 2/2 adds the visible wheels and
+// can put the showcase on terrain.
+//
+// No E2E recording ships with this project yet. CI replays everything matching
+// `games/*/assets/tests/*.testlog.json`, and a recording belongs with sub-step
+// 2/2's demo, once there is something worth watching. The omission is
+// deliberate, not an oversight.
+SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Camera",
+        camera: true,
+        transform: Some((position: (12.0, 6.0, 14.0))),
+        look_at: Some((0.0, 0.5, 0.0)),
+    ),
+    EntityDescriptor(
+        name: "Sun",
+        directional_light: Some((direction: (-0.4, -0.8, -0.3), ambient: (0.25, 0.25, 0.28))),
+    ),
+    EntityDescriptor(
+        // Top face at y = 0, so the car's wheel geometry below is readable
+        // against a round number.
+        name: "Ground",
+        primitive: Some(Cube),
+        transform: Some((position: (0.0, -0.5, 0.0), scale: (200.0, 1.0, 200.0))),
+        rigidbody: Some(Static),
+        collider: Some((shape: Box(hx: 100.0, hy: 0.5, hz: 100.0), friction: 0.8)),
+    ),
+    EntityDescriptor(
+        // The chassis box is 1.8 x 0.8 x 4.0, centred at y = 1.0, so its local
+        // y spans -0.4..0.4. The wheels mount at local y = -0.2 -- INSIDE that
+        // box, where real wheels sit. That is also what makes the chassis
+        // exclusion in `PhysicsWorld::update_vehicle` matter: a ray starting
+        // inside the chassis hits it at zero distance without one.
+        //
+        // Suspension reaches rest_length + radius = 0.5 + 0.35 = 0.85 from a
+        // mount at world y = 0.8, so the wheels touch the ground at y = 0 with
+        // a little compression holding the body up.
+        //
+        // Front wheels steer, rear wheels drive: per-wheel booleans rather than
+        // a drivetrain setting, so four-wheel drive would just be four `drives`.
+        name: "Car",
+        primitive: Some(Cube),
+        transform: Some((position: (0.0, 1.0, 0.0), scale: (1.8, 0.8, 4.0))),
+        script: Some("assets/scripts/drive.js"),
+        rigidbody: Some(Dynamic),
+        collider: Some((shape: Box(hx: 0.9, hy: 0.4, hz: 2.0), friction: 0.8)),
+        components: [
+            ("bsengine_physics::components::Vehicle", "(wheels: [(connection: (0.8, -0.2, 1.4), radius: 0.35, suspension_rest_length: 0.5, steers: true, drives: false, suspension_stiffness: 30.0, damping_compression: 0.4, damping_relaxation: 0.6, friction_slip: 2.0, max_suspension_travel: 0.4), (connection: (-0.8, -0.2, 1.4), radius: 0.35, suspension_rest_length: 0.5, steers: true, drives: false, suspension_stiffness: 30.0, damping_compression: 0.4, damping_relaxation: 0.6, friction_slip: 2.0, max_suspension_travel: 0.4), (connection: (0.8, -0.2, -1.4), radius: 0.35, suspension_rest_length: 0.5, steers: false, drives: true, suspension_stiffness: 30.0, damping_compression: 0.4, damping_relaxation: 0.6, friction_slip: 2.0, max_suspension_travel: 0.4), (connection: (-0.8, -0.2, -1.4), radius: 0.35, suspension_rest_length: 0.5, steers: false, drives: true, suspension_stiffness: 30.0, damping_compression: 0.4, damping_relaxation: 0.6, friction_slip: 2.0, max_suspension_travel: 0.4)], throttle: 0.0, steering: 0.0, brake: 0.0)"),
+        ],
+    ),
+])

--- a/games/vehicle-demo/assets/scenes/main.ron.meta
+++ b/games/vehicle-demo/assets/scenes/main.ron.meta
@@ -1,0 +1,6 @@
+(
+    guid: "9f298d02-41cf-4592-803d-f49b36c16468",
+    hash: "blake3:9e22733e8659126278405ba7141b2958f9e65511a56ad5bee2cb9045b9003275",
+    size: Some(3585),
+    former_paths: [],
+)

--- a/games/vehicle-demo/assets/scripts/drive.js
+++ b/games/vehicle-demo/assets/scripts/drive.js
@@ -1,0 +1,27 @@
+// Drives the car from WASD through the three vehicle input setters.
+//
+// The engine force is small because the chassis is light: its collider is
+// 1.8 x 0.8 x 4.0 at the default density of 1.0, so it masses about 5.8 kg.
+// A few hundred newtons on that launches it off the ground entirely, which is
+// how the first version of the braking test ended up comparing two airborne
+// runs that decelerated identically.
+const ENGINE_FORCE = 20.0;
+const BRAKE_FORCE = 50.0;
+const STEER_ANGLE = 0.5;
+
+function onUpdate(self) {
+    let throttle = 0.0;
+    if (Bsengine.isKeyPressed("W")) throttle += ENGINE_FORCE;
+    if (Bsengine.isKeyPressed("S")) throttle -= ENGINE_FORCE;
+
+    let steering = 0.0;
+    if (Bsengine.isKeyPressed("A")) steering += STEER_ANGLE;
+    if (Bsengine.isKeyPressed("D")) steering -= STEER_ANGLE;
+
+    // Set all three every frame rather than only on change: these are held
+    // inputs, and leaving a stale throttle set is how a car keeps accelerating
+    // after the key is released.
+    Bsengine.vehicle.setThrottle(self, throttle);
+    Bsengine.vehicle.setSteering(self, steering);
+    Bsengine.vehicle.setBrake(self, Bsengine.isKeyPressed("Space") ? BRAKE_FORCE : 0.0);
+}

--- a/games/vehicle-demo/assets/scripts/drive.js.meta
+++ b/games/vehicle-demo/assets/scripts/drive.js.meta
@@ -1,0 +1,6 @@
+(
+    guid: "4d516d06-0119-4c1e-a9df-aa570d829740",
+    hash: "blake3:3c374ba1413d9cd3f7f2887e76e3ad2a0d85bfe051585fc46b6f8c27586a0a19",
+    size: Some(1200),
+    former_paths: [],
+)

--- a/games/vehicle-demo/project.toml
+++ b/games/vehicle-demo/project.toml
@@ -1,0 +1,8 @@
+[project]
+name = "Vehicle Demo"
+entry_scene = "assets/scenes/main.ron"
+
+[window]
+title = "Vehicle Demo"
+width = 1280
+height = 720


### PR DESCRIPTION
ENGINE_ROADMAP item 53, **sub-step 1/2**. Closes completion conditions 1 (`Vehicle` with wheel raycasts + suspension), 2 (scripted throttle/steering/brake) and 4 (tests + CI). Condition 3, the demo scene with visible wheels, is sub-step 2/2.

## A correction to the roadmap text

Item 53 says suspension can reuse "item 51 스프링 조인트". **There is no spring joint in this engine** — item 51 shipped exactly `Fixed`, `Revolute` and `Spherical`. Designing against that phrase would have meant building one first. It isn't needed: Rapier's `WheelTuning` carries stiffness, damping, travel and max force directly, so suspension is a wheel parameter rather than a constraint.

## Rapier's controller, not a hand-rolled one

`rapier3d` 0.33 already ships `DynamicRayCastVehicleController`, a port of Bullet's `btRaycastVehicle` — no feature flag, no experimental warning. Each wheel carries `steering`, `engine_force` and `brake`, a 1:1 match for condition 2. Same "entrance, not the plumbing" shape as item 51.

`steers`/`drives` are **per-wheel booleans** rather than a car-level drivetrain enum, so four-wheel drive or four-wheel steering needs no new variant. `direction_cs`/`axle_cs` aren't authored — they follow from the chassis convention, so a scene writes a mount point and a radius, not basis vectors.

## Two bugs the app-level test found

Neither was visible from any crate-level test.

**1. Frame-rate-dependent handling.** `update_vehicle` took `dt` from the caller and `sync_vehicles` passed wall-clock frame delta — but `step_world` ignores `Time` entirely and integrates at a fixed `integration_parameters.dt`. The two could disagree, computing wheel forces for one interval while the simulation advanced by another. `update_vehicle` now reads the timestep from the same parameters `step` uses and takes no `dt` argument, so they cannot diverge. The unit tests could not have caught this: their fixture pinned `Time` to exactly 1/60, which happened to match.

**2. The test was fighting the demo script.** The first E2E version wrote `Vehicle.throttle` directly and measured 0.23 m. `drive.js` runs every frame and set the throttle straight back to 0.0, because no key was held. The test now holds **W**, which is both the real path and strictly more coverage: key → script → `setThrottle` op → `SetVehicleInput` → component → `sync_vehicles` → Rapier.

## Measurements, with margins

Every bound is far from its measured value, deliberately — an earlier feature in this repo shipped a test whose bound was satisfied by ~2e-12 of solver noise.

| Assertion | Measured | Bound |
|---|---|---|
| throttle drives forward | **14.00 m** | > 1.0 |
| no throttle stays put | **0.034 m** | < 0.25 |
| steering changes heading | **83.8°** | > 5.0 |
| suspension holds chassis | **y = 0.964** | > 0.55 (0.4 = resting flat) |
| braking vs coasting | **1.13 vs 6.83 m/s** | < 75% |
| E2E, W held vs not | **13.77 m vs 0.021 m** | > 1.0, < 25% |

**Mutation-verified rather than labelled as such.** Cutting the `engine_force` assignment drops the throttle run to 0.03444338 m — byte-identical to the idle run, not merely close — which is what proves the distance comes from the throttle path. Likewise `update_vehicle`'s chassis exclusion: the test mounts its wheel *inside* the chassis, and that depth is load-bearing. An earlier version mounted at exactly the bottom face, where the ray starts on the boundary pointing outward, and deleting the exclusion changed nothing.

The braking test earned its keep during development: coasting and braking ended at an identical 56.38 m/s because 4000 N on a 5.76 kg chassis launched the car airborne, leaving the brake nothing to act through. A "speed decreased" assertion would have hidden that behind drag.

## Verification

- `cargo test --workspace --exclude bsengine-editor` — 76 suites ok
- `cargo test -p bsengine-editor --lib` — 937 passed
- `cargo test -p bsengine-runtime --bins` — green (binary crate; `--lib` falsely reports 0 passed)
- **All 8 E2E replay recordings pass locally** — required because a new `games/` project changes what CI's glob picks up. `vehicle-demo` deliberately ships **no** recording; one belongs with sub-step 2/2's demo.
- catalogue: **66 components / 269 ops**, 0 violations (65 + `Vehicle`; `WheelConfig` is not a component)
- clippy: one new `field_reassign_with_default` introduced here, fixed. Two others in `animation_state_machine.rs` predate this branch (they came from #1820) and are left alone rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)