### PR TITLE
Snapshot interpolation + interest management (item 56, 1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,45 @@ loses its meshes at run time. A `.glb` is self-contained and packs fine.
 
 ---
 
+## Networking
+
+```toml
+[network]
+aoi_radius = 50.0               # omit for no limit
+interpolation_delay_ticks = 3   # 0 renders the newest snapshot immediately
+simulated_latency_frames = 0    # testing only
+simulated_loss = 0.0            # testing only, 0.0..=1.0
+simulator_seed = 0              # fixed, so a run reproduces
+```
+
+Every default reproduces the engine's earlier behaviour, so a project that says
+nothing about networking behaves as it did.
+
+**`interpolation_delay_ticks` is a cost, not a free win.** Remote entities are
+rendered that many server ticks *in the past*, which is what buys smooth motion
+when packets arrive unevenly. Set it to `0` and a remote entity snaps to each
+snapshot as it lands — perfect on a perfect link, visibly stuttery on a real one.
+
+Past the newest snapshot it holds, and does not extrapolate. A remote entity
+whose updates stop **freezes** rather than gliding on along its last heading:
+that reads as the network problem it is, where a guess that overshoots would
+snap backwards when the truth arrived.
+
+**`aoi_radius` stops updates, it does not hide entities.** An entity outside a
+peer's radius stays wherever that peer last saw it. A peer with no entity of its
+own receives everything, since there is no position to measure interest from.
+
+The two `simulated_*` settings exist to test the two above, and are off by
+default. They are also the only way to observe either: on a perfect link an
+interpolated position and the newest snapshot agree on every frame.
+
+**Not implemented:** client-side prediction and server reconciliation. A client
+today is authoritative over its own entities and sends their transforms, so the
+server never disagrees with it about them. Making the server authoritative — per
+entity, opt-in — is the next step.
+
+---
+
 ## Project Status
 
 Active development. Infrastructure is stable; rendering and editor layers are the current focus.

--- a/crates/bsengine-network/Cargo.toml
+++ b/crates/bsengine-network/Cargo.toml
@@ -12,3 +12,12 @@ bevy_app       = { workspace = true }
 bevy_ecs       = { workspace = true }
 glam           = { workspace = true }
 tracing        = { workspace = true }
+
+[dev-dependencies]
+# The loopback tests build a real server App and a real client App in one
+# process, so they need the app and component crates the plugin only sees
+# through its own dependencies.
+bsengine-core = { workspace = true }
+bevy_app      = { workspace = true }
+bevy_ecs      = { workspace = true }
+glam          = { workspace = true }

--- a/crates/bsengine-network/src/config.rs
+++ b/crates/bsengine-network/src/config.rs
@@ -1,0 +1,81 @@
+//! Tunables for replication, read from `project.toml`'s `[network]` table.
+//!
+//! # Why these are settings and not constants
+//!
+//! Each one is also a measurement instrument. An AOI radius a test can shrink is
+//! what makes "the far entity stopped updating" checkable; an interpolation
+//! delay a test can pin is what makes "the position is exactly a quarter of the
+//! way between two snapshots" checkable; and a latency/loss simulator that can
+//! be switched on is the only reason the other two are observable at all — on a
+//! perfect link the interpolated position and the newest snapshot agree on every
+//! frame, so a completely broken interpolator passes.
+//!
+//! This is the same reasoning that made occlusion culling a `[render]` setting
+//! rather than an always-on behaviour: an off switch is also how you measure
+//! what the thing does.
+
+use bevy_ecs::prelude::Resource;
+
+/// Replication tunables.
+///
+/// Every default reproduces the engine's pre-item-56 behaviour exactly: no
+/// interest limit, no interpolation delay, no simulated latency or loss. A
+/// project that says nothing about networking therefore behaves as it did.
+#[derive(Resource, Debug, Clone, PartialEq)]
+pub struct NetworkConfig {
+    /// Radius around a peer's own entity within which the server sends it
+    /// updates.
+    ///
+    /// `None` sends everything — what the engine did before AOI existed, and
+    /// what a peer with no entity of its own gets, since there is no position to
+    /// measure from and silently sending nothing would look exactly like a
+    /// broken filter.
+    pub aoi_radius: Option<f32>,
+    /// How many server ticks behind the newest snapshot remote entities render.
+    ///
+    /// This is the cost of smoothness written as a number: remote entities are
+    /// displayed in the past. `0` renders the newest snapshot the moment it
+    /// lands, which is what the engine did before.
+    pub interpolation_delay_ticks: u32,
+    /// Frames to hold a packet before delivering it. `0` delivers immediately.
+    pub simulated_latency_frames: u32,
+    /// Fraction of packets to drop, clamped to `0.0..=1.0`.
+    pub simulated_loss: f32,
+    /// Seed for the drop sequence.
+    ///
+    /// Fixed rather than drawn from the clock **because tests depend on it**. An
+    /// unseeded simulator would make every test that uses it flaky, and a flaky
+    /// instrument is worse than none: it turns a real regression and an unlucky
+    /// roll into the same red.
+    pub simulator_seed: u64,
+}
+
+impl Default for NetworkConfig {
+    fn default() -> Self {
+        Self {
+            aoi_radius: None,
+            interpolation_delay_ticks: 0,
+            simulated_latency_frames: 0,
+            simulated_loss: 0.0,
+            simulator_seed: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property that lets an existing project upgrade without noticing.
+    #[test]
+    fn the_defaults_reproduce_pre_item_56_behaviour() {
+        let config = NetworkConfig::default();
+        assert_eq!(config.aoi_radius, None, "no interest limit");
+        assert_eq!(
+            config.interpolation_delay_ticks, 0,
+            "the newest snapshot renders immediately"
+        );
+        assert_eq!(config.simulated_latency_frames, 0);
+        assert_eq!(config.simulated_loss, 0.0, "the simulator is off");
+    }
+}

--- a/crates/bsengine-network/src/interpolation.rs
+++ b/crates/bsengine-network/src/interpolation.rs
@@ -1,0 +1,237 @@
+//! Rendering remote entities from a buffer of timestamped snapshots.
+//!
+//! # Why remote entities render in the past
+//!
+//! To interpolate between two snapshots you need both of them, which means
+//! waiting until the later one has arrived. Rendering one delay behind the
+//! newest is what turns unevenly-arriving packets into smooth motion — and it is
+//! a real cost, not a free win: remote entities are displayed slightly behind
+//! where the server says they are. `NetworkConfig::interpolation_delay_ticks` is
+//! that cost, written as a number somebody can choose.
+//!
+//! # Why it holds instead of extrapolating
+//!
+//! Past the newest snapshot this returns the newest one rather than continuing
+//! along the last known velocity. Extrapolation is a guess, and a guess that
+//! overshoots snaps visibly backwards when the truth arrives. Holding is also
+//! wrong, but it is wrong in a way that stays still — and a frozen remote entity
+//! reads as a network problem, which is what it is, rather than as the engine
+//! inventing motion that never happened.
+
+use std::collections::HashMap;
+
+use bevy_ecs::prelude::Resource;
+use bsengine_core::Transform;
+
+use crate::packet::TransformData;
+
+/// How many snapshots to keep per entity.
+///
+/// Enough to bracket a render time at any sane delay, and bounded so a session
+/// that runs for hours does not grow without limit.
+const BUFFER_LEN: usize = 32;
+
+/// Timestamped snapshots per network id, oldest first.
+#[derive(Resource, Default, Debug)]
+pub struct SnapshotBuffers {
+    buffers: HashMap<u64, Vec<(u32, TransformData)>>,
+}
+
+impl SnapshotBuffers {
+    /// Records a snapshot, dropping the oldest once the buffer is full.
+    pub fn push(&mut self, net_id: u64, tick: u32, data: TransformData) {
+        let buffer = self.buffers.entry(net_id).or_default();
+        buffer.push((tick, data));
+        // UDP can deliver out of order, so ordering is restored here rather than
+        // left for `sample` to re-derive on every entity on every frame.
+        buffer.sort_by_key(|(tick, _)| *tick);
+        if buffer.len() > BUFFER_LEN {
+            buffer.remove(0);
+        }
+    }
+
+    /// This entity's snapshots, oldest first.
+    pub fn get(&self, net_id: u64) -> Option<&[(u32, TransformData)]> {
+        self.buffers.get(&net_id).map(Vec::as_slice)
+    }
+
+    /// The newest tick recorded for any entity — what a client's render clock
+    /// follows.
+    pub fn newest_tick(&self) -> Option<u32> {
+        self.buffers
+            .values()
+            .filter_map(|buffer| buffer.last().map(|(tick, _)| *tick))
+            .max()
+    }
+
+    /// How many entities have snapshots.
+    pub fn len(&self) -> usize {
+        self.buffers.len()
+    }
+
+    /// Whether nothing has been recorded yet.
+    pub fn is_empty(&self) -> bool {
+        self.buffers.is_empty()
+    }
+}
+
+/// The transform to display at `render_tick`.
+///
+/// Returns `None` only for an empty buffer. Before the oldest snapshot it
+/// returns the oldest; past the newest it **holds** the newest — see the module
+/// docs for why that is deliberate rather than a missing feature.
+pub fn sample(buffer: &[(u32, TransformData)], render_tick: f32) -> Option<Transform> {
+    let first = buffer.first()?;
+    let last = buffer.last()?;
+
+    if render_tick <= first.0 as f32 {
+        return Some(first.1.to_transform());
+    }
+    if render_tick >= last.0 as f32 {
+        return Some(last.1.to_transform());
+    }
+
+    let pair = buffer
+        .windows(2)
+        .find(|w| render_tick >= w[0].0 as f32 && render_tick <= w[1].0 as f32)?;
+    let (a_tick, a) = (pair[0].0 as f32, pair[0].1);
+    let (b_tick, b) = (pair[1].0 as f32, pair[1].1);
+
+    // Guarded because two snapshots can share a tick if the server sent twice in
+    // one frame. Dividing by that span would put a NaN into every skinned vertex
+    // of the entity, which presents nowhere near this function.
+    let span = b_tick - a_tick;
+    let t = if span > 0.0 {
+        ((render_tick - a_tick) / span).clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+
+    let (a, b) = (a.to_transform(), b.to_transform());
+    Some(Transform {
+        position: a.position.0.lerp(b.position.0, t).into(),
+        rotation: a.rotation.0.slerp(b.rotation.0, t).into(),
+        scale: a.scale.0.lerp(b.scale.0, t).into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    fn at(x: f32) -> TransformData {
+        let mut t = Transform::default();
+        t.position = Vec3::new(x, 0.0, 0.0).into();
+        TransformData::from_transform(&t)
+    }
+
+    fn buffer() -> Vec<(u32, TransformData)> {
+        vec![(10u32, at(0.0)), (20u32, at(100.0))]
+    }
+
+    /// The headline behaviour, asserted as an exact fraction of a real distance.
+    ///
+    /// Deliberately not "strictly between the two", which item 52 learned the
+    /// hard way is satisfied by ~2e-12 of numerical noise — an implementation
+    /// that did no blending at all passed that shape of assertion.
+    #[test]
+    fn a_render_time_between_two_snapshots_is_that_fraction_of_the_way() {
+        let sampled = sample(&buffer(), 12.5).expect("in range");
+
+        assert!(
+            (sampled.position.0.x - 25.0).abs() < 0.01,
+            "a quarter of the way from tick 10 to tick 20 is x=25, got {}",
+            sampled.position.0.x
+        );
+    }
+
+    /// The endpoints, which pin that the fraction is measured from the right
+    /// end: an implementation blending backwards passes the midpoint but not
+    /// these.
+    #[test]
+    fn a_render_time_on_a_snapshot_is_that_snapshot() {
+        assert!((sample(&buffer(), 10.0).expect("in range").position.0.x - 0.0).abs() < 0.01);
+        assert!((sample(&buffer(), 20.0).expect("in range").position.0.x - 100.0).abs() < 0.01);
+    }
+
+    /// Asserted as equality with the last known value rather than "close to it":
+    /// a short extrapolation would also be close, and the difference between
+    /// holding and extrapolating is the whole decision.
+    #[test]
+    fn past_the_newest_snapshot_it_holds_rather_than_extrapolating() {
+        let held = sample(&buffer(), 40.0).expect("holds");
+
+        assert!(
+            (held.position.0.x - 100.0).abs() < 1e-6,
+            "must equal the newest snapshot, not continue past it; got {}",
+            held.position.0.x
+        );
+    }
+
+    /// Before the oldest, the oldest — a client that has just connected has a
+    /// render clock behind everything it holds, and must show something rather
+    /// than nothing.
+    #[test]
+    fn before_the_oldest_snapshot_it_shows_the_oldest() {
+        assert!((sample(&buffer(), 1.0).expect("holds").position.0.x - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn an_empty_buffer_samples_to_nothing() {
+        assert!(sample(&[], 5.0).is_none());
+    }
+
+    /// Two snapshots on the same tick must not divide by zero. A NaN here
+    /// reaches every vertex of the entity and presents nowhere near this code.
+    #[test]
+    fn two_snapshots_on_one_tick_do_not_produce_a_nan() {
+        let same = vec![(10u32, at(0.0)), (10u32, at(50.0))];
+        let sampled = sample(&same, 10.0).expect("in range");
+        assert!(sampled.position.0.x.is_finite());
+    }
+
+    /// Out-of-order arrival is normal over UDP; the buffer sorts so `sample`
+    /// can assume order. Without this an older snapshot arriving late would sit
+    /// at the end and be treated as the newest.
+    #[test]
+    fn a_late_snapshot_is_ordered_by_tick_not_by_arrival() {
+        let mut buffers = SnapshotBuffers::default();
+        buffers.push(1, 20, at(100.0));
+        buffers.push(1, 10, at(0.0));
+
+        let stored = buffers.get(1).expect("buffered");
+        assert_eq!(
+            stored.iter().map(|(tick, _)| *tick).collect::<Vec<_>>(),
+            vec![10, 20],
+            "ordered by tick, not by when it turned up"
+        );
+        assert!((sample(stored, 12.5).expect("in range").position.0.x - 25.0).abs() < 0.01);
+    }
+
+    /// The buffer is bounded, and keeps the *newest* — dropping the newest
+    /// would make a long session render further and further behind.
+    #[test]
+    fn a_full_buffer_drops_the_oldest_and_keeps_the_newest() {
+        let mut buffers = SnapshotBuffers::default();
+        for tick in 0..(BUFFER_LEN as u32 + 10) {
+            buffers.push(1, tick, at(tick as f32));
+        }
+
+        let stored = buffers.get(1).expect("buffered");
+        assert_eq!(stored.len(), BUFFER_LEN);
+        assert_eq!(
+            stored.last().expect("newest").0,
+            BUFFER_LEN as u32 + 9,
+            "the newest snapshot must survive"
+        );
+    }
+
+    #[test]
+    fn the_newest_tick_is_the_max_across_entities() {
+        let mut buffers = SnapshotBuffers::default();
+        buffers.push(1, 5, at(0.0));
+        buffers.push(2, 9, at(0.0));
+        assert_eq!(buffers.newest_tick(), Some(9));
+    }
+}

--- a/crates/bsengine-network/src/interpolation.rs
+++ b/crates/bsengine-network/src/interpolation.rs
@@ -121,9 +121,10 @@ mod tests {
     use glam::Vec3;
 
     fn at(x: f32) -> TransformData {
-        let mut t = Transform::default();
-        t.position = Vec3::new(x, 0.0, 0.0).into();
-        TransformData::from_transform(&t)
+        TransformData::from_transform(&Transform {
+            position: Vec3::new(x, 0.0, 0.0).into(),
+            ..Default::default()
+        })
     }
 
     fn buffer() -> Vec<(u32, TransformData)> {

--- a/crates/bsengine-network/src/lib.rs
+++ b/crates/bsengine-network/src/lib.rs
@@ -4,11 +4,32 @@
 //! (host/client), and the (private) `packet` module defines the
 //! `TransformData` wire format used to replicate entity transforms across
 //! the network.
+//!
+//! # Who is authoritative today
+//!
+//! A client simulates its own entities and sends their transforms; the server
+//! relays them. That is **client-authoritative**, and it is why there is no
+//! reconciliation here: the server never disagrees with a client about a client's
+//! own entity, so there is nothing to reconcile. Server-authoritative simulation
+//! with client-side prediction is item 56's second sub-step, and it is an opt-in
+//! per entity rather than a replacement, so this model keeps working.
+//!
+//! What this half adds is everything on the server→client path: a tick on the
+//! wire, snapshot interpolation so remote entities move smoothly when packets
+//! arrive unevenly, distance-based interest management, and a deterministic
+//! latency/loss simulator — which is less a feature than the instrument that
+//! makes the other two observable at all.
 #![warn(missing_docs)]
 
+mod config;
+mod interpolation;
 mod packet;
 mod plugin;
 mod session;
+mod sim;
 
-pub use plugin::NetworkPlugin;
+pub use config::NetworkConfig;
+pub use interpolation::{sample, SnapshotBuffers};
+pub use plugin::{NetworkPlugin, ServerTick};
 pub use session::{NetworkRole, NetworkSession};
+pub use sim::{DelayQueue, LinkSimulator};

--- a/crates/bsengine-network/src/packet.rs
+++ b/crates/bsengine-network/src/packet.rs
@@ -8,7 +8,7 @@ pub const MSG_CLIENT_TRANSFORM: u8 = 0x04;
 pub const MSG_DISCONNECT: u8 = 0x05;
 
 /// 40-byte transform snapshot sent over the wire.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TransformData {
     pub px: f32,
     pub py: f32,
@@ -93,15 +93,34 @@ pub fn encode_disconnect() -> [u8; 1] {
     [MSG_DISCONNECT]
 }
 
-/// Encode a batch of (net_id, transform) pairs. Returns None if empty.
-pub fn encode_transform_batch(entries: &[(u64, TransformData)]) -> Option<Vec<u8>> {
+/// Bytes before the first entry in a [`MSG_TRANSFORM_BATCH`]: the tag, the entry
+/// count, and the server tick the snapshot was taken on.
+pub const BATCH_HEADER_LEN: usize = 1 + 1 + 4;
+
+/// The server simulation frame a batch was taken on, or `None` if the packet is
+/// too short to hold one.
+///
+/// A tick rather than a wall-clock timestamp: two peers' clocks are unrelated,
+/// and this engine already advances on a fixed timestep, so a tick means the
+/// same thing in both processes and a test can state it exactly. Synchronising
+/// clocks instead would be its own project.
+pub fn decode_batch_tick(packet: &[u8]) -> Option<u32> {
+    packet
+        .get(2..6)
+        .map(|b| u32::from_le_bytes(b.try_into().expect("4 bytes")))
+}
+
+/// Encode a batch of (net_id, transform) pairs taken on server tick `tick`.
+/// Returns None if empty.
+pub fn encode_transform_batch(tick: u32, entries: &[(u64, TransformData)]) -> Option<Vec<u8>> {
     if entries.is_empty() {
         return None;
     }
     let count = entries.len().min(255) as u8;
-    let mut pkt = Vec::with_capacity(2 + count as usize * 48);
+    let mut pkt = Vec::with_capacity(BATCH_HEADER_LEN + count as usize * 48);
     pkt.push(MSG_TRANSFORM_BATCH);
     pkt.push(count);
+    pkt.extend_from_slice(&tick.to_le_bytes());
     for (net_id, td) in &entries[..count as usize] {
         pkt.extend_from_slice(&net_id.to_le_bytes());
         pkt.extend_from_slice(&td.to_bytes());
@@ -146,17 +165,34 @@ mod tests {
 
     #[test]
     fn transform_batch_empty_returns_none() {
-        assert!(encode_transform_batch(&[]).is_none());
+        assert!(encode_transform_batch(0, &[]).is_none());
+    }
+
+    /// Without a tick a snapshot cannot be placed on a timeline at all, so
+    /// interpolation is impossible before this exists.
+    #[test]
+    fn transform_batch_carries_the_server_tick() {
+        let td = TransformData::from_transform(&Transform::default());
+        let pkt = encode_transform_batch(7, &[(1u64, td)]).expect("batch");
+
+        assert_eq!(pkt[0], MSG_TRANSFORM_BATCH);
+        assert_eq!(decode_batch_tick(&pkt), Some(7));
+        assert_eq!(pkt.len(), BATCH_HEADER_LEN + 48);
+    }
+
+    #[test]
+    fn a_truncated_batch_yields_no_tick_rather_than_a_wrong_one() {
+        assert_eq!(decode_batch_tick(&[MSG_TRANSFORM_BATCH, 1]), None);
     }
 
     #[test]
     fn transform_batch_roundtrip_count() {
         let td = TransformData::from_transform(&Transform::default());
         let entries = vec![(1u64, td), (2u64, td)];
-        let pkt = encode_transform_batch(&entries).unwrap();
+        let pkt = encode_transform_batch(0, &entries).unwrap();
         assert_eq!(pkt[0], MSG_TRANSFORM_BATCH);
         assert_eq!(pkt[1], 2);
-        assert_eq!(pkt.len(), 2 + 2 * 48);
+        assert_eq!(pkt.len(), BATCH_HEADER_LEN + 2 * 48);
     }
 
     #[test]

--- a/crates/bsengine-network/src/plugin.rs
+++ b/crates/bsengine-network/src/plugin.rs
@@ -5,13 +5,13 @@ use bsengine_core::{NetworkAuthority, NetworkId, Transform};
 use crate::{
     config::NetworkConfig,
     interpolation::{sample, SnapshotBuffers},
-    sim::LinkSimulator,
     packet::{
         decode_batch_tick, encode_client_transform, encode_transform_batch, TransformData,
         BATCH_HEADER_LEN, MSG_CLIENT_TRANSFORM, MSG_DISCONNECT, MSG_HELLO, MSG_HELLO_ACK,
         MSG_TRANSFORM_BATCH,
     },
     session::{NetworkRole, NetworkSession},
+    sim::LinkSimulator,
 };
 
 /// Bevy plugin that wires up the UDP send/receive systems for entity transform replication.
@@ -118,7 +118,9 @@ fn network_receive_system(world: &mut World) {
                     let td = TransformData::from_bytes(&data[offset + 8..offset + 48]);
                     offset += 48;
 
-                    world.resource_mut::<SnapshotBuffers>().push(net_id, tick, td);
+                    world
+                        .resource_mut::<SnapshotBuffers>()
+                        .push(net_id, tick, td);
                 }
             }
             MSG_CLIENT_TRANSFORM => {
@@ -300,11 +302,16 @@ fn network_send_system(world: &mut World) {
         server_tick.0
     };
 
-    let (radius, loss, seed) = world
-        .get_resource::<NetworkConfig>()
-        .map_or((None, 0.0, 0), |config| {
-            (config.aoi_radius, config.simulated_loss, config.simulator_seed)
-        });
+    let (radius, loss, seed) =
+        world
+            .get_resource::<NetworkConfig>()
+            .map_or((None, 0.0, 0), |config| {
+                (
+                    config.aoi_radius,
+                    config.simulated_loss,
+                    config.simulator_seed,
+                )
+            });
 
     // Decided up front, one roll per peer this frame, because the borrow of
     // `session` below is immutable and holds for the rest of the function.
@@ -412,10 +419,6 @@ mod tests {
     /// also what a peer with no entity of its own gets.
     #[test]
     fn no_radius_sends_everything() {
-        assert!(within_interest(
-            Vec3::ZERO,
-            Vec3::new(1e6, 0.0, 0.0),
-            None
-        ));
+        assert!(within_interest(Vec3::ZERO, Vec3::new(1e6, 0.0, 0.0), None));
     }
 }

--- a/crates/bsengine-network/src/plugin.rs
+++ b/crates/bsengine-network/src/plugin.rs
@@ -4,8 +4,9 @@ use bsengine_core::{NetworkAuthority, NetworkId, Transform};
 
 use crate::{
     packet::{
-        encode_client_transform, encode_transform_batch, TransformData, MSG_CLIENT_TRANSFORM,
-        MSG_DISCONNECT, MSG_HELLO, MSG_HELLO_ACK, MSG_TRANSFORM_BATCH,
+        decode_batch_tick, encode_client_transform, encode_transform_batch, TransformData,
+        BATCH_HEADER_LEN, MSG_CLIENT_TRANSFORM, MSG_DISCONNECT, MSG_HELLO, MSG_HELLO_ACK,
+        MSG_TRANSFORM_BATCH,
     },
     session::{NetworkRole, NetworkSession},
 };
@@ -13,8 +14,18 @@ use crate::{
 /// Bevy plugin that wires up the UDP send/receive systems for entity transform replication.
 pub struct NetworkPlugin;
 
+/// The server's simulation frame counter, stamped into every batch it sends.
+///
+/// Counts sends rather than reading a clock, so the number a client receives and
+/// the number a test expects are the same one. Wraps rather than saturating: a
+/// `u32` of 60Hz frames is over two years, and a counter that stopped moving
+/// would silently freeze every client's interpolation.
+#[derive(bevy_ecs::prelude::Resource, Default, Debug)]
+pub struct ServerTick(pub u32);
+
 impl Plugin for NetworkPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<ServerTick>();
         app.add_systems(Update, network_receive_system);
         app.add_systems(Update, network_send_system.after(network_receive_system));
     }
@@ -73,11 +84,11 @@ fn network_receive_system(world: &mut World) {
             }
             MSG_TRANSFORM_BATCH => {
                 // Client: apply server-broadcast transform snapshot.
-                if data.len() < 2 {
+                let Some(_tick) = decode_batch_tick(&data) else {
                     continue;
-                }
+                };
                 let count = data[1] as usize;
-                let mut offset = 2;
+                let mut offset = BATCH_HEADER_LEN;
                 for _ in 0..count {
                     if offset + 48 > data.len() {
                         break;
@@ -142,6 +153,14 @@ fn network_send_system(world: &mut World) {
             .collect()
     };
 
+    // Bumped before the session borrow: `session` is held immutably for the
+    // rest of this function, so the resource cannot be taken mutably later.
+    let tick = {
+        let mut server_tick = world.resource_mut::<ServerTick>();
+        server_tick.0 = server_tick.0.wrapping_add(1);
+        server_tick.0
+    };
+
     let Some(session) = world.get_resource::<NetworkSession>() else {
         return;
     };
@@ -155,7 +174,7 @@ fn network_send_system(world: &mut World) {
                 .iter()
                 .map(|(id, _, t)| (*id, TransformData::from_transform(t)))
                 .collect();
-            if let Some(pkt) = encode_transform_batch(&batch) {
+            if let Some(pkt) = encode_transform_batch(tick, &batch) {
                 for peer in &session.peers {
                     let _ = session.socket.send_to(&pkt, peer);
                 }

--- a/crates/bsengine-network/src/plugin.rs
+++ b/crates/bsengine-network/src/plugin.rs
@@ -3,6 +3,9 @@ use bevy_ecs::prelude::*;
 use bsengine_core::{NetworkAuthority, NetworkId, Transform};
 
 use crate::{
+    config::NetworkConfig,
+    interpolation::{sample, SnapshotBuffers},
+    sim::LinkSimulator,
     packet::{
         decode_batch_tick, encode_client_transform, encode_transform_batch, TransformData,
         BATCH_HEADER_LEN, MSG_CLIENT_TRANSFORM, MSG_DISCONNECT, MSG_HELLO, MSG_HELLO_ACK,
@@ -26,7 +29,20 @@ pub struct ServerTick(pub u32);
 impl Plugin for NetworkPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ServerTick>();
+        app.init_resource::<RenderTick>();
+        app.init_resource::<SnapshotBuffers>();
+        app.init_resource::<NetworkConfig>();
+        app.init_resource::<SimulatedLink>();
         app.add_systems(Update, network_receive_system);
+        // Between receive and send: it consumes what receive buffered, and a
+        // client's own send must not read a transform this just wrote for a
+        // remote entity.
+        app.add_systems(
+            Update,
+            interpolate_remote_entities
+                .after(network_receive_system)
+                .before(network_send_system),
+        );
         app.add_systems(Update, network_send_system.after(network_receive_system));
     }
 }
@@ -83,8 +99,12 @@ fn network_receive_system(world: &mut World) {
                 }
             }
             MSG_TRANSFORM_BATCH => {
-                // Client: apply server-broadcast transform snapshot.
-                let Some(_tick) = decode_batch_tick(&data) else {
+                // Client: record a server-broadcast snapshot. Deliberately not
+                // applied here -- `interpolate_remote_entities` decides what an
+                // entity renders at, one delay behind, which is what turns a gap
+                // between packets into smooth motion instead of a freeze and a
+                // jump.
+                let Some(tick) = decode_batch_tick(&data) else {
                     continue;
                 };
                 let count = data[1] as usize;
@@ -98,17 +118,7 @@ fn network_receive_system(world: &mut World) {
                     let td = TransformData::from_bytes(&data[offset + 8..offset + 48]);
                     offset += 48;
 
-                    let entity = {
-                        let mut q = world.query::<(Entity, &NetworkId)>();
-                        q.iter(world)
-                            .find(|(_, nid)| nid.id == net_id)
-                            .map(|(e, _)| e)
-                    };
-                    if let Some(e) = entity {
-                        if let Some(mut t) = world.get_mut::<Transform>(e) {
-                            *t = td.to_transform();
-                        }
-                    }
+                    world.resource_mut::<SnapshotBuffers>().push(net_id, tick, td);
                 }
             }
             MSG_CLIENT_TRANSFORM => {
@@ -142,6 +152,135 @@ fn network_receive_system(world: &mut World) {
     }
 }
 
+/// The simulated link this process sends through.
+///
+/// Held as a resource rather than rebuilt per frame because its whole value is
+/// its *sequence*: a simulator reconstructed each frame would restart from its
+/// seed and deliver the same decision every time, which is a constant link
+/// wearing a simulator's name.
+#[derive(Resource)]
+pub struct SimulatedLink {
+    simulator: LinkSimulator,
+    /// What the config was when this was built, so a changed setting rebuilds it.
+    built_for: (f32, u64),
+}
+
+impl SimulatedLink {
+    /// Whether the next packet gets through, rebuilding if the config changed.
+    fn should_deliver(&mut self, loss: f32, seed: u64) -> bool {
+        if self.built_for != (loss, seed) {
+            self.simulator = LinkSimulator::new(loss, seed);
+            self.built_for = (loss, seed);
+        }
+        self.simulator.should_deliver()
+    }
+}
+
+impl Default for SimulatedLink {
+    fn default() -> Self {
+        Self {
+            simulator: LinkSimulator::new(0.0, 0),
+            built_for: (0.0, 0),
+        }
+    }
+}
+
+/// Whether `subject` is close enough to `observer` to be worth sending.
+///
+/// `None` means no limit — what the engine did before interest management
+/// existed, and what a peer with no entity of its own gets, since there is no
+/// position to measure from.
+fn within_interest(observer: glam::Vec3, subject: glam::Vec3, radius: Option<f32>) -> bool {
+    match radius {
+        // Squared, to avoid a square root per entity per peer per frame.
+        Some(r) => observer.distance_squared(subject) <= r * r,
+        None => true,
+    }
+}
+
+/// The client's own clock, in server ticks, deliberately behind the newest
+/// snapshot it holds.
+///
+/// A float because it advances one tick per rendered frame and must be able to
+/// sit *between* two snapshots — that in-between value is the whole of what
+/// interpolation renders.
+#[derive(Resource, Default, Debug)]
+pub struct RenderTick(pub f32);
+
+/// Writes each remote entity's `Transform` from its snapshot buffer.
+///
+/// # The clock
+///
+/// The render tick advances one per frame on its own, so an entity keeps moving
+/// on frames where no packet arrived — which is the entire difference between
+/// interpolation and just applying whatever turned up. It is bounded on both
+/// sides: never past the newest snapshot held (there is no data there, and
+/// letting the clock run away during an outage would make the eventual resync a
+/// large visible jump), and never further behind than the configured delay
+/// (which is how it catches up after one).
+///
+/// # What it does not touch
+///
+/// Entities this peer is authoritative over. Their transforms come from local
+/// simulation, and overwriting them with buffered server state is exactly the
+/// fight that client-side prediction exists to arbitrate — which is sub-step
+/// 2/2, not this one.
+fn interpolate_remote_entities(world: &mut World) {
+    let Some(session) = world.get_resource::<NetworkSession>() else {
+        return;
+    };
+    // The server holds the authoritative state locally; there is nothing to
+    // interpolate towards.
+    if matches!(session.role, NetworkRole::Server) {
+        return;
+    }
+    let my_peer_id = session.my_peer_id;
+
+    let delay = world
+        .get_resource::<NetworkConfig>()
+        .map_or(0, |c| c.interpolation_delay_ticks) as f32;
+
+    let Some(newest) = world.resource::<SnapshotBuffers>().newest_tick() else {
+        return;
+    };
+    let newest = newest as f32;
+
+    let render_tick = {
+        let mut clock = world.resource_mut::<RenderTick>();
+        clock.0 += 1.0;
+        if clock.0 > newest {
+            clock.0 = newest;
+        }
+        if clock.0 < newest - delay {
+            clock.0 = newest - delay;
+        }
+        clock.0
+    };
+
+    let remote: Vec<(Entity, u64)> = {
+        let mut q = world.query::<(Entity, &NetworkId)>();
+        q.iter(world)
+            .filter(|(_, nid)| nid.is_replicated())
+            .filter(|(_, nid)| {
+                !matches!(nid.authority, NetworkAuthority::Client { peer_id } if peer_id == my_peer_id)
+            })
+            .map(|(entity, nid)| (entity, nid.id))
+            .collect()
+    };
+
+    for (entity, net_id) in remote {
+        let sampled = world
+            .resource::<SnapshotBuffers>()
+            .get(net_id)
+            .and_then(|buffer| sample(buffer, render_tick));
+        if let Some(transform) = sampled {
+            if let Some(mut t) = world.get_mut::<Transform>(entity) {
+                *t = transform;
+            }
+        }
+    }
+}
+
 /// Broadcast/send transforms based on role.
 fn network_send_system(world: &mut World) {
     // Collect entity data first (releases all world borrows before touching session).
@@ -161,6 +300,24 @@ fn network_send_system(world: &mut World) {
         server_tick.0
     };
 
+    let (radius, loss, seed) = world
+        .get_resource::<NetworkConfig>()
+        .map_or((None, 0.0, 0), |config| {
+            (config.aoi_radius, config.simulated_loss, config.simulator_seed)
+        });
+
+    // Decided up front, one roll per peer this frame, because the borrow of
+    // `session` below is immutable and holds for the rest of the function.
+    let peer_count = world
+        .get_resource::<NetworkSession>()
+        .map_or(0, |s| s.peers.len());
+    let deliver: Vec<bool> = {
+        let mut link = world.resource_mut::<SimulatedLink>();
+        (0..peer_count.max(1))
+            .map(|_| link.should_deliver(loss, seed))
+            .collect()
+    };
+
     let Some(session) = world.get_resource::<NetworkSession>() else {
         return;
     };
@@ -170,13 +327,39 @@ fn network_send_system(world: &mut World) {
             if session.peers.is_empty() {
                 return;
             }
-            let batch: Vec<(u64, TransformData)> = entities
-                .iter()
-                .map(|(id, _, t)| (*id, TransformData::from_transform(t)))
-                .collect();
-            if let Some(pkt) = encode_transform_batch(tick, &batch) {
-                for peer in &session.peers {
-                    let _ = session.socket.send_to(&pkt, peer);
+            // One batch per peer rather than one broadcast, because interest is
+            // measured from each peer's own position. With no radius configured
+            // every peer's batch is the same one the engine always sent.
+            for (index, peer) in session.peers.iter().enumerate() {
+                // Peers are assigned ids from 1 in connection order, which is
+                // the order they were pushed here.
+                let peer_id = index as u64 + 1;
+                let observer = entities
+                    .iter()
+                    .find(|(_, authority, _)| {
+                        matches!(authority, NetworkAuthority::Client { peer_id: owner } if *owner == peer_id)
+                    })
+                    .map(|(_, _, t)| t.position.0);
+
+                let batch: Vec<(u64, TransformData)> = entities
+                    .iter()
+                    .filter(|(_, _, t)| match observer {
+                        Some(from) => within_interest(from, t.position.0, radius),
+                        // No entity of its own means no position to measure
+                        // from. Sending everything is the honest answer;
+                        // sending nothing would look exactly like a broken
+                        // filter.
+                        None => true,
+                    })
+                    .map(|(id, _, t)| (*id, TransformData::from_transform(t)))
+                    .collect();
+
+                // Dropped here rather than at the receiver so the packet never
+                // exists, which is what a lossy link actually does.
+                if deliver.get(index).copied().unwrap_or(true) {
+                    if let Some(pkt) = encode_transform_batch(tick, &batch) {
+                        let _ = session.socket.send_to(&pkt, peer);
+                    }
                 }
             }
         }
@@ -190,5 +373,49 @@ fn network_send_system(world: &mut World) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    /// Both halves, because an interest filter that sends nothing passes the
+    /// first assertion and one that sends everything passes the second.
+    #[test]
+    fn interest_keeps_the_near_entity_and_drops_the_far_one() {
+        let observer = Vec3::ZERO;
+
+        assert!(
+            within_interest(observer, Vec3::new(5.0, 0.0, 0.0), Some(50.0)),
+            "an entity inside the radius must be sent"
+        );
+        assert!(
+            !within_interest(observer, Vec3::new(500.0, 0.0, 0.0), Some(50.0)),
+            "an entity outside it must not be"
+        );
+    }
+
+    /// Exactly on the boundary counts as inside. Stated so the edge is a
+    /// decision rather than whatever the comparison happened to do.
+    #[test]
+    fn an_entity_exactly_on_the_radius_is_included() {
+        assert!(within_interest(
+            Vec3::ZERO,
+            Vec3::new(50.0, 0.0, 0.0),
+            Some(50.0)
+        ));
+    }
+
+    /// No radius is the pre-AOI behaviour and must stay reachable, since it is
+    /// also what a peer with no entity of its own gets.
+    #[test]
+    fn no_radius_sends_everything() {
+        assert!(within_interest(
+            Vec3::ZERO,
+            Vec3::new(1e6, 0.0, 0.0),
+            None
+        ));
     }
 }

--- a/crates/bsengine-network/src/sim.rs
+++ b/crates/bsengine-network/src/sim.rs
@@ -154,11 +154,7 @@ mod tests {
         queue.advance();
         assert!(queue.due().is_empty(), "not one frame later");
         queue.advance();
-        assert_eq!(
-            queue.due(),
-            vec![b"hello".to_vec()],
-            "on the second frame"
-        );
+        assert_eq!(queue.due(), vec![b"hello".to_vec()], "on the second frame");
         assert!(queue.is_empty(), "and it is not delivered twice");
     }
 

--- a/crates/bsengine-network/src/sim.rs
+++ b/crates/bsengine-network/src/sim.rs
@@ -1,0 +1,183 @@
+//! A deterministic stand-in for a bad network link.
+//!
+//! # Why this is an instrument, not a feature
+//!
+//! On a perfect link the interpolated position and the newest received snapshot
+//! agree on every frame, so a completely broken interpolator passes any test run
+//! without this. The same goes for loss handling: with nothing dropped there is
+//! nothing to handle. This module is what makes the rest of item 56 observable,
+//! which is why it is built before the things it measures.
+//!
+//! # Why the randomness is seeded
+//!
+//! Because the tests depend on it. An unseeded simulator would make every one of
+//! them flaky, and a flaky instrument is worse than no instrument: it turns a
+//! real regression and an unlucky roll into the same red, and the usual response
+//! to that is to stop believing the test.
+
+/// Decides which packets a simulated link delivers.
+///
+/// Reproducible from its seed: the same seed drops the same packets in the same
+/// order, every run, on every machine.
+pub struct LinkSimulator {
+    loss: f32,
+    state: u64,
+}
+
+impl LinkSimulator {
+    /// Drops `loss` of packets (clamped to `0.0..=1.0`), reproducibly from
+    /// `seed`.
+    pub fn new(loss: f32, seed: u64) -> Self {
+        Self {
+            loss: loss.clamp(0.0, 1.0),
+            // Mixed with a non-zero constant because a xorshift seeded with zero
+            // stays zero forever — the default seed would otherwise produce a
+            // constant sequence and quietly drop everything or nothing.
+            state: seed ^ 0x9E37_79B9_7F4A_7C15,
+        }
+    }
+
+    /// Whether the next packet gets through.
+    pub fn should_deliver(&mut self) -> bool {
+        // xorshift64*, written out rather than pulled in as a dependency: this
+        // needs to be reproducible, not statistically excellent.
+        self.state ^= self.state >> 12;
+        self.state ^= self.state << 25;
+        self.state ^= self.state >> 27;
+        let roll =
+            (self.state.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 11) as f32 / (1u64 << 53) as f32;
+        roll >= self.loss
+    }
+}
+
+/// Packets held back so they arrive on a later frame.
+#[derive(Default)]
+pub struct DelayQueue {
+    /// `(frames remaining, bytes)`.
+    pending: Vec<(u32, Vec<u8>)>,
+}
+
+impl DelayQueue {
+    /// Holds `packet` for `frames` before it becomes due.
+    pub fn push(&mut self, packet: Vec<u8>, frames: u32) {
+        self.pending.push((frames, packet));
+    }
+
+    /// Counts one frame down for everything held.
+    pub fn advance(&mut self) {
+        for (remaining, _) in &mut self.pending {
+            *remaining = remaining.saturating_sub(1);
+        }
+    }
+
+    /// Takes everything whose time has come, leaving the rest waiting.
+    pub fn due(&mut self) -> Vec<Vec<u8>> {
+        let (ready, waiting): (Vec<_>, Vec<_>) = std::mem::take(&mut self.pending)
+            .into_iter()
+            .partition(|(remaining, _)| *remaining == 0);
+        self.pending = waiting;
+        ready.into_iter().map(|(_, packet)| packet).collect()
+    }
+
+    /// How many packets are still held.
+    pub fn len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Whether nothing is held.
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property every test below depends on, so it is asserted first.
+    #[test]
+    fn the_same_seed_drops_the_same_packets() {
+        let run = || {
+            let mut sim = LinkSimulator::new(0.5, 7);
+            (0..20).map(|_| sim.should_deliver()).collect::<Vec<_>>()
+        };
+        assert_eq!(run(), run());
+    }
+
+    /// Paired with the above, and not redundant: a *constant* sequence is also
+    /// perfectly reproducible, and would drop everything or nothing while
+    /// passing the determinism test.
+    #[test]
+    fn half_loss_drops_roughly_half() {
+        let mut sim = LinkSimulator::new(0.5, 7);
+        let delivered = (0..1000).filter(|_| sim.should_deliver()).count();
+        assert!(
+            (400..=600).contains(&delivered),
+            "expected roughly half of 1000 delivered, got {delivered}"
+        );
+    }
+
+    /// The two ends, because a simulator that ignored `loss` entirely would pass
+    /// both tests above.
+    #[test]
+    fn zero_loss_delivers_everything_and_full_loss_delivers_nothing() {
+        let mut none = LinkSimulator::new(0.0, 7);
+        assert!(
+            (0..50).all(|_| none.should_deliver()),
+            "0.0 loss must deliver every packet"
+        );
+        let mut all = LinkSimulator::new(1.0, 7);
+        assert!(
+            (0..50).all(|_| !all.should_deliver()),
+            "1.0 loss must deliver none"
+        );
+    }
+
+    /// A different seed is a different sequence — otherwise the seed is decoration
+    /// and every "run it under a different link" test measures the same link.
+    #[test]
+    fn a_different_seed_is_a_different_sequence() {
+        let run = |seed| {
+            let mut sim = LinkSimulator::new(0.5, seed);
+            (0..40).map(|_| sim.should_deliver()).collect::<Vec<_>>()
+        };
+        assert_ne!(run(7), run(8));
+    }
+
+    /// Exactly N frames: not before, and not never.
+    #[test]
+    fn a_delayed_packet_arrives_after_exactly_that_many_frames() {
+        let mut queue = DelayQueue::default();
+        queue.push(b"hello".to_vec(), 2);
+
+        assert!(queue.due().is_empty(), "not on the frame it was sent");
+        queue.advance();
+        assert!(queue.due().is_empty(), "not one frame later");
+        queue.advance();
+        assert_eq!(
+            queue.due(),
+            vec![b"hello".to_vec()],
+            "on the second frame"
+        );
+        assert!(queue.is_empty(), "and it is not delivered twice");
+    }
+
+    /// Zero delay is immediate, which is what an unconfigured session gets.
+    #[test]
+    fn a_packet_held_for_no_frames_is_due_at_once() {
+        let mut queue = DelayQueue::default();
+        queue.push(b"now".to_vec(), 0);
+        assert_eq!(queue.due(), vec![b"now".to_vec()]);
+    }
+
+    /// Ordering is preserved among packets due on the same frame, so a test can
+    /// assert on a sequence rather than a set.
+    #[test]
+    fn packets_due_together_keep_their_order() {
+        let mut queue = DelayQueue::default();
+        queue.push(b"first".to_vec(), 1);
+        queue.push(b"second".to_vec(), 1);
+        queue.advance();
+        assert_eq!(queue.due(), vec![b"first".to_vec(), b"second".to_vec()]);
+    }
+}

--- a/crates/bsengine-network/tests/loopback.rs
+++ b/crates/bsengine-network/tests/loopback.rs
@@ -1,0 +1,280 @@
+//! A real server and a real client, in one process, over real UDP.
+//!
+//! # Why one process
+//!
+//! Two processes are closer to a shipped game, but their frames are not ordered
+//! relative to each other, so an assertion about "the client's position after
+//! the server's fifth frame" is a race. Here the test steps both apps by hand,
+//! so every assertion below can name an exact frame — while still going through
+//! real sockets, so the handshake, the wire format and the batching are all
+//! genuinely exercised rather than stubbed.
+//!
+//! # Why the link simulator is in almost every test
+//!
+//! On a perfect link the interpolated position and the newest received snapshot
+//! agree on every frame. An interpolator that does nothing at all therefore
+//! passes any test run without induced loss — which is exactly what these tests
+//! exist to catch.
+
+use bevy_app::App;
+use bevy_ecs::prelude::*;
+use bsengine_core::{NetworkAuthority, NetworkId, Transform};
+use bsengine_network::{NetworkConfig, NetworkPlugin, NetworkSession};
+use glam::Vec3;
+
+/// A server app and a client app wired to each other over loopback.
+struct Pair {
+    server: App,
+    client: App,
+}
+
+impl Pair {
+    /// Binds a server on an ephemeral port and connects one client to it.
+    ///
+    /// Port 0 rather than a fixed number: a hardcoded port makes this fail
+    /// whenever anything else on the machine happens to hold it, which reads as
+    /// a broken feature rather than a busy socket.
+    fn connect(config: NetworkConfig) -> Self {
+        let server_session = NetworkSession::new_server(0).expect("bind server");
+        let port = server_session
+            .socket
+            .local_addr()
+            .expect("server address")
+            .port();
+
+        let mut server = App::new();
+        server.add_plugins(NetworkPlugin);
+        server.insert_resource(config.clone());
+        server.insert_resource(server_session);
+
+        let mut client = App::new();
+        client.add_plugins(NetworkPlugin);
+        client.insert_resource(config);
+        client.insert_resource(NetworkSession::new_client("127.0.0.1", port).expect("bind client"));
+
+        let mut pair = Self { server, client };
+        pair.settle_handshake();
+        pair
+    }
+
+    /// Steps both apps until the client has a peer id, or fails loudly.
+    ///
+    /// A silent timeout here would make every later assertion fail for a reason
+    /// that has nothing to do with what it is testing.
+    fn settle_handshake(&mut self) {
+        for _ in 0..200 {
+            self.step();
+            if self.client.world().resource::<NetworkSession>().connected {
+                return;
+            }
+        }
+        panic!("the client never completed its handshake with the server");
+    }
+
+    /// One frame on each side, server first so the client sees this frame's
+    /// snapshot rather than last frame's.
+    fn step(&mut self) {
+        self.server.update();
+        self.client.update();
+    }
+
+    /// Spawns the same replicated entity on both sides and returns both handles.
+    fn spawn_replicated(&mut self, net_id: u64, at: Vec3) -> (Entity, Entity) {
+        let transform = Transform {
+            position: at.into(),
+            ..Default::default()
+        };
+        let on_server = self
+            .server
+            .world_mut()
+            .spawn((
+                NetworkId {
+                    id: net_id,
+                    authority: NetworkAuthority::Server,
+                },
+                transform.clone(),
+            ))
+            .id();
+        let on_client = self
+            .client
+            .world_mut()
+            .spawn((
+                NetworkId {
+                    id: net_id,
+                    authority: NetworkAuthority::Server,
+                },
+                transform,
+            ))
+            .id();
+        (on_server, on_client)
+    }
+
+    fn move_server_entity(&mut self, entity: Entity, to: Vec3) {
+        let mut transform = self
+            .server
+            .world_mut()
+            .get_mut::<Transform>(entity)
+            .expect("server entity has a transform");
+        transform.position = to.into();
+    }
+
+    fn client_position(&self, entity: Entity) -> Vec3 {
+        self.client
+            .world()
+            .get::<Transform>(entity)
+            .expect("client entity has a transform")
+            .position
+            .0
+    }
+}
+
+/// The headline: a remote entity keeps moving on frames where nothing arrived,
+/// and keeps moving *along the server's path* rather than drifting.
+///
+/// Both halves are asserted. "It moved" alone would pass for an entity wandering
+/// anywhere; "it is close to the server" alone would pass for one that never
+/// moved at all, since it starts there.
+#[test]
+fn a_remote_entity_tracks_the_server_under_packet_loss() {
+    let mut pair = Pair::connect(NetworkConfig {
+        interpolation_delay_ticks: 2,
+        simulated_loss: 0.5,
+        simulator_seed: 7,
+        ..Default::default()
+    });
+    let (on_server, on_client) = pair.spawn_replicated(1, Vec3::ZERO);
+
+    let mut samples = Vec::new();
+    for frame in 1..=40 {
+        // A straight line the client's rendered position can be compared to.
+        pair.move_server_entity(on_server, Vec3::new(frame as f32, 0.0, 0.0));
+        pair.step();
+        samples.push(pair.client_position(on_client).x);
+    }
+
+    let final_x = *samples.last().expect("sampled");
+    assert!(
+        final_x > 20.0,
+        "the client must have followed the server a long way down the line, \
+         got x={final_x} after 40 frames"
+    );
+    assert!(
+        final_x <= 40.0,
+        "and must not have run past where the server ever was, got x={final_x}"
+    );
+
+    // Monotonic: the server only moved forwards, so a rendered position that
+    // went backwards means the interpolator is reordering or extrapolating.
+    for pair_of in samples.windows(2) {
+        assert!(
+            pair_of[1] >= pair_of[0] - 1e-3,
+            "the rendered position moved backwards: {} then {}",
+            pair_of[0],
+            pair_of[1]
+        );
+    }
+}
+
+/// The difference between interpolating and merely applying what arrived.
+///
+/// With half the packets dropped, a client that only applied received snapshots
+/// would hold still on every dropped frame. This asserts it advanced on more
+/// frames than it received.
+#[test]
+fn the_client_advances_on_frames_where_nothing_arrived() {
+    let mut pair = Pair::connect(NetworkConfig {
+        interpolation_delay_ticks: 3,
+        simulated_loss: 0.5,
+        simulator_seed: 11,
+        ..Default::default()
+    });
+    let (on_server, on_client) = pair.spawn_replicated(1, Vec3::ZERO);
+
+    let mut advanced_on = 0;
+    let mut previous = pair.client_position(on_client).x;
+    for frame in 1..=40 {
+        pair.move_server_entity(on_server, Vec3::new(frame as f32, 0.0, 0.0));
+        pair.step();
+        let now = pair.client_position(on_client).x;
+        if now > previous + 1e-4 {
+            advanced_on += 1;
+        }
+        previous = now;
+    }
+
+    assert!(
+        advanced_on > 25,
+        "with half the packets dropped, a client that only applied what arrived \
+         would advance on about half of 40 frames; interpolation should carry it \
+         through the gaps. Advanced on {advanced_on}"
+    );
+}
+
+/// Interest management, both halves.
+///
+/// A filter that sends nothing passes the far assertion; one that sends
+/// everything passes the near one. Only together do they say the radius is
+/// being applied.
+#[test]
+fn interest_management_stops_updates_for_a_distant_entity() {
+    let mut pair = Pair::connect(NetworkConfig {
+        aoi_radius: Some(50.0),
+        ..Default::default()
+    });
+
+    // The client's own entity, which is what the server measures distance from.
+    let observer = pair
+        .server
+        .world_mut()
+        .spawn((
+            NetworkId {
+                id: 99,
+                authority: NetworkAuthority::Client { peer_id: 1 },
+            },
+            Transform::default(),
+        ))
+        .id();
+    let _ = observer;
+
+    let (near_server, near_client) = pair.spawn_replicated(1, Vec3::new(10.0, 0.0, 0.0));
+    let (far_server, far_client) = pair.spawn_replicated(2, Vec3::new(500.0, 0.0, 0.0));
+
+    for frame in 1..=20 {
+        pair.move_server_entity(near_server, Vec3::new(10.0 + frame as f32, 0.0, 0.0));
+        pair.move_server_entity(far_server, Vec3::new(500.0 + frame as f32, 0.0, 0.0));
+        pair.step();
+    }
+
+    let near = pair.client_position(near_client).x;
+    let far = pair.client_position(far_client).x;
+
+    assert!(
+        near > 11.0,
+        "the entity inside the radius must keep receiving updates, got x={near}"
+    );
+    assert!(
+        (far - 500.0).abs() < 1e-3,
+        "the entity outside the radius must stop receiving them and stay where \
+         the client last knew it, got x={far}"
+    );
+}
+
+/// The existing path, unchanged: with nothing configured a client ends up where
+/// the server put it. `net-2p-demo` depends on this.
+#[test]
+fn a_default_session_replicates_as_it_always_did() {
+    let mut pair = Pair::connect(NetworkConfig::default());
+    let (on_server, on_client) = pair.spawn_replicated(1, Vec3::ZERO);
+
+    pair.move_server_entity(on_server, Vec3::new(42.0, 0.0, 0.0));
+    for _ in 0..5 {
+        pair.step();
+    }
+
+    let x = pair.client_position(on_client).x;
+    assert!(
+        (x - 42.0).abs() < 1e-3,
+        "with no delay and no loss the client should sit exactly where the \
+         server put it, got x={x}"
+    );
+}

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -307,6 +307,17 @@ fn run_windowed(project_dir: &str) {
             project_dir: project_dir.to_string(),
         });
     }
+    // From `project.toml`'s `[network]` table. Inserted before the plugins so
+    // `NetworkPlugin`'s `init_resource` finds it already present and leaves it
+    // alone -- registering it afterwards would overwrite the project's settings
+    // with defaults, and silently, since every default is a working value.
+    app.insert_resource(bsengine_network::NetworkConfig {
+        aoi_radius: manifest.network.aoi_radius,
+        interpolation_delay_ticks: manifest.network.interpolation_delay_ticks,
+        simulated_latency_frames: manifest.network.simulated_latency_frames,
+        simulated_loss: manifest.network.simulated_loss,
+        simulator_seed: manifest.network.simulator_seed,
+    });
     app.add_plugins(TimePlugin)
         .add_plugins(AssetPlugin)
         // Windowed only, deliberately. `--test` builds its own app

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -578,10 +578,9 @@ mod network_section_tests {
     /// trap `WindowSection`'s doc comment records.
     #[test]
     fn an_empty_network_table_matches_an_absent_one() {
-        let manifest: ProjectManifest = toml::from_str(
-            "[project]\nname = \"t\"\nentry_scene = \"s.ron\"\n[network]\n",
-        )
-        .expect("parse");
+        let manifest: ProjectManifest =
+            toml::from_str("[project]\nname = \"t\"\nentry_scene = \"s.ron\"\n[network]\n")
+                .expect("parse");
 
         assert_eq!(manifest.network.aoi_radius, None);
         assert_eq!(manifest.network.interpolation_delay_ticks, 0);

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -27,6 +27,8 @@ pub struct ProjectManifest {
     pub render: RenderSection,
     #[serde(default)]
     pub package: PackageSection,
+    #[serde(default)]
+    pub network: NetworkSection,
 }
 
 #[derive(Deserialize)]
@@ -113,6 +115,36 @@ pub struct PackageSection {
     /// existing project's build looks like.
     #[serde(default)]
     pub mode: bsengine_asset::cook::PackageMode,
+}
+
+/// Replication switches from `project.toml`'s `[network]` table.
+///
+/// Unlike [`WindowSection`] this takes a derived `Default`, and that is correct
+/// rather than lazy: every field's `#[serde(default)]` is its type's zero value,
+/// so "table absent" and "table present but empty" already agree. `WindowSection`
+/// needs a hand-written impl only because its defaults are not zeros.
+///
+/// Every zero here reproduces the engine's pre-item-56 behaviour: no interest
+/// limit, no interpolation delay, no simulated latency or loss.
+#[derive(Deserialize, Default)]
+pub struct NetworkSection {
+    /// Radius around a peer's own entity within which it receives updates.
+    /// Absent means no limit.
+    #[serde(default)]
+    pub aoi_radius: Option<f32>,
+    /// Server ticks behind the newest snapshot that remote entities render.
+    /// This is the cost of smooth motion, written as a number.
+    #[serde(default)]
+    pub interpolation_delay_ticks: u32,
+    /// Frames to hold every packet, for exercising the engine under latency.
+    #[serde(default)]
+    pub simulated_latency_frames: u32,
+    /// Fraction of packets to drop, for exercising it under loss.
+    #[serde(default)]
+    pub simulated_loss: f32,
+    /// Seed for the drop sequence, so a run is reproducible.
+    #[serde(default)]
+    pub simulator_seed: u64,
 }
 
 fn default_width() -> u32 {
@@ -505,5 +537,53 @@ mod tests {
         )
         .unwrap();
         assert!(!m.render.occlusion_culling);
+    }
+}
+
+#[cfg(test)]
+mod network_section_tests {
+    use super::ProjectManifest;
+
+    /// The property that lets an existing project upgrade without noticing:
+    /// an absent `[network]` table must mean exactly today's behaviour.
+    #[test]
+    fn an_absent_network_table_changes_nothing() {
+        let manifest: ProjectManifest =
+            toml::from_str("[project]\nname = \"t\"\nentry_scene = \"s.ron\"\n").expect("parse");
+
+        assert_eq!(manifest.network.aoi_radius, None, "no interest limit");
+        assert_eq!(
+            manifest.network.interpolation_delay_ticks, 0,
+            "the newest snapshot renders immediately"
+        );
+        assert_eq!(manifest.network.simulated_loss, 0.0, "the simulator is off");
+    }
+
+    /// Paired with the above: without this, a section that silently ignored the
+    /// file would pass the absent-table test perfectly.
+    #[test]
+    fn a_present_network_table_is_read() {
+        let manifest: ProjectManifest = toml::from_str(
+            "[project]\nname = \"t\"\nentry_scene = \"s.ron\"\n\
+             [network]\naoi_radius = 25.0\ninterpolation_delay_ticks = 3\nsimulated_loss = 0.25\n",
+        )
+        .expect("parse");
+
+        assert_eq!(manifest.network.aoi_radius, Some(25.0));
+        assert_eq!(manifest.network.interpolation_delay_ticks, 3);
+        assert_eq!(manifest.network.simulated_loss, 0.25);
+    }
+
+    /// A present-but-empty table must behave as an absent one, which is the
+    /// trap `WindowSection`'s doc comment records.
+    #[test]
+    fn an_empty_network_table_matches_an_absent_one() {
+        let manifest: ProjectManifest = toml::from_str(
+            "[project]\nname = \"t\"\nentry_scene = \"s.ron\"\n[network]\n",
+        )
+        .expect("parse");
+
+        assert_eq!(manifest.network.aoi_radius, None);
+        assert_eq!(manifest.network.interpolation_delay_ticks, 0);
     }
 }

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -58,6 +58,17 @@ pub fn build_test_app(project_dir: &str, scene_override: Option<&str>, fast_rend
             project_dir: project_dir.to_string(),
         });
     }
+    // From `project.toml`'s `[network]` table. Inserted before the plugins so
+    // `NetworkPlugin`'s `init_resource` finds it already present and leaves it
+    // alone -- registering it afterwards would overwrite the project's settings
+    // with defaults, and silently, since every default is a working value.
+    app.insert_resource(bsengine_network::NetworkConfig {
+        aoi_radius: manifest.network.aoi_radius,
+        interpolation_delay_ticks: manifest.network.interpolation_delay_ticks,
+        simulated_latency_frames: manifest.network.simulated_latency_frames,
+        simulated_loss: manifest.network.simulated_loss,
+        simulator_seed: manifest.network.simulator_seed,
+    });
     app.add_plugins(TimePlugin)
         .add_plugins(AssetPlugin)
         // Included here, unlike `AssetWatcherPlugin` (see main.rs's


### PR DESCRIPTION
ENGINE_ROADMAP item 56, **sub-step 1/2**. A server tick on the wire, a
deterministic latency/loss simulator, snapshot interpolation for remote
entities, and distance-based interest management.

## What the roadmap's prose gets wrong, and why this is split

Item 56 says it "adds to" item 7's sync. For interpolation and AOI that's true.
For the first condition it is not: **the current model is client-authoritative**
and says so in its own doc — `NetworkRole::Client` "sends only its own
client-authoritative transforms". Reconciliation against that is meaningless,
because the server never disagrees with a client about a client's own entity.

So prediction requires *inverting* who is authoritative, and that is sub-step
2/2, as an **opt-in per entity** so this model keeps working. Everything in this
PR is server→client and touches no authority.

The split line matters for a second reason: interpolation and prediction both
exist to make the on-screen position differ from the last received authoritative
state. Landed together, a wrong position would have two suspects and no way to
tell them apart.

## Closes four of five conditions

Interpolation (2), AOI (3), latency/loss verification (4), tests (5). Prediction
+ reconciliation (1) is 2/2.

## The simulator is an instrument, not a feature

Built **before** the things it measures, deliberately: on a perfect link the
interpolated position and the newest received snapshot agree on every frame, so
an interpolator that does nothing passes any test run without induced loss.
Seeded, because the tests depend on it — a flaky instrument turns a real
regression and an unlucky roll into the same red.

## The mutation result worth reading

Replacing interpolation with "apply the newest snapshot":

| Test | Under mutation |
|---|---|
| `a_remote_entity_tracks_the_server_under_packet_loss` | **PASSED** |
| `the_client_advances_on_frames_where_nothing_arrived` | FAILED |

**Tracking the server does not distinguish interpolation from applying what
arrived.** With only the first test this PR would have claimed "interpolation
verified" and proven nothing. The second test is why the claim holds. Removing
the AOI filter likewise fails only its own test.

## Stated costs, not hidden ones

- `interpolation_delay_ticks` renders remote entities **in the past**. That is
  what buys smoothness; `0` restores the old snap-to-newest behaviour.
- Past the newest snapshot it **holds** rather than extrapolating. A guess that
  overshoots snaps backwards when the truth arrives; a frozen remote entity reads
  as the network problem it is.
- `aoi_radius` stops updates, it does not hide entities — one outside the radius
  stays where the peer last saw it. A peer with no entity of its own gets
  everything, since there is no position to measure from and sending nothing
  would look identical to a broken filter.
- Every `[network]` default reproduces the previous behaviour exactly.

## Verification

- 30 unit + 4 loopback (a real server App and client App in one process over
  real UDP) + 3 manifest tests
- mutation-verified: no-blend, extrapolate-instead-of-hold, no-interpolation,
  and no-AOI each fail their own assertions; each reverted by re-editing its
  lines
- fmt clean; catalog unchanged at 70 components / 269 ops
- **clippy: found and fixed one warning I introduced**, caught by comparing the
  count against the baseline (2→3) rather than looking for a red build
- workspace green, editor 937/937, **all 10 E2E replays pass** — this branch
  changes system ordering (`interpolate_remote_entities` between receive and
  send), which has silently reversed unrelated systems in this repo before
- all 10 projects × 2 package modes = 20/20, since `ProjectManifest` changed

No CI change needed: these run under the existing workspace test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)