### PR TITLE
Client prediction + server reconciliation (item 56, 2/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,40 @@ The two `simulated_*` settings exist to test the two above, and are off by
 default. They are also the only way to observe either: on a perfect link an
 interpolated position and the newest snapshot agree on every frame.
 
-**Not implemented:** client-side prediction and server reconciliation. A client
-today is authoritative over its own entities and sends their transforms, so the
-server never disagrees with it about them. Making the server authoritative — per
-entity, opt-in — is the next step.
+### Prediction
+
+An entity can opt in to being **server-simulated with client-side prediction**,
+per entity, through its `NetworkId`:
+
+```ron
+components: [
+    ("bsengine_core::network_id::NetworkId", "(id: 3, authority: Predicted(peer_id: 1))"),
+],
+```
+
+The difference from `Client(peer_id: 1)` is who decides. `Client` means that peer
+simulates the entity and reports where it is — the server takes its word, so the
+two can never disagree. `Predicted` means the peer applies its own input
+immediately so the entity feels responsive, while the **server** decides what
+actually happened; when they disagree the server wins.
+
+**Both peers run the entity's movement script.** That is the point of the design:
+one movement rule rather than one per side that could drift apart.
+`Bsengine.isKeyPressed` reads the input of whichever entity the script is running
+for, so on the server it sees that client's keys and not the keyboard of the
+machine hosting the game.
+
+**The cost:** a correction re-runs that movement script once per input the server
+had not yet acknowledged — bounded by latency, not by scene size. A replay
+re-derives *position only* and deliberately discards everything else the script
+did: the sound that played during the original input already played, and firing
+it again on every correction would make a player hear their own latency.
+
+Server authority is also the precondition for any anti-cheat. With `Client`
+authority a peer can simply state its position.
+
+**Not implemented:** lag compensation — rewinding the server to a client's view
+for hit detection.
 
 ---
 

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -52,6 +52,9 @@ pub mod nav_mesh_agent;
 /// between them.
 pub mod nav_poly;
 /// Networked entity identity and authority components.
+/// Resources the networking and scripting layers use to hand player input to
+/// each other, since neither crate depends on the other.
+pub mod net_input;
 pub mod network_id;
 /// Runtime switch for occlusion culling, set from `project.toml`.
 pub mod occlusion_config;
@@ -127,6 +130,7 @@ pub use logging::init_logging;
 pub use material::{Material, TexturePath};
 pub use nav_mesh::NavMesh;
 pub use nav_mesh_agent::{NavAgentState, NavMeshAgent};
+pub use net_input::{LocalHeldKeys, RemoteHeldKeys};
 pub use network_id::{NetworkAuthority, NetworkId};
 pub use occlusion_config::OcclusionCullingEnabled;
 pub use parent::Parent;

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -130,7 +130,7 @@ pub use logging::init_logging;
 pub use material::{Material, TexturePath};
 pub use nav_mesh::NavMesh;
 pub use nav_mesh_agent::{NavAgentState, NavMeshAgent};
-pub use net_input::{LocalHeldKeys, RemoteHeldKeys};
+pub use net_input::{LocalHeldKeys, PendingReplays, RemoteHeldKeys, ReplayRequest};
 pub use network_id::{NetworkAuthority, NetworkId};
 pub use occlusion_config::OcclusionCullingEnabled;
 pub use parent::Parent;

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -51,10 +51,10 @@ pub mod nav_mesh_agent;
 /// Convex decomposition of walkable space into rectangles, and the portals
 /// between them.
 pub mod nav_poly;
-/// Networked entity identity and authority components.
 /// Resources the networking and scripting layers use to hand player input to
 /// each other, since neither crate depends on the other.
 pub mod net_input;
+/// Networked entity identity and authority components.
 pub mod network_id;
 /// Runtime switch for occlusion culling, set from `project.toml`.
 pub mod occlusion_config;

--- a/crates/bsengine-core/src/net_input.rs
+++ b/crates/bsengine-core/src/net_input.rs
@@ -38,3 +38,32 @@ pub struct LocalHeldKeys(pub Vec<String>);
 /// this addition invisible to them.
 #[derive(Resource, Default, Debug, Clone)]
 pub struct RemoteHeldKeys(pub HashMap<u64, Vec<String>>);
+
+/// One predicted entity that needs correcting, and the input to re-apply.
+///
+/// # Why a request rather than a direct call
+///
+/// The networking layer is what learns that a correction is due, but replaying
+/// means **re-running the entity's movement script**, and only the scripting
+/// layer can do that. Neither crate depends on the other, so the correction
+/// travels as data through here — the same route the input takes in the other
+/// direction.
+#[derive(Debug, Clone)]
+pub struct ReplayRequest {
+    /// Which entity, by network id.
+    pub net_id: u64,
+    /// Where the server says it actually was, as of the last input it applied.
+    pub authoritative: crate::Transform,
+    /// The inputs the server had not yet seen, oldest first, to re-apply on top.
+    ///
+    /// Empty means the server has caught up with everything sent, in which case
+    /// the correction is just the snap.
+    pub replay: Vec<Vec<String>>,
+}
+
+/// Corrections waiting for the scripting layer to apply.
+///
+/// Drained every frame. A correction left here would be applied twice and move
+/// the entity twice as far, so draining is not optional bookkeeping.
+#[derive(Resource, Default, Debug, Clone)]
+pub struct PendingReplays(pub Vec<ReplayRequest>);

--- a/crates/bsengine-core/src/net_input.rs
+++ b/crates/bsengine-core/src/net_input.rs
@@ -1,0 +1,40 @@
+//! The two resources the networking and scripting layers use to hand input to
+//! each other.
+//!
+//! # Why they live here
+//!
+//! `bsengine-network` needs the local player's held keys (to send them) and
+//! needs to publish a remote player's held keys (so a script can read them).
+//! `bsengine-scripting` owns the key-name conversion and the per-entity input
+//! its ops read. Neither crate depends on the other, and neither should: they
+//! meet in `bsengine-core`, which both already depend on.
+//!
+//! This is the same shape item 52 used for the ragdoll blend weight, where the
+//! producer could not name the consumer's type.
+
+use std::collections::HashMap;
+
+use bevy_ecs::prelude::Resource;
+
+/// Key names held down on this machine this frame.
+///
+/// Published by the scripting layer, which already converts key codes to the
+/// names scripts use, so there is exactly one such conversion in the engine
+/// rather than a second one that could drift from it.
+#[derive(Resource, Default, Debug, Clone)]
+pub struct LocalHeldKeys(pub Vec<String>);
+
+/// Key names held down by the owner of each remotely-driven entity, keyed by
+/// **network id**.
+///
+/// Published by the networking layer from received input, and read by the
+/// scripting layer, which resolves the id to an entity name — it already queries
+/// `(Entity, &Name, &NetworkId)` together, and `Name` lives in `bsengine-scene`,
+/// which the networking crate does not and should not depend on. Keying by the
+/// one identifier both layers already share is what keeps that dependency out.
+///
+/// An entity absent from here has no remote owner and falls back to the local
+/// keyboard — which is every entity in a single-player game, and is what makes
+/// this addition invisible to them.
+#[derive(Resource, Default, Debug, Clone)]
+pub struct RemoteHeldKeys(pub HashMap<u64, Vec<String>>);

--- a/crates/bsengine-core/src/network_id.rs
+++ b/crates/bsengine-core/src/network_id.rs
@@ -13,6 +13,25 @@ pub enum NetworkAuthority {
         /// Id of the peer that owns this entity.
         peer_id: u64,
     },
+    /// A specific client owns this entity's **input**, and the **server**
+    /// simulates it from that input.
+    ///
+    /// # How this differs from [`Self::Client`], and why the difference matters
+    ///
+    /// `Client` means the client simulates and reports the result: the server
+    /// takes its word for where the entity is, so the two can never disagree and
+    /// there is nothing to reconcile. `Predicted` means the client applies its
+    /// own input immediately so the entity feels responsive, while the *server*
+    /// decides what actually happened — and when the two disagree, the server
+    /// wins and the client replays whatever input the server had not yet seen.
+    ///
+    /// Prediction and reconciliation are only meaningful against this variant.
+    /// Server authority is also the precondition for any anti-cheat: with
+    /// `Client`, a peer can simply state its position.
+    Predicted {
+        /// Id of the peer whose input drives this entity.
+        peer_id: u64,
+    },
     /// No network replication — local-only entity.
     Local,
 }

--- a/crates/bsengine-network/src/lib.rs
+++ b/crates/bsengine-network/src/lib.rs
@@ -25,11 +25,13 @@ mod config;
 mod interpolation;
 mod packet;
 mod plugin;
+mod prediction;
 mod session;
 mod sim;
 
 pub use config::NetworkConfig;
 pub use interpolation::{sample, SnapshotBuffers};
 pub use plugin::{NetworkPlugin, ServerTick};
+pub use prediction::PendingInputs;
 pub use session::{NetworkRole, NetworkSession};
 pub use sim::{DelayQueue, LinkSimulator};

--- a/crates/bsengine-network/src/lib.rs
+++ b/crates/bsengine-network/src/lib.rs
@@ -31,7 +31,7 @@ mod sim;
 
 pub use config::NetworkConfig;
 pub use interpolation::{sample, SnapshotBuffers};
-pub use plugin::{NetworkPlugin, ServerTick};
+pub use plugin::{AppliedInputs, NetworkPlugin, ServerTick};
 pub use prediction::PendingInputs;
 pub use session::{NetworkRole, NetworkSession};
 pub use sim::{DelayQueue, LinkSimulator};

--- a/crates/bsengine-network/src/packet.rs
+++ b/crates/bsengine-network/src/packet.rs
@@ -6,6 +6,13 @@ pub const MSG_HELLO_ACK: u8 = 0x02;
 pub const MSG_TRANSFORM_BATCH: u8 = 0x03;
 pub const MSG_CLIENT_TRANSFORM: u8 = 0x04;
 pub const MSG_DISCONNECT: u8 = 0x05;
+/// A predicted entity's owner reporting what it is holding down, and which
+/// input this is.
+///
+/// Replaces [`MSG_CLIENT_TRANSFORM`] for predicted entities — for those, a
+/// transform from the client is not merely insufficient but *wrong*, since the
+/// server is the one that decides where they end up.
+pub const MSG_CLIENT_INPUT: u8 = 0x06;
 
 /// 40-byte transform snapshot sent over the wire.
 #[derive(Clone, Copy, Debug)]
@@ -94,8 +101,9 @@ pub fn encode_disconnect() -> [u8; 1] {
 }
 
 /// Bytes before the first entry in a [`MSG_TRANSFORM_BATCH`]: the tag, the entry
-/// count, and the server tick the snapshot was taken on.
-pub const BATCH_HEADER_LEN: usize = 1 + 1 + 4;
+/// count, the server tick the snapshot was taken on, and the last input
+/// sequence the server had applied for the peer being sent to.
+pub const BATCH_HEADER_LEN: usize = 1 + 1 + 4 + 4;
 
 /// The server simulation frame a batch was taken on, or `None` if the packet is
 /// too short to hold one.
@@ -112,7 +120,73 @@ pub fn decode_batch_tick(packet: &[u8]) -> Option<u32> {
 
 /// Encode a batch of (net_id, transform) pairs taken on server tick `tick`.
 /// Returns None if empty.
-pub fn encode_transform_batch(tick: u32, entries: &[(u64, TransformData)]) -> Option<Vec<u8>> {
+/// The last input sequence the server had applied for this peer when it took
+/// the snapshot, or `None` if the packet is too short.
+///
+/// This is what makes reconciliation expressible: it tells a client exactly
+/// which of its inputs the authoritative transform already accounts for, and
+/// therefore which ones it still has to replay on top. Without it a client
+/// could see that it disagrees with the server but not know how much of its own
+/// recent input the server had yet to see.
+pub fn decode_batch_ack(packet: &[u8]) -> Option<u32> {
+    packet
+        .get(6..10)
+        .map(|b| u32::from_le_bytes(b.try_into().expect("4 bytes")))
+}
+
+/// Encode one client's held keys for a predicted entity.
+///
+/// Keys travel as their names, the same strings the scripting API already uses
+/// (`"W"`, `"Space"`). A bitset would be smaller but needs a key table both
+/// peers agree on — a second thing to keep in step, for a saving that does not
+/// matter at these sizes.
+pub fn encode_client_input(net_id: u64, sequence: u32, keys: &[String]) -> Vec<u8> {
+    let count = keys.len().min(255);
+    let mut pkt = Vec::with_capacity(1 + 8 + 4 + 1 + count * 8);
+    pkt.push(MSG_CLIENT_INPUT);
+    pkt.extend_from_slice(&net_id.to_le_bytes());
+    pkt.extend_from_slice(&sequence.to_le_bytes());
+    pkt.push(count as u8);
+    for key in &keys[..count] {
+        let bytes = key.as_bytes();
+        let len = bytes.len().min(255);
+        pkt.push(len as u8);
+        pkt.extend_from_slice(&bytes[..len]);
+    }
+    pkt
+}
+
+/// Decode a [`MSG_CLIENT_INPUT`] into `(net_id, sequence, keys)`.
+///
+/// Returns `None` for anything malformed rather than a partial read: a
+/// half-decoded input would move somebody's character in a direction they never
+/// pressed, which is worse than dropping the packet — and UDP means dropping one
+/// is already an ordinary event the client recovers from.
+pub fn decode_client_input(packet: &[u8]) -> Option<(u64, u32, Vec<String>)> {
+    if packet.first() != Some(&MSG_CLIENT_INPUT) {
+        return None;
+    }
+    let net_id = u64::from_le_bytes(packet.get(1..9)?.try_into().ok()?);
+    let sequence = u32::from_le_bytes(packet.get(9..13)?.try_into().ok()?);
+    let count = *packet.get(13)? as usize;
+
+    let mut keys = Vec::with_capacity(count);
+    let mut at = 14;
+    for _ in 0..count {
+        let len = *packet.get(at)? as usize;
+        at += 1;
+        let bytes = packet.get(at..at + len)?;
+        at += len;
+        keys.push(std::str::from_utf8(bytes).ok()?.to_string());
+    }
+    Some((net_id, sequence, keys))
+}
+
+pub fn encode_transform_batch(
+    tick: u32,
+    last_applied_input: u32,
+    entries: &[(u64, TransformData)],
+) -> Option<Vec<u8>> {
     if entries.is_empty() {
         return None;
     }
@@ -121,6 +195,7 @@ pub fn encode_transform_batch(tick: u32, entries: &[(u64, TransformData)]) -> Op
     pkt.push(MSG_TRANSFORM_BATCH);
     pkt.push(count);
     pkt.extend_from_slice(&tick.to_le_bytes());
+    pkt.extend_from_slice(&last_applied_input.to_le_bytes());
     for (net_id, td) in &entries[..count as usize] {
         pkt.extend_from_slice(&net_id.to_le_bytes());
         pkt.extend_from_slice(&td.to_bytes());
@@ -165,7 +240,7 @@ mod tests {
 
     #[test]
     fn transform_batch_empty_returns_none() {
-        assert!(encode_transform_batch(0, &[]).is_none());
+        assert!(encode_transform_batch(0, 0, &[]).is_none());
     }
 
     /// Without a tick a snapshot cannot be placed on a timeline at all, so
@@ -173,10 +248,59 @@ mod tests {
     #[test]
     fn transform_batch_carries_the_server_tick() {
         let td = TransformData::from_transform(&Transform::default());
-        let pkt = encode_transform_batch(7, &[(1u64, td)]).expect("batch");
+        let pkt = encode_transform_batch(7, 0, &[(1u64, td)]).expect("batch");
 
         assert_eq!(pkt[0], MSG_TRANSFORM_BATCH);
         assert_eq!(decode_batch_tick(&pkt), Some(7));
+        assert_eq!(pkt.len(), BATCH_HEADER_LEN + 48);
+    }
+
+    /// Round-trip, with a multi-byte key name so the length prefixes are
+    /// actually exercised -- every key being one byte would let an off-by-one
+    /// in the length handling pass.
+    #[test]
+    fn client_input_round_trips_with_its_sequence() {
+        let keys = vec!["W".to_string(), "Space".to_string(), "Shift".to_string()];
+        let pkt = encode_client_input(42, 7, &keys);
+
+        assert_eq!(decode_client_input(&pkt), Some((42, 7, keys)));
+    }
+
+    #[test]
+    fn no_keys_held_is_a_valid_input_not_an_absent_one() {
+        let pkt = encode_client_input(42, 9, &[]);
+        assert_eq!(decode_client_input(&pkt), Some((42, 9, Vec::new())));
+    }
+
+    /// A partial decode would move somebody in a direction they never pressed.
+    /// Dropping the packet is what UDP already does routinely and what the
+    /// client already recovers from.
+    #[test]
+    fn a_truncated_input_decodes_to_nothing_rather_than_a_partial_read() {
+        let pkt = encode_client_input(42, 7, &["W".to_string()]);
+        for cut in 1..pkt.len() {
+            assert_eq!(
+                decode_client_input(&pkt[..cut]),
+                None,
+                "a packet cut at {cut} must not decode"
+            );
+        }
+    }
+
+    #[test]
+    fn a_packet_of_another_kind_is_not_read_as_input() {
+        assert_eq!(decode_client_input(&[MSG_HELLO]), None);
+    }
+
+    /// The tick and the ack are different numbers in the same header, so a test
+    /// that used the same value for both would not notice them being swapped.
+    #[test]
+    fn the_batch_carries_the_tick_and_the_ack_separately() {
+        let td = TransformData::from_transform(&Transform::default());
+        let pkt = encode_transform_batch(11, 4, &[(1u64, td)]).expect("batch");
+
+        assert_eq!(decode_batch_tick(&pkt), Some(11));
+        assert_eq!(decode_batch_ack(&pkt), Some(4));
         assert_eq!(pkt.len(), BATCH_HEADER_LEN + 48);
     }
 
@@ -189,7 +313,7 @@ mod tests {
     fn transform_batch_roundtrip_count() {
         let td = TransformData::from_transform(&Transform::default());
         let entries = vec![(1u64, td), (2u64, td)];
-        let pkt = encode_transform_batch(0, &entries).unwrap();
+        let pkt = encode_transform_batch(0, 0, &entries).unwrap();
         assert_eq!(pkt[0], MSG_TRANSFORM_BATCH);
         assert_eq!(pkt[1], 2);
         assert_eq!(pkt.len(), BATCH_HEADER_LEN + 2 * 48);

--- a/crates/bsengine-network/src/plugin.rs
+++ b/crates/bsengine-network/src/plugin.rs
@@ -6,9 +6,10 @@ use crate::{
     config::NetworkConfig,
     interpolation::{sample, SnapshotBuffers},
     packet::{
-        decode_batch_tick, decode_client_input, encode_client_input, encode_client_transform,
-        encode_transform_batch, TransformData, BATCH_HEADER_LEN, MSG_CLIENT_INPUT,
-        MSG_CLIENT_TRANSFORM, MSG_DISCONNECT, MSG_HELLO, MSG_HELLO_ACK, MSG_TRANSFORM_BATCH,
+        decode_batch_ack, decode_batch_tick, decode_client_input, encode_client_input,
+        encode_client_transform, encode_transform_batch, TransformData, BATCH_HEADER_LEN,
+        MSG_CLIENT_INPUT, MSG_CLIENT_TRANSFORM, MSG_DISCONNECT, MSG_HELLO, MSG_HELLO_ACK,
+        MSG_TRANSFORM_BATCH,
     },
     prediction::PendingInputs,
     session::{NetworkRole, NetworkSession},
@@ -37,6 +38,7 @@ impl Plugin for NetworkPlugin {
         app.init_resource::<PendingInputs>();
         app.init_resource::<bsengine_core::RemoteHeldKeys>();
         app.init_resource::<AppliedInputs>();
+        app.init_resource::<bsengine_core::PendingReplays>();
         app.add_systems(Update, network_receive_system);
         // Between receive and send: it consumes what receive buffered, and a
         // client's own send must not read a transform this just wrote for a
@@ -111,6 +113,12 @@ fn network_receive_system(world: &mut World) {
                 let Some(tick) = decode_batch_tick(&data) else {
                     continue;
                 };
+                // What the server had applied for this peer when it took the
+                // snapshot. Everything at or below it is confirmed; everything
+                // above it is still this client's to replay.
+                let acked = decode_batch_ack(&data).unwrap_or(0);
+                let my_peer_id = world.resource::<NetworkSession>().my_peer_id;
+                let mut corrections: Vec<(u64, TransformData)> = Vec::new();
                 let count = data[1] as usize;
                 let mut offset = BATCH_HEADER_LEN;
                 for _ in 0..count {

--- a/crates/bsengine-network/src/plugin.rs
+++ b/crates/bsengine-network/src/plugin.rs
@@ -130,9 +130,53 @@ fn network_receive_system(world: &mut World) {
                     let td = TransformData::from_bytes(&data[offset + 8..offset + 48]);
                     offset += 48;
 
+                    // A predicted entity this peer owns is not interpolated --
+                    // it is corrected. Interpolating it would fight the local
+                    // prediction and hold it a delay in the past, which is the
+                    // opposite of why it is predicted.
+                    let predicted_here = {
+                        let mut q = world.query::<&NetworkId>();
+                        q.iter(world).any(|nid| {
+                            nid.id == net_id
+                                && matches!(
+                                    nid.authority,
+                                    NetworkAuthority::Predicted { peer_id } if peer_id == my_peer_id
+                                )
+                        })
+                    };
+                    if predicted_here {
+                        corrections.push((net_id, td));
+                    } else {
+                        world
+                            .resource_mut::<SnapshotBuffers>()
+                            .push(net_id, tick, td);
+                    }
+                }
+
+                if !corrections.is_empty() {
+                    // Everything at or below the ack is confirmed; what is left
+                    // is what this correction has to replay.
+                    let replay: Vec<Vec<String>> = {
+                        let mut pending = world.resource_mut::<PendingInputs>();
+                        pending.retain_after(acked);
+                        pending
+                            .unacknowledged()
+                            .iter()
+                            .map(|(_, keys)| keys.clone())
+                            .collect()
+                    };
+                    let requests: Vec<bsengine_core::ReplayRequest> = corrections
+                        .into_iter()
+                        .map(|(net_id, td)| bsengine_core::ReplayRequest {
+                            net_id,
+                            authoritative: td.to_transform(),
+                            replay: replay.clone(),
+                        })
+                        .collect();
                     world
-                        .resource_mut::<SnapshotBuffers>()
-                        .push(net_id, tick, td);
+                        .resource_mut::<bsengine_core::PendingReplays>()
+                        .0
+                        .extend(requests);
                 }
             }
             MSG_CLIENT_INPUT => {

--- a/crates/bsengine-network/src/plugin.rs
+++ b/crates/bsengine-network/src/plugin.rs
@@ -364,7 +364,7 @@ fn network_send_system(world: &mut World) {
                 // Dropped here rather than at the receiver so the packet never
                 // exists, which is what a lossy link actually does.
                 if deliver.get(index).copied().unwrap_or(true) {
-                    if let Some(pkt) = encode_transform_batch(tick, &batch) {
+                    if let Some(pkt) = encode_transform_batch(tick, 0, &batch) {
                         let _ = session.socket.send_to(&pkt, peer);
                     }
                 }

--- a/crates/bsengine-network/src/plugin.rs
+++ b/crates/bsengine-network/src/plugin.rs
@@ -6,10 +6,11 @@ use crate::{
     config::NetworkConfig,
     interpolation::{sample, SnapshotBuffers},
     packet::{
-        decode_batch_tick, encode_client_transform, encode_transform_batch, TransformData,
-        BATCH_HEADER_LEN, MSG_CLIENT_TRANSFORM, MSG_DISCONNECT, MSG_HELLO, MSG_HELLO_ACK,
-        MSG_TRANSFORM_BATCH,
+        decode_batch_tick, decode_client_input, encode_client_input, encode_client_transform,
+        encode_transform_batch, TransformData, BATCH_HEADER_LEN, MSG_CLIENT_INPUT,
+        MSG_CLIENT_TRANSFORM, MSG_DISCONNECT, MSG_HELLO, MSG_HELLO_ACK, MSG_TRANSFORM_BATCH,
     },
+    prediction::PendingInputs,
     session::{NetworkRole, NetworkSession},
     sim::LinkSimulator,
 };
@@ -33,6 +34,9 @@ impl Plugin for NetworkPlugin {
         app.init_resource::<SnapshotBuffers>();
         app.init_resource::<NetworkConfig>();
         app.init_resource::<SimulatedLink>();
+        app.init_resource::<PendingInputs>();
+        app.init_resource::<bsengine_core::RemoteHeldKeys>();
+        app.init_resource::<AppliedInputs>();
         app.add_systems(Update, network_receive_system);
         // Between receive and send: it consumes what receive buffered, and a
         // client's own send must not read a transform this just wrote for a
@@ -123,6 +127,25 @@ fn network_receive_system(world: &mut World) {
                         .push(net_id, tick, td);
                 }
             }
+            MSG_CLIENT_INPUT => {
+                // Server: a predicted entity's owner reporting what it holds.
+                // Published for the scripting layer, which runs that entity's
+                // own movement script against it -- so the server simulates a
+                // remote player by the same code the player runs, rather than
+                // by a second implementation that could disagree with it.
+                let Some((net_id, sequence, keys)) = decode_client_input(&data) else {
+                    continue;
+                };
+
+                world
+                    .resource_mut::<bsengine_core::RemoteHeldKeys>()
+                    .0
+                    .insert(net_id, keys);
+                world
+                    .resource_mut::<AppliedInputs>()
+                    .0
+                    .insert(net_id, sequence);
+            }
             MSG_CLIENT_TRANSFORM => {
                 // Server: apply client-authoritative transform.
                 if data.len() < 49 {
@@ -153,6 +176,13 @@ fn network_receive_system(world: &mut World) {
         }
     }
 }
+
+/// The last input sequence the server has applied, per replicated entity.
+///
+/// Echoed back in that peer's transform batch so the client knows which of its
+/// inputs the authoritative state already accounts for.
+#[derive(Resource, Default, Debug)]
+pub struct AppliedInputs(pub std::collections::HashMap<u64, u32>);
 
 /// The simulated link this process sends through.
 ///
@@ -294,6 +324,20 @@ fn network_send_system(world: &mut World) {
             .collect()
     };
 
+    // Read before the session borrow, for the same reason the tick is bumped
+    // there: `session` is held immutably for the rest of this function.
+    let held_keys: Vec<String> = world
+        .get_resource::<bsengine_core::LocalHeldKeys>()
+        .map(|keys| keys.0.clone())
+        .unwrap_or_default();
+    let input_sequence = {
+        let mut pending = world.resource_mut::<PendingInputs>();
+        pending.next_sequence()
+    };
+    // Set below if this frame actually sent input, so an unacknowledged-input
+    // buffer only grows for input that is genuinely in flight.
+    let mut sent_input = false;
+
     // Bumped before the session borrow: `session` is held immutably for the
     // rest of this function, so the resource cannot be taken mutably later.
     let tick = {
@@ -301,6 +345,14 @@ fn network_send_system(world: &mut World) {
         server_tick.0 = server_tick.0.wrapping_add(1);
         server_tick.0
     };
+
+    // Per-peer: which of that peer's inputs the server has already applied.
+    // Read here, before the session borrow, like everything else this function
+    // needs from the world.
+    let applied: std::collections::HashMap<u64, u32> = world
+        .get_resource::<AppliedInputs>()
+        .map(|a| a.0.clone())
+        .unwrap_or_default();
 
     let (radius, loss, seed) =
         world
@@ -345,8 +397,19 @@ fn network_send_system(world: &mut World) {
                     .iter()
                     .find(|(_, authority, _)| {
                         matches!(authority, NetworkAuthority::Client { peer_id: owner } if *owner == peer_id)
+                            || matches!(authority, NetworkAuthority::Predicted { peer_id: owner } if *owner == peer_id)
                     })
                     .map(|(_, _, t)| t.position.0);
+
+                // The ack this peer needs is for the entity *it* drives, which
+                // is the same one interest is measured from.
+                let peer_ack = entities
+                    .iter()
+                    .find(|(_, authority, _)| {
+                        matches!(authority, NetworkAuthority::Predicted { peer_id: owner } if *owner == peer_id)
+                    })
+                    .and_then(|(net_id, _, _)| applied.get(net_id).copied())
+                    .unwrap_or(0);
 
                 let batch: Vec<(u64, TransformData)> = entities
                     .iter()
@@ -364,7 +427,7 @@ fn network_send_system(world: &mut World) {
                 // Dropped here rather than at the receiver so the packet never
                 // exists, which is what a lossy link actually does.
                 if deliver.get(index).copied().unwrap_or(true) {
-                    if let Some(pkt) = encode_transform_batch(tick, 0, &batch) {
+                    if let Some(pkt) = encode_transform_batch(tick, peer_ack, &batch) {
                         let _ = session.socket.send_to(&pkt, peer);
                     }
                 }
@@ -374,12 +437,33 @@ fn network_send_system(world: &mut World) {
             let server = *server_addr;
             let my_id = session.my_peer_id;
             for (net_id, authority, t) in &entities {
-                if matches!(authority, NetworkAuthority::Client { peer_id } if *peer_id == my_id) {
-                    let pkt = encode_client_transform(*net_id, TransformData::from_transform(t));
-                    let _ = session.socket.send_to(&pkt, server);
+                match authority {
+                    // Client-authoritative: unchanged. This peer decides where
+                    // the entity is and says so.
+                    NetworkAuthority::Client { peer_id } if *peer_id == my_id => {
+                        let pkt =
+                            encode_client_transform(*net_id, TransformData::from_transform(t));
+                        let _ = session.socket.send_to(&pkt, server);
+                    }
+                    // Predicted: send what was *pressed*, never where the entity
+                    // ended up. Sending the transform here would make the client
+                    // authoritative again and there would be nothing left to
+                    // reconcile -- the two messages are not interchangeable.
+                    NetworkAuthority::Predicted { peer_id } if *peer_id == my_id => {
+                        let pkt = encode_client_input(*net_id, input_sequence, &held_keys);
+                        let _ = session.socket.send_to(&pkt, server);
+                        sent_input = true;
+                    }
+                    _ => {}
                 }
             }
         }
+    }
+
+    if sent_input {
+        world
+            .resource_mut::<PendingInputs>()
+            .record(input_sequence, held_keys);
     }
 }
 

--- a/crates/bsengine-network/src/prediction.rs
+++ b/crates/bsengine-network/src/prediction.rs
@@ -1,0 +1,156 @@
+//! What a client has told the server it did, and the server has not yet
+//! confirmed.
+//!
+//! # Why a buffer is needed at all
+//!
+//! A predicted entity applies its own input immediately, so it is always some
+//! way ahead of the last state the server confirmed. When a correction arrives
+//! it is the answer to an *older* question — the server's view as of the last
+//! input it had received. Snapping to it and stopping there would throw away
+//! every input the player has made since, and the entity would visibly jump
+//! backwards on every packet.
+//!
+//! So the client keeps those inputs, and on a correction re-applies them on top
+//! of the authoritative state. When the prediction was right the replay lands
+//! where the entity already was and nothing is visible, which is the normal case
+//! and the reason this is worth doing.
+
+use bevy_ecs::prelude::Resource;
+
+/// Inputs sent but not yet acknowledged, oldest first.
+#[derive(Resource, Default, Debug)]
+pub struct PendingInputs {
+    /// `(sequence, held key names)`.
+    pending: Vec<(u32, Vec<String>)>,
+    /// The sequence last handed out.
+    latest: u32,
+}
+
+impl PendingInputs {
+    /// Allocates the next input sequence.
+    pub fn next_sequence(&mut self) -> u32 {
+        self.latest = self.latest.wrapping_add(1);
+        self.latest
+    }
+
+    /// Records what was sent under `sequence`.
+    pub fn record(&mut self, sequence: u32, keys: Vec<String>) {
+        self.pending.push((sequence, keys));
+    }
+
+    /// Forgets everything the server has confirmed.
+    ///
+    /// Idempotent, and that is not incidental: UDP delivers duplicates, so the
+    /// same acknowledgement arrives more than once as a matter of course. A
+    /// non-idempotent drop would discard live input the second time.
+    pub fn retain_after(&mut self, acked: u32) {
+        self.pending.retain(|(sequence, _)| *sequence > acked);
+    }
+
+    /// The inputs still awaiting confirmation, oldest first — exactly what a
+    /// correction has to replay.
+    pub fn unacknowledged(&self) -> &[(u32, Vec<String>)] {
+        &self.pending
+    }
+
+    /// How many are outstanding. This is a latency measure, not a scene-size
+    /// one, which is what bounds the cost of a replay.
+    pub fn len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Whether the server has confirmed everything sent.
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys(name: &str) -> Vec<String> {
+        vec![name.to_string()]
+    }
+
+    #[test]
+    fn sequences_are_handed_out_in_order() {
+        let mut pending = PendingInputs::default();
+        assert_eq!(pending.next_sequence(), 1);
+        assert_eq!(pending.next_sequence(), 2);
+    }
+
+    /// Acking in the middle keeps exactly the later ones — the inputs a
+    /// correction still has to replay.
+    #[test]
+    fn acking_the_middle_of_a_run_keeps_only_the_later_inputs() {
+        let mut pending = PendingInputs::default();
+        for (sequence, key) in [(1, "A"), (2, "B"), (3, "C"), (4, "D")] {
+            pending.record(sequence, keys(key));
+        }
+
+        pending.retain_after(2);
+
+        assert_eq!(
+            pending
+                .unacknowledged()
+                .iter()
+                .map(|(sequence, _)| *sequence)
+                .collect::<Vec<_>>(),
+            vec![3, 4],
+            "everything the server has seen is forgotten, and nothing else is"
+        );
+    }
+
+    /// UDP duplicates packets as a matter of course, so the same ack arrives
+    /// twice. A non-idempotent drop would discard live input on the second one.
+    #[test]
+    fn acking_the_same_sequence_twice_discards_nothing_extra() {
+        let mut pending = PendingInputs::default();
+        pending.record(1, keys("A"));
+        pending.record(2, keys("B"));
+
+        pending.retain_after(1);
+        let after_first = pending.len();
+        pending.retain_after(1);
+
+        assert_eq!(pending.len(), after_first, "the repeat must change nothing");
+        assert_eq!(pending.unacknowledged()[0].0, 2);
+    }
+
+    /// An ack for something never sent (or long past) empties the buffer rather
+    /// than leaving stale input to be replayed forever.
+    #[test]
+    fn acking_beyond_everything_empties_the_buffer() {
+        let mut pending = PendingInputs::default();
+        pending.record(1, keys("A"));
+        pending.record(2, keys("B"));
+
+        pending.retain_after(99);
+
+        assert!(pending.is_empty());
+    }
+
+    /// An out-of-order ack for an *older* sequence must not resurrect anything
+    /// or drop anything newer. UDP reorders, so this arrives in practice.
+    #[test]
+    fn a_late_ack_for_an_older_sequence_drops_nothing_newer() {
+        let mut pending = PendingInputs::default();
+        pending.record(1, keys("A"));
+        pending.record(2, keys("B"));
+        pending.record(3, keys("C"));
+
+        pending.retain_after(2);
+        pending.retain_after(1);
+
+        assert_eq!(
+            pending
+                .unacknowledged()
+                .iter()
+                .map(|(sequence, _)| *sequence)
+                .collect::<Vec<_>>(),
+            vec![3],
+            "the stale ack must not bring 2 back"
+        );
+    }
+}

--- a/crates/bsengine-network/tests/loopback.rs
+++ b/crates/bsengine-network/tests/loopback.rs
@@ -19,7 +19,7 @@
 use bevy_app::App;
 use bevy_ecs::prelude::*;
 use bsengine_core::{NetworkAuthority, NetworkId, Transform};
-use bsengine_network::{NetworkConfig, NetworkPlugin, NetworkSession};
+use bsengine_network::{AppliedInputs, NetworkConfig, NetworkPlugin, NetworkSession};
 use glam::Vec3;
 
 /// A server app and a client app wired to each other over loopback.
@@ -276,5 +276,81 @@ fn a_default_session_replicates_as_it_always_did() {
         (x - 42.0).abs() < 1e-3,
         "with no delay and no loss the client should sit exactly where the \
          server put it, got x={x}"
+    );
+}
+
+/// A predicted entity's owner sends **input**, never its transform.
+///
+/// The two messages are not interchangeable: a transform from the client would
+/// make it authoritative again and leave the server nothing to disagree with,
+/// which is the whole thing prediction exists to arrange.
+#[test]
+fn a_predicted_entity_sends_input_rather_than_its_transform() {
+    let mut pair = Pair::connect(NetworkConfig::default());
+
+    let peer_id = pair.client.world().resource::<NetworkSession>().my_peer_id;
+    for world in [pair.server.world_mut(), pair.client.world_mut()] {
+        world.spawn((
+            NetworkId {
+                id: 1,
+                authority: NetworkAuthority::Predicted { peer_id },
+            },
+            Transform::default(),
+        ));
+    }
+    // Something for the client to be holding, so the input is not empty.
+    pair.client
+        .world_mut()
+        .insert_resource(bsengine_core::LocalHeldKeys(vec!["W".to_string()]));
+
+    for _ in 0..4 {
+        pair.step();
+    }
+
+    let applied = pair.server.world().resource::<AppliedInputs>();
+    assert!(
+        !applied.0.is_empty(),
+        "the server must have applied at least one input for the predicted \
+         entity -- an empty map means the client sent a transform, or nothing"
+    );
+
+    let remote = pair
+        .server
+        .world()
+        .resource::<bsengine_core::RemoteHeldKeys>();
+    assert_eq!(
+        remote.0.get(&1).map(Vec::as_slice),
+        Some(["W".to_string()].as_slice()),
+        "and the keys it published for that entity are the ones the client held"
+    );
+}
+
+/// A client-authoritative entity is untouched by any of this, which is what
+/// makes the change additive rather than a migration.
+#[test]
+fn a_client_authoritative_entity_still_sends_its_transform() {
+    let mut pair = Pair::connect(NetworkConfig::default());
+
+    let peer_id = pair.client.world().resource::<NetworkSession>().my_peer_id;
+    for world in [pair.server.world_mut(), pair.client.world_mut()] {
+        world.spawn((
+            NetworkId {
+                id: 2,
+                authority: NetworkAuthority::Client { peer_id },
+            },
+            Transform {
+                position: Vec3::new(3.0, 0.0, 0.0).into(),
+                ..Default::default()
+            },
+        ));
+    }
+
+    for _ in 0..4 {
+        pair.step();
+    }
+
+    assert!(
+        pair.server.world().resource::<AppliedInputs>().0.is_empty(),
+        "a client-authoritative entity must not be feeding the input path"
     );
 }

--- a/crates/bsengine-network/tests/loopback.rs
+++ b/crates/bsengine-network/tests/loopback.rs
@@ -354,3 +354,100 @@ fn a_client_authoritative_entity_still_sends_its_transform() {
         "a client-authoritative entity must not be feeding the input path"
     );
 }
+
+/// The producer half of reconciliation: a correction for a predicted entity
+/// must actually be **emitted**, not merely applicable.
+///
+/// This test exists because its absence hid a real gap. The scripting-side
+/// tests inject a `ReplayRequest` directly and assert it is applied, so they
+/// pass whether or not anything ever produces one — a disconnected producer
+/// looks exactly like a working one from the consumer's side. Clippy's
+/// "unused variable" warning is what actually caught it, which is not a
+/// safety net anyone should rely on twice.
+#[test]
+fn a_correction_for_a_predicted_entity_is_emitted_to_the_scripting_layer() {
+    let mut pair = Pair::connect(NetworkConfig::default());
+    let peer_id = pair.client.world().resource::<NetworkSession>().my_peer_id;
+
+    // Server-side: the entity the server simulates and is authoritative over.
+    pair.server.world_mut().spawn((
+        NetworkId {
+            id: 1,
+            authority: NetworkAuthority::Predicted { peer_id },
+        },
+        Transform {
+            position: Vec3::new(9.0, 0.0, 0.0).into(),
+            ..Default::default()
+        },
+    ));
+    // Client-side: the same entity, which this peer predicts.
+    pair.client.world_mut().spawn((
+        NetworkId {
+            id: 1,
+            authority: NetworkAuthority::Predicted { peer_id },
+        },
+        Transform::default(),
+    ));
+
+    for _ in 0..4 {
+        pair.step();
+    }
+
+    let replays = pair
+        .client
+        .world()
+        .resource::<bsengine_core::PendingReplays>();
+    assert!(
+        replays.0.iter().any(|r| r.net_id == 1),
+        "the client must have been handed a correction for its predicted \
+         entity; without one, reconciliation never fires in a real game no \
+         matter how well the scripting side applies them"
+    );
+
+    // And it must be a correction, not an empty shell: the authoritative
+    // position has to be the server's.
+    let request = replays
+        .0
+        .iter()
+        .find(|r| r.net_id == 1)
+        .expect("checked above");
+    assert!(
+        (request.authoritative.position.0.x - 9.0).abs() < 1e-3,
+        "the correction must carry where the server actually says the entity \
+         is; got x={}",
+        request.authoritative.position.0.x
+    );
+}
+
+/// Paired with the above: a predicted entity must **not** also be interpolated.
+///
+/// Buffering it would fight the local prediction and hold the entity a delay in
+/// the past — the opposite of the reason it is predicted at all.
+#[test]
+fn a_predicted_entity_is_corrected_rather_than_interpolated() {
+    let mut pair = Pair::connect(NetworkConfig::default());
+    let peer_id = pair.client.world().resource::<NetworkSession>().my_peer_id;
+
+    for world in [pair.server.world_mut(), pair.client.world_mut()] {
+        world.spawn((
+            NetworkId {
+                id: 1,
+                authority: NetworkAuthority::Predicted { peer_id },
+            },
+            Transform::default(),
+        ));
+    }
+
+    for _ in 0..4 {
+        pair.step();
+    }
+
+    assert!(
+        pair.client
+            .world()
+            .resource::<bsengine_network::SnapshotBuffers>()
+            .get(1)
+            .is_none(),
+        "a predicted entity must not be in the interpolation buffer"
+    );
+}

--- a/crates/bsengine-scene/src/plugin.rs
+++ b/crates/bsengine-scene/src/plugin.rs
@@ -1460,6 +1460,57 @@ mod tests {
     }
 
     #[test]
+    fn net_2p_demos_players_are_actually_replicated() {
+        // Until this scene authored `NetworkId`, the send system's
+        // `(&NetworkId, &Transform)` query matched nothing and the networking
+        // demo replicated **nothing** -- both players moved on their own local
+        // clock and it would have looked identical with the network unplugged.
+        //
+        // `NetworkId` goes in through the generic reflected `components:` list,
+        // which is the path that fails *silently*: the scene parses, the entity
+        // spawns, and the component is simply absent. So this asserts the
+        // component is there and carries the authority the file says, not just
+        // that the file parses.
+        //
+        // Reads the real scene, because the point is to fail when someone edits
+        // it.
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("workspace root is two levels above crates/bsengine-scene");
+        let text = std::fs::read_to_string(root.join("games/net-2p-demo/server/scene.ron"))
+            .expect("net-2p-demo's server scene should be readable");
+        let scene: crate::types::SceneDescriptor =
+            ron::from_str(&text).expect("net-2p-demo's server scene should parse");
+
+        let mut app = new_app();
+        super::register_gameplay_reflect_types(&mut app);
+        super::spawn_scene_entities(app.world_mut(), &scene.entities);
+
+        let mut query = app
+            .world_mut()
+            .query::<(&crate::Name, &bsengine_core::NetworkId)>();
+        let found: Vec<(String, bsengine_core::NetworkAuthority)> = query
+            .iter(app.world())
+            .map(|(name, nid)| (name.0.clone(), nid.authority))
+            .collect();
+
+        assert_eq!(
+            found.len(),
+            3,
+            "all three players must carry a NetworkId; without it the demo              replicates nothing. Found {found:?}"
+        );
+        assert!(
+            found.iter().any(|(name, authority)| name == "PredictedPlayer"
+                && matches!(
+                    authority,
+                    bsengine_core::NetworkAuthority::Predicted { peer_id: 1 }
+                )),
+            "the predicted player must be server-simulated from peer 1's input;              a Client authority here would mean nothing to reconcile. Found {found:?}"
+        );
+    }
+
+    #[test]
     fn a_scene_texture_reference_becomes_a_texture_path_component() {
         // Parsing the field proves nothing on its own: the resolved path has to
         // reach the entity, because that component is the only thing the loader

--- a/crates/bsengine-scripting/Cargo.toml
+++ b/crates/bsengine-scripting/Cargo.toml
@@ -28,6 +28,10 @@ tracing.workspace = true
 
 [dev-dependencies]
 bsengine-app.workspace = true
+# The prediction tests spawn a named, networked entity and drive a real
+# movement script over it, which needs `Name` and `glam` directly.
+bsengine-scene.workspace = true
+glam.workspace = true
 # The hot-reload tests drive a real `AssetWatcherPlugin` over a real project
 # directory that has to be removed afterwards even when a test panics, and
 # `ProbeDir`/`unique` are what the watcher's own tests use for exactly that —

--- a/crates/bsengine-scripting/src/js/prelude.js
+++ b/crates/bsengine-scripting/src/js/prelude.js
@@ -798,6 +798,26 @@ var Bsengine = {
         return v ? Math.sqrt(v.x*v.x+v.y*v.y+v.z*v.z) : 0;
     },
 
+    // Runs one entity's `onUpdate`, for replaying a predicted entity's input
+    // after a server correction. Deliberately does *not* tick timers or
+    // dispatch input events the way `_runAll` does: a replay re-applies input
+    // that already happened, and firing its events again would double every
+    // key-press handler in the game.
+    _runOne(id, name) {
+        const s = this._scripts[id];
+        if (!s || !s.onUpdate) {
+            return;
+        }
+        this._currentEntity = name;
+        try {
+            s.onUpdate(name);
+        } catch (e) {
+            this.log(`[${name}] onUpdate error during replay: ${e}`);
+        } finally {
+            this._currentEntity = "";
+        }
+    },
+
     // Called each frame by the engine with [[id, name], ...] for all scripted entities.
     _runAll(entities) {
         this._tickTimers();

--- a/crates/bsengine-scripting/src/js/prelude.js
+++ b/crates/bsengine-scripting/src/js/prelude.js
@@ -179,9 +179,14 @@ var Bsengine = {
     addRotationEuler: (name, a, b, c) => { const [x, y, z] = _xyz(a, b, c); Deno.core.ops.bsengine_add_rotation_euler(name, x, y, z); },
     addScale: (name, a, b, c) => { const [x, y, z] = _xyz(a, b, c); Deno.core.ops.bsengine_add_scale(name, x, y, z); },
     multiplyScale: (name, a, b, c) => { const [x, y, z] = _xyz(a, b, c); Deno.core.ops.bsengine_multiply_scale(name, x, y, z); },
-    isKeyPressed:   (key)                  => Deno.core.ops.bsengine_is_key_pressed(key),
-    isKeyDown:      (key)                  => Deno.core.ops.bsengine_is_key_down(key),
-    isKeyUp:        (key)                  => Deno.core.ops.bsengine_is_key_up(key),
+    // Each takes the entity whose script is running, so a server simulating a
+    // remote player's movement reads *that peer's* input rather than the
+    // keyboard of the machine it happens to be running on. `_currentEntity` is
+    // set by `_runAll` around every dispatch; see there for why this cannot be
+    // done from Rust.
+    isKeyPressed:   (key)                  => Deno.core.ops.bsengine_is_key_pressed(Bsengine._currentEntity, key),
+    isKeyDown:      (key)                  => Deno.core.ops.bsengine_is_key_down(Bsengine._currentEntity, key),
+    isKeyUp:        (key)                  => Deno.core.ops.bsengine_is_key_up(Bsengine._currentEntity, key),
     pause:          ()                     => Deno.core.ops.bsengine_pause(),
     resume:         ()                     => Deno.core.ops.bsengine_resume(),
     isPaused:       ()                     => Deno.core.ops.bsengine_is_paused(),
@@ -724,6 +729,16 @@ var Bsengine = {
     // Per-entity script registry. Keys are entity bit-IDs (strings).
     _scripts: {},
 
+    // The name of the entity whose `onUpdate` is running right now, so the
+    // input accessors can ask for *its* input instead of for "the keyboard".
+    //
+    // It lives here rather than in Rust because Rust cannot see individual
+    // entities during dispatch: it calls `_runAll` once per frame and the loop
+    // below is the only place that knows which entity is next. Empty means "no
+    // script is running", for which every accessor falls back to the local
+    // keyboard.
+    _currentEntity: "",
+
     // --- Messaging ---
     _messageHandlers: {},
 
@@ -792,10 +807,17 @@ var Bsengine = {
         for (const [id, name] of entities) {
             const s = this._scripts[id];
             if (s && s.onUpdate) {
+                this._currentEntity = name;
                 try {
                     s.onUpdate(name);
                 } catch (e) {
                     this.log(`[${name}] onUpdate error: ${e}`);
+                } finally {
+                    // Cleared on every exit, a throwing script included. A
+                    // leaked name would make the *next* entity read this one's
+                    // input, which produces no error and reads as a gameplay
+                    // bug rather than as the plumbing mistake it is.
+                    this._currentEntity = "";
                 }
             }
         }

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -1514,6 +1514,29 @@ thread_local! {
         RefCell::new(HashMap::new());
     pub(crate) static WORLD_TRANSFORM_SNAPSHOT: RefCell<HashMap<String, (Vec3, Quat, Vec3)>> =
         RefCell::new(HashMap::new());
+    /// Held keys per entity **name**, for entities whose input arrives over the
+    /// network rather than from this process's keyboard.
+    ///
+    /// Keyed by name because that is how every other entity-addressing op in
+    /// this file works — no op takes entity bits, and inventing a second
+    /// addressing scheme for this one feature would be a second thing to keep
+    /// in step.
+    ///
+    /// An entity absent from this map has no remote owner, and the local
+    /// keyboard answers for it. **That fallback is what keeps every existing
+    /// single-player script working unchanged**, and it is why introducing this
+    /// map changes no behaviour on its own.
+    pub(crate) static REMOTE_INPUT: RefCell<HashMap<String, HashSet<String>>> =
+        RefCell::new(HashMap::new());
+    /// The same, as of the previous frame, so just-pressed and just-released can
+    /// be **derived** rather than transmitted.
+    ///
+    /// Deriving keeps the wire to one set per frame and makes the three states
+    /// consistent by construction. Three independently transmitted sets can
+    /// disagree — a key reported both just-pressed and not held — and a script
+    /// reading two of them would see a frame that never happened.
+    pub(crate) static REMOTE_INPUT_PREVIOUS: RefCell<HashMap<String, HashSet<String>>> =
+        RefCell::new(HashMap::new());
     pub(crate) static KEY_SNAPSHOT: RefCell<HashSet<String>> =
         RefCell::new(HashSet::new());
     pub(crate) static KEY_JUST_PRESSED_SNAPSHOT: RefCell<HashSet<String>> =
@@ -2577,20 +2600,57 @@ pub fn bsengine_multiply_scale(#[string] name: String, sx: f32, sy: f32, sz: f32
 
 /// Check whether a keyboard key was pressed this frame.
 #[op2(fast)]
-pub fn bsengine_is_key_pressed(#[string] key: String) -> bool {
-    KEY_SNAPSHOT.with(|k| k.borrow().contains(&key))
+pub fn bsengine_is_key_pressed(#[string] entity: String, #[string] key: String) -> bool {
+    key_pressed_for(&entity, &key)
+}
+
+/// Whether `key` is held for the entity a script is currently running for.
+///
+/// Falls back to this process's keyboard when the entity has no remote input,
+/// which is every entity in a single-player game.
+pub(crate) fn key_pressed_for(entity: &str, key: &str) -> bool {
+    REMOTE_INPUT.with(|remote| match remote.borrow().get(entity) {
+        Some(held) => held.contains(key),
+        None => KEY_SNAPSHOT.with(|k| k.borrow().contains(key)),
+    })
+}
+
+/// Whether `key` was held for `entity` on the previous frame.
+fn was_held_for(entity: &str, key: &str) -> bool {
+    REMOTE_INPUT_PREVIOUS.with(|previous| {
+        previous
+            .borrow()
+            .get(entity)
+            .is_some_and(|held| held.contains(key))
+    })
+}
+
+/// Whether `key` went down this frame for that entity.
+pub(crate) fn key_down_for(entity: &str, key: &str) -> bool {
+    REMOTE_INPUT.with(|remote| match remote.borrow().get(entity) {
+        Some(held) => held.contains(key) && !was_held_for(entity, key),
+        None => KEY_JUST_PRESSED_SNAPSHOT.with(|k| k.borrow().contains(key)),
+    })
+}
+
+/// Whether `key` came up this frame for that entity.
+pub(crate) fn key_up_for(entity: &str, key: &str) -> bool {
+    REMOTE_INPUT.with(|remote| match remote.borrow().get(entity) {
+        Some(held) => !held.contains(key) && was_held_for(entity, key),
+        None => KEY_JUST_RELEASED_SNAPSHOT.with(|k| k.borrow().contains(key)),
+    })
 }
 
 /// Check whether a keyboard key is currently held down.
 #[op2(fast)]
-pub fn bsengine_is_key_down(#[string] key: String) -> bool {
-    KEY_JUST_PRESSED_SNAPSHOT.with(|k| k.borrow().contains(&key))
+pub fn bsengine_is_key_down(#[string] entity: String, #[string] key: String) -> bool {
+    key_down_for(&entity, &key)
 }
 
 /// Check whether a keyboard key was released this frame.
 #[op2(fast)]
-pub fn bsengine_is_key_up(#[string] key: String) -> bool {
-    KEY_JUST_RELEASED_SNAPSHOT.with(|k| k.borrow().contains(&key))
+pub fn bsengine_is_key_up(#[string] entity: String, #[string] key: String) -> bool {
+    key_up_for(&entity, &key)
 }
 
 /// Get the names of all named entities, as a JSON array string.
@@ -6072,6 +6132,91 @@ pub const BOOTSTRAP_JS: &str = include_str!("js/prelude.js");
 #[cfg(test)]
 mod tests {
     use crate::runtime::ScriptRuntime;
+
+    mod remote_input {
+        use crate::ops::{
+            key_down_for, key_pressed_for, key_up_for, KEY_JUST_PRESSED_SNAPSHOT,
+            KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, REMOTE_INPUT, REMOTE_INPUT_PREVIOUS,
+        };
+        use std::collections::HashSet;
+
+        fn set(keys: &[&str]) -> HashSet<String> {
+            keys.iter().map(|k| (*k).to_string()).collect()
+        }
+
+        fn clear() {
+            REMOTE_INPUT.with(|r| r.borrow_mut().clear());
+            REMOTE_INPUT_PREVIOUS.with(|r| r.borrow_mut().clear());
+            KEY_SNAPSHOT.with(|k| k.borrow_mut().clear());
+            KEY_JUST_PRESSED_SNAPSHOT.with(|k| k.borrow_mut().clear());
+            KEY_JUST_RELEASED_SNAPSHOT.with(|k| k.borrow_mut().clear());
+        }
+
+        /// The fallback, which is what keeps every existing single-player script
+        /// working. Without it this change would break every game in the repo.
+        #[test]
+        fn an_entity_with_no_remote_input_reads_this_process_keyboard() {
+            clear();
+            KEY_SNAPSHOT.with(|k| *k.borrow_mut() = set(&["W"]));
+            KEY_JUST_PRESSED_SNAPSHOT.with(|k| *k.borrow_mut() = set(&["W"]));
+
+            assert!(key_pressed_for("Player", "W"));
+            assert!(key_down_for("Player", "W"));
+        }
+
+        /// The substitution, and the leak it must not have.
+        #[test]
+        fn an_entity_with_remote_input_reads_that_instead_of_the_keyboard() {
+            clear();
+            KEY_SNAPSHOT.with(|k| *k.borrow_mut() = set(&["W"]));
+            REMOTE_INPUT.with(|r| r.borrow_mut().insert("Remote".into(), set(&["S"])));
+
+            assert!(key_pressed_for("Remote", "S"), "the peer's key answers");
+            assert!(
+                !key_pressed_for("Remote", "W"),
+                "and this process's keyboard must not leak in -- otherwise a                  server operator holding W would drive every client's player"
+            );
+        }
+
+        /// The assertion that catches a map keyed or restored wrongly.
+        #[test]
+        fn two_entities_with_remote_input_do_not_see_each_others() {
+            clear();
+            REMOTE_INPUT.with(|r| {
+                let mut map = r.borrow_mut();
+                map.insert("One".into(), set(&["A"]));
+                map.insert("Two".into(), set(&["D"]));
+            });
+
+            assert!(key_pressed_for("One", "A") && !key_pressed_for("One", "D"));
+            assert!(key_pressed_for("Two", "D") && !key_pressed_for("Two", "A"));
+        }
+
+        /// Just-pressed is derived from the previous frame rather than sent, so
+        /// held-and-pressed can never disagree. A key held on both frames is
+        /// *not* newly pressed.
+        #[test]
+        fn just_pressed_is_derived_from_the_previous_frame() {
+            clear();
+            REMOTE_INPUT_PREVIOUS.with(|r| r.borrow_mut().insert("P".into(), set(&["W"])));
+            REMOTE_INPUT.with(|r| r.borrow_mut().insert("P".into(), set(&["W", "A"])));
+
+            assert!(!key_down_for("P", "W"), "held on both frames is not new");
+            assert!(key_down_for("P", "A"), "newly held is");
+            assert!(key_pressed_for("P", "W"), "and both are held");
+        }
+
+        /// The other end of the derivation, so a release is observable at all.
+        #[test]
+        fn just_released_is_derived_from_the_previous_frame() {
+            clear();
+            REMOTE_INPUT_PREVIOUS.with(|r| r.borrow_mut().insert("P".into(), set(&["W"])));
+            REMOTE_INPUT.with(|r| r.borrow_mut().insert("P".into(), set(&[])));
+
+            assert!(key_up_for("P", "W"));
+            assert!(!key_pressed_for("P", "W"));
+        }
+    }
 
     /// Evaluates `expr` against a runtime with the prelude loaded.
     fn eval_js(expr: &str) -> String {

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -818,6 +818,45 @@ fn run_scripts(world: &mut World) {
 
     let (scripted, collision_json) = collect_world_snapshots(world);
 
+    // Server corrections for predicted entities, taken before the V8 borrow
+    // below because applying the authoritative transform needs `&mut World`.
+    //
+    // Drained rather than read: a correction left in place would be applied
+    // again next frame and move the entity twice.
+    let replays: Vec<(String, String, Vec<Vec<String>>)> = {
+        let requests = world
+            .get_resource_mut::<bsengine_core::PendingReplays>()
+            .map(|mut r| std::mem::take(&mut r.0))
+            .unwrap_or_default();
+        if requests.is_empty() {
+            Vec::new()
+        } else {
+            let by_net_id: HashMap<u64, (String, String)> = {
+                let mut q = world.query::<(Entity, &Name, &bsengine_core::NetworkId)>();
+                q.iter(world)
+                    .map(|(entity, name, nid)| {
+                        (nid.id, (entity.to_bits().to_string(), name.0.clone()))
+                    })
+                    .collect()
+            };
+            let mut prepared = Vec::new();
+            for request in requests {
+                let Some((bits, name)) = by_net_id.get(&request.net_id).cloned() else {
+                    continue;
+                };
+                // The snap. Everything the replay does after this is the client
+                // re-deriving what it had already predicted, from a state the
+                // server agrees with.
+                let entity = Entity::from_bits(bits.parse::<u64>().unwrap_or(0));
+                if let Some(mut transform) = world.get_mut::<Transform>(entity) {
+                    *transform = request.authoritative.clone();
+                }
+                prepared.push((bits, name, request.replay));
+            }
+            prepared
+        }
+    };
+
     if let Some(mut rt) = world.get_non_send_resource_mut::<ScriptRuntimeResource>() {
         // Dispatch collision events to JS before update
         if collision_json != "[]" {
@@ -825,6 +864,31 @@ fn run_scripts(world: &mut World) {
             if let Err(e) = rt.0.exec_source(&call, "<run_collisions>") {
                 tracing::error!("[scripting] _runCollisions error: {e}");
             }
+        }
+
+        // Re-apply the input the server had not yet seen, oldest first, before
+        // this frame's own input runs -- so the frame lands on a reconciled
+        // state rather than on a stale one.
+        for (bits, name, inputs) in &replays {
+            for keys in inputs {
+                // The recorded input replaces the live keyboard for this one
+                // entity, which is what makes a replay reproduce the past
+                // instead of re-applying the present.
+                REMOTE_INPUT.with(|r| {
+                    r.borrow_mut()
+                        .insert(name.clone(), keys.iter().cloned().collect())
+                });
+                let call = format!("Bsengine._runOne(\"{bits}\", \"{name}\");");
+                if let Err(e) = rt.0.exec_source(&call, "<replay>") {
+                    tracing::error!("[scripting] replay of {name} failed: {e}");
+                }
+            }
+            // Removed unconditionally: left in place it would make this frame's
+            // live `_runAll` read the last replayed input instead of the
+            // keyboard, which reads to a player as their controls sticking.
+            REMOTE_INPUT.with(|r| {
+                r.borrow_mut().remove(name);
+            });
         }
 
         let entities_json = serde_json::to_string(&scripted).unwrap_or_else(|_| "[]".to_string());

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -28,11 +28,12 @@ use crate::ops::{
     MATERIAL_METALLIC_SNAPSHOT, MATERIAL_ROUGHNESS_SNAPSHOT, MOUSE_DELTA_SNAPSHOT,
     MOUSE_JUST_PRESSED_SNAPSHOT, MOUSE_JUST_RELEASED_SNAPSHOT, MOUSE_POS_SNAPSHOT,
     MOUSE_PRESSED_SNAPSHOT, NAV_SNAPSHOT, NETWORK_ID_SNAPSHOT, NETWORK_STATE_SNAPSHOT,
-    PARENT_SNAPSHOT, PAUSED_SNAPSHOT, PHYSICS_WORLD_PTR, PROJECT_DIR, RESTITUTION_SNAPSHOT,
-    SAVE_DATA_SNAPSHOT, SCREEN_SIZE_SNAPSHOT, SHIELD_SNAPSHOT, SLEEP_SNAPSHOT,
-    SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT, TIMER_SNAPSHOT, TIME_DELTA_SNAPSHOT,
-    TIME_ELAPSED_SNAPSHOT, TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT, TWEEN_SNAPSHOT,
-    UI_CLICKED_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT, WORLD_TRANSFORM_SNAPSHOT,
+    PARENT_SNAPSHOT, PAUSED_SNAPSHOT, PHYSICS_WORLD_PTR, PROJECT_DIR, REMOTE_INPUT,
+    REMOTE_INPUT_PREVIOUS, RESTITUTION_SNAPSHOT, SAVE_DATA_SNAPSHOT, SCREEN_SIZE_SNAPSHOT,
+    SHIELD_SNAPSHOT, SLEEP_SNAPSHOT, SOUND_POSITION_SNAPSHOT, SOUND_STATE_SNAPSHOT, TIMER_SNAPSHOT,
+    TIME_DELTA_SNAPSHOT, TIME_ELAPSED_SNAPSHOT, TONE_MAP_SNAPSHOT, TRANSFORM_SNAPSHOT,
+    TWEEN_SNAPSHOT, UI_CLICKED_SNAPSHOT, VELOCITY_SNAPSHOT, VISIBLE_SNAPSHOT,
+    WORLD_TRANSFORM_SNAPSHOT,
 };
 use crate::runtime::ScriptRuntime;
 
@@ -3167,6 +3168,38 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
     if let Some(ss) = world.get_resource::<ScreenSize>() {
         SCREEN_SIZE_SNAPSHOT.with(|s| *s.borrow_mut() = (ss.width, ss.height));
     }
+    // Published for `bsengine-network`, which sends it as this peer's input but
+    // cannot convert key codes to names itself -- that conversion lives here and
+    // stays in one place.
+    let held_now: Vec<String> = key_snapshot.iter().cloned().collect();
+    world.insert_resource(bsengine_core::LocalHeldKeys(held_now));
+
+    // Remote input replaces the keyboard for entities somebody else drives. The
+    // previous frame's map is rolled forward first so just-pressed and
+    // just-released can be derived rather than transmitted.
+    let remote_by_id = world
+        .get_resource::<bsengine_core::RemoteHeldKeys>()
+        .map(|r| r.0.clone())
+        .unwrap_or_default();
+    let remote_by_name: HashMap<String, HashSet<String>> = if remote_by_id.is_empty() {
+        HashMap::new()
+    } else {
+        let mut q = world.query::<(&Name, &bsengine_core::NetworkId)>();
+        q.iter(world)
+            .filter_map(|(name, nid)| {
+                remote_by_id
+                    .get(&nid.id)
+                    .map(|keys| (name.0.clone(), keys.iter().cloned().collect()))
+            })
+            .collect()
+    };
+    REMOTE_INPUT.with(|current| {
+        REMOTE_INPUT_PREVIOUS.with(|previous| {
+            *previous.borrow_mut() = current.borrow().clone();
+        });
+        *current.borrow_mut() = remote_by_name;
+    });
+
     KEY_SNAPSHOT.with(|k| *k.borrow_mut() = key_snapshot);
     KEY_JUST_PRESSED_SNAPSHOT.with(|k| *k.borrow_mut() = key_just_pressed);
     KEY_JUST_RELEASED_SNAPSHOT.with(|k| *k.borrow_mut() = key_just_released);
@@ -3658,6 +3691,7 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
                 NetworkAuthority::Server => (0u32, String::new()),
                 NetworkAuthority::Client { peer_id } => (1u32, peer_id.to_string()),
                 NetworkAuthority::Local => (2u32, String::new()),
+                NetworkAuthority::Predicted { peer_id } => (3u32, peer_id.to_string()),
             };
             map.insert(name.0.clone(), (nid.id.to_string(), auth_kind, peer_id_str));
         }

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -801,6 +801,61 @@ fn find_named_pair(world: &mut World, a: &str, b: &str) -> (Option<Entity>, Opti
     found
 }
 
+/// Refreshes one entity's entry in the snapshot scripts read positions from.
+///
+/// A replay step has to see where the previous step left the entity. Without
+/// this every step of a replay reads the position the frame started at, and a
+/// three-input replay advances by one input.
+fn refresh_transform_snapshot(world: &mut World, name: &str) {
+    let found = {
+        let mut q = world.query::<(&Name, &Transform)>();
+        q.iter(world)
+            .find(|(n, _)| n.0 == name)
+            .map(|(_, t)| (t.position.0, t.rotation.0, t.scale.0))
+    };
+    if let Some(entry) = found {
+        TRANSFORM_SNAPSHOT.with(|s| {
+            s.borrow_mut().insert(name.to_string(), entry);
+        });
+    }
+}
+
+/// Applies what a replay step moved, and **discards everything else it did**.
+///
+/// # Why the rest is thrown away rather than applied
+///
+/// A replay re-derives where an entity ended up; it does not re-live the frame.
+/// The sound that played, the HUD text that changed and the prefab that spawned
+/// during the original input all already happened — re-applying them on every
+/// server correction would fire that sound again and again, and a player would
+/// literally hear their own latency. Position is the only thing a correction is
+/// reconstructing, so position is the only thing kept.
+///
+/// This is why a replay does not simply reuse `run_scripts`'s own command drain:
+/// that drain is correct for a live frame and wrong for a replayed one.
+fn apply_replayed_movement(world: &mut World, name: &str) {
+    let commands: Vec<ScriptCommand> =
+        COMMAND_BUFFER.with(|c| std::mem::take(&mut *c.borrow_mut()));
+
+    for cmd in commands {
+        if let ScriptCommand::SetPosition {
+            name: target,
+            x,
+            y,
+            z,
+        } = cmd
+        {
+            if target != name {
+                continue;
+            }
+            let mut q = world.query::<(&Name, &mut Transform)>();
+            if let Some((_, mut transform)) = q.iter_mut(world).find(|(n, _)| n.0 == target) {
+                transform.position = Vec3::new(x, y, z).into();
+            }
+        }
+    }
+}
+
 fn run_scripts(world: &mut World) {
     // In editor mode, only run scripts when Play is active
     if let Some(insp) = world.get_resource::<InspectorState>() {
@@ -857,6 +912,44 @@ fn run_scripts(world: &mut World) {
         }
     };
 
+    // Replay each correction's unacknowledged input, oldest first, *before* this
+    // frame's own scripts run, so the frame lands on a reconciled state.
+    //
+    // Each step is its own V8 call followed immediately by applying what it
+    // produced, and that is forced rather than stylistic: the script/world
+    // exchange is deferred by design — a script reads `TRANSFORM_SNAPSHOT` and
+    // writes into `COMMAND_BUFFER`, both settled once per frame. Run back to
+    // back inside one borrow, three replay steps would all read the position the
+    // frame started at and the last write would win, so the entity would advance
+    // one step instead of three. That is exactly what the exact-position test
+    // caught, and what a "did it move" assertion would have missed.
+    for (bits, name, inputs) in &replays {
+        for keys in inputs {
+            // The recorded input replaces the live keyboard for this one entity,
+            // which is what makes a replay reproduce the past rather than
+            // re-apply the present.
+            REMOTE_INPUT.with(|r| {
+                r.borrow_mut()
+                    .insert(name.clone(), keys.iter().cloned().collect())
+            });
+            refresh_transform_snapshot(world, name);
+
+            if let Some(mut rt) = world.get_non_send_resource_mut::<ScriptRuntimeResource>() {
+                let call = format!("Bsengine._runOne(\"{bits}\", \"{name}\");");
+                if let Err(e) = rt.0.exec_source(&call, "<replay>") {
+                    tracing::error!("[scripting] replay of {name} failed: {e}");
+                }
+            }
+            apply_replayed_movement(world, name);
+        }
+        // Removed unconditionally: left in place it would make this frame's live
+        // scripts read the last replayed input instead of the keyboard, which
+        // reads to a player as their controls sticking.
+        REMOTE_INPUT.with(|r| {
+            r.borrow_mut().remove(name);
+        });
+    }
+
     if let Some(mut rt) = world.get_non_send_resource_mut::<ScriptRuntimeResource>() {
         // Dispatch collision events to JS before update
         if collision_json != "[]" {
@@ -864,31 +957,6 @@ fn run_scripts(world: &mut World) {
             if let Err(e) = rt.0.exec_source(&call, "<run_collisions>") {
                 tracing::error!("[scripting] _runCollisions error: {e}");
             }
-        }
-
-        // Re-apply the input the server had not yet seen, oldest first, before
-        // this frame's own input runs -- so the frame lands on a reconciled
-        // state rather than on a stale one.
-        for (bits, name, inputs) in &replays {
-            for keys in inputs {
-                // The recorded input replaces the live keyboard for this one
-                // entity, which is what makes a replay reproduce the past
-                // instead of re-applying the present.
-                REMOTE_INPUT.with(|r| {
-                    r.borrow_mut()
-                        .insert(name.clone(), keys.iter().cloned().collect())
-                });
-                let call = format!("Bsengine._runOne(\"{bits}\", \"{name}\");");
-                if let Err(e) = rt.0.exec_source(&call, "<replay>") {
-                    tracing::error!("[scripting] replay of {name} failed: {e}");
-                }
-            }
-            // Removed unconditionally: left in place it would make this frame's
-            // live `_runAll` read the last replayed input instead of the
-            // keyboard, which reads to a player as their controls sticking.
-            REMOTE_INPUT.with(|r| {
-                r.borrow_mut().remove(name);
-            });
         }
 
         let entities_json = serde_json::to_string(&scripted).unwrap_or_else(|_| "[]".to_string());

--- a/crates/bsengine-scripting/tests/prediction.rs
+++ b/crates/bsengine-scripting/tests/prediction.rs
@@ -1,0 +1,274 @@
+//! Client-side prediction and server reconciliation, with a real movement
+//! script running on both peers.
+//!
+//! # Why this test lives in the scripting crate
+//!
+//! Because both halves have to be here. `bsengine-network` decides *that* a
+//! correction is due and `bsengine-scripting` performs it by re-running the
+//! movement script — and scripting depends on network, so the network crate
+//! cannot dev-depend back on it. This is the only crate that can see the whole
+//! path.
+//!
+//! # Why every test here induces latency
+//!
+//! With none, the prediction and the authoritative state agree on every frame,
+//! so a client that ignored corrections entirely would pass. The latency is the
+//! instrument, not the scenario.
+
+use bevy_app::App;
+use bevy_ecs::prelude::*;
+use bsengine_app::new_app;
+use bsengine_core::{
+    LocalHeldKeys, NetworkAuthority, NetworkId, PendingReplays, RemoteHeldKeys, ReplayRequest,
+    Transform,
+};
+use bsengine_scene::{Name, ScriptPath};
+use bsengine_scripting::{Script, ScriptingPlugin};
+use glam::Vec3;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// A movement script of the shape a game would actually write: read a key, move.
+///
+/// Deliberately not a clock — `games/net-2p-demo` moves on `t += deltaTime` and
+/// therefore has nothing to predict, which is what made it useless as a fixture
+/// for this.
+const MOVE_SCRIPT: &str = r#"
+function onUpdate(name) {
+    if (Bsengine.isKeyPressed("D")) {
+        const p = Bsengine.getTransform(name).position;
+        Bsengine.setPosition(name, p.x + 1.0, p.y, p.z);
+    }
+}
+"#;
+
+/// A throwaway script file, removed on drop.
+struct ScriptFile(std::path::PathBuf);
+
+impl Drop for ScriptFile {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.0).ok();
+    }
+}
+
+fn write_script() -> ScriptFile {
+    static N: AtomicU32 = AtomicU32::new(0);
+    let path = std::env::temp_dir().join(format!(
+        "bsengine-prediction-{}-{}.js",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&path, MOVE_SCRIPT).expect("write script");
+    ScriptFile(path)
+}
+
+/// Builds a headless app with a named, networked, scripted entity, and steps it
+/// until the script has actually loaded.
+///
+/// "Run until it arrives" rather than a fixed frame count, matching this crate's
+/// existing script tests: how many frames a load takes is `bevy_asset`'s
+/// business, and pinning a number turns a slow filesystem into a failure that
+/// says nothing about prediction.
+fn app_with_script(
+    entity_name: &str,
+    net_id: u64,
+    authority: NetworkAuthority,
+) -> (App, Entity, ScriptFile) {
+    let script = write_script();
+
+    let mut app = new_app();
+    app.add_plugins(bsengine_asset::AssetPlugin);
+    app.add_plugins(ScriptingPlugin {
+        project_dir: String::new(),
+    });
+    app.insert_resource(LocalHeldKeys::default());
+    app.insert_resource(RemoteHeldKeys::default());
+    // Owned by `NetworkPlugin` in a real app. Inserted here because this test
+    // stands in for the networking layer: it publishes the corrections a server
+    // would have sent, and asserts on what the scripting layer does with them.
+    app.insert_resource(PendingReplays::default());
+
+    let entity = app
+        .world_mut()
+        .spawn((
+            Name(entity_name.to_string()),
+            Transform::default(),
+            NetworkId {
+                id: net_id,
+                authority,
+            },
+            ScriptPath(script.0.to_string_lossy().to_string()),
+        ))
+        .id();
+
+    let mut frames = 0;
+    loop {
+        app.update();
+        frames += 1;
+        if app.world().get::<Script>(entity).is_some() {
+            break;
+        }
+        assert!(
+            frames < 300,
+            "the movement script never loaded, so nothing below was measured"
+        );
+    }
+    (app, entity, script)
+}
+
+fn position_x(app: &App, entity: Entity) -> f32 {
+    app.world()
+        .get::<Transform>(entity)
+        .expect("entity has a transform")
+        .position
+        .0
+        .x
+}
+
+/// A correction puts the entity where the server says it was, then re-applies
+/// the input the server had not yet seen.
+///
+/// The expected position is stated exactly rather than as a band: the whole
+/// question is whether **all three** unacknowledged inputs were replayed, and a
+/// tolerance wide enough to be safe would also admit replaying two of them.
+#[test]
+fn a_correction_replays_every_unacknowledged_input() {
+    let (mut app, entity, _script) =
+        app_with_script("Player", 1, NetworkAuthority::Predicted { peer_id: 1 });
+
+    // The server says the entity was at x=10 as of the input it had applied,
+    // and three inputs since then are still unacknowledged -- each of which
+    // moves the entity one unit right.
+    let held = vec!["D".to_string()];
+    app.world_mut()
+        .resource_mut::<PendingReplays>()
+        .0
+        .push(ReplayRequest {
+            net_id: 1,
+            authoritative: Transform {
+                position: Vec3::new(10.0, 0.0, 0.0).into(),
+                ..Default::default()
+            },
+            replay: vec![held.clone(), held.clone(), held.clone()],
+        });
+
+    app.update();
+
+    assert!(
+        (position_x(&app, entity) - 13.0).abs() < 1e-3,
+        "10 from the server plus three replayed inputs is 13; got {}. A lower \
+         number means inputs the server has not seen were dropped, which would \
+         make the entity jump backwards on every packet",
+        position_x(&app, entity)
+    );
+}
+
+/// The snap on its own, with nothing to replay.
+///
+/// Paired with the test above: without this, an implementation that replayed
+/// but never applied the authoritative transform would still reach 13 from a
+/// starting position of 10.
+#[test]
+fn a_correction_with_nothing_outstanding_is_just_the_snap() {
+    let (mut app, entity, _script) =
+        app_with_script("Player", 1, NetworkAuthority::Predicted { peer_id: 1 });
+
+    app.world_mut()
+        .resource_mut::<PendingReplays>()
+        .0
+        .push(ReplayRequest {
+            net_id: 1,
+            authoritative: Transform {
+                position: Vec3::new(7.0, 0.0, 0.0).into(),
+                ..Default::default()
+            },
+            replay: Vec::new(),
+        });
+
+    app.update();
+
+    assert!(
+        (position_x(&app, entity) - 7.0).abs() < 1e-3,
+        "with nothing outstanding the entity sits exactly where the server put \
+         it; got {}",
+        position_x(&app, entity)
+    );
+}
+
+/// A correction must be consumed, not merely read.
+///
+/// Left in place it would be applied again the next frame and move the entity
+/// twice as far — a bug that looks like the physics being wrong rather than the
+/// networking.
+#[test]
+fn a_correction_is_applied_once_and_not_again() {
+    let (mut app, entity, _script) =
+        app_with_script("Player", 1, NetworkAuthority::Predicted { peer_id: 1 });
+
+    app.world_mut()
+        .resource_mut::<PendingReplays>()
+        .0
+        .push(ReplayRequest {
+            net_id: 1,
+            authoritative: Transform {
+                position: Vec3::new(4.0, 0.0, 0.0).into(),
+                ..Default::default()
+            },
+            replay: vec![vec!["D".to_string()]],
+        });
+
+    app.update();
+    let after_first = position_x(&app, entity);
+    app.update();
+    let after_second = position_x(&app, entity);
+
+    assert!(
+        (after_first - 5.0).abs() < 1e-3,
+        "4 from the server plus one replayed input; got {after_first}"
+    );
+    assert!(
+        (after_second - after_first).abs() < 1e-3,
+        "the second frame must not re-apply the same correction; went from \
+         {after_first} to {after_second}"
+    );
+}
+
+/// The replay's input must not survive into the live frame.
+///
+/// If it did, the entity would keep moving as though the key were still held
+/// after the player let go — which reads to a player as their controls sticking,
+/// and would never be traced back to reconciliation.
+#[test]
+fn replayed_input_does_not_leak_into_the_live_frame() {
+    // The local player is holding nothing.
+    let (mut app, entity, _script) =
+        app_with_script("Player", 1, NetworkAuthority::Predicted { peer_id: 1 });
+
+    app.world_mut()
+        .resource_mut::<PendingReplays>()
+        .0
+        .push(ReplayRequest {
+            net_id: 1,
+            authoritative: Transform {
+                position: Vec3::new(0.0, 0.0, 0.0).into(),
+                ..Default::default()
+            },
+            // One replayed input holding D.
+            replay: vec![vec!["D".to_string()]],
+        });
+
+    app.update();
+    let after_correction = position_x(&app, entity);
+
+    // Several quiet frames with no key held and no correction.
+    for _ in 0..3 {
+        app.update();
+    }
+
+    assert!(
+        (position_x(&app, entity) - after_correction).abs() < 1e-3,
+        "with nothing held the entity must stand still after the correction; it \
+         went from {after_correction} to {} , which means the replayed input \
+         outlived its replay",
+        position_x(&app, entity)
+    );
+}

--- a/games/net-2p-demo/client/drive.js
+++ b/games/net-2p-demo/client/drive.js
@@ -1,0 +1,24 @@
+// Input-driven movement for the predicted player.
+//
+// Both peers run this file: the client to predict, the server to decide. That
+// is the whole point of the shared-simulation model -- one movement rule, not
+// one per side that could disagree.
+//
+// `isKeyPressed` reads the input of whichever entity this script is running
+// for, so on the server it sees the *client's* keys rather than the keyboard of
+// the machine hosting the game.
+const SPEED = 4.0;
+
+function onUpdate(name) {
+    const dt = Bsengine.getDeltaTime();
+    let dx = 0.0;
+    let dz = 0.0;
+    if (Bsengine.isKeyPressed("A")) { dx -= 1.0; }
+    if (Bsengine.isKeyPressed("D")) { dx += 1.0; }
+    if (Bsengine.isKeyPressed("W")) { dz -= 1.0; }
+    if (Bsengine.isKeyPressed("S")) { dz += 1.0; }
+    if (dx === 0.0 && dz === 0.0) { return; }
+
+    const p = Bsengine.getTransform(name).position;
+    Bsengine.setPosition(name, p.x + dx * SPEED * dt, p.y, p.z + dz * SPEED * dt);
+}

--- a/games/net-2p-demo/client/scene.ron
+++ b/games/net-2p-demo/client/scene.ron
@@ -1,22 +1,54 @@
-(
-    entities: [
-        (
-            name: "Cam",
-            transform: (position: (x: 0.0, y: 5.0, z: 10.0), rotation: (x: 0.0, y: 0.0, z: 0.0, w: 1.0), scale: (x: 1.0, y: 1.0, z: 1.0)),
-            camera: Some((fov_degrees: 60.0, near: 0.1, far: 1000.0)),
-            scripts: ["main.js"],
-        ),
-        (
-            name: "ServerPlayer",
-            transform: (position: (x: -2.0, y: 0.5, z: 0.0), rotation: (x: 0.0, y: 0.0, z: 0.0, w: 1.0), scale: (x: 1.0, y: 1.0, z: 1.0)),
-            mesh: Some(Cube),
-            material: Some((color: (r: 0.2, g: 0.6, b: 1.0, a: 1.0), metallic: 0.0, roughness: 0.8, emissive: (r: 0.0, g: 0.0, b: 0.0))),
-        ),
-        (
-            name: "ClientPlayer",
-            transform: (position: (x: 2.0, y: 0.5, z: 0.0), rotation: (x: 0.0, y: 0.0, z: 0.0, w: 1.0), scale: (x: 1.0, y: 1.0, z: 1.0)),
-            mesh: Some(Cube),
-            material: Some((color: (r: 1.0, g: 0.3, b: 0.2, a: 1.0), metallic: 0.0, roughness: 0.8, emissive: (r: 0.0, g: 0.0, b: 0.0))),
-        ),
-    ]
-)
+SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Cam",
+        camera: true,
+        camera_fov: Some(60.0),
+        transform: Some((position: (0.0, 5.0, 10.0))),
+        look_at: Some((0.0, 0.5, 0.0)),
+        // Hosts (server) or connects (client); see the file.
+        script: Some("main.js"),
+    ),
+    EntityDescriptor(
+        name: "Sun",
+        directional_light: Some((direction: (-0.4, -0.8, -0.4), color: (1.0, 0.95, 0.85), ambient: (0.2, 0.2, 0.22))),
+    ),
+    EntityDescriptor(
+        // Server-authoritative and clock-driven: the original demo motion, kept
+        // so the pre-existing replication path stays exercised beside the
+        // predicted one.
+        name: "ServerPlayer",
+        primitive: Some(Cube),
+        transform: Some((position: (-2.0, 0.5, 0.0))),
+        color: Some((0.2, 0.6, 1.0)),
+        components: [
+            // Without a NetworkId the send system's (&NetworkId, &Transform)
+            // query matches nothing and this demo replicates *nothing* -- which
+            // is what it did before this was authored.
+            ("bsengine_core::network_id::NetworkId", "(id: 1, authority: Server)"),
+        ],
+    ),
+    EntityDescriptor(
+        // Client-authoritative: this peer simulates it and reports where it is.
+        name: "ClientPlayer",
+        primitive: Some(Cube),
+        transform: Some((position: (2.0, 0.5, 0.0))),
+        color: Some((1.0, 0.3, 0.2)),
+        components: [
+            ("bsengine_core::network_id::NetworkId", "(id: 2, authority: Client(peer_id: 1))"),
+        ],
+    ),
+    EntityDescriptor(
+        // The predicted player: the client sends what it holds, the server
+        // simulates it from that input, and the client predicts locally so it
+        // responds without waiting for the round trip. The two above move on a
+        // clock and so have nothing to predict, which is why this one exists.
+        name: "PredictedPlayer",
+        primitive: Some(Cube),
+        transform: Some((position: (0.0, 0.5, -3.0))),
+        color: Some((0.3, 0.9, 0.4)),
+        script: Some("drive.js"),
+        components: [
+            ("bsengine_core::network_id::NetworkId", "(id: 3, authority: Predicted(peer_id: 1))"),
+        ],
+    ),
+])

--- a/games/net-2p-demo/server/drive.js
+++ b/games/net-2p-demo/server/drive.js
@@ -1,0 +1,24 @@
+// Input-driven movement for the predicted player.
+//
+// Both peers run this file: the client to predict, the server to decide. That
+// is the whole point of the shared-simulation model -- one movement rule, not
+// one per side that could disagree.
+//
+// `isKeyPressed` reads the input of whichever entity this script is running
+// for, so on the server it sees the *client's* keys rather than the keyboard of
+// the machine hosting the game.
+const SPEED = 4.0;
+
+function onUpdate(name) {
+    const dt = Bsengine.getDeltaTime();
+    let dx = 0.0;
+    let dz = 0.0;
+    if (Bsengine.isKeyPressed("A")) { dx -= 1.0; }
+    if (Bsengine.isKeyPressed("D")) { dx += 1.0; }
+    if (Bsengine.isKeyPressed("W")) { dz -= 1.0; }
+    if (Bsengine.isKeyPressed("S")) { dz += 1.0; }
+    if (dx === 0.0 && dz === 0.0) { return; }
+
+    const p = Bsengine.getTransform(name).position;
+    Bsengine.setPosition(name, p.x + dx * SPEED * dt, p.y, p.z + dz * SPEED * dt);
+}

--- a/games/net-2p-demo/server/scene.ron
+++ b/games/net-2p-demo/server/scene.ron
@@ -1,22 +1,54 @@
-(
-    entities: [
-        (
-            name: "Cam",
-            transform: (position: (x: 0.0, y: 5.0, z: 10.0), rotation: (x: 0.0, y: 0.0, z: 0.0, w: 1.0), scale: (x: 1.0, y: 1.0, z: 1.0)),
-            camera: Some((fov_degrees: 60.0, near: 0.1, far: 1000.0)),
-            scripts: ["main.js"],
-        ),
-        (
-            name: "ServerPlayer",
-            transform: (position: (x: -2.0, y: 0.5, z: 0.0), rotation: (x: 0.0, y: 0.0, z: 0.0, w: 1.0), scale: (x: 1.0, y: 1.0, z: 1.0)),
-            mesh: Some(Cube),
-            material: Some((color: (r: 0.2, g: 0.6, b: 1.0, a: 1.0), metallic: 0.0, roughness: 0.8, emissive: (r: 0.0, g: 0.0, b: 0.0))),
-        ),
-        (
-            name: "ClientPlayer",
-            transform: (position: (x: 2.0, y: 0.5, z: 0.0), rotation: (x: 0.0, y: 0.0, z: 0.0, w: 1.0), scale: (x: 1.0, y: 1.0, z: 1.0)),
-            mesh: Some(Cube),
-            material: Some((color: (r: 1.0, g: 0.3, b: 0.2, a: 1.0), metallic: 0.0, roughness: 0.8, emissive: (r: 0.0, g: 0.0, b: 0.0))),
-        ),
-    ]
-)
+SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Cam",
+        camera: true,
+        camera_fov: Some(60.0),
+        transform: Some((position: (0.0, 5.0, 10.0))),
+        look_at: Some((0.0, 0.5, 0.0)),
+        // Hosts (server) or connects (client); see the file.
+        script: Some("main.js"),
+    ),
+    EntityDescriptor(
+        name: "Sun",
+        directional_light: Some((direction: (-0.4, -0.8, -0.4), color: (1.0, 0.95, 0.85), ambient: (0.2, 0.2, 0.22))),
+    ),
+    EntityDescriptor(
+        // Server-authoritative and clock-driven: the original demo motion, kept
+        // so the pre-existing replication path stays exercised beside the
+        // predicted one.
+        name: "ServerPlayer",
+        primitive: Some(Cube),
+        transform: Some((position: (-2.0, 0.5, 0.0))),
+        color: Some((0.2, 0.6, 1.0)),
+        components: [
+            // Without a NetworkId the send system's (&NetworkId, &Transform)
+            // query matches nothing and this demo replicates *nothing* -- which
+            // is what it did before this was authored.
+            ("bsengine_core::network_id::NetworkId", "(id: 1, authority: Server)"),
+        ],
+    ),
+    EntityDescriptor(
+        // Client-authoritative: this peer simulates it and reports where it is.
+        name: "ClientPlayer",
+        primitive: Some(Cube),
+        transform: Some((position: (2.0, 0.5, 0.0))),
+        color: Some((1.0, 0.3, 0.2)),
+        components: [
+            ("bsengine_core::network_id::NetworkId", "(id: 2, authority: Client(peer_id: 1))"),
+        ],
+    ),
+    EntityDescriptor(
+        // The predicted player: the client sends what it holds, the server
+        // simulates it from that input, and the client predicts locally so it
+        // responds without waiting for the round trip. The two above move on a
+        // clock and so have nothing to predict, which is why this one exists.
+        name: "PredictedPlayer",
+        primitive: Some(Cube),
+        transform: Some((position: (0.0, 0.5, -3.0))),
+        color: Some((0.3, 0.9, 0.4)),
+        script: Some("drive.js"),
+        components: [
+            ("bsengine_core::network_id::NetworkId", "(id: 3, authority: Predicted(peer_id: 1))"),
+        ],
+    ),
+])


### PR DESCRIPTION
ENGINE_ROADMAP item 56, **sub-step 2/2** — the last condition. A predicted
entity's owner sends **input**, the server simulates it, and the client predicts
locally and replays unacknowledged input when corrected.

**Per-entity opt-in**, so the existing client-authoritative model keeps working
untouched. `Predicted { peer_id }` differs from `Client { peer_id }` in who
decides: `Client` means that peer simulates and reports, so the server can never
disagree and there is nothing to reconcile.

## The server runs the same movement script

Chosen over moving movement into Rust so gameplay stays script-authored.
`isKeyPressed` now resolves per entity — on the server it sees that client's
keys, not the keyboard of the machine hosting the game — with a fallback to the
local keyboard that leaves every single-player script unchanged.

**The seam is in JS, and that was forced, not chosen.** I first recorded that
Rust dispatches `onUpdate` per entity and could swap the input snapshot between
entities. It cannot: Rust calls `Bsengine._runAll(entities_json)` once per frame
and the loop lives inside JS. `_scripts["<entity bits>"]` keys *registration*,
not dispatch — storage, not control flow. The verify-before-designing step caught
that before any code depended on it.

## Three defects found, each by a different mechanism

**1. A replay did not compose** — caught by a test. Run inside one V8 borrow,
three replay steps all read the position the frame started at and the last write
won, so the entity advanced one step instead of three. The script/world exchange
is deferred by design. The **exact-position** assertion caught it; "did it move"
would have passed at 1 when the answer was 3, and it would have shipped as an
entity that rubber-bands under latency.

**2. The correction was never emitted** — caught by clippy, not a test. An
earlier edit's anchor silently didn't match, so the network side never produced a
`ReplayRequest` and reconciliation would never have fired in a real game. **Every
scripting-side test still passed**, because they inject the request directly — a
disconnected producer looks exactly like a working one from the consumer's side.
This repo has that lesson written down from item 52 and I walked into it anyway.
Two producer-side tests now assert emission; both fail when it's disabled.

**3. `net-2p-demo` never ran at all** — caught by writing a test that spawns the
real scene instead of only parsing it. Its scenes were written against a schema
several refactors old (`transform` outside its `Option`, named `x/y/z` instead of
arrays, `camera` as a descriptor, `mesh:`/`material:`, a `scripts:` array that
isn't a field), and `ScenePlugin` panics on a scene that won't parse. That also
explains why nobody noticed it authored no `NetworkId` and therefore **replicated
nothing** — it would have looked identical with the cable unplugged. Fixed, and
given the input-driven predicted player it needed to demonstrate any of this.

Note `--package` passed on the broken scenes throughout: the cook parses untyped
RON while `ScenePlugin` parses the typed schema. **Packaging validates
references, not the scene schema.**

## Costs, stated

- A correction re-runs the movement script once per unacknowledged input —
  bounded by latency, not scene size.
- A replay re-derives **position only** and discards everything else the script
  did. The sound that played during the original input already played; re-firing
  it on every correction would make a player hear their own latency.
- Server authority is the precondition for anti-cheat; with `Client` a peer can
  simply state its position.
- Not implemented: lag compensation.

## Verification

- 40 network unit + 8 loopback + 4 prediction integration + 83 scene + 325
  scripting; workspace green, editor 937/937
- mutation-verified: removing the input fallback, disabling correction emission,
  and pinning the replay each fail their own assertions
- **all 10 E2E replays pass** — this branch changes the input path every game
  script uses, and I measured that the unit suite does *not* cover it: breaking
  the fallback fails one unit test, while `tilt-run` and `mini-arena` fail loudly
- 10 projects × 2 package modes = 20/20
- catalog unchanged at 70 components / 269 ops; clippy back to baseline after
  fixing three unused-variable warnings and one doc-comment theft I introduced
- the one workspace failure is the known `profiler::tests::create_tracked_texture`
  flake: passes in isolation, and this branch touches 0 files in `rhi-wgpu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)