### PR TITLE
fix: loader no longer overwrites a scene-authored AnimationPlayer

### DIFF
--- a/crates/bsengine-gltf/src/plugin.rs
+++ b/crates/bsengine-gltf/src/plugin.rs
@@ -118,6 +118,7 @@ fn load_gltf_assets(
             &GltfAsset,
             Option<&mut PendingGltf>,
             Option<&Transform>,
+            Option<&AnimationPlayer>,
         ),
         Without<MeshRenderer>,
     >,
@@ -126,7 +127,7 @@ fn load_gltf_assets(
     mut gltf_assets: ResMut<bevy_asset::Assets<LoadedGltf>>,
     asset_server: Res<bevy_asset::AssetServer>,
 ) {
-    for (entity, asset, pending, existing_transform) in query.iter_mut() {
+    for (entity, asset, pending, existing_transform, existing_player) in query.iter_mut() {
         // Request exactly once, then retain the handle. See `PendingGltf`.
         let Some(mut pending) = pending else {
             match bsengine_asset::load(
@@ -219,11 +220,45 @@ fn load_gltf_assets(
                     // AnimationPlayer::tick is a no-op whenever duration <= 0.0
                     // -- without this, the player's `time` would never
                     // advance and the clip would appear frozen forever.
-                    let duration = clip_library
-                        .clips
-                        .get(&first_clip_name)
-                        .map(|c| c.duration)
-                        .unwrap_or(0.0);
+                    let duration_of = |name: &str| {
+                        clip_library
+                            .clips
+                            .get(name)
+                            .map(|c| c.duration)
+                            .unwrap_or(0.0)
+                    };
+
+                    // A scene that authored its own `AnimationPlayer` keeps it.
+                    //
+                    // This used to insert a fresh player unconditionally, which
+                    // meant a skinned character's starting clip could not be
+                    // chosen in a scene at all: whatever was authored survived
+                    // or was clobbered depending on when the glTF finished
+                    // loading. `Transform` two lines below has always had this
+                    // guard; `AnimationPlayer` simply never got one.
+                    //
+                    // The duration is refreshed from the clip library either
+                    // way. It is the one field an author cannot know -- it
+                    // comes out of the file -- and a wrong one silently either
+                    // freezes the animation (0.0) or loops it early.
+                    let player = match existing_player {
+                        Some(authored) => {
+                            let mut p = authored.clone();
+                            if !clip_library.clips.contains_key(&p.clip) {
+                                tracing::warn!(
+                                    "[gltf] scene asked for clip {:?}, which {} does not                                      contain; falling back to {:?}",
+                                    p.clip,
+                                    asset.path,
+                                    first_clip_name
+                                );
+                                p.clip = first_clip_name.clone();
+                            }
+                            p.duration = duration_of(&p.clip);
+                            p
+                        }
+                        None => AnimationPlayer::new(first_clip_name.clone())
+                            .with_duration(duration_of(&first_clip_name)),
+                    };
                     e.insert((
                         SkinnedMesh {
                             mesh_id,
@@ -238,7 +273,7 @@ fn load_gltf_assets(
                             joint_matrices: Vec::new(),
                         },
                         clip_library,
-                        AnimationPlayer::new(first_clip_name).with_duration(duration),
+                        player,
                     ));
                 }
                 e.remove::<(GltfAsset, PendingGltf)>();
@@ -1084,6 +1119,119 @@ mod tests {
             "the id recorded at load time still holds the pre-reload geometry: \
              the rebuild never reached the GPU, so a hot reload would change \
              nothing on screen"
+        );
+    }
+
+    /// Loads the fox, optionally with an `AnimationPlayer` already on the
+    /// entity, and returns the player the loader left behind.
+    fn load_fox_with_authored_player(authored: Option<AnimationPlayer>) -> AnimationPlayer {
+        use crate::skinned_mesh::{SkinnedMesh, SkinnedMeshPlugin};
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../games/mini-arena/assets/models/fox.glb");
+        let path = fixture.to_str().unwrap().to_owned();
+
+        let mut app = new_app();
+        app.add_plugins(bsengine_asset::AssetPlugin);
+        app.add_plugins(WgpuRHIPlugin::windowed());
+        app.add_plugins(GltfPlugin);
+        app.add_plugins(SkinnedMeshPlugin);
+        insert_headless_gpu_registries(&mut app);
+
+        let mut spawned = app.world_mut().spawn(GltfAsset::new(path));
+        if let Some(p) = authored {
+            spawned.insert(p);
+        }
+        let e = spawned.id();
+
+        for _ in 0..200 {
+            app.update();
+            if app.world().get::<SkinnedMesh>(e).is_some() {
+                break;
+            }
+        }
+        app.world()
+            .get::<AnimationPlayer>(e)
+            .expect("the loader must leave a player on a skinned character")
+            .clone()
+    }
+
+    #[test]
+    fn a_scene_authored_clip_survives_the_gltf_load() {
+        // The loader used to insert `AnimationPlayer::new(first_clip_name)`
+        // unconditionally, so a skinned character's starting clip could not be
+        // chosen in a scene at all -- an authored one survived or was clobbered
+        // depending on when the load landed. That is exactly how it presented:
+        // a test that passed standalone and failed under load.
+        //
+        // `Transform` two lines below the insert has always had this guard.
+        let authored = AnimationPlayer {
+            clip: "Run".to_string(),
+            time: 0.0,
+            speed: 2.0,
+            duration: 0.0,
+            looping: false,
+            playing: true,
+        };
+        let got = load_fox_with_authored_player(Some(authored));
+
+        assert_eq!(got.clip, "Run", "the authored clip must survive the load");
+        assert_eq!(
+            got.speed, 2.0,
+            "and so must the rest of the authored player"
+        );
+        assert!(
+            !got.looping,
+            "including the fields the loader has no opinion on"
+        );
+
+        // Duration is the exception, and deliberately so: it comes out of the
+        // file, an author cannot know it, and a wrong one silently either
+        // freezes the animation (0.0, since `tick` is a no-op at <= 0.0) or
+        // loops it early. It is refreshed even though the rest is preserved.
+        assert!(
+            got.duration > 0.0,
+            "the duration must be refreshed from the clip, not left at the \
+             authored 0.0 -- `tick` is a no-op at 0.0 and the character would \
+             stand frozen"
+        );
+    }
+
+    #[test]
+    fn a_character_with_no_authored_player_still_gets_the_loaders_default() {
+        // The opposite direction. Without this, a guard that simply skipped
+        // insertion whenever anything looked present would leave unauthored
+        // characters with no player at all -- and they are the common case.
+        let got = load_fox_with_authored_player(None);
+        assert!(
+            !got.clip.is_empty(),
+            "an unauthored character must still get a clip from the file"
+        );
+        assert!(
+            got.duration > 0.0,
+            "and a usable duration, or it stands frozen"
+        );
+    }
+
+    #[test]
+    fn an_authored_clip_the_file_lacks_falls_back_and_says_so() {
+        // A typo in a scene must not present as "the character does not move".
+        let authored = AnimationPlayer {
+            clip: "NoSuchClip".to_string(),
+            time: 0.0,
+            speed: 1.0,
+            duration: 0.0,
+            looping: true,
+            playing: true,
+        };
+        let got = load_fox_with_authored_player(Some(authored));
+        assert_ne!(
+            got.clip, "NoSuchClip",
+            "a clip the file does not contain must fall back to one it does"
+        );
+        assert!(
+            got.duration > 0.0,
+            "and the fallback must be playable, not frozen at 0.0"
         );
     }
 

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -3484,26 +3484,32 @@ mod tests {
         let fox = find(&mut app, "Fox");
         let shadow = find(&mut app, "Shadow");
 
-        // Put the Shadow on a DIFFERENT clip, and do it HERE rather than in the
-        // scene: `GltfPlugin` inserts `AnimationPlayer::new(first_clip_name)`
-        // unconditionally when the glTF finishes loading, so anything the scene
-        // authored is overwritten at a moment that depends on load timing.
-        //
-        // The different clip is load-bearing. Both characters are the same rig,
-        // so on the same animation every bone agrees by coincidence and the
-        // unmapped-bone assertion below cannot tell "kept its own pose" from
-        // "was copied wholesale".
-        {
-            let mut player = app
-                .world_mut()
-                .get_mut::<bsengine_core::AnimationPlayer>(shadow)
-                .expect("the Shadow gets an AnimationPlayer once fox.glb loads");
-            player.clip = "Run".to_string();
-            player.time = 0.0;
-        }
-        for _ in 0..30 {
-            execute_command(&mut app, &mut frame, Command::Step { frames: 1 });
-        }
+        // The Shadow's clip is authored in the scene now that the loader
+        // respects an existing `AnimationPlayer`. This asserts that, because
+        // the whole unmapped-bone half below depends on the two characters
+        // being on different animations -- on the same clip every bone agrees
+        // by coincidence.
+        let shadow_clip = app
+            .world()
+            .get::<bsengine_core::AnimationPlayer>(shadow)
+            .expect("the Shadow must have a player")
+            .clip
+            .clone();
+        let fox_clip = app
+            .world()
+            .get::<bsengine_core::AnimationPlayer>(fox)
+            .expect("the Fox must have a player")
+            .clip
+            .clone();
+        println!("fox on {fox_clip:?}, shadow on {shadow_clip:?}");
+        assert_eq!(
+            shadow_clip, "Run",
+            "the scene-authored clip must survive the glTF load"
+        );
+        assert_eq!(
+            fox_clip, "Survey",
+            "and so must the Fox's -- both are pinned in the scene because the              loader's default clip comes from a HashMap iteration and is not              deterministic, which had the two characters playing the SAME              animation and made the unmapped-bone check below meaningless"
+        );
 
         // The name must have resolved, or nothing downstream ran at all.
         let retarget = app

--- a/games/ik-demo/assets/scenes/main.ron
+++ b/games/ik-demo/assets/scenes/main.ron
@@ -75,6 +75,13 @@ SceneDescriptor(entities: [
         // y = 1.0 and three of its four feet could not reach the ground at all.
         transform: Some((position: (4.0, 0.35, 5.0), scale: (0.02, 0.02, 0.02))),
         components: [
+            // Pinned explicitly, not left to the loader's default. That default
+            // is `clip_library.clips.keys().next()` over a HashMap, so which
+            // clip a character starts on is not deterministic -- the Fox landed
+            // on the same clip as the Shadow often enough to make
+            // `the_demo_target_rig_follows_the_fox` compare two characters
+            // playing the same animation.
+            ("bsengine_core::animation_player::AnimationPlayer", "(clip: \"Survey\", time: 0.0, speed: 1.0, duration: 0.0, looping: true, playing: true)"),
             ("bsengine_gltf::skinned_mesh::IkChains", "(chains: [(root_bone: \"b_LeftLeg01_015\", mid_bone: \"b_LeftLeg02_016\", tip_bone: \"b_LeftFoot01_017\", target: (0.0, 0.0, 0.0), weight: 1.0), (root_bone: \"b_RightLeg01_019\", mid_bone: \"b_RightLeg02_020\", tip_bone: \"b_RightFoot01_021\", target: (0.0, 0.0, 0.0), weight: 1.0), (root_bone: \"b_LeftUpperArm_09\", mid_bone: \"b_LeftForeArm_010\", tip_bone: \"b_LeftHand_011\", target: (0.0, 0.0, 0.0), weight: 1.0), (root_bone: \"b_RightUpperArm_06\", mid_bone: \"b_RightForeArm_07\", tip_bone: \"b_RightHand_08\", target: (0.0, 0.0, 0.0), weight: 1.0)])"),
             ("bsengine_physics::components::FootIkGround", "(max_drop: 2.0, offset: 0.0, probe_height: 0.5)"),
         ],
@@ -98,12 +105,16 @@ SceneDescriptor(entities: [
         gltf: Some((path: "assets/models/fox.glb")),
         transform: Some((position: (6.5, 0.35, 5.0), scale: (0.02, 0.02, 0.02))),
         components: [
-            // NOTE: the clip cannot be chosen here. `GltfPlugin` inserts
-            // `AnimationPlayer::new(first_clip_name)` unconditionally when the
-            // glTF finishes loading, overwriting whatever a scene authored --
-            // so `the_demo_target_rig_follows_the_fox` sets the Shadow's clip
-            // after stepping instead. Authoring it here passed standalone and
-            // failed in the full suite, purely on load timing.
+            // A DIFFERENT clip from the Fox's, deliberately: both characters
+            // are the same rig, so on the same animation every bone agrees by
+            // coincidence and `the_demo_target_rig_follows_the_fox` cannot tell
+            // "kept its own pose" from "was copied wholesale".
+            //
+            // Authoring this here only works because the loader now respects an
+            // existing `AnimationPlayer`; it used to be overwritten on load.
+            // `duration` is refreshed from the file regardless, so the 0.0 here
+            // is a placeholder rather than a claim.
+            ("bsengine_core::animation_player::AnimationPlayer", "(clip: \"Run\", time: 0.0, speed: 1.0, duration: 0.0, looping: true, playing: true)"),
             ("bsengine_gltf::skinned_mesh::RetargetSource", "(source: \"Fox\", pairs: [(\"b_LeftLeg01_015\", \"b_LeftLeg01_015\"), (\"b_LeftLeg02_016\", \"b_LeftLeg02_016\"), (\"b_RightLeg01_019\", \"b_RightLeg01_019\"), (\"b_RightLeg02_020\", \"b_RightLeg02_020\")])"),
         ],
     ),

--- a/games/ik-demo/assets/scenes/main.ron.meta
+++ b/games/ik-demo/assets/scenes/main.ron.meta
@@ -1,6 +1,6 @@
 (
-    guid: "172c56b5-82b4-409a-bb65-dc5524886b70",
-    hash: "blake3:326d25843a384485971262e72867b0dc05626c1335226a3ffd7c19083d8d7edc",
-    size: Some(6644),
+    guid: "030e15d9-2c5e-48fd-8b01-2cbb539b446f",
+    hash: "blake3:ee8fe753f7efe85a98859124b94aac230824f91c995b428016c79af2d299b7e5",
+    size: Some(7534),
     former_paths: [],
 )


### PR DESCRIPTION
Fixes an engine behaviour found while building item 54's retargeting demo, at the user's request to handle it before moving on.

## The bug

`load_gltf_assets` inserted `AnimationPlayer::new(first_clip_name)` **unconditionally** when a glTF finished loading, so a skinned character's starting clip could not be chosen in a scene at all — an authored one survived or was clobbered depending on when the load landed.

`Transform`, two lines below the same insert, has always had an `existing.is_none()` guard. `AnimationPlayer` simply never got one.

It presented as a test that **passed standalone and failed in the full workspace run** — a shape that reads like a flake and was not one. Under load the overwrite landed differently and two characters ended up on the same clip.

## The fix

An authored player is kept, with one deliberate exception: **`duration` is always refreshed from the clip library.** It is the field an author cannot know — it comes out of the file — and a wrong one silently freezes the animation (`tick` is a no-op at `<= 0.0`) or loops it early. A clip the file does not contain warns and falls back, rather than presenting as "the character does not move".

## A second defect, visible only after the first was fixed

`first_clip_name` comes from `clips.keys().next()` over a **HashMap**, so which clip an unauthored character starts on is **not deterministic**. In `ik-demo` the Fox kept landing on the same clip as the Shadow, which made the retargeting demo's unmapped-bone assertion compare two characters playing the same animation — an assertion that could not fail.

Both clips are now pinned in the scene, which this fix is what makes possible, and the test asserts both. Measured with them pinned: `fox on "Survey", shadow on "Run"`, the mapped leg bone matching to four decimals while the unmapped bone differs clearly.

## Tests

Three, covering both directions:

- an authored clip survives, with its `speed` and `looping` intact and its `duration` corrected
- a character with **no** authored player still gets the loader's default — the common case a careless "skip if anything is present" guard would break
- a typo'd clip falls back to a playable one

**Mutation-verified**: ignoring the authored player drops `speed` from the authored 2.0 to the loader's 1.0 and the first test fails.

The demo's test-side workaround for the overwrite is gone, replaced by an assertion that the scene-authored clip survived — the thing that had to be worked around is now the thing being checked.

## Verification

- `cargo test --workspace --exclude bsengine-editor` — 76 suites ok, exit 0
- `cargo test -p bsengine-editor --lib` — 937 passed
- `cargo test -p bsengine-asset --test committed_sidecars` — passed (scene edited, so LF-normalised before the sidecar was regenerated)
- 10 E2E replays pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)