### PR TITLE
pak archive mode + packaging-mode setting (item 55, 2/2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,18 +259,23 @@ jobs:
             exit 1
           fi
 
+          # Both modes: a project can cook cleanly and still fail to pack --
+          # a .gltf that reads sibling files from disk cannot go in an archive,
+          # and `--mode pak` is what says so.
           status=0
-          for project in "${projects[@]}"; do
-            out="$(mktemp -d)/dist"
-            echo "::group::$project"
-            if "$bin" --package "$project" --out "$out"; then
-              echo "PASS $project"
-            else
-              echo "FAIL $project"
-              status=1
-            fi
-            echo "::endgroup::"
-            rm -rf "$out"
+          for mode in loose pak; do
+            for project in "${projects[@]}"; do
+              out="$(mktemp -d)/dist"
+              echo "::group::$project ($mode)"
+              if "$bin" --package "$project" --out "$out" --mode "$mode"; then
+                echo "PASS $project ($mode)"
+              else
+                echo "FAIL $project ($mode)"
+                status=1
+              fi
+              echo "::endgroup::"
+              rm -rf "$out"
+            done
           done
-          echo "packaged ${#projects[@]} project(s)"
+          echo "packaged ${#projects[@]} project(s) in 2 mode(s)"
           exit $status

--- a/README.md
+++ b/README.md
@@ -131,8 +131,31 @@ what that scene references. Unlike a path spelled only in a script, an entry
 here that resolves to nothing **fails** the build: this list is written on
 purpose, so a typo in it is a mistake rather than a guess.
 
-Output is a directory, not a single file. A packed single-file mode, and the
-project setting that chooses between them, is the next step.
+### Packaging modes
+
+```toml
+[package]
+mode = "pak"          # or "loose" (the default)
+```
+
+`--mode <loose|pak>` on the command line overrides the setting for one build.
+
+**`loose`** writes `assets/` as ordinary files beside the executable. Any tool
+can open them, which is what makes it the default and the mode to reach for when
+a build misbehaves.
+
+**`pak`** writes a single `game.pak` instead — an index plus the asset bytes,
+the shape Unreal, Unity and Godot all use. Fewer files to ship, and only this
+engine can read them.
+
+The build is then `exe + project.toml + game.pak`: **fewer files, but still not
+one file.** Embedding the archive into the executable, the way Godot embeds a
+`.pck`, is the route to a literal single file and is not implemented.
+
+One asset kind cannot be packed: a `.gltf` that references sibling `.bin` or
+image files resolves them through the filesystem, which an archive has none of.
+`--mode pak` fails the build and names them rather than shipping a game that
+loses its meshes at run time. A `.glb` is self-contained and packs fine.
 
 ---
 

--- a/crates/bsengine-asset/src/cook.rs
+++ b/crates/bsengine-asset/src/cook.rs
@@ -329,6 +329,33 @@ pub fn package(
             }
         }
         PackageMode::Pak => {
+            // A `.gltf` resolves its buffers and images through sibling files
+            // on disk, which an archive has none of — `bsengine-gltf`'s loader
+            // documents why a byte reader cannot replicate that. Refused here so
+            // the build fails with a sentence somebody can act on, rather than
+            // shipping and losing its meshes at run time, where a failed asset
+            // load is only a warning. `.glb` is self-contained and packs fine.
+            let unpackable: Vec<&String> = cooked
+                .assets
+                .iter()
+                .filter(|asset| extension_of(asset).is_some_and(|e| e.eq_ignore_ascii_case("gltf")))
+                .collect();
+            if !unpackable.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "these assets cannot go in an archive because they read \
+                         sibling files from disk: {}. Convert them to .glb, or \
+                         package with --mode loose.",
+                        unpackable
+                            .iter()
+                            .map(|a| a.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                ));
+            }
+
             // Sidecars are deliberately NOT packed, though loose mode ships
             // them. They exist so the engine can recover a reference whose
             // asset has moved, and nothing moves inside a sealed archive —
@@ -875,7 +902,8 @@ mod tests {
             PackageMode::Loose,
             &exe,
             &out,
-        ).expect("package");
+        )
+        .expect("package");
 
         assert!(cooked.is_ok(), "unexpected problems: {:?}", cooked.missing);
         assert!(out.join("project.toml").is_file(), "the manifest must ship");
@@ -1005,7 +1033,7 @@ mod tests {
             &exe,
             &out,
         )
-            .expect_err("a non-empty output directory must be refused");
+        .expect_err("a non-empty output directory must be refused");
 
         assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
         assert!(
@@ -1033,7 +1061,8 @@ mod tests {
             PackageMode::Loose,
             &exe,
             &out,
-        ).expect("package");
+        )
+        .expect("package");
 
         assert!(!cooked.is_ok(), "the cook must report the missing model");
         assert!(

--- a/crates/bsengine-asset/src/cook.rs
+++ b/crates/bsengine-asset/src/cook.rs
@@ -228,6 +228,30 @@ pub fn cook(
     Ok(report)
 }
 
+/// What shape a build's assets take on disk.
+///
+/// A project setting rather than a fixed behaviour, matching how Unity and
+/// Unreal expose packaging: the two have genuinely different virtues, and which
+/// one a project wants is not something the engine can decide for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageMode {
+    /// `assets/` as ordinary files beside the executable. Inspectable with any
+    /// tool, which is what makes it both the default and the mode to fall back
+    /// to whenever a build misbehaves.
+    #[default]
+    Loose,
+    /// One [`PAK_FILE_NAME`] archive. Fewer files to ship, at the cost of
+    /// needing this engine to read them.
+    Pak,
+}
+
+/// The archive's name inside a build.
+///
+/// Fixed rather than configurable: the runtime has to find it before it has
+/// read anything that could have told it where to look.
+pub const PAK_FILE_NAME: &str = "game.pak";
+
 /// Cooks `project_dir` and writes a runnable build into `out_dir`.
 ///
 /// `runtime_exe` is the binary to ship. The caller passes it rather than this
@@ -252,6 +276,7 @@ pub fn package(
     project_dir: impl AsRef<Path>,
     entry_scene: &str,
     extra_assets: &[String],
+    mode: PackageMode,
     runtime_exe: &Path,
     out_dir: &Path,
 ) -> io::Result<CookedProject> {
@@ -290,14 +315,30 @@ pub fn package(
     })?;
     copy(runtime_exe, &out_dir.join(exe_name))?;
 
-    for asset in &cooked.assets {
-        copy(&project_dir.join(asset), &out_dir.join(asset))?;
-        // An asset without a sidecar is normal — nothing has scanned the
-        // project yet — so only one that exists and cannot be copied is worth
-        // failing on.
-        let sidecar = format!("{asset}.meta");
-        if project_dir.join(&sidecar).is_file() {
-            copy(&project_dir.join(&sidecar), &out_dir.join(&sidecar))?;
+    match mode {
+        PackageMode::Loose => {
+            for asset in &cooked.assets {
+                copy(&project_dir.join(asset), &out_dir.join(asset))?;
+                // An asset without a sidecar is normal — nothing has scanned the
+                // project yet — so only one that exists and cannot be copied is
+                // worth failing on.
+                let sidecar = format!("{asset}.meta");
+                if project_dir.join(&sidecar).is_file() {
+                    copy(&project_dir.join(&sidecar), &out_dir.join(&sidecar))?;
+                }
+            }
+        }
+        PackageMode::Pak => {
+            // Sidecars are deliberately NOT packed, though loose mode ships
+            // them. They exist so the engine can recover a reference whose
+            // asset has moved, and nothing moves inside a sealed archive —
+            // every path in it was resolved by the cook that wrote it, and no
+            // rename can reach it afterwards.
+            let mut entries = Vec::with_capacity(cooked.assets.len());
+            for asset in &cooked.assets {
+                entries.push((asset.clone(), std::fs::read(project_dir.join(asset))?));
+            }
+            crate::pak::write_pak(out_dir.join(PAK_FILE_NAME), &entries)?;
         }
     }
 
@@ -827,7 +868,14 @@ mod tests {
         let exe = probe.fake_runtime();
         let out = probe.0.join("dist");
 
-        let cooked = package(&probe.0, "assets/scenes/main.ron", &[], &exe, &out).expect("package");
+        let cooked = package(
+            &probe.0,
+            "assets/scenes/main.ron",
+            &[],
+            PackageMode::Loose,
+            &exe,
+            &out,
+        ).expect("package");
 
         assert!(cooked.is_ok(), "unexpected problems: {:?}", cooked.missing);
         assert!(out.join("project.toml").is_file(), "the manifest must ship");
@@ -850,6 +898,93 @@ mod tests {
         );
     }
 
+    /// The negative half is the point: if loose assets are written beside the
+    /// archive, "one archive" is not true and every later pak test could be
+    /// quietly reading those files instead.
+    #[test]
+    fn pak_mode_writes_one_archive_and_no_loose_assets() {
+        let probe = Probe::create();
+        probe.write(
+            "project.toml",
+            "[project]\nname = \"P\"\nentry_scene = \"assets/scenes/main.ron\"\n",
+        );
+        probe.write(
+            "assets/scenes/main.ron",
+            r#"(entities: [(name: "Hero", gltf: Some(Path("assets/models/hero.glb")))])"#,
+        );
+        probe.write("assets/models/hero.glb", "glb");
+        let exe = probe.fake_runtime();
+        let out = probe.0.join("dist");
+
+        let cooked = package(
+            &probe.0,
+            "assets/scenes/main.ron",
+            &[],
+            PackageMode::Pak,
+            &exe,
+            &out,
+        )
+        .expect("package");
+
+        assert!(cooked.is_ok(), "unexpected problems: {:?}", cooked.missing);
+        assert!(
+            out.join(PAK_FILE_NAME).is_file(),
+            "the archive must be written"
+        );
+        assert!(
+            out.join("project.toml").is_file(),
+            "the manifest stays loose -- it is the bootstrap"
+        );
+        assert!(
+            !out.join("assets").exists(),
+            "pak mode must not also write loose assets"
+        );
+    }
+
+    /// The archive holds exactly the collected set — the same set loose mode
+    /// ships — so the two modes cannot silently disagree about what a build
+    /// contains.
+    #[test]
+    fn the_archive_holds_exactly_the_collected_set() {
+        let probe = Probe::create();
+        probe.write(
+            "project.toml",
+            "[project]\nname = \"P\"\nentry_scene = \"assets/scenes/main.ron\"\n",
+        );
+        probe.write(
+            "assets/scenes/main.ron",
+            r#"(entities: [(name: "Hero", gltf: Some(Path("assets/models/hero.glb")))])"#,
+        );
+        probe.write("assets/models/hero.glb", "glb");
+        probe.write("assets/textures/unused.png", "png");
+        let exe = probe.fake_runtime();
+        let out = probe.0.join("dist");
+
+        let cooked = package(
+            &probe.0,
+            "assets/scenes/main.ron",
+            &[],
+            PackageMode::Pak,
+            &exe,
+            &out,
+        )
+        .expect("package");
+
+        let pak = crate::pak::Pak::open(out.join(PAK_FILE_NAME)).expect("open the archive");
+        let mut in_archive: Vec<&str> = pak.paths().collect();
+        in_archive.sort_unstable();
+        let mut collected: Vec<&str> = cooked.assets.iter().map(String::as_str).collect();
+        collected.sort_unstable();
+        assert_eq!(
+            in_archive, collected,
+            "the archive must hold exactly what the cook collected"
+        );
+        assert!(
+            !in_archive.contains(&"assets/textures/unused.png"),
+            "and nothing it did not"
+        );
+    }
+
     /// A leftover from a previous run is exactly what "only used assets"
     /// promises not to ship — and deleting a directory the caller named is not
     /// something a build command should decide to do.
@@ -862,7 +997,14 @@ mod tests {
         std::fs::create_dir_all(&out).expect("create out");
         std::fs::write(out.join("stale.txt"), "old").expect("write stale");
 
-        let error = package(&probe.0, "assets/scenes/main.ron", &[], &exe, &out)
+        let error = package(
+            &probe.0,
+            "assets/scenes/main.ron",
+            &[],
+            PackageMode::Loose,
+            &exe,
+            &out,
+        )
             .expect_err("a non-empty output directory must be refused");
 
         assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
@@ -884,7 +1026,14 @@ mod tests {
         let exe = probe.fake_runtime();
         let out = probe.0.join("dist");
 
-        let cooked = package(&probe.0, "assets/scenes/main.ron", &[], &exe, &out).expect("package");
+        let cooked = package(
+            &probe.0,
+            "assets/scenes/main.ron",
+            &[],
+            PackageMode::Loose,
+            &exe,
+            &out,
+        ).expect("package");
 
         assert!(!cooked.is_ok(), "the cook must report the missing model");
         assert!(

--- a/crates/bsengine-asset/src/lib.rs
+++ b/crates/bsengine-asset/src/lib.rs
@@ -43,6 +43,8 @@ pub mod identity;
 /// Chooses between synchronous (blocking, zero-latency) and asynchronous
 /// (`AssetServer`-driven) loading, plus the dispatch helper itself.
 pub mod load_mode;
+/// The `.pak` container a packaged build's assets are stored in.
+pub mod pak;
 /// Wires `bevy_asset`'s `AssetPlugin` into the app and registers this
 /// crate's own asset types.
 pub mod plugin;

--- a/crates/bsengine-asset/src/lib.rs
+++ b/crates/bsengine-asset/src/lib.rs
@@ -45,6 +45,8 @@ pub mod identity;
 pub mod load_mode;
 /// The `.pak` container a packaged build's assets are stored in.
 pub mod pak;
+/// Serving a packaged build's assets to `bevy_asset` out of a `.pak`.
+pub mod pak_reader;
 /// Wires `bevy_asset`'s `AssetPlugin` into the app and registers this
 /// crate's own asset types.
 pub mod plugin;

--- a/crates/bsengine-asset/src/lib.rs
+++ b/crates/bsengine-asset/src/lib.rs
@@ -47,6 +47,9 @@ pub mod load_mode;
 pub mod pak;
 /// Serving a packaged build's assets to `bevy_asset` out of a `.pak`.
 pub mod pak_reader;
+/// Reading scene RON out of a `.pak` -- the three `std::fs` sites
+/// `pak_reader` cannot reach.
+pub mod pak_source;
 /// Wires `bevy_asset`'s `AssetPlugin` into the app and registers this
 /// crate's own asset types.
 pub mod plugin;
@@ -76,7 +79,7 @@ pub use bevy_asset::{Asset, AssetServer, Assets, Handle};
 pub use heightmap_loader::HeightmapAssetLoader;
 pub use identity::{AssetGuid, AssetIdentityPlugin, AssetIndex};
 pub use load_mode::{load, load_async, LoadMode};
-pub use plugin::AssetPlugin;
+pub use plugin::{AssetPlugin, PakAssetPlugin};
 pub use slot::{AssetSlot, Polled};
 pub use status::{AssetStatus, AssetStatusPlugin, AssetStatuses};
 pub use texture_loader::TextureAssetLoader;

--- a/crates/bsengine-asset/src/pak.rs
+++ b/crates/bsengine-asset/src/pak.rs
@@ -1,0 +1,293 @@
+//! The `.pak` container: one file holding a packaged build's assets.
+//!
+//! # Why a custom container rather than zip
+//!
+//! Every shipping engine surveyed uses one — Unreal `.pak`, Unity's
+//! AssetBundle, Godot `.pck` — and the reason is random access. A runtime reads
+//! one asset at a known offset, so any compression has to be per-entry for that
+//! to survive; Unity's advice to prefer chunked LZ4 over whole-archive LZMA at
+//! runtime is the same constraint stated from the other side. Starting
+//! uncompressed keeps offset reads trivially correct and leaves per-entry
+//! compression as an additive change to the entry record rather than a rewrite.
+//!
+//! id Tech's `.pk3` is a real zip and a real precedent, and zip would buy
+//! inspectability with an ordinary tool. Declined for a new dependency tree and
+//! for the control over layout a custom index keeps — with the cost taken
+//! knowingly, since a `.pak` cannot be opened with 7-zip. The loose build mode
+//! is the answer when somebody needs to see the files.
+//!
+//! # Layout
+//!
+//! ```text
+//! "BSPK\0"                      magic
+//! u32                           format version
+//! u32                           entry count
+//! entry × count {
+//!     u32   path length
+//!     bytes path (UTF-8, '/'-separated, project-relative)
+//!     u64   offset into the blob
+//!     u64   length
+//! }
+//! blob                          contents, back to back
+//! ```
+//!
+//! All integers little-endian. Offsets are relative to the start of the blob
+//! rather than of the file, so the index can grow without rewriting every
+//! offset in it.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::path::Path;
+
+/// Identifies the format, and its absence identifies a file that is not one.
+pub(crate) const MAGIC: &[u8; 5] = b"BSPK\0";
+
+/// The format this build writes and can read.
+const VERSION: u32 = 1;
+
+/// One opened archive: the index, and the bytes it points into.
+///
+/// The whole file is held in memory. A packaged game's assets are the same
+/// bytes it would otherwise have on disk and are read once at startup, which is
+/// what makes [`Self::get`] a slice rather than a seek — but it does mean this
+/// is not the shape for an archive larger than memory. Recorded as a limit
+/// rather than hidden: the projects this ships for are megabytes.
+pub struct Pak {
+    /// Path to (offset, length) within [`Self::blob`].
+    index: BTreeMap<String, (u64, u64)>,
+    blob: Vec<u8>,
+}
+
+/// Written by hand rather than derived: a derived impl would print the whole
+/// blob — every byte of every asset — into any message that formats a `Pak`,
+/// including a test failure. The shape is what a reader actually wants to know.
+impl std::fmt::Debug for Pak {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Pak")
+            .field("entries", &self.index.len())
+            .field("bytes", &self.blob.len())
+            .finish()
+    }
+}
+
+impl Pak {
+    /// Reads an archive from disk.
+    ///
+    /// # Errors
+    ///
+    /// When the file cannot be read, or is not a readable archive of a version
+    /// this build understands.
+    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::from_bytes(std::fs::read(path)?)
+    }
+
+    /// Parses an archive already in memory.
+    ///
+    /// # Errors
+    ///
+    /// When the bytes are not an archive, are a version this build does not
+    /// understand, or carry an entry pointing outside the blob.
+    pub fn from_bytes(bytes: Vec<u8>) -> io::Result<Self> {
+        let invalid = |what: String| io::Error::new(io::ErrorKind::InvalidData, what);
+        let mut at = 0usize;
+
+        let take = |at: &mut usize, n: usize| -> io::Result<&[u8]> {
+            let end = at
+                .checked_add(n)
+                .ok_or_else(|| invalid("archive is truncated".to_string()))?;
+            let slice = bytes
+                .get(*at..end)
+                .ok_or_else(|| invalid("archive is truncated".to_string()))?;
+            *at = end;
+            Ok(slice)
+        };
+
+        if take(&mut at, MAGIC.len())? != MAGIC.as_slice() {
+            return Err(invalid("not a BSPK archive".to_string()));
+        }
+        let version = u32::from_le_bytes(take(&mut at, 4)?.try_into().expect("4 bytes"));
+        if version != VERSION {
+            return Err(invalid(format!(
+                "archive format version {version}, but this build reads {VERSION}"
+            )));
+        }
+        let count = u32::from_le_bytes(take(&mut at, 4)?.try_into().expect("4 bytes"));
+
+        let mut index = BTreeMap::new();
+        for _ in 0..count {
+            let path_len = u32::from_le_bytes(take(&mut at, 4)?.try_into().expect("4 bytes"));
+            let path = std::str::from_utf8(take(&mut at, path_len as usize)?)
+                .map_err(|_| invalid("an entry path is not UTF-8".to_string()))?
+                .to_string();
+            let offset = u64::from_le_bytes(take(&mut at, 8)?.try_into().expect("8 bytes"));
+            let length = u64::from_le_bytes(take(&mut at, 8)?.try_into().expect("8 bytes"));
+            index.insert(path, (offset, length));
+        }
+
+        let blob = bytes[at..].to_vec();
+        // Checked once here rather than on every `get`, so a corrupt archive
+        // fails at open with a message naming the entry instead of returning
+        // `None` forever and reading as "that asset was never packed".
+        for (path, (offset, length)) in &index {
+            let end = offset
+                .checked_add(*length)
+                .ok_or_else(|| invalid(format!("{path}'s length overflows")))?;
+            if end > blob.len() as u64 {
+                return Err(invalid(format!("{path} points past the end of the archive")));
+            }
+        }
+
+        Ok(Self { index, blob })
+    }
+
+    /// The bytes stored for `path`, or `None` if the archive has no such entry.
+    pub fn get(&self, path: &str) -> Option<&[u8]> {
+        let (offset, length) = self.index.get(path)?;
+        // Bounds were checked once at open, so this cannot be out of range.
+        Some(&self.blob[*offset as usize..(*offset + *length) as usize])
+    }
+
+    /// Every path in the archive.
+    pub fn paths(&self) -> impl Iterator<Item = &str> {
+        self.index.keys().map(String::as_str)
+    }
+
+    /// Whether any entry lives under `prefix` — which is how a directory exists
+    /// at all in a container that stores no directory records.
+    pub fn has_prefix(&self, prefix: &str) -> bool {
+        let with_slash = format!("{}/", prefix.trim_end_matches('/'));
+        self.index.keys().any(|path| path.starts_with(&with_slash))
+    }
+}
+
+/// Serialises `entries` into archive bytes.
+///
+/// # Errors
+///
+/// When a path is longer than `u32::MAX` bytes, which no real asset path is.
+pub(crate) fn write_pak_bytes(entries: &[(String, Vec<u8>)]) -> io::Result<Vec<u8>> {
+    let mut index = Vec::new();
+    let mut blob = Vec::new();
+    for (path, contents) in entries {
+        let path_len = u32::try_from(path.len()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, format!("{path} is too long"))
+        })?;
+        index.extend_from_slice(&path_len.to_le_bytes());
+        index.extend_from_slice(path.as_bytes());
+        index.extend_from_slice(&(blob.len() as u64).to_le_bytes());
+        index.extend_from_slice(&(contents.len() as u64).to_le_bytes());
+        blob.extend_from_slice(contents);
+    }
+
+    let mut out = Vec::with_capacity(MAGIC.len() + 8 + index.len() + blob.len());
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&VERSION.to_le_bytes());
+    out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+    out.extend_from_slice(&index);
+    out.extend_from_slice(&blob);
+    Ok(out)
+}
+
+/// Writes an archive of `entries` to `path`.
+///
+/// # Errors
+///
+/// When serialisation fails, or the file cannot be written.
+pub fn write_pak(path: impl AsRef<Path>, entries: &[(String, Vec<u8>)]) -> io::Result<()> {
+    std::fs::write(path, write_pak_bytes(entries)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A file whose bytes *are* the magic is the case a naive reader gets
+    /// wrong, so it lives in the shared fixture rather than in its own test.
+    fn fixture() -> Vec<(String, Vec<u8>)> {
+        vec![
+            ("assets/a.txt".to_string(), b"first".to_vec()),
+            ("assets/nested/b.bin".to_string(), MAGIC.to_vec()),
+            ("assets/c.txt".to_string(), b"third".to_vec()),
+        ]
+    }
+
+    /// Paired on purpose: a reader returning the whole blob for every path
+    /// would satisfy a single-entry round-trip, and one returning the first
+    /// entry for every path would satisfy "some bytes came back".
+    #[test]
+    fn every_entry_reads_back_byte_identical() {
+        let bytes = write_pak_bytes(&fixture()).expect("write");
+        let pak = Pak::from_bytes(bytes).expect("open");
+
+        for (path, expected) in fixture() {
+            assert_eq!(
+                pak.get(&path).map(<[u8]>::to_vec),
+                Some(expected),
+                "{path} did not read back byte-identical"
+            );
+        }
+    }
+
+    /// Distinct contents are what make the test above meaningful; this pins
+    /// that the fixture actually has them, so it cannot rot into three
+    /// identical entries that agree no matter what `get` returns.
+    #[test]
+    fn the_fixture_entries_are_distinguishable() {
+        let all: Vec<Vec<u8>> = fixture().into_iter().map(|(_, bytes)| bytes).collect();
+        let mut unique = all.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), all.len(), "fixture entries must differ");
+    }
+
+    #[test]
+    fn a_path_not_in_the_archive_is_absent_not_empty() {
+        let pak = Pak::from_bytes(write_pak_bytes(&fixture()).expect("write")).expect("open");
+        assert_eq!(
+            pak.get("assets/missing.txt"),
+            None,
+            "an absent path must be None, never empty bytes -- empty bytes read \
+             as a valid zero-length asset"
+        );
+    }
+
+    #[test]
+    fn a_file_that_is_not_a_pak_is_rejected() {
+        assert!(Pak::from_bytes(b"not an archive".to_vec()).is_err());
+    }
+
+    #[test]
+    fn an_entry_pointing_past_the_end_is_rejected_at_open() {
+        let mut bytes = write_pak_bytes(&fixture()).expect("write");
+        // The first entry's length field: magic(5) + version(4) + count(4) +
+        // path_len(4) + path("assets/a.txt" = 12) + offset(8).
+        let length_at = 5 + 4 + 4 + 4 + 12 + 8;
+        bytes[length_at..length_at + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+
+        let error = Pak::from_bytes(bytes).expect_err("a corrupt entry must be refused");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn the_archive_lists_exactly_what_was_written() {
+        let pak = Pak::from_bytes(write_pak_bytes(&fixture()).expect("write")).expect("open");
+        let mut listed: Vec<&str> = pak.paths().collect();
+        listed.sort_unstable();
+        assert_eq!(
+            listed,
+            vec!["assets/a.txt", "assets/c.txt", "assets/nested/b.bin"]
+        );
+    }
+
+    #[test]
+    fn a_directory_exists_when_something_lives_under_it() {
+        let pak = Pak::from_bytes(write_pak_bytes(&fixture()).expect("write")).expect("open");
+        assert!(pak.has_prefix("assets"));
+        assert!(pak.has_prefix("assets/nested"));
+        assert!(
+            !pak.has_prefix("assets/a.txt"),
+            "a file is not a directory, even though its path is a prefix of nothing"
+        );
+        assert!(!pak.has_prefix("elsewhere"));
+    }
+}

--- a/crates/bsengine-asset/src/pak.rs
+++ b/crates/bsengine-asset/src/pak.rs
@@ -133,7 +133,9 @@ impl Pak {
                 .checked_add(*length)
                 .ok_or_else(|| invalid(format!("{path}'s length overflows")))?;
             if end > blob.len() as u64 {
-                return Err(invalid(format!("{path} points past the end of the archive")));
+                return Err(invalid(format!(
+                    "{path} points past the end of the archive"
+                )));
             }
         }
 

--- a/crates/bsengine-asset/src/pak_reader.rs
+++ b/crates/bsengine-asset/src/pak_reader.rs
@@ -25,32 +25,14 @@ use crate::pak::Pak;
 /// Turns a path as `AssetServer::load` received it into the key the archive
 /// stores it under.
 ///
-/// # The rule, and why it is a rule rather than a guess
-///
-/// `bsengine_core::resolve_project_path` builds every asset path in this engine
-/// as `format!("{project_dir}/{path}")`, while the cook keys entries by the
-/// project-relative `path` alone. So this removes exactly the prefix that
-/// function added — nothing cleverer. A build run from inside itself has a
-/// project directory of `.`, which is why the `./` case is spelled out.
-///
-/// Separators are normalised because a `Path` carries whichever the caller
-/// wrote, and on Windows both appear.
-///
-/// A path that does not start with the project directory comes back normalised
-/// but otherwise untouched. Forcing it to match would invent an entry, and the
-/// archive answering for a file it does not hold is worse than a miss.
+/// Delegates to [`crate::pak_source::archive_key`] rather than repeating the
+/// rule. The two readers look into the same archive with paths built by the
+/// same function, so a second copy that drifted would mean one of them silently
+/// reading from disk -- which is a bug this feature actually shipped once, when
+/// the scene side stripped only `./` and so missed every absolute project
+/// directory.
 fn archive_key(path: &Path, project_dir: &str) -> String {
-    let text = path.to_string_lossy().replace('\\', "/");
-    let project = project_dir.replace('\\', "/");
-    let project = project.trim_end_matches('/');
-
-    let stripped = if project.is_empty() || project == "." {
-        text.strip_prefix("./").unwrap_or(&text)
-    } else {
-        text.strip_prefix(&format!("{project}/"))
-            .unwrap_or_else(|| text.strip_prefix("./").unwrap_or(&text))
-    };
-    stripped.to_string()
+    crate::pak_source::archive_key(&path.to_string_lossy(), project_dir)
 }
 
 /// Serves `bevy_asset` reads out of an opened archive.
@@ -161,11 +143,9 @@ mod tests {
     /// key is what `Pak` stores" unproven.
     #[test]
     fn a_normalised_key_finds_the_entry_it_names() {
-        let bytes = crate::pak::write_pak_bytes(&[(
-            "assets/models/fox.glb".to_string(),
-            b"mesh".to_vec(),
-        )])
-        .expect("write");
+        let bytes =
+            crate::pak::write_pak_bytes(&[("assets/models/fox.glb".to_string(), b"mesh".to_vec())])
+                .expect("write");
         let pak = Pak::from_bytes(bytes).expect("open");
 
         assert_eq!(

--- a/crates/bsengine-asset/src/pak_reader.rs
+++ b/crates/bsengine-asset/src/pak_reader.rs
@@ -1,0 +1,177 @@
+//! Serving a packaged build's assets to `bevy_asset` out of a [`Pak`].
+//!
+//! # Why this backs the *default* source
+//!
+//! Registered as a *named* source, every `AssetServer::load` call site in the
+//! engine would need a `pak://` prefix — dozens of edits, in crates that should
+//! not have to know a build was packaged. Registered as the **default**, none of
+//! them change at all.
+//!
+//! That works because `AssetSourceBuilders::init_default_source`
+//! (`bevy_asset-0.14/src/io/source.rs:351`) is `get_or_insert_with`: a default
+//! registered *before* `AssetPlugin` is added survives it untouched. The
+//! ordering is not optional — sources are built during `AssetPlugin::build`, so
+//! anything registered afterwards is ignored.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use bevy_asset::io::{
+    AssetReader, AssetReaderError, ErasedAssetReader, PathStream, Reader, VecReader,
+};
+
+use crate::pak::Pak;
+
+/// Turns a path as `AssetServer::load` received it into the key the archive
+/// stores it under.
+///
+/// # The rule, and why it is a rule rather than a guess
+///
+/// `bsengine_core::resolve_project_path` builds every asset path in this engine
+/// as `format!("{project_dir}/{path}")`, while the cook keys entries by the
+/// project-relative `path` alone. So this removes exactly the prefix that
+/// function added — nothing cleverer. A build run from inside itself has a
+/// project directory of `.`, which is why the `./` case is spelled out.
+///
+/// Separators are normalised because a `Path` carries whichever the caller
+/// wrote, and on Windows both appear.
+///
+/// A path that does not start with the project directory comes back normalised
+/// but otherwise untouched. Forcing it to match would invent an entry, and the
+/// archive answering for a file it does not hold is worse than a miss.
+fn archive_key(path: &Path, project_dir: &str) -> String {
+    let text = path.to_string_lossy().replace('\\', "/");
+    let project = project_dir.replace('\\', "/");
+    let project = project.trim_end_matches('/');
+
+    let stripped = if project.is_empty() || project == "." {
+        text.strip_prefix("./").unwrap_or(&text)
+    } else {
+        text.strip_prefix(&format!("{project}/"))
+            .unwrap_or_else(|| text.strip_prefix("./").unwrap_or(&text))
+    };
+    stripped.to_string()
+}
+
+/// Serves `bevy_asset` reads out of an opened archive.
+pub struct PakAssetReader {
+    pak: Arc<Pak>,
+    project_dir: String,
+}
+
+impl PakAssetReader {
+    /// Serves `pak`, reading load paths as relative to `project_dir` — the same
+    /// string `resolve_project_path` prepends.
+    pub fn new(pak: Arc<Pak>, project_dir: impl Into<String>) -> Self {
+        Self {
+            pak,
+            project_dir: project_dir.into(),
+        }
+    }
+}
+
+impl AssetReader for PakAssetReader {
+    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+        let key = archive_key(path, &self.project_dir);
+        match self.pak.get(&key) {
+            Some(bytes) => Ok(Box::new(VecReader::new(bytes.to_vec()))),
+            None => Err(AssetReaderError::NotFound(path.to_path_buf())),
+        }
+    }
+
+    /// Always `NotFound`, which is already this engine's live behaviour:
+    /// [`crate::AssetPlugin`] builds `bevy_asset` with `AssetMetaCheck::Never`
+    /// because this crate's identity sidecars use the very filename `bevy_asset`
+    /// reserves for its own meta. Packing them would be packing that collision.
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+        Err(AssetReaderError::NotFound(path.to_path_buf()))
+    }
+
+    /// Refused rather than answered with an empty listing: nothing in this
+    /// engine loads a directory, and an empty stream would read as "the
+    /// directory is there and holds nothing" — the wrong answer to give about
+    /// an archive that may well hold it.
+    async fn read_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<Box<PathStream>, AssetReaderError> {
+        Err(AssetReaderError::NotFound(path.to_path_buf()))
+    }
+
+    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+        Ok(self.pak.has_prefix(&archive_key(path, &self.project_dir)))
+    }
+}
+
+/// Builds the boxed reader `AssetSourceBuilder::with_reader` asks for.
+pub fn erased(pak: Arc<Pak>, project_dir: String) -> Box<dyn ErasedAssetReader> {
+    Box::new(PakAssetReader::new(pak, project_dir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact shapes `resolve_project_path` produces.
+    ///
+    /// This is the single most likely thing in the feature to be silently
+    /// wrong, and the failure is quiet in the worst way: a key that never
+    /// matches sends every asset to the disk fallback, which is *present* in a
+    /// source tree, so everything looks fine right up until a shipped build
+    /// loads nothing.
+    #[test]
+    fn a_load_path_is_normalised_to_an_archive_key() {
+        // project_dir "." — a build run from inside itself, the shipped case
+        assert_eq!(
+            archive_key(Path::new("./assets/models/fox.glb"), "."),
+            "assets/models/fox.glb"
+        );
+        // project_dir naming a directory — the source-tree case
+        assert_eq!(
+            archive_key(
+                Path::new("games/mini-arena/assets/x.png"),
+                "games/mini-arena"
+            ),
+            "assets/x.png"
+        );
+        // Windows separators, which `Path` hands through unchanged
+        assert_eq!(
+            archive_key(Path::new(r".\assets\models\fox.glb"), "."),
+            "assets/models/fox.glb"
+        );
+        // Already project-relative
+        assert_eq!(archive_key(Path::new("assets/a.txt"), "."), "assets/a.txt");
+        // An empty project dir is what `resolve_project_path` treats as "no
+        // prefix at all", so it must behave like "."
+        assert_eq!(archive_key(Path::new("assets/a.txt"), ""), "assets/a.txt");
+    }
+
+    /// A path outside the project keeps its shape rather than being mangled
+    /// into a false match — the archive must not answer for what it lacks.
+    #[test]
+    fn an_unrelated_path_is_not_forced_to_match() {
+        assert_eq!(
+            archive_key(Path::new("elsewhere/x.png"), "games/mini-arena"),
+            "elsewhere/x.png"
+        );
+    }
+
+    /// Paired with the above: the keys really do reach entries in a real
+    /// archive. Testing the string function alone would leave "the normalised
+    /// key is what `Pak` stores" unproven.
+    #[test]
+    fn a_normalised_key_finds_the_entry_it_names() {
+        let bytes = crate::pak::write_pak_bytes(&[(
+            "assets/models/fox.glb".to_string(),
+            b"mesh".to_vec(),
+        )])
+        .expect("write");
+        let pak = Pak::from_bytes(bytes).expect("open");
+
+        assert_eq!(
+            pak.get(&archive_key(Path::new("./assets/models/fox.glb"), ".")),
+            Some(b"mesh".as_slice()),
+            "the key a load path normalises to must be the key the cook stored"
+        );
+    }
+}

--- a/crates/bsengine-asset/src/pak_source.rs
+++ b/crates/bsengine-asset/src/pak_source.rs
@@ -1,0 +1,241 @@
+//! Reading scene RON out of a packaged build's archive.
+//!
+//! # Why this exists beside [`crate::pak_reader`]
+//!
+//! A custom `AssetReader` serves everything that goes through `bevy_asset` —
+//! meshes, textures, audio, scripts. Scene RON does not: it is read
+//! synchronously at `Startup` with plain `std::fs`, in three places
+//! (`bsengine-scene`'s entry scene and prefabs, `bsengine-runtime`'s runtime
+//! scene loads). Moving scenes onto the asset server would turn spawning into
+//! an async step and shift the frame timing all ten E2E recordings depend on —
+//! a refactor with its own risk budget, not something to fold into packaging.
+//!
+//! # Why the archive is a process global
+//!
+//! Because it genuinely is one: a process runs one game, out of one archive,
+//! and never swaps it. The alternative is threading an `Option<&Pak>` through
+//! `instantiate_prefab_from_path` and everything it recurses into — the same
+//! plumbing `RESOLVING_PREFABS` already exists in `bsengine-scene` to avoid,
+//! for the same reason.
+//!
+//! The decision-making is kept out of the global: [`read_from`] is a pure
+//! function of an explicit `Option<&Pak>`, and [`read_to_string`] is the thin
+//! accessor that supplies it. Tests drive the pure one, so no test has to set
+//! process-wide state that would then leak into every other test in its binary.
+
+use std::io;
+use std::sync::{Arc, OnceLock};
+
+use crate::pak::Pak;
+
+/// The archive this process serves scenes from, and the project directory whose
+/// prefix its paths carry.
+static ARCHIVE: OnceLock<(Arc<Pak>, String)> = OnceLock::new();
+
+/// Serves scene reads from `pak` for the rest of this process's life.
+///
+/// `project_dir` is the same string `bsengine_core::resolve_project_path`
+/// prepends to every path, and therefore the prefix [`archive_key`] removes.
+///
+/// Returns whether it was set — `false` means one was already installed, which
+/// a host doing this once at startup never sees.
+pub fn install(pak: Arc<Pak>, project_dir: impl Into<String>) -> bool {
+    ARCHIVE.set((pak, project_dir.into())).is_ok()
+}
+
+/// The archive installed by [`install`], if any, and its project directory.
+pub fn archive() -> Option<(&'static Arc<Pak>, &'static str)> {
+    ARCHIVE.get().map(|(pak, dir)| (pak, dir.as_str()))
+}
+
+/// Turns a path as the engine spells it into the key the archive stores it
+/// under.
+///
+/// # The rule, and why it is a rule rather than a guess
+///
+/// `bsengine_core::resolve_project_path` builds every path in this engine as
+/// `format!("{project_dir}/{path}")`, while the cook keys entries by the
+/// project-relative `path` alone. So this removes exactly the prefix that
+/// function added — nothing cleverer. A build run from inside itself has a
+/// project directory of `.`, which is why that case is spelled out; a test or a
+/// host that names an absolute directory is why the general case is too.
+///
+/// Separators are normalised because a path carries whichever the caller wrote,
+/// and on Windows both appear.
+///
+/// A path that does not start with the project directory comes back normalised
+/// but otherwise untouched. Forcing it to match would invent an entry, and an
+/// archive answering for a file it does not hold is worse than a miss.
+///
+/// # Why both readers share this
+///
+/// [`crate::pak_reader`] serves `bevy_asset`'s loads and this module serves
+/// scene reads, but they are looking into the same archive with paths built by
+/// the same function. Two copies of this rule that drifted apart would mean one
+/// of them silently reading from disk — which is exactly the bug the first
+/// version of this module shipped, where it stripped only `./` and so missed
+/// every absolute project directory.
+pub fn archive_key(path: &str, project_dir: &str) -> String {
+    let text = path.replace('\\', "/");
+    let project = project_dir.replace('\\', "/");
+    let project = project.trim_end_matches('/');
+
+    let stripped = if project.is_empty() || project == "." {
+        text.strip_prefix("./").unwrap_or(&text)
+    } else {
+        text.strip_prefix(&format!("{project}/"))
+            .unwrap_or_else(|| text.strip_prefix("./").unwrap_or(&text))
+    };
+    stripped.to_string()
+}
+
+/// The text of a scene or prefab, from `pak` if it holds one and from disk
+/// otherwise.
+///
+/// # Why it falls back rather than failing
+///
+/// The fallback is what lets loose mode and pak mode run the *same* code: one
+/// path through the engine, with the archive simply absent in an unpackaged
+/// run, instead of two paths that can drift apart. It also means a packaged
+/// build whose archive is missing an entry degrades to reading the file if one
+/// happens to be there — which is why the packaging tests assert no loose assets
+/// sit beside the archive, since otherwise a pak build that read nothing from
+/// the archive would look identical to one that worked.
+///
+/// # Errors
+///
+/// When the archive holds the path but not as UTF-8, or when neither the
+/// archive nor the disk can supply it.
+pub fn read_from(pak: Option<&Pak>, project_dir: &str, path: &str) -> io::Result<String> {
+    if let Some(pak) = pak {
+        if let Some(bytes) = pak.get(&archive_key(path, project_dir)) {
+            return String::from_utf8(bytes.to_vec()).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("{path} is in the archive but is not UTF-8: {e}"),
+                )
+            });
+        }
+    }
+    std::fs::read_to_string(path)
+}
+
+/// [`read_from`], against whatever archive this process installed.
+///
+/// # Errors
+///
+/// Whatever [`read_from`] returns.
+pub fn read_to_string(path: &str) -> io::Result<String> {
+    match archive() {
+        Some((pak, project_dir)) => read_from(Some(pak), project_dir, path),
+        None => std::fs::read_to_string(path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn archive_of(entries: &[(&str, &str)]) -> Pak {
+        let owned: Vec<(String, Vec<u8>)> = entries
+            .iter()
+            .map(|(path, text)| ((*path).to_string(), text.as_bytes().to_vec()))
+            .collect();
+        Pak::from_bytes(crate::pak::write_pak_bytes(&owned).expect("write")).expect("open")
+    }
+
+    /// Both spellings a scene path arrives in — bare, and prefixed by the `./`
+    /// that `resolve_project_path` adds for a build run from inside itself.
+    #[test]
+    fn a_scene_in_the_archive_is_read_from_it() {
+        let pak = archive_of(&[("assets/scenes/main.ron", "(entities: [])")]);
+
+        assert_eq!(
+            read_from(Some(&pak), ".", "assets/scenes/main.ron").expect("read"),
+            "(entities: [])"
+        );
+        assert_eq!(
+            read_from(Some(&pak), ".", "./assets/scenes/main.ron").expect("read"),
+            "(entities: [])",
+            "a './'-prefixed path is the shape a build run from inside itself \
+             produces, and must reach the same entry"
+        );
+    }
+
+    /// The shape that shipped broken: a host handed an **absolute** project
+    /// directory, which is what `bsengine-runtime`'s own E2E does. The first
+    /// version of this module stripped only `./`, so every such path missed the
+    /// archive and fell through to a disk read that could not succeed either.
+    ///
+    /// Caught by the end-to-end test and not by any unit test here, because
+    /// every fixture used `.` — the one project directory for which the broken
+    /// rule and the correct one agree.
+    #[test]
+    fn an_absolute_project_directory_still_finds_the_entry() {
+        let pak = archive_of(&[("assets/scenes/main.ron", "(entities: [])")]);
+
+        assert_eq!(
+            read_from(
+                Some(&pak),
+                "C:/Temp/bsengine-package-e2e-1",
+                "C:/Temp/bsengine-package-e2e-1/assets/scenes/main.ron",
+            )
+            .expect("read"),
+            "(entities: [])"
+        );
+        assert_eq!(
+            archive_key(r"C:\Temp\build\assets\scenes\main.ron", r"C:\Temp\build"),
+            "assets/scenes/main.ron",
+            "backslashes on both sides must normalise the same way"
+        );
+    }
+
+    /// The fallback, and the reason loose mode needs no separate code path.
+    #[test]
+    fn a_path_the_archive_lacks_falls_back_to_disk() {
+        let dir = std::env::temp_dir().join(format!("bsengine-pak-source-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create");
+        let on_disk = dir.join("loose.ron");
+        std::fs::write(&on_disk, "(entities: [])").expect("write");
+
+        let pak = archive_of(&[("assets/scenes/other.ron", "(entities: [])")]);
+        let read = read_from(Some(&pak), ".", &on_disk.to_string_lossy()).expect("read");
+
+        std::fs::remove_dir_all(&dir).ok();
+        assert_eq!(read, "(entities: [])");
+    }
+
+    /// With no archive at all — an unpackaged run — this is plain disk reading.
+    #[test]
+    fn without_an_archive_it_reads_the_disk() {
+        let dir =
+            std::env::temp_dir().join(format!("bsengine-pak-source-none-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create");
+        let on_disk = dir.join("loose.ron");
+        std::fs::write(&on_disk, "loose").expect("write");
+
+        let read = read_from(None, ".", &on_disk.to_string_lossy()).expect("read");
+
+        std::fs::remove_dir_all(&dir).ok();
+        assert_eq!(read, "loose");
+    }
+
+    /// The archive wins over a file of the same name, which is what makes a
+    /// packaged build read its own contents rather than whatever happens to sit
+    /// in the working directory.
+    #[test]
+    fn the_archive_is_preferred_over_a_file_of_the_same_name() {
+        let dir =
+            std::env::temp_dir().join(format!("bsengine-pak-source-pref-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("assets/scenes")).expect("create");
+        let path = "assets/scenes/main.ron";
+        let full = dir.join(path);
+        std::fs::write(&full, "FROM DISK").expect("write");
+
+        let pak = archive_of(&[(path, "FROM ARCHIVE")]);
+        let read = read_from(Some(&pak), ".", path).expect("read");
+
+        std::fs::remove_dir_all(&dir).ok();
+        assert_eq!(read, "FROM ARCHIVE");
+    }
+}

--- a/crates/bsengine-asset/src/plugin.rs
+++ b/crates/bsengine-asset/src/plugin.rs
@@ -84,6 +84,44 @@ fn asset_source_root() -> String {
 /// their own plugins — this only owns the types defined in this crate.
 pub struct AssetPlugin;
 
+/// Serves a packaged build's assets out of its `.pak` instead of from files.
+///
+/// # It must be added *before* [`AssetPlugin`]
+///
+/// That is the whole reason this is a separate plugin rather than a field on
+/// `AssetPlugin`. `bevy_asset::AssetPlugin::build` builds its sources there and
+/// then, so a source registered afterwards is silently ignored; registering
+/// here, from a plugin a host adds on the line above, puts the ordering
+/// requirement where somebody reading the host can see it.
+///
+/// It also keeps `AssetPlugin` a unit struct. Around eighty places across eight
+/// crates construct it — almost all of them tests that have no opinion about
+/// packaging — and giving it a field would have edited every one of them to say
+/// so.
+///
+/// Registering as the **default** source rather than a named one is what leaves
+/// every `AssetServer::load` call site alone; see [`crate::pak_reader`].
+pub struct PakAssetPlugin {
+    /// The opened archive to serve.
+    pub pak: std::sync::Arc<crate::pak::Pak>,
+    /// The project directory as the engine spells it — the same string
+    /// `bsengine_core::resolve_project_path` prepends to every asset path, and
+    /// therefore the prefix the reader has to remove to get an archive key.
+    pub project_dir: String,
+}
+
+impl Plugin for PakAssetPlugin {
+    fn build(&self, app: &mut App) {
+        let pak = self.pak.clone();
+        let project_dir = self.project_dir.clone();
+        app.register_asset_source(
+            bevy_asset::io::AssetSourceId::Default,
+            bevy_asset::io::AssetSourceBuilder::default()
+                .with_reader(move || crate::pak_reader::erased(pak.clone(), project_dir.clone())),
+        );
+    }
+}
+
 impl Plugin for AssetPlugin {
     fn build(&self, app: &mut App) {
         // bevy_asset's AssetServer::load spawns its background load task on

--- a/crates/bsengine-gltf/src/asset_loader.rs
+++ b/crates/bsengine-gltf/src/asset_loader.rs
@@ -1,14 +1,28 @@
-use bevy_asset::io::Reader;
+use bevy_asset::io::{AsyncReadExt, Reader};
 use bevy_asset::{AssetLoader, LoadContext};
 
 use crate::loader::{GltfLoader, LoadedGltf};
 
-/// Backs `LoadMode::Async` for glTF via `AssetServer::load`. Ignores the
-/// byte `reader` entirely and re-runs `GltfLoader::load_full` against the
-/// real filesystem path from `LoadContext::path()` — gltf-rs needs a real
-/// path (not just bytes) to resolve sibling .bin/image files for non-.glb
-/// assets, which `bevy_asset`'s byte-only `Reader` can't replicate without
-/// reimplementing gltf-rs's own resolution logic.
+/// Extension of a self-contained glTF: geometry, buffers and images in one
+/// file, with nothing beside it to resolve.
+const SELF_CONTAINED_EXTENSION: &str = "glb";
+
+/// Backs `LoadMode::Async` for glTF via `AssetServer::load`.
+///
+/// # Two paths, and why both have to exist
+///
+/// A `.glb` is self-contained, so it is decoded from the bytes `reader` hands
+/// over. That is the only thing that works in a packaged build, where the asset
+/// lives inside a `.pak` and there is no filesystem path to open — and it is
+/// why this loader stopped ignoring its reader.
+///
+/// Everything else falls back to re-reading the **filesystem path** from
+/// `LoadContext::path()`. `gltf-rs` needs a real path to resolve a `.gltf`'s
+/// sibling `.bin` and image files, which a byte-only `Reader` cannot replicate
+/// without reimplementing that resolution. The consequence is stated rather than
+/// hidden: **a `.gltf` with sibling files cannot be served from an archive**,
+/// and `bsengine_asset::cook` refuses to pack one rather than letting it fail at
+/// run time.
 #[derive(Default)]
 pub struct GltfSourceLoader;
 
@@ -19,14 +33,30 @@ impl AssetLoader for GltfSourceLoader {
 
     async fn load<'a>(
         &'a self,
-        _reader: &'a mut Reader<'_>,
+        reader: &'a mut Reader<'_>,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let path = load_context
             .path()
             .to_str()
-            .ok_or_else(|| "glTF asset path is not valid UTF-8".to_string())?;
-        GltfLoader::load_full(path)
+            .ok_or_else(|| "glTF asset path is not valid UTF-8".to_string())?
+            .to_string();
+
+        let self_contained = load_context
+            .path()
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case(SELF_CONTAINED_EXTENSION));
+
+        if self_contained {
+            let mut bytes = Vec::new();
+            reader
+                .read_to_end(&mut bytes)
+                .await
+                .map_err(|e| format!("gltf: cannot read {path}: {e}"))?;
+            return GltfLoader::load_full_from_slice(&bytes);
+        }
+
+        GltfLoader::load_full(&path)
     }
 }

--- a/crates/bsengine-gltf/src/loader.rs
+++ b/crates/bsengine-gltf/src/loader.rs
@@ -121,9 +121,40 @@ impl GltfLoader {
 
     /// Loads a GLTF/GLB file, parsing its meshes, textures, and animations
     /// into engine-native data.
+    ///
+    /// Reads through the filesystem, which is what lets `gltf-rs` resolve a
+    /// `.gltf`'s sibling `.bin` and image files. See
+    /// [`Self::load_full_from_slice`] for the case where there is no
+    /// filesystem to resolve against.
     pub fn load_full(path: &str) -> Result<LoadedGltf, String> {
         let (doc, buffers, raw_images) = gltf::import(path).map_err(|e| format!("gltf: {e}"))?;
+        Self::from_parts(doc, buffers, raw_images)
+    }
 
+    /// The same, from bytes already in hand.
+    ///
+    /// # When this works, and when it cannot
+    ///
+    /// Only for a **self-contained** asset — a `.glb`, or a `.gltf` whose
+    /// buffers and images are embedded as data URIs. A `.gltf` that references
+    /// sibling files has nothing to resolve them against here, and `gltf-rs`
+    /// will say so rather than silently returning a model with no geometry.
+    ///
+    /// This exists because a packaged build serves assets out of a `.pak`,
+    /// where there is no path to hand to [`Self::load_full`] at all.
+    pub fn load_full_from_slice(bytes: &[u8]) -> Result<LoadedGltf, String> {
+        let (doc, buffers, raw_images) =
+            gltf::import_slice(bytes).map_err(|e| format!("gltf: {e}"))?;
+        Self::from_parts(doc, buffers, raw_images)
+    }
+
+    /// Turns what `gltf-rs` produced into engine-native data, however it was
+    /// read.
+    fn from_parts(
+        doc: gltf::Document,
+        buffers: Vec<gltf::buffer::Data>,
+        raw_images: Vec<gltf::image::Data>,
+    ) -> Result<LoadedGltf, String> {
         let images: Vec<GltfImageData> = raw_images
             .iter()
             .map(|img| {

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -41,14 +41,31 @@ fn main() {
 
     if first_arg == "--package" {
         let project_dir = args.next().unwrap_or_else(|| ".".to_string());
-        let out_dir = match args.next().as_deref() {
-            Some("--out") => args
-                .next()
-                .unwrap_or_else(|| panic!("--out requires a directory")),
-            Some(other) => panic!("unknown argument after project dir: {other}"),
-            None => format!("{project_dir}/dist"),
-        };
-        std::process::exit(run_package(&project_dir, &out_dir));
+        let mut out_dir = None;
+        let mut mode = None;
+        while let Some(flag) = args.next() {
+            match flag.as_str() {
+                "--out" => {
+                    out_dir = Some(
+                        args.next()
+                            .unwrap_or_else(|| panic!("--out requires a directory")),
+                    );
+                }
+                "--mode" => {
+                    let value = args
+                        .next()
+                        .unwrap_or_else(|| panic!("--mode requires loose or pak"));
+                    mode = Some(match value.as_str() {
+                        "loose" => bsengine_asset::cook::PackageMode::Loose,
+                        "pak" => bsengine_asset::cook::PackageMode::Pak,
+                        other => panic!("unknown --mode {other}; expected loose or pak"),
+                    });
+                }
+                other => panic!("unknown argument after project dir: {other}"),
+            }
+        }
+        let out_dir = out_dir.unwrap_or_else(|| format!("{project_dir}/dist"));
+        std::process::exit(run_package(&project_dir, &out_dir, mode));
     }
 
     if first_arg == "--test" {
@@ -154,7 +171,11 @@ fn run_fixup(project_dir: &str, as_json: bool) -> i32 {
 /// warning and does **not** fail the run, for the reason
 /// [`bsengine_asset::cook::ScriptMention`] records: it is a guess that a quoted
 /// string was a path, and it can as easily be dead code.
-fn run_package(project_dir: &str, out_dir: &str) -> i32 {
+fn run_package(
+    project_dir: &str,
+    out_dir: &str,
+    mode_override: Option<bsengine_asset::cook::PackageMode>,
+) -> i32 {
     bsengine_core::init_logging();
 
     let manifest_path = format!("{project_dir}/project.toml");
@@ -181,10 +202,16 @@ fn run_package(project_dir: &str, out_dir: &str) -> i32 {
         }
     };
 
+    // The flag wins over the manifest, the ordinary precedence for a build
+    // option: the setting says what this project normally produces, the flag
+    // says what this one invocation should.
+    let mode = mode_override.unwrap_or(manifest.package.mode);
+
     let cooked = match bsengine_asset::cook::package(
         project_dir,
         &manifest.project.entry_scene,
         &manifest.package.extra_assets,
+        mode,
         &exe,
         std::path::Path::new(out_dir),
     ) {
@@ -225,6 +252,31 @@ fn run_package(project_dir: &str, out_dir: &str) -> i32 {
     0
 }
 
+/// Opens `<project_dir>/game.pak` when this is a packaged build, and installs
+/// it for scene reads.
+///
+/// Returns the archive so the caller can also hand it to
+/// [`bsengine_asset::PakAssetPlugin`], which must be added **before**
+/// `AssetPlugin` — `bevy_asset` builds its sources during that plugin's
+/// `build`, so a source registered afterwards is silently ignored.
+///
+/// A missing archive is the ordinary unpackaged case and means loose files. One
+/// that is present but unreadable is not: it would leave the game reading
+/// whatever files happen to be lying around instead of the build it shipped
+/// with, so it stops here rather than degrading into a half-working game.
+fn open_pak(project_dir: &str) -> Option<std::sync::Arc<bsengine_asset::pak::Pak>> {
+    let path = std::path::Path::new(project_dir).join(bsengine_asset::cook::PAK_FILE_NAME);
+    if !path.is_file() {
+        return None;
+    }
+    let pak = std::sync::Arc::new(
+        bsengine_asset::pak::Pak::open(&path)
+            .unwrap_or_else(|e| panic!("Cannot read {}: {e}", path.display())),
+    );
+    bsengine_asset::pak_source::install(pak.clone(), project_dir);
+    Some(pak)
+}
+
 fn run_windowed(project_dir: &str) {
     let manifest_path = format!("{project_dir}/project.toml");
 
@@ -244,6 +296,17 @@ fn run_windowed(project_dir: &str) {
     app.insert_resource(bsengine_core::OcclusionCullingEnabled(
         manifest.render.occlusion_culling,
     ));
+    // Before `AssetPlugin`, and that ordering is the whole reason this is a
+    // separate plugin: `bevy_asset` builds its sources during that plugin's
+    // `build`, so a source registered afterwards is silently ignored -- and a
+    // silently ignored pak source means a packaged build quietly reading loose
+    // files instead of its own archive.
+    if let Some(pak) = open_pak(project_dir) {
+        app.add_plugins(bsengine_asset::PakAssetPlugin {
+            pak,
+            project_dir: project_dir.to_string(),
+        });
+    }
     app.add_plugins(TimePlugin)
         .add_plugins(AssetPlugin)
         // Windowed only, deliberately. `--test` builds its own app

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -107,6 +107,12 @@ pub struct PackageSection {
     /// guess.
     #[serde(default)]
     pub extra_assets: Vec<String>,
+    /// Whether a build's assets are loose files or one archive.
+    ///
+    /// Defaults to loose, so upgrading the engine never changes what an
+    /// existing project's build looks like.
+    #[serde(default)]
+    pub mode: bsengine_asset::cook::PackageMode,
 }
 
 fn default_width() -> u32 {
@@ -218,7 +224,10 @@ pub fn handle_scene_load(world: &mut World) {
     let pending = world.remove_resource::<PendingSceneLoad>();
     let Some(pending) = pending else { return };
 
-    let content = match std::fs::read_to_string(&pending.path) {
+    // Through the archive when this is a packaged build, from disk otherwise.
+    // This is the site a script's `loadScene` reaches, so a second level of a
+    // packaged game arrives here and nowhere else.
+    let content = match bsengine_asset::pak_source::read_to_string(&pending.path) {
         Ok(c) => c,
         Err(e) => {
             tracing::error!("[scene] failed to read {}: {e}", pending.path);

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -47,6 +47,17 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>, fast_rend
     app.insert_resource(bsengine_core::OcclusionCullingEnabled(
         manifest.render.occlusion_culling,
     ));
+    // Before `AssetPlugin`, and that ordering is the whole reason this is a
+    // separate plugin: `bevy_asset` builds its sources during that plugin's
+    // `build`, so a source registered afterwards is silently ignored -- and a
+    // silently ignored pak source means a packaged build quietly reading loose
+    // files instead of its own archive.
+    if let Some(pak) = crate::open_pak(project_dir) {
+        app.add_plugins(bsengine_asset::PakAssetPlugin {
+            pak,
+            project_dir: project_dir.to_string(),
+        });
+    }
     app.add_plugins(TimePlugin)
         .add_plugins(AssetPlugin)
         // Included here, unlike `AssetWatcherPlugin` (see main.rs's

--- a/crates/bsengine-runtime/tests/package.rs
+++ b/crates/bsengine-runtime/tests/package.rs
@@ -40,10 +40,24 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-#[test]
-fn a_packaged_game_replays_its_recording_without_the_editor() {
+/// Packages `games/mini-arena` in `mode` and replays its recording against the
+/// result, returning the build so a caller can assert on its shape.
+///
+/// Shared by both modes on purpose: the two builds must be interchangeable from
+/// the game's point of view, and running them through the identical assertions
+/// is what says so.
+fn package_and_replay(mode: &str) -> Output {
+    package_and_replay_project(
+        "games/mini-arena",
+        "assets/tests/basic-playthrough.testlog.json",
+        mode,
+    )
+}
+
+/// The same, for any project and recording.
+fn package_and_replay_project(project_rel: &str, recording_rel: &str, mode: &str) -> Output {
     let root = repo_root();
-    let project = root.join("games/mini-arena");
+    let project = root.join(project_rel);
     let output = Output::new();
 
     let status = Command::new(env!("CARGO_BIN_EXE_bsengine-runtime"))
@@ -51,9 +65,14 @@ fn a_packaged_game_replays_its_recording_without_the_editor() {
         .arg(&project)
         .arg("--out")
         .arg(&output.0)
+        .arg("--mode")
+        .arg(mode)
         .status()
         .expect("run --package");
-    assert!(status.success(), "packaging mini-arena failed: {status}");
+    assert!(
+        status.success(),
+        "packaging {project_rel} as {mode} failed: {status}"
+    );
 
     // The recording is not an asset — nothing references it, and `scan`
     // excludes `assets/tests/` by name — so it is correctly absent from the
@@ -62,7 +81,7 @@ fn a_packaged_game_replays_its_recording_without_the_editor() {
         !output.0.join("assets/tests").exists(),
         "test recordings are not assets and must not ship"
     );
-    let recording = project.join("assets/tests/basic-playthrough.testlog.json");
+    let recording = project.join(recording_rel);
 
     let packaged_exe = output.0.join(
         Path::new(env!("CARGO_BIN_EXE_bsengine-runtime"))
@@ -89,9 +108,9 @@ fn a_packaged_game_replays_its_recording_without_the_editor() {
 
     assert!(
         run.status.success(),
-        "the packaged build must reproduce mini-arena's recorded playthrough, \
-         which it cannot do if the cook left out an asset the game needs to \
-         play: {}\n{log}",
+        "the {mode} build of {project_rel} must reproduce its recorded \
+         playthrough, which it cannot do if the cook left out an asset the game \
+         needs to play: {}\n{log}",
         run.status
     );
 
@@ -107,8 +126,64 @@ fn a_packaged_game_replays_its_recording_without_the_editor() {
         .collect();
     assert!(
         failures.is_empty(),
-        "the packaged build asked for {} asset(s) it did not have:\n{}",
+        "the {mode} build asked for {} asset(s) it did not have:\n{}",
         failures.len(),
         failures.join("\n")
+    );
+
+    output
+}
+
+#[test]
+fn a_packaged_game_replays_its_recording_without_the_editor() {
+    let output = package_and_replay("loose");
+    assert!(
+        output.0.join("assets").is_dir(),
+        "a loose build carries its assets as ordinary files"
+    );
+}
+
+/// The archive half.
+///
+/// The no-loose-assets assertion is the load-bearing one. Without it, a pak
+/// build that silently fell back to reading files would pass every assertion
+/// above identically — the archive could be empty, or never opened — and the
+/// whole feature would be unproven. With nothing on disk to fall back to,
+/// a passing replay can only mean the archive was read.
+#[test]
+fn a_pak_packaged_game_replays_its_recording_from_the_archive() {
+    let output = package_and_replay("pak");
+
+    assert!(
+        output.0.join("game.pak").is_file(),
+        "the build must carry an archive"
+    );
+    assert!(
+        !output.0.join("assets").exists(),
+        "a pak build must not also carry loose assets -- with them present the \
+         replay proves nothing about the archive, since it could have read the \
+         files instead"
+    );
+}
+
+/// The scene shim, which no `AssetReader` covers.
+///
+/// `tilt-run` is the only game that calls `Bsengine.loadScene`, and clearing
+/// level 1 transitions into level 2 — so this drives the *runtime* scene-load
+/// site (`scene_systems::handle_scene_load`) rather than the entry-scene one
+/// that every other test exercises. A pak build whose shim only handled the
+/// entry scene would start fine, play level 1 from the archive, and die at the
+/// transition.
+#[test]
+fn a_pak_build_loads_a_second_scene_through_the_shim() {
+    let output = package_and_replay_project(
+        "games/tilt-run",
+        "assets/tests/level1-clear.testlog.json",
+        "pak",
+    );
+
+    assert!(
+        !output.0.join("assets").exists(),
+        "nothing to fall back to, so the second scene came out of the archive"
     );
 }

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -89,7 +89,7 @@ impl Plugin for ScenePlugin {
         app.add_systems(
             Startup,
             (move |world: &mut World| {
-                let content = std::fs::read_to_string(&path)
+                let content = bsengine_asset::pak_source::read_to_string(&path)
                     .unwrap_or_else(|e| panic!("Failed to read scene {path}: {e}"));
                 let scene: SceneDescriptor = ron::from_str(&content)
                     .unwrap_or_else(|e| panic!("Failed to parse scene {path}: {e}"));
@@ -228,7 +228,9 @@ pub fn instantiate_prefab_from_path(
         ));
     }
 
-    let content = std::fs::read_to_string(prefab_path)
+    // Through the archive when this is a packaged build, from disk otherwise;
+    // `pak_source` documents why that is one function rather than two paths.
+    let content = bsengine_asset::pak_source::read_to_string(prefab_path)
         .map_err(|e| format!("prefab '{prefab_path}' could not be read: {e}"))?;
     let prefab: crate::types::PrefabDescriptor = ron::from_str(&content)
         .map_err(|e| format!("prefab '{prefab_path}' failed to parse: {e}"))?;


### PR DESCRIPTION
ENGINE_ROADMAP item 55, **sub-step 2/2**. `--package --mode pak` writes a single
`game.pak` instead of an `assets/` tree, and `project.toml`'s `[package] mode`
chooses between them the way Unity and Unreal expose packaging.

## The single-file condition stays unchecked, deliberately

Output is `exe + project.toml + game.pak` — fewer files, **not one file**.
Embedding the archive into the executable (Godot's `.pck` approach) is the route
to a literal single file; it was offered during design and explicitly not taken
this round. Checking that box would be overclaiming, so the roadmap keeps it
open with embedding recorded as the way to close it.

## Format

A custom container: magic, version, an index of `(path, offset, length)`, then
the bytes. Uncompressed.

Every shipping engine surveyed uses a custom container — Unreal `.pak`, Unity
AssetBundle, Godot `.pck` — and the reason is random access: a runtime reads one
asset at a known offset, so compression has to be per-entry for that to survive.
(Unity's advice to prefer chunked LZ4 over whole-archive LZMA at runtime is the
same constraint from the other side.) Uncompressed keeps offset reads trivially
correct and leaves per-entry compression additive. id Tech's `.pk3` is a real zip
precedent, declined for a dependency tree and layout control — with the cost
taken knowingly, since a `.pak` can't be opened with 7-zip. Loose mode remains
the answer when a build misbehaves.

## Two readers, because there are two read paths

`PakAssetPlugin` registers the archive as bevy's **default** `AssetSource`, so
**no `AssetServer::load` call site changes** — no `pak://` prefix anywhere. That
works because `AssetSourceBuilders::init_default_source` is `get_or_insert_with`,
so a default registered *before* `AssetPlugin` survives it. It's a separate
plugin rather than a field because ~80 sites across 8 crates construct
`AssetPlugin`, nearly all tests with no opinion about packaging — and because a
plugin added on the line above makes the ordering requirement visible.

`pak_source` covers the three `std::fs` scene sites no `AssetReader` reaches
(entry scene, prefabs, runtime `loadScene`). Scenes deliberately did **not** move
onto `bevy_asset`: that would turn spawning async and shift the frame timing all
ten E2E recordings depend on.

## Two things running it corrected, both with unit tests fully green

- **`GltfSourceLoader` ignored its reader outright**, re-reading the path from
  disk — so nothing glTF could ever come from an archive. My survey concluded
  "bevy_asset content is covered by a custom reader" and never asked whether a
  *loader* might bypass it. Now a `.glb` decodes from the reader's bytes; a
  `.gltf` (which resolves sibling files through the filesystem) still uses the
  path, and the cook **refuses to pack one** rather than shipping a game that
  loses its meshes at run time, where a failed load is only a warning.
- **`archive_key` existed twice and one copy was wrong.** `pak_source` stripped
  only `./`, so every absolute project directory missed the archive and fell
  through to a disk read. Now one shared rule. Every unit fixture used `.` — the
  single project directory for which the broken rule and the correct one agree —
  so only the E2E could see it.

## Verification

- pak unit tests 16/16 (format, reader, shim, cook)
- E2E 3/3: loose, pak, and pak crossing into a second scene via `loadScene`
  (`tilt-run`, the only game that uses it)
- **Mutation-verified**: forcing `PakAssetReader::read` to `NotFound` fails the
  pak test while loose still passes. The `!assets.exists()` assertion is what
  makes that meaningful — with nothing on disk to fall back to, a passing replay
  can only mean the archive was read.
- all 10 projects × 2 modes = 20/20 package cleanly
- fmt clean; catalog unchanged at 70 components / 269 ops (this adds neither);
  clippy adds no warnings over the baseline
- workspace green, editor 937/937, **all 10 E2E replays pass** — this branch
  touched all three scene-read sites and the glTF loader, so that last one is
  the real evidence loose mode didn't regress

CI now packages every project in **both** modes: a project can cook cleanly and
still fail to pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)