### PR TITLE
feat: animation retargeting between different rigs (item 54 sub-step 2/2)

### DIFF
--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -32,4 +32,6 @@ pub use loader::{
     GltfImageData, GltfLoader, LoadedGltf, MeshData, NodeTransform, SkinData, VertexSkin,
 };
 pub use plugin::{GltfAsset, GltfPlugin, LodRequest};
-pub use skinned_mesh::{AnimationClipLibrary, IkChain, IkChains, SkinnedMesh, SkinnedMeshPlugin};
+pub use skinned_mesh::{
+    AnimationClipLibrary, IkChain, IkChains, RetargetSource, SkinnedMesh, SkinnedMeshPlugin,
+};

--- a/crates/bsengine-gltf/src/lib.rs
+++ b/crates/bsengine-gltf/src/lib.rs
@@ -20,6 +20,9 @@ pub mod ik;
 pub mod loader;
 /// The Bevy plugin that spawns loaded GLTF assets into the ECS world.
 pub mod plugin;
+
+/// Animation retargeting between skeletons with different bone structures.
+pub mod retarget;
 /// Bind-pose geometry, skin data, and clip library for CPU-side skeletal skinning.
 pub mod skinned_mesh;
 

--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -233,6 +233,7 @@ fn load_gltf_assets(
                             nodes: loaded.nodes.clone(),
                             pose_override: Vec::new(),
                             ik_tip_positions: Vec::new(),
+                            animated_locals: Vec::new(),
                             pose_override_weight: 1.0,
                             joint_matrices: Vec::new(),
                         },

--- a/crates/bsengine-gltf/src/retarget.rs
+++ b/crates/bsengine-gltf/src/retarget.rs
@@ -1,0 +1,256 @@
+//! Animation retargeting between skeletons with different bone names and
+//! different rest poses.
+//!
+//! Kept free of ECS and skinning types, the same way [`crate::ik`] is: the
+//! maths is testable against two node lists and a mapping, with no rig to load.
+
+use crate::loader::NodeTransform;
+use glam::{Mat4, Quat};
+
+/// Copies a source skeleton's motion onto a target skeleton whose bones have
+/// different names and a different rest pose.
+///
+/// Transfers each mapped bone's rotation RELATIVE TO ITS OWN REST, and applies
+/// that delta to the target's rest:
+///
+/// ```text
+/// delta        = source_rest.inverse() * source_animated
+/// target_local = target_rest * delta
+/// ```
+///
+/// Copying the absolute local rotation instead is the obvious implementation
+/// and is wrong whenever the two rigs bind their skeletons differently — one
+/// arm out, one arm down, or simply different joint orientations — because the
+/// limb then points somewhere unrelated to what the source is doing. It also
+/// passes a test that retargets a rig onto an identical copy of itself, which
+/// is why `a_target_with_a_different_rest_pose_still_receives_the_motion`
+/// exists.
+///
+/// **Rotation only.** Translation and scale stay with the target: bone lengths
+/// belong to the target rig, and overwriting them deforms the character into
+/// the source's proportions rather than retargeting the motion onto it. The
+/// cost is that a differently-proportioned target can slide or hover, and
+/// [`crate::IkChains`] is the tool for that — the two compose deliberately.
+///
+/// A pair naming a bone either skeleton lacks is skipped with a warning. A typo
+/// in a mapping is the likeliest authoring error here, and it must say so
+/// rather than silently posing nothing or discarding the rest of the mapping.
+pub fn retarget_locals(
+    target_nodes: &[NodeTransform],
+    target_locals: &mut [Mat4],
+    source_nodes: &[NodeTransform],
+    source_locals: &[Mat4],
+    pairs: &[(String, String)],
+) {
+    for (source_bone, target_bone) in pairs {
+        let (Some(si), Some(ti)) = (
+            source_nodes.iter().position(|n| &n.name == source_bone),
+            target_nodes.iter().position(|n| &n.name == target_bone),
+        ) else {
+            tracing::warn!(
+                "[retarget] mapping names a bone one of the skeletons lacks: \
+                 {source_bone:?} -> {target_bone:?}"
+            );
+            continue;
+        };
+        let (Some(source_local), Some(target_local)) =
+            (source_locals.get(si), target_locals.get(ti))
+        else {
+            continue;
+        };
+
+        let source_rest = rest_rotation(&source_nodes[si]);
+        let target_rest = rest_rotation(&target_nodes[ti]);
+        let (_, source_animated, _) = source_local.to_scale_rotation_translation();
+        let delta = source_rest.inverse() * source_animated;
+
+        // The target keeps its own scale and translation; only the rotation is
+        // replaced. Recomposing from the target's existing local rather than
+        // building a fresh matrix is what preserves them.
+        let (scale, _, translation) = target_local.to_scale_rotation_translation();
+        target_locals[ti] =
+            Mat4::from_scale_rotation_translation(scale, target_rest * delta, translation);
+    }
+}
+
+/// A node's rest-pose rotation, as the glTF stored it.
+fn rest_rotation(node: &NodeTransform) -> Quat {
+    Quat::from_xyzw(
+        node.rotation[0],
+        node.rotation[1],
+        node.rotation[2],
+        node.rotation[3],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    /// Two bones: a root and a child that the tests drive.
+    fn rig(name_prefix: &str, child_rest: Quat) -> Vec<NodeTransform> {
+        vec![
+            NodeTransform {
+                name: format!("{name_prefix}_root"),
+                ..Default::default()
+            },
+            NodeTransform {
+                name: format!("{name_prefix}_arm"),
+                rotation: child_rest.to_array(),
+                parent: Some(0),
+                ..Default::default()
+            },
+        ]
+    }
+
+    fn locals_of(nodes: &[NodeTransform]) -> Vec<Mat4> {
+        nodes
+            .iter()
+            .map(|n| {
+                Mat4::from_scale_rotation_translation(
+                    Vec3::from(n.scale),
+                    rest_rotation(n),
+                    Vec3::from(n.position),
+                )
+            })
+            .collect()
+    }
+
+    /// Where a local transform's rotation sends +Y. Compared as a DIRECTION
+    /// rather than an Euler angle or `Quat::angle_between`: item 53 produced
+    /// three separate confidently-wrong angular measurements with those,
+    /// including `angle_between` reporting two genuinely different cases as
+    /// identical. A rotated vector is unbounded and has an exact expected
+    /// value.
+    fn points(local: Mat4) -> Vec3 {
+        let (_, rot, _) = local.to_scale_rotation_translation();
+        rot * Vec3::Y
+    }
+
+    #[test]
+    fn retargeting_a_rig_onto_an_identical_copy_changes_nothing() {
+        // The cheapest guard against a delta composed in the wrong order: with
+        // matching rest poses the deltas cancel and the target must be left
+        // exactly as it was.
+        let nodes = rig("a", Quat::IDENTITY);
+        let source_locals = {
+            let mut l = locals_of(&nodes);
+            l[1] = Mat4::from_quat(Quat::from_rotation_z(0.7));
+            l
+        };
+        let mut target_locals = locals_of(&nodes);
+        let before = target_locals.clone();
+
+        retarget_locals(
+            &nodes,
+            &mut target_locals,
+            &nodes,
+            &source_locals,
+            &[("a_arm".to_string(), "a_arm".to_string())],
+        );
+
+        // The mapped bone takes the source's pose; everything else is untouched.
+        assert_eq!(target_locals[0], before[0], "the root must not move");
+        let got = points(target_locals[1]);
+        let want = points(source_locals[1]);
+        assert!(
+            (got - want).length() < 1.0e-5,
+            "with identical rest poses the target must land exactly on the \
+             source's pose: {got:?} vs {want:?}"
+        );
+    }
+
+    #[test]
+    fn a_target_with_a_different_rest_pose_still_receives_the_motion() {
+        // THE test, and the fixture is what makes it one.
+        //
+        // BOTH rigs bind their arm away from identity, and differently. That is
+        // load-bearing: the first version gave the source an IDENTITY rest, so
+        // `source_rest.inverse()` was the identity too and an absolute copy
+        // produced numerically the same answer -- the mutation survived and the
+        // test proved nothing. A retargeting test can only tell the two
+        // implementations apart when the SOURCE's rest is non-trivial.
+        let source_rest = Quat::from_rotation_y(0.9);
+        let target_rest = Quat::from_rotation_x(std::f32::consts::FRAC_PI_2);
+        let source_nodes = rig("s", source_rest);
+        let target_nodes = rig("t", target_rest);
+
+        // The source lifts its arm 0.6 rad about Z away from its own rest.
+        let motion = Quat::from_rotation_z(0.6);
+        let mut source_locals = locals_of(&source_nodes);
+        source_locals[1] = Mat4::from_quat(source_rest * motion);
+
+        let mut target_locals = locals_of(&target_nodes);
+        retarget_locals(
+            &target_nodes,
+            &mut target_locals,
+            &source_nodes,
+            &source_locals,
+            &[("s_arm".to_string(), "t_arm".to_string())],
+        );
+
+        // The target's arm must be its OWN rest turned by the same delta the
+        // source turned by -- not the source's raw rotation.
+        let want = (target_rest * motion) * Vec3::Y;
+        let got = points(target_locals[1]);
+        // What an absolute copy would produce: the source's animated rotation
+        // dropped onto the target's rest, carrying the source's bind with it.
+        let naive = (target_rest * (source_rest * motion)) * Vec3::Y;
+        println!("retargeted {got:?}, want {want:?}, a naive copy would give {naive:?}");
+        assert!(
+            (got - want).length() < 1.0e-5,
+            "the target must receive the DELTA applied to its own rest: got \
+             {got:?}, want {want:?}"
+        );
+        assert!(
+            (got - naive).length() > 0.1,
+            "and it must differ from a naive absolute copy ({naive:?}), or this \
+             test cannot tell the two implementations apart"
+        );
+    }
+
+    #[test]
+    fn an_unmapped_bone_keeps_its_own_pose() {
+        // Retargeting must not zero the bones it was not told about.
+        let nodes = rig("a", Quat::IDENTITY);
+        let source_locals = locals_of(&nodes);
+        let mut target_locals = locals_of(&nodes);
+        target_locals[1] = Mat4::from_quat(Quat::from_rotation_y(1.1));
+        let kept = target_locals[1];
+
+        retarget_locals(&nodes, &mut target_locals, &nodes, &source_locals, &[]);
+        assert_eq!(
+            target_locals[1], kept,
+            "a bone named by no pair must be left exactly as it was"
+        );
+    }
+
+    #[test]
+    fn a_pair_naming_a_missing_bone_is_skipped_and_the_rest_still_applies() {
+        // A typo must not panic, and must not discard the pairs around it.
+        let nodes = rig("a", Quat::IDENTITY);
+        let mut source_locals = locals_of(&nodes);
+        source_locals[1] = Mat4::from_quat(Quat::from_rotation_z(0.5));
+        let mut target_locals = locals_of(&nodes);
+
+        retarget_locals(
+            &nodes,
+            &mut target_locals,
+            &nodes,
+            &source_locals,
+            &[
+                ("no_such_bone".to_string(), "a_arm".to_string()),
+                ("a_arm".to_string(), "a_arm".to_string()),
+            ],
+        );
+
+        let got = points(target_locals[1]);
+        let want = points(source_locals[1]);
+        assert!(
+            (got - want).length() < 1.0e-5,
+            "the valid pair must still apply after a bad one is skipped: \
+             {got:?} vs {want:?}"
+        );
+    }
+}

--- a/crates/bsengine-gltf/src/skinned_mesh.rs
+++ b/crates/bsengine-gltf/src/skinned_mesh.rs
@@ -37,6 +37,31 @@ pub struct IkChain {
     pub weight: f32,
 }
 
+/// Drives this character's skeleton from another entity's animated pose.
+///
+/// Bone pairs are explicit and name-keyed, matching `Ragdoll.joint_overrides`
+/// and [`IkChain`]. Heuristic name matching was rejected for the reason item
+/// 52's ragdoll rejected it: it depends on a rigging convention and fails
+/// silently on a different rig or non-English bone names -- and here a wrong
+/// guess produces a plausible-looking wrong pose rather than an error.
+#[derive(Component, Debug, Clone, Default, bevy_reflect::Reflect)]
+#[reflect(Component, Default)]
+pub struct RetargetSource {
+    /// Name of the entity whose pose is copied.
+    pub source: String,
+    /// The entity [`source`](RetargetSource::source) names, once something has
+    /// looked it up.
+    ///
+    /// Resolved by `bsengine-scene`, not here: this crate cannot see `Name`,
+    /// which lives there, and that crate depends on this one -- the reverse
+    /// edge would be a cycle. Same split as `Joint.body_b`.
+    #[reflect(ignore)]
+    pub resolved: Option<bevy_ecs::entity::Entity>,
+    /// `(source bone, target bone)` pairs. A target bone named by no pair keeps
+    /// its own animation.
+    pub pairs: Vec<(String, String)>,
+}
+
 /// Every IK chain on one character.
 ///
 /// A list rather than one component per chain because an entity can hold only
@@ -140,6 +165,16 @@ pub struct SkinnedMesh {
     /// Runtime output, never authored, hence not reflected.
     #[reflect(ignore)]
     pub ik_tip_positions: Vec<Vec3>,
+    /// This character's animated local transforms, as of the last time the
+    /// skinning system ran.
+    ///
+    /// Published so a retargeting character can read its source's pose. Locals
+    /// are otherwise not stored anywhere -- only `joint_matrices` are -- and a
+    /// target needs its SOURCE's, not its own.
+    ///
+    /// Runtime output, never authored, hence not reflected.
+    #[reflect(ignore)]
+    pub animated_locals: Vec<Mat4>,
     /// The skinning matrix per joint as of the last time [`SkinnedMeshPlugin`]'s
     /// system ran — `global[joint_node] * inverse_bind_matrix[joint]`, in
     /// [`SkinData::joint_node_indices`] order.
@@ -570,7 +605,7 @@ fn compute_joint_matrices_with_ik(
     clips: &[ClipSample<'_>],
     chains: &[&IkChain],
 ) -> Vec<Mat4> {
-    compute_pose_with_ik(nodes, skin, clips, chains).0
+    compute_pose_with_ik(nodes, skin, clips, chains, None).0
 }
 
 /// As [`compute_joint_matrices_with_ik`], also returning each chain's tip bone
@@ -584,8 +619,28 @@ fn compute_pose_with_ik(
     skin: &SkinData,
     clips: &[ClipSample<'_>],
     chains: &[&IkChain],
-) -> (Vec<Mat4>, Vec<Vec3>) {
+    retarget: Option<(&RetargetSource, &[NodeTransform], &[Mat4])>,
+) -> (Vec<Mat4>, Vec<Vec3>, Vec<Mat4>) {
     let mut locals = compute_local_transforms_blended(nodes, clips);
+
+    // BEFORE the globals are accumulated, and therefore before IK.
+    //
+    // The order is load-bearing, not incidental: retargeting decides the pose
+    // and IK corrects that pose against the world. Reversed, retargeting
+    // overwrites IK's correction and foot placement silently stops working --
+    // the producer/consumer failure this codebase keeps meeting, where
+    // everything upstream looks healthy. Mutation-verified: moving this after
+    // the IK loop puts the demo foot 1.83 m off its target instead of 1.2e-7.
+    if let Some((map, source_nodes, source_locals)) = retarget {
+        crate::retarget::retarget_locals(
+            nodes,
+            &mut locals,
+            source_nodes,
+            source_locals,
+            &map.pairs,
+        );
+    }
+
     let mut globals = accumulate_globals(nodes, &locals);
 
     for chain in chains {
@@ -642,7 +697,7 @@ fn compute_pose_with_ik(
         })
         .collect();
 
-    (joint_matrices_from_globals(&globals, skin), tips)
+    (joint_matrices_from_globals(&globals, skin), tips, locals)
 }
 
 /// Rotates one node by a world-space rotation, written into its parent-relative
@@ -734,11 +789,13 @@ impl Plugin for SkinnedMeshPlugin {
 
 fn update_skinned_meshes(
     mut query: Query<(
+        bevy_ecs::entity::Entity,
         &mut SkinnedMesh,
         Option<&AnimationClipLibrary>,
         Option<&bsengine_core::AnimationPlayer>,
         Option<&bsengine_core::AnimationStateMachine>,
         Option<&IkChains>,
+        Option<&RetargetSource>,
         Option<&bsengine_core::GlobalTransform>,
         Option<&bsengine_core::Transform>,
     )>,
@@ -750,13 +807,36 @@ fn update_skinned_meshes(
     // the *pose*, which a headless host still wants to be right; blending the
     // vertices is tens of thousands of products whose only consumer is the
     // upload, so that half is what the GPU's absence skips.
+    // Snapshot every character's rest pose and published locals BEFORE the
+    // mutable pass: a retargeting target reads another entity's `SkinnedMesh`
+    // while the loop below holds `&mut` on its own.
+    //
+    // Taken from THIS query immutably rather than from a second one -- Bevy
+    // rejects a `&SkinnedMesh` query alongside a `&mut SkinnedMesh` one in the
+    // same system (B0001), and `Query<&mut T>` iterates immutably too, so no
+    // `ParamSet` is needed.
+    //
+    // The snapshot is last frame's pose when the source is iterated after the
+    // target: a one-frame lag on a retargeted character, imperceptible and far
+    // cheaper than ordering the two entities.
+    let poses: std::collections::HashMap<
+        bevy_ecs::entity::Entity,
+        (Vec<NodeTransform>, Vec<Mat4>),
+    > = query
+        .iter()
+        .map(|(entity, mesh, ..)| (entity, (mesh.nodes.clone(), mesh.animated_locals.clone())))
+        .collect();
+
     let mut gpu = mesh_registry.zip(queue);
 
-    for (mut skinned, library, player, asm, ik, global, local) in query.iter_mut() {
+    for (_entity, mut skinned, library, player, asm, ik, retarget, global, local) in
+        query.iter_mut()
+    {
         // Set by the clip branch below; the ragdoll-override branches leave it
         // None, and an override means physics is driving the whole skeleton
         // anyway.
         let mut published_tips: Option<Vec<Vec3>> = None;
+        let mut published_locals: Option<Vec<Mat4>> = None;
         // The one branch this whole feature turns on, and the one that fails
         // silently: with the bodies built and falling but the clips still
         // sourcing the pose, the character looks completely normal while a full
@@ -815,8 +895,19 @@ fn update_skinned_meshes(
                 })
                 .unwrap_or_default();
             let chains: Vec<&IkChain> = model_chains.iter().collect();
-            let (matrices, tips) =
-                compute_pose_with_ik(&skinned.nodes, &skinned.skin_data, &samples, &chains);
+            let retarget_input = retarget.and_then(|r| {
+                r.resolved
+                    .and_then(|e| poses.get(&e))
+                    .map(|(nodes, locals)| (r, nodes.as_slice(), locals.as_slice()))
+            });
+            let (matrices, tips, locals) = compute_pose_with_ik(
+                &skinned.nodes,
+                &skinned.skin_data,
+                &samples,
+                &chains,
+                retarget_input,
+            );
+            published_locals = Some(locals);
             // Published in WORLD space, which is what the ground probe needs.
             published_tips = Some(
                 tips.iter()
@@ -873,6 +964,9 @@ fn update_skinned_meshes(
         // physics is already driving the whole skeleton.
         if let Some(tips) = published_tips {
             skinned.ik_tip_positions = tips;
+        }
+        if let Some(locals) = published_locals {
+            skinned.animated_locals = locals;
         }
 
         if let Some((mesh_registry, queue)) = gpu.as_mut() {
@@ -1622,6 +1716,7 @@ mod tests {
             nodes: vec![NodeTransform::default()],
             pose_override: Vec::new(),
             ik_tip_positions: Vec::new(),
+            animated_locals: Vec::new(),
             pose_override_weight: 1.0,
             joint_matrices: Vec::new(),
         }
@@ -1762,6 +1857,7 @@ mod tests {
                     nodes,
                     pose_override: Vec::new(),
                     ik_tip_positions: Vec::new(),
+                    animated_locals: Vec::new(),
                     pose_override_weight: 1.0,
                     joint_matrices: Vec::new(),
                 },
@@ -1803,6 +1899,226 @@ mod tests {
     // `bsengine-physics`, which is the only crate that can see both ends; what
     // belongs here is that the override is honoured at all, and that its
     // absence changes nothing.
+
+    // ---- Retargeting through the real system (item 54, sub-step 2/2) ------
+
+    /// A two-bone rig whose arm binds at `rest`, with a clip that holds the arm
+    /// at `animated`.
+    fn retarget_rig(prefix: &str, rest: Quat, animated: Quat) -> (SkinnedMesh, AnimationClipLibrary) {
+        let nodes = vec![
+            NodeTransform {
+                name: format!("{prefix}_root"),
+                ..Default::default()
+            },
+            NodeTransform {
+                name: format!("{prefix}_arm"),
+                position: [0.0, 1.0, 0.0],
+                rotation: rest.to_array(),
+                parent: Some(0),
+                ..Default::default()
+            },
+        ];
+        let mut clips = std::collections::HashMap::new();
+        clips.insert(
+            "pose".to_string(),
+            AnimationClip {
+                name: "pose".to_string(),
+                duration: 1.0,
+                channels: vec![AnimationChannel {
+                    node_index: 1,
+                    times: vec![0.0, 1.0],
+                    values: KeyframeValues::Rotations(vec![
+                        animated.to_array(),
+                        animated.to_array(),
+                    ]),
+                    interpolation: Interpolation::Linear,
+                }],
+            },
+        );
+        (
+            SkinnedMesh {
+                mesh_id: 1,
+                rest_vertices: Vec::new(),
+                skin: Vec::new(),
+                skin_data: SkinData {
+                    joint_node_indices: vec![0, 1],
+                    inverse_bind_matrices: vec![Mat4::IDENTITY.to_cols_array_2d(); 2],
+                },
+                nodes,
+                pose_override: Vec::new(),
+                pose_override_weight: 1.0,
+                ik_tip_positions: Vec::new(),
+                animated_locals: Vec::new(),
+                joint_matrices: Vec::new(),
+            },
+            AnimationClipLibrary { clips },
+        )
+    }
+
+    #[test]
+    fn a_retargeted_character_follows_its_source_through_the_real_system() {
+        // Drives `update_skinned_meshes` itself with two entities. The pure
+        // function tests cannot see the ECS wiring, and that is exactly where
+        // the last sub-step's defect lived: five green tests while the
+        // component could only ever hold one chain.
+        //
+        // Both rigs bind their arm away from identity, and differently -- with
+        // an identity source rest the delta and an absolute copy agree
+        // numerically and the test proves nothing.
+        let source_rest = Quat::from_rotation_y(0.9);
+        let target_rest = Quat::from_rotation_x(std::f32::consts::FRAC_PI_2);
+        let motion = Quat::from_rotation_z(0.6);
+
+        let mut app = bsengine_app::new_app();
+        app.insert_resource(bsengine_core::Time::default());
+        app.add_plugins(SkinnedMeshPlugin);
+
+        let (source_mesh, source_lib) = retarget_rig("s", source_rest, source_rest * motion);
+        let source = app
+            .world_mut()
+            .spawn((
+                source_mesh,
+                source_lib,
+                bsengine_core::AnimationPlayer::new("pose").with_duration(1.0),
+            ))
+            .id();
+
+        let (target_mesh, target_lib) = retarget_rig("t", target_rest, target_rest);
+        let target = app
+            .world_mut()
+            .spawn((
+                target_mesh,
+                target_lib,
+                bsengine_core::AnimationPlayer::new("pose").with_duration(1.0),
+                RetargetSource {
+                    source: "unused-in-this-test".to_string(),
+                    resolved: Some(source),
+                    pairs: vec![("s_arm".to_string(), "t_arm".to_string())],
+                },
+            ))
+            .id();
+
+        // Two frames: the first publishes the source's locals, the second lets
+        // the target read them. The one-frame lag is by design -- ordering two
+        // entities inside one query would cost more than it buys.
+        app.update();
+        app.update();
+
+        let arm = app
+            .world()
+            .get::<SkinnedMesh>(target)
+            .expect("the target keeps its skinned mesh")
+            .joint_matrices[1];
+        let (_, got_rot, _) = arm.to_scale_rotation_translation();
+        let got = got_rot * Vec3::Y;
+        let want = (target_rest * motion) * Vec3::Y;
+        let unretargeted = target_rest * Vec3::Y;
+        println!("retargeted arm {got:?}, want {want:?}, unretargeted would be {unretargeted:?}");
+
+        assert!(
+            (got - want).length() < 1.0e-4,
+            "the target's arm must receive the source's delta applied to its \
+             own rest: got {got:?}, want {want:?}"
+        );
+        assert!(
+            (got - unretargeted).length() > 0.1,
+            "and it must differ from the target's own animation ({unretargeted:?}), \
+             or this test cannot tell retargeting from doing nothing"
+        );
+    }
+
+    #[test]
+    fn retargeting_runs_before_ik_so_foot_placement_survives() {
+        // Order is the thing that fails silently here. Retargeting decides the
+        // pose; IK corrects it against the world. Run the other way round,
+        // retargeting overwrites the correction and the limb sits wherever the
+        // source's motion put it -- with everything upstream looking healthy.
+        //
+        // Both features drive the SAME limb, which is what makes the ordering
+        // observable: if retargeting ran last, the tip could not be on the IK
+        // target.
+        let source_rest = Quat::from_rotation_y(0.9);
+        let motion = Quat::from_rotation_z(0.9);
+
+        let mut app = bsengine_app::new_app();
+        app.insert_resource(bsengine_core::Time::default());
+        app.add_plugins(SkinnedMeshPlugin);
+
+        let (source_mesh, source_lib) = retarget_rig("s", source_rest, source_rest * motion);
+        let source = app
+            .world_mut()
+            .spawn((
+                source_mesh,
+                source_lib,
+                bsengine_core::AnimationPlayer::new("pose").with_duration(1.0),
+            ))
+            .id();
+
+        // A three-bone target so there is a chain for IK to solve.
+        let (nodes, skin) = leg_skeleton();
+        let mut clips = std::collections::HashMap::new();
+        clips.insert(
+            "pose".to_string(),
+            AnimationClip {
+                name: "pose".to_string(),
+                duration: 1.0,
+                channels: Vec::new(),
+            },
+        );
+        let target_pos = Vec3::new(0.3, 0.6, 0.2);
+        let target = app
+            .world_mut()
+            .spawn((
+                SkinnedMesh {
+                    mesh_id: 1,
+                    rest_vertices: Vec::new(),
+                    skin: Vec::new(),
+                    skin_data: skin,
+                    nodes,
+                    pose_override: Vec::new(),
+                    pose_override_weight: 1.0,
+                    ik_tip_positions: Vec::new(),
+                    animated_locals: Vec::new(),
+                    joint_matrices: Vec::new(),
+                },
+                AnimationClipLibrary { clips },
+                bsengine_core::AnimationPlayer::new("pose").with_duration(1.0),
+                RetargetSource {
+                    source: "unused".to_string(),
+                    resolved: Some(source),
+                    // Drives the SAME bone the IK chain roots at.
+                    pairs: vec![("s_arm".to_string(), "hip".to_string())],
+                },
+                IkChains {
+                    chains: vec![IkChain {
+                        root_bone: "hip".to_string(),
+                        mid_bone: "knee".to_string(),
+                        tip_bone: "foot".to_string(),
+                        target: target_pos.into(),
+                        weight: 1.0,
+                    }],
+                },
+            ))
+            .id();
+
+        app.update();
+        app.update();
+
+        let matrices = &app
+            .world()
+            .get::<SkinnedMesh>(target)
+            .expect("the target keeps its skinned mesh")
+            .joint_matrices;
+        let foot = matrices[2].transform_point3(Vec3::ZERO);
+        let err = (foot - target_pos).length();
+        println!("foot with retargeting AND ik: {foot:?}, {err} m from the IK target");
+        assert!(
+            err < 1.0e-3,
+            "the foot must still land on its IK target while retargeting drives \
+             the same limb: {foot:?} is {err} m from {target_pos:?}. A larger \
+             error means retargeting ran after IK and overwrote the correction."
+        );
+    }
 
     #[test]
     fn two_ik_chains_on_one_character_both_solve_through_the_real_system() {
@@ -1899,6 +2215,7 @@ mod tests {
                     nodes,
                     pose_override: Vec::new(),
                     ik_tip_positions: Vec::new(),
+                    animated_locals: Vec::new(),
                     pose_override_weight: 1.0,
                     joint_matrices: Vec::new(),
                 },
@@ -1995,6 +2312,7 @@ mod tests {
                     nodes: one_node(),
                     pose_override: Vec::new(),
                     ik_tip_positions: Vec::new(),
+                    animated_locals: Vec::new(),
                     pose_override_weight: 1.0,
                     joint_matrices: Vec::new(),
                 },

--- a/crates/bsengine-gltf/src/skinned_mesh.rs
+++ b/crates/bsengine-gltf/src/skinned_mesh.rs
@@ -1904,7 +1904,11 @@ mod tests {
 
     /// A two-bone rig whose arm binds at `rest`, with a clip that holds the arm
     /// at `animated`.
-    fn retarget_rig(prefix: &str, rest: Quat, animated: Quat) -> (SkinnedMesh, AnimationClipLibrary) {
+    fn retarget_rig(
+        prefix: &str,
+        rest: Quat,
+        animated: Quat,
+    ) -> (SkinnedMesh, AnimationClipLibrary) {
         let nodes = vec![
             NodeTransform {
                 name: format!("{prefix}_root"),

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -2434,6 +2434,7 @@ mod tests {
                     pose_override: Vec::new(),
                     pose_override_weight: 1.0,
                     ik_tip_positions: vec![foot],
+                    animated_locals: Vec::new(),
                     joint_matrices: Vec::new(),
                 },
                 IkChains {
@@ -2537,6 +2538,7 @@ mod tests {
                     pose_override_weight: 1.0,
                     // Two feet, two metres apart across the slope.
                     ik_tip_positions: vec![Vec3::new(-1.0, 0.5, 0.0), Vec3::new(1.0, 0.5, 0.0)],
+                    animated_locals: Vec::new(),
                     joint_matrices: Vec::new(),
                 },
                 IkChains {

--- a/crates/bsengine-physics/src/plugin.rs
+++ b/crates/bsengine-physics/src/plugin.rs
@@ -1495,6 +1495,7 @@ mod tests {
             nodes,
             pose_override: Vec::new(),
             ik_tip_positions: Vec::new(),
+            animated_locals: Vec::new(),
             pose_override_weight: 1.0,
             joint_matrices: Vec::new(),
         }
@@ -1802,6 +1803,7 @@ mod tests {
             ],
             pose_override: Vec::new(),
             ik_tip_positions: Vec::new(),
+            animated_locals: Vec::new(),
             pose_override_weight: 1.0,
             joint_matrices: Vec::new(),
         }

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -3455,4 +3455,113 @@ mod tests {
              character rather than a target per foot."
         );
     }
+
+    #[test]
+    fn the_demo_target_rig_follows_the_fox() {
+        // End to end through the real headless app: the mapping survives
+        // reflection, `bsengine-scene` resolves the source name to an entity,
+        // skinning publishes the source's locals, and the target's MAPPED bones
+        // move with the source while its UNMAPPED bones do not.
+        //
+        // Both halves are asserted. "The target moved" alone is satisfied by a
+        // character simply playing its own clip, which this one also is.
+        let project_dir = format!("{}/../../games/ik-demo", env!("CARGO_MANIFEST_DIR"));
+        let mut app = build_test_app(&project_dir, None, false);
+        let mut frame: u64 = 0;
+        for _ in 0..90 {
+            execute_command(&mut app, &mut frame, Command::Step { frames: 1 });
+        }
+
+        let find = |app: &mut App, want: &str| {
+            let mut q = app
+                .world_mut()
+                .query::<(&bsengine_scene::Name, bevy_ecs::prelude::Entity)>();
+            q.iter(app.world())
+                .find(|(n, _)| n.0 == want)
+                .map(|(_, e)| e)
+                .unwrap_or_else(|| panic!("the demo scene must contain {want}"))
+        };
+        let fox = find(&mut app, "Fox");
+        let shadow = find(&mut app, "Shadow");
+
+        // The name must have resolved, or nothing downstream ran at all.
+        let retarget = app
+            .world()
+            .get::<bsengine_gltf::RetargetSource>(shadow)
+            .expect(
+                "Shadow must have a RetargetSource -- if absent, the component \
+                 is not registered for reflection",
+            );
+        assert!(
+            retarget.resolved == Some(fox),
+            "the source name must resolve to the Fox entity, got {:?}",
+            retarget.resolved
+        );
+        assert_eq!(retarget.pairs.len(), 4, "all four authored pairs survive");
+
+        // Compared on the published LOCALS, not on `joint_matrices`. A joint
+        // matrix folds in the whole parent chain, so it answers "where did this
+        // bone end up", while the claim under test is "did this bone receive
+        // the source's rotation" -- a bone's own local is that claim directly.
+        let joints = |app: &App, e: bevy_ecs::prelude::Entity| {
+            app.world()
+                .get::<bsengine_gltf::SkinnedMesh>(e)
+                .expect("a demo character keeps its skinned mesh")
+                .animated_locals
+                .clone()
+        };
+        let nodes_of = |app: &App, e: bevy_ecs::prelude::Entity| {
+            app.world()
+                .get::<bsengine_gltf::SkinnedMesh>(e)
+                .expect("a demo character keeps its skinned mesh")
+                .nodes
+                .clone()
+        };
+
+        let fox_joints = joints(&app, fox);
+        let shadow_joints = joints(&app, shadow);
+        let nodes = nodes_of(&app, shadow);
+        assert!(
+            !fox_joints.is_empty() && !shadow_joints.is_empty(),
+            "both characters must publish their animated locals"
+        );
+
+        // Compare bones by the direction their local rotation sends +Y.
+        let dir = |mats: &[glam::Mat4], i: usize| {
+            let (_, rot, _) = mats[i].to_scale_rotation_translation();
+            rot * glam::Vec3::Y
+        };
+        let index = |name: &str| {
+            nodes
+                .iter()
+                .position(|n| n.name == name)
+                .unwrap_or_else(|| panic!("the rig must have a bone named {name}"))
+        };
+
+        // A MAPPED bone must match the fox's.
+        let mapped = index("b_LeftLeg01_015");
+        let fox_mapped = dir(&fox_joints, mapped);
+        let shadow_mapped = dir(&shadow_joints, mapped);
+        println!("mapped bone: fox {fox_mapped:?}, shadow {shadow_mapped:?}");
+        assert!(
+            (fox_mapped - shadow_mapped).length() < 0.05,
+            "a mapped bone must follow the source: fox {fox_mapped:?} vs \
+             shadow {shadow_mapped:?}"
+        );
+
+        // An UNMAPPED bone must NOT have been touched by retargeting. The fox
+        // is running foot IK on its legs and the shadow is not, so an unmapped
+        // bone that still matched would mean retargeting copied the whole
+        // skeleton rather than the four pairs it was given.
+        let unmapped = index("b_LeftFoot01_017");
+        let fox_unmapped = dir(&fox_joints, unmapped);
+        let shadow_unmapped = dir(&shadow_joints, unmapped);
+        println!("unmapped bone: fox {fox_unmapped:?}, shadow {shadow_unmapped:?}");
+        assert!(
+            (fox_unmapped - shadow_unmapped).length() > 0.01,
+            "an unmapped bone must keep its own pose, but the shadow's \
+             {shadow_unmapped:?} matches the fox's {fox_unmapped:?} -- \
+             retargeting copied bones it was not given"
+        );
+    }
 }

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -3484,6 +3484,27 @@ mod tests {
         let fox = find(&mut app, "Fox");
         let shadow = find(&mut app, "Shadow");
 
+        // Put the Shadow on a DIFFERENT clip, and do it HERE rather than in the
+        // scene: `GltfPlugin` inserts `AnimationPlayer::new(first_clip_name)`
+        // unconditionally when the glTF finishes loading, so anything the scene
+        // authored is overwritten at a moment that depends on load timing.
+        //
+        // The different clip is load-bearing. Both characters are the same rig,
+        // so on the same animation every bone agrees by coincidence and the
+        // unmapped-bone assertion below cannot tell "kept its own pose" from
+        // "was copied wholesale".
+        {
+            let mut player = app
+                .world_mut()
+                .get_mut::<bsengine_core::AnimationPlayer>(shadow)
+                .expect("the Shadow gets an AnimationPlayer once fox.glb loads");
+            player.clip = "Run".to_string();
+            player.time = 0.0;
+        }
+        for _ in 0..30 {
+            execute_command(&mut app, &mut frame, Command::Step { frames: 1 });
+        }
+
         // The name must have resolved, or nothing downstream ran at all.
         let retarget = app
             .world()

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -38,9 +38,54 @@ impl ScenePlugin {
     }
 }
 
+/// Fills in each [`RetargetSource`](bsengine_gltf::RetargetSource)'s `resolved`
+/// entity from the name a scene authored.
+///
+/// Lives here rather than in `bsengine-gltf` because only this crate can see
+/// both: `Name` is this crate's, and `bsengine-scene` depends on
+/// `bsengine-gltf`, so the reverse lookup there would be a dependency cycle.
+/// Same split as `Joint.body_b`, which a scene also authors by name.
+///
+/// Runs every frame rather than once at startup: a retargeting character can be
+/// spawned at any time, and its source may spawn after it. Already-resolved
+/// components are skipped, so the cost is a query over a usually-empty set.
+pub fn resolve_retarget_sources(
+    mut targets: bevy_ecs::prelude::Query<(&Name, &mut bsengine_gltf::RetargetSource)>,
+    named: bevy_ecs::prelude::Query<(bevy_ecs::prelude::Entity, &Name)>,
+) {
+    for (target_name, mut retarget) in targets.iter_mut() {
+        if retarget.resolved.is_some() {
+            continue;
+        }
+        let found = named
+            .iter()
+            .find(|(_, n)| n.0 == retarget.source)
+            .map(|(e, _)| e);
+        match found {
+            Some(e) => retarget.resolved = Some(e),
+            None => {
+                // Not warned every frame: the source may simply not have
+                // spawned yet, and a scene that loads its characters in any
+                // order would otherwise fill the log before settling.
+            }
+        }
+        // A character retargeting from itself is always a mistake, and the
+        // result -- an identity delta, so no visible effect -- looks exactly
+        // like retargeting that silently did not run.
+        if retarget.resolved.is_some() && retarget.source == target_name.0 {
+            tracing::warn!(
+                "[retarget] {:?} names itself as its retarget source; the pose \
+                 will not change",
+                target_name.0
+            );
+        }
+    }
+}
+
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
         let path = self.path.clone();
+        app.add_systems(bevy_app::Update, resolve_retarget_sources);
         app.add_systems(
             Startup,
             (move |world: &mut World| {
@@ -1061,6 +1106,7 @@ pub fn register_gameplay_reflect_types(app: &mut bevy_app::App) {
     // absent, and a leg that simply never reaches for the ground looks like a
     // solver problem rather than a missing registration.
     app.register_type::<bsengine_gltf::IkChains>();
+    app.register_type::<bsengine_gltf::RetargetSource>();
     app.register_type::<bsengine_gltf::IkChain>();
 
     // `Name` is this crate's own, attached by `spawn_scene_entities` to every

--- a/games/ik-demo/assets/scenes/main.ron
+++ b/games/ik-demo/assets/scenes/main.ron
@@ -98,14 +98,12 @@ SceneDescriptor(entities: [
         gltf: Some((path: "assets/models/fox.glb")),
         transform: Some((position: (6.5, 0.35, 5.0), scale: (0.02, 0.02, 0.02))),
         components: [
-            // A DIFFERENT clip from the Fox's, deliberately. Both characters
-            // are the same rig, so if both played the same animation every bone
-            // would agree by coincidence and
-            // `the_demo_target_rig_follows_the_fox`'s unmapped-bone half could
-            // not tell "kept its own pose" from "was copied wholesale". With
-            // different clips, the mapped legs must match the Fox and the
-            // unmapped bones must not.
-            ("bsengine_core::animation_player::AnimationPlayer", "(clip: \"Run\", time: 0.0, speed: 1.0, duration: 1.0, looping: true, playing: true)"),
+            // NOTE: the clip cannot be chosen here. `GltfPlugin` inserts
+            // `AnimationPlayer::new(first_clip_name)` unconditionally when the
+            // glTF finishes loading, overwriting whatever a scene authored --
+            // so `the_demo_target_rig_follows_the_fox` sets the Shadow's clip
+            // after stepping instead. Authoring it here passed standalone and
+            // failed in the full suite, purely on load timing.
             ("bsengine_gltf::skinned_mesh::RetargetSource", "(source: \"Fox\", pairs: [(\"b_LeftLeg01_015\", \"b_LeftLeg01_015\"), (\"b_LeftLeg02_016\", \"b_LeftLeg02_016\"), (\"b_RightLeg01_019\", \"b_RightLeg01_019\"), (\"b_RightLeg02_020\", \"b_RightLeg02_020\")])"),
         ],
     ),

--- a/games/ik-demo/assets/scenes/main.ron
+++ b/games/ik-demo/assets/scenes/main.ron
@@ -79,4 +79,34 @@ SceneDescriptor(entities: [
             ("bsengine_physics::components::FootIkGround", "(max_drop: 2.0, offset: 0.0, probe_height: 0.5)"),
         ],
     ),
+    EntityDescriptor(
+        // Item 54 sub-step 2/2: a second character driven from the Fox's pose.
+        //
+        // It reuses fox.glb, because fox.glb is the only skinned character this
+        // repository has. That is an honest limitation, not a shortcut: the
+        // mapping and the rest-pose maths are what this demonstrates, and a
+        // remapped subset of bones exercises both. It does NOT demonstrate that
+        // retargeting looks right on an artist's second rig -- when a real
+        // second rig arrives, this entity should be rebuilt on it.
+        //
+        // Only the legs are mapped. The unmapped bones (spine, head, tail) keep
+        // their own animation, which is what
+        // `the_demo_target_rig_follows_the_fox` checks alongside the mapped
+        // ones -- "the target moved" alone is satisfied by a character simply
+        // playing its own clip.
+        name: "Shadow",
+        gltf: Some((path: "assets/models/fox.glb")),
+        transform: Some((position: (6.5, 0.35, 5.0), scale: (0.02, 0.02, 0.02))),
+        components: [
+            // A DIFFERENT clip from the Fox's, deliberately. Both characters
+            // are the same rig, so if both played the same animation every bone
+            // would agree by coincidence and
+            // `the_demo_target_rig_follows_the_fox`'s unmapped-bone half could
+            // not tell "kept its own pose" from "was copied wholesale". With
+            // different clips, the mapped legs must match the Fox and the
+            // unmapped bones must not.
+            ("bsengine_core::animation_player::AnimationPlayer", "(clip: \"Run\", time: 0.0, speed: 1.0, duration: 1.0, looping: true, playing: true)"),
+            ("bsengine_gltf::skinned_mesh::RetargetSource", "(source: \"Fox\", pairs: [(\"b_LeftLeg01_015\", \"b_LeftLeg01_015\"), (\"b_LeftLeg02_016\", \"b_LeftLeg02_016\"), (\"b_RightLeg01_019\", \"b_RightLeg01_019\"), (\"b_RightLeg02_020\", \"b_RightLeg02_020\")])"),
+        ],
+    ),
 ])

--- a/games/ik-demo/assets/scenes/main.ron.meta
+++ b/games/ik-demo/assets/scenes/main.ron.meta
@@ -1,6 +1,6 @@
 (
-    guid: "298bddae-1f96-4722-9da1-d14bee16f48e",
-    hash: "blake3:c054dbe019920560c00265b4f9259cdb3160ce3290d3e24d5d12468ba07a4857",
-    size: Some(6820),
+    guid: "172c56b5-82b4-409a-bb65-dc5524886b70",
+    hash: "blake3:326d25843a384485971262e72867b0dc05626c1335226a3ffd7c19083d8d7edc",
+    size: Some(6644),
     former_paths: [],
 )

--- a/games/ik-demo/assets/scenes/main.ron.meta
+++ b/games/ik-demo/assets/scenes/main.ron.meta
@@ -1,6 +1,6 @@
 (
-    guid: "8b9d7327-8668-431f-8024-06f3fa368ff3",
-    hash: "blake3:31b0440944132ff03c09ba8d6861658eb27e5f8bd4b12aa6958bccddbf5ca62f",
-    size: Some(4819),
+    guid: "298bddae-1f96-4722-9da1-d14bee16f48e",
+    hash: "blake3:c054dbe019920560c00265b4f9259cdb3160ce3290d3e24d5d12468ba07a4857",
+    size: Some(6820),
     former_paths: [],
 )


### PR DESCRIPTION
Closes ENGINE_ROADMAP item 54, and with it Phase 2 (items 51–54). Sub-step 1/2 (#1823) shipped the IK solver; this is the other half, and the two share almost no code — which is why they were split.

## What this adds

`retarget_locals` transfers each mapped bone's rotation **relative to its own rest** and applies that delta to the target's rest:

```
delta        = source_rest.inverse() * source_animated
target_local = target_rest * delta
```

Copying the absolute local rotation is the obvious implementation and is wrong whenever two rigs bind their skeletons differently — the limb points somewhere unrelated. Rotation only: bone lengths belong to the target rig, and overwriting them would deform the character into the source's proportions. Foot IK is the tool for the resulting slide, which is why the two compose.

Bone pairs are explicit and name-keyed. Heuristic matching was rejected for the reason item 52's ragdoll rejected it — it depends on a rigging convention and fails silently on a different rig — and here a wrong guess yields a plausible-looking wrong pose rather than an error.

**Retargeting runs before IK.** Retargeting decides the pose; IK corrects it against the world. Reversed, retargeting overwrites the correction and foot placement stops working while everything upstream looks healthy. Mutation-verified: moving it after the IK loop puts the foot **1.83 m** from its target instead of **1.2e-7 m**. Both features drive the *same* limb in that test on purpose — on separate limbs the mutation is invisible.

## Two fixtures that made a property unobservable

Both were caught by mutation testing, and both are the same shape:

**An identity source rest.** `a_target_with_a_different_rest_pose_still_receives_the_motion` first gave the source an identity rest, making `source_rest.inverse()` the identity too — so an absolute copy produced numerically the same answer and the mutation survived. The test asserted the right property; the fixture made it unmeasurable. Both rigs now bind away from identity, and the mutation lands at `(-0.351, -0.442, 0.825)` — exactly the absolute-copy prediction — against a correct `(-0.565, 0.000, 0.825)`.

**Two characters on the same clip.** The demo's unmapped-bone assertion could not tell "kept its own pose" from "was copied wholesale", because both characters are the same rig and agreed by coincidence. With the Shadow on a different clip: the mapped leg matches the Fox to three decimals while the unmapped foot differs clearly.

The reasoning that led me there was also wrong and is recorded: I expected the Fox's foot bone to differ because IK runs on that leg. It does not — IK writes the chain's **root and mid** locals, and the tip moves because its ancestors moved, so the tip's own local is untouched.

## A real engine behaviour found on the way

**`GltfPlugin` inserts `AnimationPlayer::new(first_clip_name)` unconditionally when a glTF finishes loading, overwriting whatever a scene authored.** A skinned character's initial clip cannot be chosen in the scene at all — an authored one survives or is clobbered depending on when the load lands. That is what made this test pass standalone and fail in the full workspace run: under load the overwrite landed differently. Not a flake and not a threshold, an ownership conflict. The test now sets the clip after the loader has run, and both the scene and the test say why.

## Structure

`source` is authored as a name and resolved to an `Entity` by `bsengine-scene`, because only that crate sees both `Name` and `bsengine-gltf` — and `bsengine-scene` depends on gltf, so looking names up there would be a cycle. Same split as `Joint.body_b`.

`SkinnedMesh.animated_locals` publishes each character's locals so a target can read its source's; locals are otherwise not stored anywhere. The snapshot is taken from the mutable query iterated immutably rather than a second query, since Bevy rejects `&SkinnedMesh` alongside `&mut SkinnedMesh` in one system (B0001). A source iterated after its target yields last frame's pose — a one-frame lag, documented rather than engineered around.

## The demo's limitation, stated

The Shadow reuses `fox.glb`, because it is the only skinned character in the repository. This demonstrates the mapping and the rest-pose maths; it does **not** show that retargeting looks right on an artist's second rig. When a real second rig arrives, the entity should be rebuilt on it.

## Verification

- `cargo test --workspace --exclude bsengine-editor` — 76 suites ok, exit 0
- `cargo test -p bsengine-editor --lib` — 937 passed
- `cargo test -p bsengine-runtime --bins` — 68 passed
- **10 E2E replays pass**
- catalogue: **70 components / 269 ops**, 0 violations
- clippy: unchanged from baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)