### PR TITLE
feat(editor): Timeline panel — track view, scrubbing, cutscene preview (item 57, 2/2a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,25 @@ Bsengine.timeline.eventFired("intro_over");   // true only on the frame it fires
 
 `games/cutscene-demo` is a working example. See it before writing one.
 
+### The Timeline panel
+
+The editor's **Timeline** panel draws a timeline's tracks and scrubs it.
+Selecting an entity with a `TimelinePlayer` opens the timeline it names; the
+path box opens any `.ron` file, and keeps winning until a different timeline
+entity is selected.
+
+**Preview** (off by default) turns the viewport into the cutscene camera at the
+playhead and poses the entities the animation tracks name. It is off by default
+because silently taking over the viewport would be surprising. It restores every
+animation it touched when you turn it off — the opposite of the runtime's rule,
+deliberately, because looking at a cutscene must not be a way to edit the scene.
+The camera is never restored because it is never changed: the preview overrides
+the editor's own view rather than moving the scene's camera entity.
+
+The panel does not yet edit or save; keyframe editing is the next piece of work.
+Event tracks are drawn but have no effect here, since the editor runs no
+gameplay scripts to receive them.
+
 ### The four track kinds
 
 **`Camera`** moves the camera smoothly between keys. Keys carry `look_at` rather

--- a/apps/bsengine-editor-app/src/main.rs
+++ b/apps/bsengine-editor-app/src/main.rs
@@ -3,7 +3,7 @@ use bsengine_asset::{AssetIdentityPlugin, AssetPlugin, AssetStatusPlugin, AssetW
 use bsengine_core::{Camera, DirectionalLight, GlobalTransform, InspectorState, Transform};
 use bsengine_ecs::{Added, Commands, Entity, Query, ResMut};
 use bsengine_editor::EditorPlugin;
-use bsengine_gltf::GltfPlugin;
+use bsengine_gltf::{GltfPlugin, SkinnedMeshPlugin};
 use bsengine_input::InputPlugin;
 use bsengine_render::{MeshRenderer, RenderPlugin};
 use bsengine_rhi_wgpu::{
@@ -85,6 +85,14 @@ fn main() {
         })
         .add_plugins(InputPlugin)
         .add_plugins(GltfPlugin)
+        // Without this nothing poses a skeleton: `update_skinned_meshes` is
+        // registered only by `SkinnedMeshPlugin`, so before this line every
+        // skinned character in the editor rendered in its bind pose and never
+        // moved. The Timeline panel's animation preview depends on it, but the
+        // fix is not timeline-specific -- it is the same class of bug as
+        // `TerrainPlugin` (item 44) and `TimelinePlugin` (item 57 sub-step 1/2)
+        // being absent from a host that needed them.
+        .add_plugins(SkinnedMeshPlugin)
         .add_plugins(RenderPlugin)
         .add_plugins(EditorPlugin)
         .add_plugins(ScriptingPlugin { project_dir })

--- a/crates/bsengine-core/src/inspector.rs
+++ b/crates/bsengine-core/src/inspector.rs
@@ -424,6 +424,42 @@ pub struct TerrainBrushStroke {
     pub world_pos: [f32; 3],
 }
 
+/// The camera pose the Timeline panel wants previewed this frame.
+///
+/// Carried as a quaternion rather than the euler degrees
+/// [`InspectorEntityInfo`] uses, because the value usually comes straight
+/// from `crate::timeline::CameraPose::rotation()` and a round trip through
+/// euler angles would be a lossy step with nothing to gain.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreviewCamera {
+    /// World-space camera position.
+    pub position: [f32; 3],
+    /// World-space camera orientation, as `[x, y, z, w]`.
+    pub rotation: [f32; 4],
+    /// Vertical field of view in degrees, when the previewed shot names one.
+    /// `None` leaves the editor camera's own field of view alone.
+    pub fov_y_degrees: Option<f32>,
+}
+
+/// What the Timeline panel wants previewed this frame, or absent when the
+/// panel's **Preview** toggle is off.
+///
+/// A plain [`InspectorState`] field rather than an [`InspectorCmd`] because
+/// this is continuous per-frame state, not a one-shot undoable action -- the
+/// same reasoning that put the terrain brush's drag deltas here. The panel
+/// republishes it every frame it is previewing, so a stale request cannot
+/// outlive the panel that made it.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TimelinePreview {
+    /// Where the cutscene camera is at the playhead, if the timeline has a
+    /// camera or shot track. Applied by overriding the editor's
+    /// view-projection, so the scene's own camera entity is never touched.
+    pub camera: Option<PreviewCamera>,
+    /// `(entity name, clip name, time within the clip)` for every animation
+    /// track whose most recent key is at or before the playhead.
+    pub clips: Vec<(String, String, f32)>,
+}
+
 /// Editor-side resource holding the current entity snapshot, selection,
 /// pending edit commands, and all viewport/gizmo/camera UI state.
 #[derive(Resource)]
@@ -506,6 +542,12 @@ pub struct InspectorState {
     // Which viewport gizmo is active for the selected entity.
     /// Which viewport gizmo (translate/rotate) is currently active.
     pub gizmo_mode: GizmoMode,
+
+    /// What the Timeline panel wants previewed this frame; `None` when no
+    /// preview is active. Written by the panel, consumed by
+    /// `bsengine_editor`'s `update_editor_camera` (the camera half) and
+    /// `apply_timeline_preview_animation` (the animation half).
+    pub timeline_preview: Option<TimelinePreview>,
 
     // Terrain brush tool state. See `TerrainBrushKind`/`TerrainBrushSettings`/
     // `TerrainBrushStroke` above for the full picture.
@@ -601,6 +643,7 @@ impl Default for InspectorState {
             editor_proj: [[0.0; 4]; 4],
             editor_cam_pos: [0.0; 3],
             gizmo_mode: GizmoMode::Translate,
+            timeline_preview: None,
             terrain_brush_active: false,
             terrain_brush_settings: TerrainBrushSettings::default(),
             terrain_pick: None,

--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -123,8 +123,8 @@ pub use follow::{Follow, LookAt};
 pub use global_transform::GlobalTransform;
 pub use hud_texts::HudTexts;
 pub use inspector::{
-    EditorPlayState, GizmoMode, InspectorCmd, InspectorEntityInfo, InspectorState,
-    TerrainBrushKind, TerrainBrushSettings, TerrainBrushStroke, PRIMITIVE_KINDS,
+    EditorPlayState, GizmoMode, InspectorCmd, InspectorEntityInfo, InspectorState, PreviewCamera,
+    TerrainBrushKind, TerrainBrushSettings, TerrainBrushStroke, TimelinePreview, PRIMITIVE_KINDS,
 };
 pub use lifetime::Lifetime;
 pub use light::{DirectionalLight, PointLight, SpotLight};

--- a/crates/bsengine-editor/src/lib.rs
+++ b/crates/bsengine-editor/src/lib.rs
@@ -28,6 +28,9 @@ pub mod prefab_watcher;
 /// The MCP-facing data model: `EditorSnapshot`, `EntityInfo`, `EditorCommand`,
 /// `ReflectCommand`, and the shared resources the editor bridge reads/writes.
 pub mod snapshot;
+/// Applies the editor Timeline panel's cutscene preview, and restores what
+/// it replaced when the preview ends.
+pub mod timeline_preview;
 
 pub use plugin::EditorPlugin;
 pub use prefab_watcher::PrefabWatcherPlugin;

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -1860,8 +1860,41 @@ fn update_editor_camera(
             dist * pitch.sin(),
             dist * yaw.sin() * pitch.cos(),
         );
-    let view = glam::Mat4::look_at_rh(eye, target, glam::Vec3::Y);
-    let proj = glam::Mat4::perspective_rh(std::f32::consts::FRAC_PI_4, aspect, 0.1, 1000.0);
+    // The Timeline panel's preview replaces the orbit camera's answer here
+    // rather than writing `editor_view_proj` itself. This system assigns it
+    // unconditionally every frame, so a second writer would simply race it --
+    // and the orbit parameters above are deliberately left untouched, which is
+    // what makes ending a preview return the user to exactly the viewpoint
+    // they had instead of stranding the camera at the cutscene.
+    let preview_camera = insp
+        .timeline_preview
+        .as_ref()
+        .and_then(|p| p.camera.clone());
+
+    let (eye, view, proj) = match preview_camera {
+        Some(camera) => {
+            let eye = glam::Vec3::from(camera.position);
+            let rotation = glam::Quat::from_array(camera.rotation);
+            let fov = camera
+                .fov_y_degrees
+                .map_or(std::f32::consts::FRAC_PI_4, |d| d.to_radians());
+            // The engine's cameras look down -Z, the convention
+            // `CameraPose::rotation` builds against.
+            let forward = rotation * glam::Vec3::NEG_Z;
+            let up = rotation * glam::Vec3::Y;
+            (
+                eye,
+                glam::Mat4::look_at_rh(eye, eye + forward, up),
+                glam::Mat4::perspective_rh(fov, aspect, 0.1, 1000.0),
+            )
+        }
+        None => (
+            eye,
+            glam::Mat4::look_at_rh(eye, target, glam::Vec3::Y),
+            glam::Mat4::perspective_rh(std::f32::consts::FRAC_PI_4, aspect, 0.1, 1000.0),
+        ),
+    };
+
     insp.editor_view_proj = Some((proj * view).to_cols_array_2d());
     insp.editor_proj = proj.to_cols_array_2d();
     insp.editor_cam_pos = eye.to_array();
@@ -29976,6 +30009,72 @@ mod tests {
         app.add_plugins(McpPlugin);
         app.add_plugins(EditorPlugin);
         app.update();
+    }
+
+    /// A preview request must take over the editor's view-projection, and the
+    /// orbit state must win when there is none.
+    ///
+    /// Both halves are needed: "the view-projection changed" on its own is
+    /// satisfied by an override that is always on, which would make the
+    /// editor camera unusable and still pass.
+    #[test]
+    fn a_preview_request_overrides_the_orbit_camera() {
+        use bsengine_core::{PreviewCamera, TimelinePreview};
+
+        let mut app = new_app();
+        app.insert_resource({
+            // Field-by-field rather than functional-update syntax:
+            // `InspectorState` has a private field, so `..Default::default()`
+            // is barred outside `bsengine-core`.
+            let mut insp = InspectorState::default();
+            insp.editor_mode = true;
+            insp.viewport_size = [800.0, 600.0];
+            insp
+        });
+        app.add_systems(bevy_app::Update, super::update_editor_camera);
+
+        app.update();
+        let orbit = app
+            .world()
+            .resource::<InspectorState>()
+            .editor_view_proj
+            .expect("the orbit camera always publishes one");
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .timeline_preview = Some(TimelinePreview {
+            camera: Some(PreviewCamera {
+                position: [100.0, 50.0, 25.0],
+                rotation: [0.0, 0.0, 0.0, 1.0],
+                fov_y_degrees: None,
+            }),
+            clips: Vec::new(),
+        });
+        app.update();
+        let previewing = app
+            .world()
+            .resource::<InspectorState>()
+            .editor_view_proj
+            .expect("still published while previewing");
+        assert_ne!(
+            orbit, previewing,
+            "a preview request must take over the editor's view-projection"
+        );
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .timeline_preview = None;
+        app.update();
+        let restored = app
+            .world()
+            .resource::<InspectorState>()
+            .editor_view_proj
+            .expect("published again once preview ends");
+        assert_eq!(
+            orbit, restored,
+            "clearing the preview must return the user to the orbit viewpoint \
+             they had, not leave the camera stranded at the cutscene"
+        );
     }
 
     #[test]

--- a/crates/bsengine-editor/src/plugin.rs
+++ b/crates/bsengine-editor/src/plugin.rs
@@ -2218,6 +2218,14 @@ impl Plugin for EditorPlugin {
         app.register_type::<bsengine_core::ReflectQuat>();
         app.add_systems(Update, update_editor_snapshot);
         app.add_systems(Update, update_editor_camera);
+        // No ordering constraint. The Timeline panel publishes during egui and
+        // this consumes on the following frame -- one frame of lag, the same
+        // the terrain brush already lives with, and imperceptible while
+        // dragging a playhead.
+        app.add_systems(
+            Update,
+            crate::timeline_preview::apply_timeline_preview_animation,
+        );
         app.add_systems(Update, populate_inspector.after(update_editor_snapshot));
         app.add_systems(Update, populate_reflected_component_snapshot);
         app.add_systems(

--- a/crates/bsengine-editor/src/timeline_preview.rs
+++ b/crates/bsengine-editor/src/timeline_preview.rs
@@ -1,0 +1,190 @@
+//! Applies the editor Timeline panel's cutscene preview to the world, and
+//! undoes it when the preview ends.
+//!
+//! Its own module rather than another addition to `plugin.rs`, which is
+//! already ninety thousand lines.
+
+use bsengine_core::{AnimationPlayer, InspectorState};
+
+/// Applies the Timeline panel's animation preview, and puts back what it
+/// replaced when the preview ends.
+///
+/// The runtime deliberately restores nothing when a timeline stops (see
+/// `bsengine_app::timeline_playback`): a cutscene that exists to move the
+/// player somewhere should leave them there. An authoring tool is the
+/// opposite case — looking at a cutscene must not be a way to edit the scene
+/// — so this is the one place the two rules differ on purpose.
+pub fn apply_timeline_preview_animation(
+    inspector: Option<bevy_ecs::system::ResMut<InspectorState>>,
+    mut saved: bevy_ecs::system::Local<Vec<(bevy_ecs::entity::Entity, AnimationPlayer)>>,
+    mut players: bevy_ecs::system::Query<(
+        bevy_ecs::entity::Entity,
+        &bsengine_scene::Name,
+        &mut AnimationPlayer,
+    )>,
+) {
+    let requested: Vec<(String, String, f32)> = inspector
+        .as_ref()
+        .and_then(|insp| insp.timeline_preview.as_ref())
+        .map(|preview| preview.clips.clone())
+        .unwrap_or_default();
+
+    if requested.is_empty() {
+        // Restore in one pass and forget. An entity that has since been
+        // despawned simply is not found, which is not an error.
+        for (entity, original) in saved.drain(..) {
+            if let Ok((_, _, mut player)) = players.get_mut(entity) {
+                *player = original;
+            }
+        }
+        return;
+    }
+
+    for (name, clip, clip_time) in requested {
+        for (entity, entity_name, mut player) in players.iter_mut() {
+            if entity_name.0 != name {
+                continue;
+            }
+            // Snapshot the first time this entity is touched, never after --
+            // re-snapshotting on a later frame would save the preview's own
+            // values, and restore would then put those back.
+            if !saved.iter().any(|(e, _)| *e == entity) {
+                saved.push((entity, player.clone()));
+            }
+            player.clip = clip.clone();
+            player.time = clip_time;
+            // Paused: a scrub is a question about one instant, and the editor
+            // has no clock advancing clips anyway.
+            player.playing = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Scrubbing sets the named entity's clip and its time *within* that
+    /// clip, and leaves it paused -- scrubbing asks what an instant looks
+    /// like, not for playback to start.
+    #[test]
+    fn a_preview_sets_the_named_entitys_clip_and_time() {
+        use bsengine_core::TimelinePreview;
+
+        let mut app = bevy_app::App::new();
+        app.insert_resource(InspectorState::default());
+        app.add_systems(bevy_app::Update, apply_timeline_preview_animation);
+        let mut before = AnimationPlayer::new("Idle");
+        before.time = 3.0;
+        before.playing = true;
+        let subject = app
+            .world_mut()
+            .spawn((bsengine_scene::Name("Subject".to_string()), before))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .timeline_preview = Some(TimelinePreview {
+            camera: None,
+            clips: vec![("Subject".to_string(), "Survey".to_string(), 1.25)],
+        });
+        app.update();
+
+        let player = app.world().get::<AnimationPlayer>(subject).expect("player");
+        assert_eq!(player.clip, "Survey");
+        assert!((player.time - 1.25).abs() < 1e-6, "got {}", player.time);
+        assert!(
+            !player.playing,
+            "scrubbing shows an instant; it must not start playback"
+        );
+    }
+
+    /// The pairing that matters: ending the preview puts back exactly what
+    /// was there. Without restore, one scrub would permanently change the
+    /// scene and a save afterwards would freeze the character mid-cutscene.
+    #[test]
+    fn ending_a_preview_restores_the_animation_player() {
+        use bsengine_core::TimelinePreview;
+
+        let mut app = bevy_app::App::new();
+        app.insert_resource(InspectorState::default());
+        app.add_systems(bevy_app::Update, apply_timeline_preview_animation);
+        let mut before = AnimationPlayer::new("Idle");
+        before.time = 3.0;
+        before.playing = true;
+        let subject = app
+            .world_mut()
+            .spawn((bsengine_scene::Name("Subject".to_string()), before.clone()))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .timeline_preview = Some(TimelinePreview {
+            camera: None,
+            clips: vec![("Subject".to_string(), "Survey".to_string(), 1.25)],
+        });
+        app.update();
+        assert_eq!(
+            app.world().get::<AnimationPlayer>(subject).unwrap().clip,
+            "Survey",
+            "the preview must actually have applied, or the restore below \
+             proves nothing"
+        );
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .timeline_preview = None;
+        app.update();
+
+        let after = app.world().get::<AnimationPlayer>(subject).expect("player");
+        assert_eq!(after, &before, "the preview must leave nothing behind");
+    }
+
+    /// The snapshot is taken once, on the first frame an entity is touched.
+    /// Re-snapshotting every frame would capture the preview's own values,
+    /// and restore would then put *those* back -- which looks like working
+    /// code until a preview lasts more than one frame, i.e. always.
+    #[test]
+    fn a_multi_frame_preview_still_restores_the_original() {
+        use bsengine_core::TimelinePreview;
+
+        let mut app = bevy_app::App::new();
+        app.insert_resource(InspectorState::default());
+        app.add_systems(bevy_app::Update, apply_timeline_preview_animation);
+        let mut before = AnimationPlayer::new("Idle");
+        before.time = 3.0;
+        before.playing = true;
+        let subject = app
+            .world_mut()
+            .spawn((bsengine_scene::Name("Subject".to_string()), before.clone()))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .timeline_preview = Some(TimelinePreview {
+            camera: None,
+            clips: vec![("Subject".to_string(), "Survey".to_string(), 1.25)],
+        });
+        app.update();
+        // A second previewing frame, with the playhead moved on.
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .timeline_preview = Some(TimelinePreview {
+            camera: None,
+            clips: vec![("Subject".to_string(), "Survey".to_string(), 2.5)],
+        });
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<InspectorState>()
+            .timeline_preview = None;
+        app.update();
+
+        let after = app.world().get::<AnimationPlayer>(subject).expect("player");
+        assert_eq!(
+            after, &before,
+            "a preview lasting two frames must restore the pre-preview state, \
+             not the state the first previewing frame left behind"
+        );
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/panels/dock.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/dock.rs
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn ensure_builtin_panels_registers_six_panels() {
+    fn ensure_builtin_panels_registers_seven_panels() {
         let registry = EditorPanelRegistry::default();
         let surface = pollster::block_on(crate::surface::WgpuSurface::new_offscreen(16, 16, false))
             .expect("these tests need an adapter; a skip here would look like a pass");
@@ -292,12 +292,13 @@ mod tests {
             history,
         );
         let map = registry.0.lock().unwrap();
-        assert_eq!(map.len(), 6);
+        assert_eq!(map.len(), 7);
         assert!(map.contains_key("profiler"));
         // Registered even though `default_dock_state` does not place it:
         // that registration is what lists it in the Window menu, and
         // without it the tab id in a saved layout renders the "Panel
         // unavailable" placeholder instead of the editor.
         assert!(map.contains_key("shadergraph"));
+        assert!(map.contains_key("timeline"));
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/panels/dock.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/dock.rs
@@ -80,6 +80,9 @@ pub fn ensure_builtin_panels(
     map.entry("shadergraph".to_string()).or_insert_with(|| {
         Box::new(crate::panels::ShaderGraphPanel::default()) as Box<dyn EditorPanel>
     });
+    map.entry("timeline".to_string()).or_insert_with(|| {
+        Box::new(crate::panels::TimelinePanel::default()) as Box<dyn EditorPanel>
+    });
 }
 
 /// Loads a previously saved layout. Returns `None` if the file doesn't

--- a/crates/bsengine-rhi-wgpu/src/panels/mod.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/mod.rs
@@ -13,6 +13,8 @@ pub mod profiler;
 pub mod reflect_ui;
 /// The Shader Graph panel: a node editor for `bsengine-shadergraph` graphs.
 pub mod shadergraph;
+/// The Timeline panel: draws a cutscene's tracks and scrubs its playhead.
+pub mod timeline;
 /// The Viewport panel: renders the 3D scene plus gizmo overlays.
 pub mod viewport;
 
@@ -26,4 +28,5 @@ pub use inspector::InspectorPanel;
 pub use profiler::ProfilerPanel;
 pub use reflect_ui::draw_reflect_ui;
 pub use shadergraph::ShaderGraphPanel;
+pub use timeline::TimelinePanel;
 pub use viewport::ViewportPanel;

--- a/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
@@ -34,6 +34,14 @@ pub struct TimelinePanel {
     path_buffer: String,
     /// Playhead position, in seconds.
     time: f32,
+    /// A path the user opened explicitly, which outranks the selection until
+    /// a different timeline entity is selected.
+    explicit_path: Option<PathBuf>,
+    /// The selection this panel last saw, so it can tell a *change* of
+    /// selection from the same entity staying selected.
+    last_selected_id: Option<u64>,
+    /// What the last open did, shown in the toolbar.
+    status: Option<String>,
 
     /// Where each track's lane was drawn, rebuilt every frame.
     ///
@@ -63,6 +71,9 @@ impl Default for TimelinePanel {
             path: None,
             path_buffer: String::new(),
             time: 0.0,
+            explicit_path: None,
+            last_selected_id: None,
+            status: None,
             last_lane_rects: Vec::new(),
             last_key_positions: HashMap::new(),
             last_lane_area: egui::Rect::NOTHING,
@@ -110,6 +121,75 @@ impl TimelinePanel {
     /// The playhead position, in seconds.
     pub fn time(&self) -> f32 {
         self.time
+    }
+
+    /// Loads `path`, replacing whatever was shown.
+    ///
+    /// Errors are values, not panics: the path box is user input, and a
+    /// mistyped path must show a status line rather than take the editor
+    /// down.
+    fn load(&mut self, path: impl Into<PathBuf>) -> Result<(), String> {
+        let path = path.into();
+        let text = std::fs::read_to_string(&path)
+            .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+        let timeline: Timeline =
+            ron::from_str(&text).map_err(|e| format!("cannot parse {}: {e}", path.display()))?;
+        self.time = self.time.clamp(0.0, timeline.duration);
+        self.timeline = Some(timeline);
+        self.path = Some(path);
+        Ok(())
+    }
+
+    /// Opens `path` as the **Open** button would.
+    ///
+    /// Exists for the panel's own tests, which drive the precedence rule
+    /// without having to type into an egui text field.
+    #[cfg(test)]
+    fn open_for_test(&mut self, path: &std::path::Path) {
+        self.explicit_path = Some(path.to_path_buf());
+        if let Err(e) = self.load(path) {
+            self.status = Some(e);
+        }
+    }
+
+    /// Resolves which timeline should be shown this frame.
+    ///
+    /// An explicitly opened path wins and keeps winning; selecting a
+    /// *different* entity that has a `TimelinePlayer` clears it and resumes
+    /// following the selection. Selecting an entity **without** one leaves
+    /// the opened file alone rather than blanking the panel, because "I
+    /// clicked a light" is not a request to close the cutscene I was
+    /// looking at.
+    fn resolve_source(&mut self, ctx: &EditorPanelContext) {
+        let selected_path = ctx
+            .insp
+            .reflected_components
+            .iter()
+            .find(|(type_path, _)| type_path == "bsengine_core::timeline::TimelinePlayer")
+            .and_then(|(_, value)| {
+                value
+                    .as_any()
+                    .downcast_ref::<bsengine_core::timeline::TimelinePlayer>()
+                    .map(|p| PathBuf::from(&p.timeline))
+            });
+
+        let selection_changed = ctx.insp.selected_id != self.last_selected_id;
+        self.last_selected_id = ctx.insp.selected_id;
+        if selection_changed && selected_path.is_some() {
+            self.explicit_path = None;
+        }
+
+        let Some(wanted) = self.explicit_path.clone().or(selected_path) else {
+            return;
+        };
+        if self.path.as_deref() == Some(wanted.as_path()) {
+            return;
+        }
+        if let Err(e) = self.load(&wanted) {
+            self.status = Some(e);
+            self.timeline = None;
+            self.path = None;
+        }
     }
 
     /// The loaded timeline's duration, or `0.0` when nothing is loaded.
@@ -249,7 +329,41 @@ impl EditorPanel for TimelinePanel {
         "Timeline".to_string()
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &mut EditorPanelContext) {
+    fn ui(&mut self, ui: &mut egui::Ui, ctx: &mut EditorPanelContext) {
+        self.resolve_source(ctx);
+
+        let mut open_clicked = false;
+        ui.horizontal(|ui| {
+            ui.add(
+                egui::TextEdit::singleline(&mut self.path_buffer)
+                    .hint_text("assets/timelines/intro.ron")
+                    .desired_width(260.0_f32),
+            );
+            open_clicked = ui
+                .button(format!("{} Open", egui_phosphor::regular::FOLDER_OPEN))
+                .clicked();
+            ui.label(format!("t = {:.2} / {:.2}", self.time, self.duration()));
+        });
+        if let Some(status) = &self.status {
+            ui.label(status.clone());
+        }
+
+        // The text field is read only when Open is clicked, so a half-typed
+        // path never becomes the loaded path.
+        if open_clicked {
+            let path = PathBuf::from(self.path_buffer.trim());
+            self.explicit_path = Some(path.clone());
+            match self.load(&path) {
+                Ok(()) => self.status = Some(format!("opened {}", path.display())),
+                Err(e) => {
+                    self.status = Some(e);
+                    self.timeline = None;
+                    self.path = None;
+                }
+            }
+        }
+
+        ui.separator();
         self.draw_tracks(ui);
     }
 }
@@ -394,6 +508,124 @@ mod tests {
                 modifiers: egui::Modifiers::default(),
             }])
         }
+    }
+
+    /// Writes a timeline to a temp file so the entry-path tests drive the
+    /// real parse rather than a hand-built value.
+    struct TimelineFile(std::path::PathBuf);
+
+    impl Drop for TimelineFile {
+        fn drop(&mut self) {
+            std::fs::remove_file(&self.0).ok();
+        }
+    }
+
+    fn write_timeline(timeline: &Timeline) -> TimelineFile {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "bsengine-timeline-panel-{}-{}.ron",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&path, ron::to_string(timeline).expect("serialise")).expect("write");
+        TimelineFile(path)
+    }
+
+    /// An empty timeline, which draws zero lanes -- so a test can tell "the
+    /// other file loaded" from "the four-track file loaded" by lane count
+    /// alone.
+    fn empty_timeline() -> Timeline {
+        Timeline {
+            duration: 1.0,
+            tracks: Vec::new(),
+        }
+    }
+
+    /// Makes `id` the selection and gives it a `TimelinePlayer` naming
+    /// `path`, the way the editor populates `reflected_components` for the
+    /// selected entity.
+    fn select_timeline_entity(h: &mut Harness, id: u64, name: &str, path: &std::path::Path) {
+        h.insp.selected_id = Some(id);
+        h.insp.reflected_components = vec![(
+            "bsengine_core::timeline::TimelinePlayer".to_string(),
+            Box::new(bsengine_core::timeline::TimelinePlayer {
+                timeline: path.to_string_lossy().to_string(),
+                time: 0.0,
+                playing: false,
+                speed: 1.0,
+            }) as Box<dyn bevy_reflect::Reflect>,
+        )];
+        h.entities_snapshot = vec![InspectorEntityInfo {
+            id,
+            name: Some(name.to_string()),
+            ..Default::default()
+        }];
+    }
+
+    #[test]
+    fn selecting_an_entity_opens_its_timeline() {
+        let file = write_timeline(&four_track_timeline());
+        let mut h = Harness::new(empty_timeline());
+        select_timeline_entity(&mut h, 7, "Director", &file.0);
+        h.settle();
+
+        assert_eq!(
+            h.panel.last_lane_rects.len(),
+            4,
+            "selecting an entity with a TimelinePlayer must load the timeline \
+             it names"
+        );
+    }
+
+    /// An explicitly opened path wins over the selection, and keeps winning
+    /// while the same entity stays selected.
+    #[test]
+    fn an_explicitly_opened_path_overrides_the_selection() {
+        let selected = write_timeline(&empty_timeline());
+        let opened = write_timeline(&four_track_timeline());
+        let mut h = Harness::new(empty_timeline());
+        select_timeline_entity(&mut h, 7, "Director", &selected.0);
+        h.settle();
+        assert_eq!(
+            h.panel.last_lane_rects.len(),
+            0,
+            "the selection's timeline has no tracks"
+        );
+
+        h.panel.open_for_test(&opened.0);
+        h.settle();
+
+        assert_eq!(
+            h.panel.last_lane_rects.len(),
+            4,
+            "the opened path must win over the still-selected entity"
+        );
+    }
+
+    /// Paired with the above: selecting a *different* entity that has a
+    /// `TimelinePlayer` clears the override. Without this the override would
+    /// be a trap -- the panel would keep showing a stale file forever -- and
+    /// the test above alone cannot tell the difference.
+    #[test]
+    fn selecting_another_timeline_entity_clears_the_override() {
+        let opened = write_timeline(&four_track_timeline());
+        let other = write_timeline(&empty_timeline());
+        let mut h = Harness::new(empty_timeline());
+
+        h.panel.open_for_test(&opened.0);
+        h.settle();
+        assert_eq!(h.panel.last_lane_rects.len(), 4);
+
+        select_timeline_entity(&mut h, 9, "OtherDirector", &other.0);
+        h.settle();
+
+        assert_eq!(
+            h.panel.last_lane_rects.len(),
+            0,
+            "selecting a different entity with a TimelinePlayer must resume \
+             following the selection"
+        );
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
@@ -217,9 +217,25 @@ impl TimelinePanel {
             }
         }
 
-        ui.allocate_rect(
-            egui::Rect::from_min_max(full.min, egui::pos2(full.right(), lanes_top + lanes_height)),
-            egui::Sense::hover(),
+        // One interaction region covering the ruler and every lane, so a
+        // press anywhere on the time axis scrubs. Allocated after the lanes
+        // are laid out, so `last_lane_area` is already the rect being mapped.
+        let scrub_area = egui::Rect::from_min_max(
+            egui::pos2(lane_left, full.top()),
+            egui::pos2(full.right(), lanes_top + lanes_height),
+        );
+        let response = ui.allocate_rect(scrub_area, egui::Sense::click_and_drag());
+        if let Some(pointer) = response.interact_pointer_pos() {
+            self.time = self.x_to_time(pointer.x);
+        }
+
+        let playhead_x = self.time_to_x(self.time);
+        painter.line_segment(
+            [
+                egui::pos2(playhead_x, full.top()),
+                egui::pos2(playhead_x, lanes_top + lanes_height),
+            ],
+            egui::Stroke::new(2.0_f32, visuals.error_fg_color),
         );
     }
 }
@@ -390,6 +406,97 @@ mod tests {
             4,
             "one lane per track -- each Animation track names exactly one \
              entity, so lanes map 1:1 to tracks"
+        );
+    }
+
+    /// The central claim, and a round trip rather than a one-way check: press
+    /// where the panel says 2.5s is, and the playhead must read 2.5s back.
+    ///
+    /// A one-way assertion ("the playhead moved right") passes for any
+    /// mapping that is merely monotonic, including one off by a constant or
+    /// scaled wrongly -- which is exactly how a time axis goes wrong.
+    #[test]
+    fn pressing_at_a_time_puts_the_playhead_at_that_time() {
+        let mut h = Harness::new(four_track_timeline());
+        h.settle();
+
+        let target = 2.5;
+        let x = h.panel.time_to_x(target);
+        let y = h.panel.last_lane_rects[0].center().y;
+        h.press(egui::pos2(x, y));
+        h.drag_to(egui::pos2(x, y));
+        h.release(egui::pos2(x, y));
+
+        assert!(
+            (h.panel.time() - target).abs() < 0.05,
+            "pressed at time_to_x({target}) but the playhead reads {}",
+            h.panel.time()
+        );
+    }
+
+    /// Paired with the above: a different press must land somewhere
+    /// different, or a panel that hardcodes 2.5 passes.
+    #[test]
+    fn a_different_press_gives_a_different_time() {
+        let mut h = Harness::new(four_track_timeline());
+        h.settle();
+
+        let y = h.panel.last_lane_rects[0].center().y;
+        let x1 = h.panel.time_to_x(1.0);
+        h.press(egui::pos2(x1, y));
+        h.drag_to(egui::pos2(x1, y));
+        h.release(egui::pos2(x1, y));
+        let first = h.panel.time();
+
+        let x2 = h.panel.time_to_x(4.0);
+        h.press(egui::pos2(x2, y));
+        h.drag_to(egui::pos2(x2, y));
+        h.release(egui::pos2(x2, y));
+        let second = h.panel.time();
+
+        assert!(
+            (first - 1.0).abs() < 0.05 && (second - 4.0).abs() < 0.05,
+            "expected 1.0 then 4.0, got {first} then {second}"
+        );
+    }
+
+    /// Dragging past the right edge parks the playhead at the duration
+    /// rather than running off the timeline.
+    #[test]
+    fn dragging_past_the_end_clamps_to_the_duration() {
+        let mut h = Harness::new(four_track_timeline());
+        h.settle();
+
+        let y = h.panel.last_lane_rects[0].center().y;
+        let start = h.panel.time_to_x(3.0);
+        h.press(egui::pos2(start, y));
+        h.drag_to(egui::pos2(h.screen_rect.right() + 500.0, y));
+        h.release(egui::pos2(h.screen_rect.right() + 500.0, y));
+
+        assert!(
+            (h.panel.time() - 6.0).abs() < 1e-3,
+            "expected the 6.0s duration, got {}",
+            h.panel.time()
+        );
+    }
+
+    /// And past the left edge clamps to zero -- the other side, because a
+    /// clamp implemented on one end only passes the test above.
+    #[test]
+    fn dragging_before_the_start_clamps_to_zero() {
+        let mut h = Harness::new(four_track_timeline());
+        h.settle();
+
+        let y = h.panel.last_lane_rects[0].center().y;
+        let start = h.panel.time_to_x(3.0);
+        h.press(egui::pos2(start, y));
+        h.drag_to(egui::pos2(h.screen_rect.left() - 500.0, y));
+        h.release(egui::pos2(h.screen_rect.left() - 500.0, y));
+
+        assert!(
+            h.panel.time().abs() < 1e-3,
+            "expected 0.0, got {}",
+            h.panel.time()
         );
     }
 

--- a/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
@@ -1,0 +1,415 @@
+//! The Timeline panel: draws a `Timeline`'s tracks, scrubs its playhead, and
+//! publishes a preview request for the editor to apply.
+//!
+//! Read-only with respect to disk. Editing and saving are sub-step 2/2b, and
+//! that boundary is enforced by a test rather than by intent -- see
+//! `scrubbing_never_writes_to_the_timeline_file`.
+
+use bsengine_core::editor_panel::{EditorPanel, EditorPanelContext};
+use bsengine_core::timeline::{Timeline, Track};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Width of the track-label column, in points.
+const LABEL_WIDTH: f32 = 130.0;
+/// Height of the time ruler above the lanes, in points.
+const RULER_HEIGHT: f32 = 22.0;
+/// Height of one track lane, in points.
+const LANE_HEIGHT: f32 = 26.0;
+/// Radius of a drawn keyframe marker, in points.
+const KEY_RADIUS: f32 = 5.0;
+
+/// The Timeline panel: a track view over a cutscene, with a scrubbable
+/// playhead.
+pub struct TimelinePanel {
+    /// The parsed timeline currently shown, if one is loaded.
+    timeline: Option<Timeline>,
+    /// Path the loaded timeline came from.
+    path: Option<PathBuf>,
+    /// The path text field's contents, which is what **Open** reads.
+    ///
+    /// Separate from `path` so a half-typed path never looks like the open
+    /// file -- the same split `ShaderGraphPanel` uses, and for the same
+    /// reason.
+    path_buffer: String,
+    /// Playhead position, in seconds.
+    time: f32,
+
+    /// Where each track's lane was drawn, rebuilt every frame.
+    ///
+    /// Public for the same reason as `ShaderGraphPanel::last_port_positions`:
+    /// this project forbids hardcoded click coordinates in panel tests, and
+    /// the usual helper finds widgets by walking `Shape::Text` galleys, which
+    /// cannot find a lane -- a lane is a `Shape::Rect` carrying no text at
+    /// all. Recording the geometry satisfies the rule by construction.
+    pub last_lane_rects: Vec<egui::Rect>,
+    /// Where each key was drawn, keyed by `(track index, key index)`.
+    ///
+    /// Public for the same reason as [`TimelinePanel::last_lane_rects`]; a
+    /// key is a `Shape::Circle`. This is also what sub-step 2/2b's key
+    /// dragging will hit-test against.
+    pub last_key_positions: HashMap<(usize, usize), egui::Pos2>,
+    /// The lane area's rectangle, which the time/x mapping maps against.
+    last_lane_area: egui::Rect,
+}
+
+/// Hand-written because `egui::Rect` has no `Default`, and the meaningful
+/// starting value for `last_lane_area` is `NOTHING` rather than a zero rect:
+/// nothing has been laid out yet, and the mapping functions check for that.
+impl Default for TimelinePanel {
+    fn default() -> Self {
+        Self {
+            timeline: None,
+            path: None,
+            path_buffer: String::new(),
+            time: 0.0,
+            last_lane_rects: Vec::new(),
+            last_key_positions: HashMap::new(),
+            last_lane_area: egui::Rect::NOTHING,
+        }
+    }
+}
+
+impl TimelinePanel {
+    /// A panel showing `timeline`, with no file behind it.
+    pub fn with_timeline(timeline: Timeline) -> Self {
+        Self {
+            timeline: Some(timeline),
+            ..Default::default()
+        }
+    }
+
+    /// The x coordinate `seconds` maps to in the lane area.
+    ///
+    /// Public so tests press at a *time* rather than at a measured pixel. The
+    /// pairing with [`TimelinePanel::x_to_time`] is what makes a scrub test a
+    /// round trip -- press at `time_to_x(2.5)`, read 2.5 back -- and a test
+    /// built on recorded pixel positions alone would not check the mapping at
+    /// all.
+    pub fn time_to_x(&self, seconds: f32) -> f32 {
+        let duration = self.duration();
+        if duration <= 0.0 {
+            return self.last_lane_area.left();
+        }
+        self.last_lane_area.left()
+            + (seconds / duration).clamp(0.0, 1.0) * self.last_lane_area.width()
+    }
+
+    /// The time an x coordinate in the lane area maps to, clamped to
+    /// `0..=duration` so a drag past either end parks the playhead at that end
+    /// rather than running off the timeline.
+    pub fn x_to_time(&self, x: f32) -> f32 {
+        let duration = self.duration();
+        if self.last_lane_area.width() <= 0.0 || duration <= 0.0 {
+            return 0.0;
+        }
+        let fraction = (x - self.last_lane_area.left()) / self.last_lane_area.width();
+        (fraction * duration).clamp(0.0, duration)
+    }
+
+    /// The playhead position, in seconds.
+    pub fn time(&self) -> f32 {
+        self.time
+    }
+
+    /// The loaded timeline's duration, or `0.0` when nothing is loaded.
+    fn duration(&self) -> f32 {
+        self.timeline.as_ref().map_or(0.0, |t| t.duration)
+    }
+
+    /// A track's label, which is also what distinguishes two animation tracks
+    /// from each other.
+    fn track_label(track: &Track) -> String {
+        match track {
+            Track::Camera { .. } => "Camera".to_string(),
+            Track::CameraShot { .. } => "Shots".to_string(),
+            Track::Animation { entity, .. } => format!("Anim: {entity}"),
+            Track::Event { .. } => "Events".to_string(),
+        }
+    }
+
+    /// The times of a track's keys, in order.
+    fn track_key_times(track: &Track) -> Vec<f32> {
+        match track {
+            Track::Camera { keys } => keys.iter().map(|k| k.time).collect(),
+            Track::CameraShot { cuts } => cuts.iter().map(|c| c.time).collect(),
+            Track::Animation { keys, .. } => keys.iter().map(|k| k.time).collect(),
+            Track::Event { keys } => keys.iter().map(|k| k.time).collect(),
+        }
+    }
+
+    /// Draws the ruler, the lanes and their keys, recording the geometry as it
+    /// goes.
+    fn draw_tracks(&mut self, ui: &mut egui::Ui) {
+        self.last_lane_rects.clear();
+        self.last_key_positions.clear();
+
+        let Some(timeline) = self.timeline.clone() else {
+            ui.label("No timeline. Select an entity with a TimelinePlayer, or open a .ron file.");
+            self.last_lane_area = egui::Rect::NOTHING;
+            return;
+        };
+
+        let full = ui.available_rect_before_wrap();
+        let lane_left = full.left() + LABEL_WIDTH;
+        let lanes_top = full.top() + RULER_HEIGHT;
+        let lanes_height = LANE_HEIGHT * timeline.tracks.len() as f32;
+        self.last_lane_area = egui::Rect::from_min_max(
+            egui::pos2(lane_left, lanes_top),
+            egui::pos2(full.right(), lanes_top + lanes_height),
+        );
+
+        let painter = ui.painter().clone();
+        let visuals = ui.visuals().clone();
+
+        // One tick per second, which reads a six-second cutscene fine and does
+        // not need to scale until 2/2b adds zooming.
+        let duration = timeline.duration.max(0.001);
+        let mut second = 0.0_f32;
+        while second <= duration {
+            let x = self.time_to_x(second);
+            painter.line_segment(
+                [
+                    egui::pos2(x, full.top()),
+                    egui::pos2(x, full.top() + RULER_HEIGHT),
+                ],
+                egui::Stroke::new(1.0_f32, visuals.weak_text_color()),
+            );
+            second += 1.0;
+        }
+
+        for (i, track) in timeline.tracks.iter().enumerate() {
+            let top = lanes_top + LANE_HEIGHT * i as f32;
+            let lane = egui::Rect::from_min_max(
+                egui::pos2(lane_left, top),
+                egui::pos2(full.right(), top + LANE_HEIGHT),
+            );
+            self.last_lane_rects.push(lane);
+
+            painter.rect_filled(lane, 2.0, visuals.faint_bg_color);
+            painter.text(
+                egui::pos2(full.left() + 4.0, lane.center().y),
+                egui::Align2::LEFT_CENTER,
+                Self::track_label(track),
+                egui::FontId::default(),
+                visuals.text_color(),
+            );
+
+            for (k, key_time) in Self::track_key_times(track).into_iter().enumerate() {
+                let pos = egui::pos2(self.time_to_x(key_time), lane.center().y);
+                self.last_key_positions.insert((i, k), pos);
+                match track {
+                    // A cut is an instant, not a span, so it is a full-height
+                    // line rather than a dot sitting on the lane.
+                    Track::CameraShot { .. } => {
+                        painter.line_segment(
+                            [
+                                egui::pos2(pos.x, lane.top()),
+                                egui::pos2(pos.x, lane.bottom()),
+                            ],
+                            egui::Stroke::new(2.0_f32, visuals.warn_fg_color),
+                        );
+                    }
+                    _ => {
+                        painter.circle_filled(pos, KEY_RADIUS, visuals.strong_text_color());
+                    }
+                }
+            }
+        }
+
+        ui.allocate_rect(
+            egui::Rect::from_min_max(full.min, egui::pos2(full.right(), lanes_top + lanes_height)),
+            egui::Sense::hover(),
+        );
+    }
+}
+
+impl EditorPanel for TimelinePanel {
+    fn id(&self) -> &str {
+        "timeline"
+    }
+
+    fn title(&self) -> String {
+        "Timeline".to_string()
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &mut EditorPanelContext) {
+        self.draw_tracks(ui);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsengine_core::timeline::{AnimationKey, CameraKey, EventKey, ShotCut};
+    use bsengine_core::{InspectorEntityInfo, InspectorState};
+
+    /// A timeline with one of every track kind, so a test that counts lanes
+    /// distinguishes "drew the tracks" from "drew one lane and stopped".
+    fn four_track_timeline() -> Timeline {
+        Timeline {
+            duration: 6.0,
+            tracks: vec![
+                Track::Camera {
+                    keys: vec![
+                        CameraKey {
+                            time: 0.0,
+                            position: [0.0, 0.0, 0.0],
+                            look_at: [0.0, 0.0, -1.0],
+                        },
+                        CameraKey {
+                            time: 6.0,
+                            position: [12.0, 0.0, 0.0],
+                            look_at: [0.0, 0.0, -1.0],
+                        },
+                    ],
+                },
+                Track::CameraShot {
+                    cuts: vec![ShotCut {
+                        time: 3.5,
+                        entity: "CloseUpShot".to_string(),
+                    }],
+                },
+                Track::Animation {
+                    entity: "Subject".to_string(),
+                    keys: vec![AnimationKey {
+                        time: 0.5,
+                        clip: "Survey".to_string(),
+                    }],
+                },
+                Track::Event {
+                    keys: vec![EventKey {
+                        time: 5.5,
+                        name: "intro_over".to_string(),
+                    }],
+                },
+            ],
+        }
+    }
+
+    /// Headless multi-frame harness, following `shadergraph.rs`'s (itself
+    /// following `viewport.rs`'s). One `egui::Context` for the whole test,
+    /// because every interaction here spans frames: egui hit-tests a press
+    /// against the *previous* frame's widget rects and reports a drag as
+    /// started only on the frame after the press.
+    ///
+    /// The screen rect is given explicitly rather than left to
+    /// `RawInput::default()`, so the lane area -- and therefore every
+    /// recorded position -- is the same size on every machine.
+    struct Harness {
+        egui_ctx: egui::Context,
+        screen_rect: egui::Rect,
+        insp: InspectorState,
+        entities_snapshot: Vec<InspectorEntityInfo>,
+        panel: TimelinePanel,
+    }
+
+    impl Harness {
+        fn new(timeline: Timeline) -> Self {
+            let egui_ctx = egui::Context::default();
+            egui_ctx.set_fonts(egui::FontDefinitions::empty());
+            Self {
+                egui_ctx,
+                screen_rect: egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(1200.0, 700.0)),
+                insp: InspectorState::default(),
+                entities_snapshot: Vec::new(),
+                panel: TimelinePanel::with_timeline(timeline),
+            }
+        }
+
+        fn frame(&mut self, events: Vec<egui::Event>) -> egui::FullOutput {
+            self.egui_ctx.run(
+                egui::RawInput {
+                    screen_rect: Some(self.screen_rect),
+                    events,
+                    ..Default::default()
+                },
+                |egui_ctx| {
+                    egui::CentralPanel::default().show(egui_ctx, |ui| {
+                        let mut panel_ctx = EditorPanelContext {
+                            insp: &mut self.insp,
+                            entities_snapshot: &self.entities_snapshot,
+                            cursor_pos: (0.0, 0.0),
+                            type_registry: None,
+                        };
+                        self.panel.ui(ui, &mut panel_ctx);
+                    });
+                },
+            )
+        }
+
+        fn draw(&mut self) -> egui::FullOutput {
+            self.frame(Vec::new())
+        }
+
+        /// Two input-less frames: a press is hit-tested against the previous
+        /// frame's rects, so the frame that first lays the lanes out cannot
+        /// also receive a press against them.
+        fn settle(&mut self) -> egui::FullOutput {
+            self.draw();
+            self.draw()
+        }
+
+        /// A press on its own frame. egui's `is_decidedly_dragging` requires
+        /// `!any_pressed()`, so a press and a move sent in one `RawInput`
+        /// never report `dragged() == true`.
+        fn press(&mut self, pos: egui::Pos2) -> egui::FullOutput {
+            self.frame(vec![
+                egui::Event::PointerMoved(pos),
+                egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ])
+        }
+
+        /// The frame on which `drag_started()`/`dragged()` first turn true.
+        fn drag_to(&mut self, pos: egui::Pos2) -> egui::FullOutput {
+            self.frame(vec![egui::Event::PointerMoved(pos)])
+        }
+
+        fn release(&mut self, pos: egui::Pos2) -> egui::FullOutput {
+            self.frame(vec![egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::default(),
+            }])
+        }
+    }
+
+    #[test]
+    fn a_lane_is_drawn_for_every_track() {
+        let mut h = Harness::new(four_track_timeline());
+        h.settle();
+
+        assert_eq!(
+            h.panel.last_lane_rects.len(),
+            4,
+            "one lane per track -- each Animation track names exactly one \
+             entity, so lanes map 1:1 to tracks"
+        );
+    }
+
+    #[test]
+    fn every_key_of_every_track_is_placed() {
+        let mut h = Harness::new(four_track_timeline());
+        h.settle();
+
+        // 2 camera keys + 1 cut + 1 animation key + 1 event = 5.
+        assert_eq!(
+            h.panel.last_key_positions.len(),
+            5,
+            "a track whose keys are never placed still draws its lane, so \
+             counting lanes alone does not prove the keys were drawn"
+        );
+        for (track, key) in [(0usize, 0usize), (0, 1), (1, 0), (2, 0), (3, 0)] {
+            assert!(
+                h.panel.last_key_positions.contains_key(&(track, key)),
+                "track {track} key {key} was not placed"
+            );
+        }
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
@@ -7,6 +7,7 @@
 
 use bsengine_core::editor_panel::{EditorPanel, EditorPanelContext};
 use bsengine_core::timeline::{Timeline, Track};
+use bsengine_core::{PreviewCamera, TimelinePreview};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -42,6 +43,13 @@ pub struct TimelinePanel {
     last_selected_id: Option<u64>,
     /// What the last open did, shown in the toolbar.
     status: Option<String>,
+    /// Whether the panel is publishing a preview request.
+    ///
+    /// Off by default. Silently turning the viewport into a cutscene camera
+    /// because a panel happens to be open would be surprising -- and an off
+    /// switch is also a measurement instrument, since it is what lets a test
+    /// assert that the orbit camera wins when preview is off.
+    preview: bool,
 
     /// Where each track's lane was drawn, rebuilt every frame.
     ///
@@ -74,6 +82,7 @@ impl Default for TimelinePanel {
             explicit_path: None,
             last_selected_id: None,
             status: None,
+            preview: false,
             last_lane_rects: Vec::new(),
             last_key_positions: HashMap::new(),
             last_lane_area: egui::Rect::NOTHING,
@@ -190,6 +199,63 @@ impl TimelinePanel {
             self.timeline = None;
             self.path = None;
         }
+    }
+
+    /// Builds this frame's preview request from the playhead.
+    ///
+    /// A cut resolves against the entity snapshot rather than against the
+    /// timeline, because a shot names an ordinary entity and its pose lives
+    /// in the scene. The snapshot's rotation is euler degrees in `XYZ` order
+    /// (`bsengine_editor`'s `plugin.rs:76`), so the inverse used here is the
+    /// same pairing that file uses to write a rotation back.
+    fn build_preview(&self, ctx: &EditorPanelContext) -> Option<TimelinePreview> {
+        let timeline = self.timeline.as_ref()?;
+        let at = bsengine_core::timeline::evaluate(timeline, self.time);
+
+        let camera = if let Some(shot) = &at.shot {
+            ctx.entities_snapshot
+                .iter()
+                .find(|e| e.name.as_deref() == Some(shot.as_str()))
+                .map(|e| {
+                    let rot = e.rotation.unwrap_or([0.0; 3]);
+                    let quat = glam::Quat::from_euler(
+                        glam::EulerRot::XYZ,
+                        rot[0].to_radians(),
+                        rot[1].to_radians(),
+                        rot[2].to_radians(),
+                    );
+                    PreviewCamera {
+                        position: e.position.unwrap_or([0.0; 3]),
+                        rotation: quat.to_array(),
+                        fov_y_degrees: e.camera_fov,
+                    }
+                })
+        } else {
+            at.camera.as_ref().map(|c| PreviewCamera {
+                position: c.position,
+                rotation: c.rotation().to_array(),
+                fov_y_degrees: None,
+            })
+        };
+
+        // The most recent animation key at or before the playhead, per track,
+        // with the time reached *within* that clip. Scrubbing asks what this
+        // instant looks like, so the clip time is how long the clip has been
+        // running by now.
+        let mut clips = Vec::new();
+        for track in &timeline.tracks {
+            if let Track::Animation { entity, keys } = track {
+                if let Some(key) = keys
+                    .iter()
+                    .filter(|k| k.time <= self.time)
+                    .max_by(|a, b| a.time.total_cmp(&b.time))
+                {
+                    clips.push((entity.clone(), key.clip.clone(), self.time - key.time));
+                }
+            }
+        }
+
+        Some(TimelinePreview { camera, clips })
     }
 
     /// The loaded timeline's duration, or `0.0` when nothing is loaded.
@@ -342,6 +408,7 @@ impl EditorPanel for TimelinePanel {
             open_clicked = ui
                 .button(format!("{} Open", egui_phosphor::regular::FOLDER_OPEN))
                 .clicked();
+            ui.checkbox(&mut self.preview, "Preview");
             ui.label(format!("t = {:.2} / {:.2}", self.time, self.duration()));
         });
         if let Some(status) = &self.status {
@@ -365,6 +432,14 @@ impl EditorPanel for TimelinePanel {
 
         ui.separator();
         self.draw_tracks(ui);
+
+        // Republished every frame while previewing, and cleared the moment it
+        // is not, so a stale request cannot outlive the toggle.
+        ctx.insp.timeline_preview = if self.preview {
+            self.build_preview(ctx)
+        } else {
+            None
+        };
     }
 }
 
@@ -561,6 +636,45 @@ mod tests {
             name: Some(name.to_string()),
             ..Default::default()
         }];
+    }
+
+    /// With Preview on, the panel publishes the pose `evaluate` gives for the
+    /// playhead.
+    #[test]
+    fn preview_publishes_the_camera_pose_for_the_playhead() {
+        let mut h = Harness::new(four_track_timeline());
+        h.panel.preview = true;
+        h.settle();
+
+        let y = h.panel.last_lane_rects[0].center().y;
+        let x = h.panel.time_to_x(3.0);
+        h.press(egui::pos2(x, y));
+        h.drag_to(egui::pos2(x, y));
+        h.release(egui::pos2(x, y));
+        h.draw();
+
+        let preview = h.insp.timeline_preview.clone().expect("a preview request");
+        let camera = preview.camera.expect("a camera pose");
+        // Half way along a 0..12 dolly over 6 seconds.
+        assert!(
+            (camera.position[0] - 6.0).abs() < 0.2,
+            "expected x near 6.0 at t=3.0, got {}",
+            camera.position[0]
+        );
+    }
+
+    /// Paired with the above: Preview off must publish nothing at all.
+    /// Without this, a panel that always previews passes the test above.
+    #[test]
+    fn preview_off_publishes_nothing() {
+        let mut h = Harness::new(four_track_timeline());
+        h.panel.preview = false;
+        h.settle();
+
+        assert!(
+            h.insp.timeline_preview.is_none(),
+            "preview is off, so the panel must publish no request"
+        );
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/timeline.rs
@@ -663,6 +663,53 @@ mod tests {
         );
     }
 
+    /// A cut resolves against the scene, not the timeline: the pose comes
+    /// from the named entity's snapshot entry, including its field of view.
+    ///
+    /// Bounded on both sides. "Past where the dolly was" is not the same
+    /// claim as "at the shot", and only the upper bound rules out a preview
+    /// that simply kept dollying.
+    #[test]
+    fn a_cut_previews_the_shot_entitys_pose() {
+        let mut h = Harness::new(four_track_timeline());
+        h.entities_snapshot = vec![InspectorEntityInfo {
+            id: 1,
+            name: Some("CloseUpShot".to_string()),
+            position: Some([1.5, 1.2, 2.5]),
+            rotation: Some([0.0, 0.0, 0.0]),
+            camera_fov: Some(35.0),
+            ..Default::default()
+        }];
+        h.panel.preview = true;
+        h.settle();
+
+        let y = h.panel.last_lane_rects[0].center().y;
+        let x = h.panel.time_to_x(4.0); // past the cut at 3.5
+        h.press(egui::pos2(x, y));
+        h.drag_to(egui::pos2(x, y));
+        h.release(egui::pos2(x, y));
+        h.draw();
+
+        let camera = h
+            .insp
+            .timeline_preview
+            .clone()
+            .expect("a preview request")
+            .camera
+            .expect("a camera pose");
+        assert!(
+            (camera.position[0] - 1.5).abs() < 1e-3,
+            "expected the shot entity's x=1.5, got {} -- the dolly would be \
+             past x=8 by now",
+            camera.position[0]
+        );
+        assert_eq!(
+            camera.fov_y_degrees,
+            Some(35.0),
+            "a shot carries its own field of view"
+        );
+    }
+
     /// Paired with the above: Preview off must publish nothing at all.
     /// Without this, a panel that always previews passes the test above.
     #[test]
@@ -739,6 +786,38 @@ mod tests {
             0,
             "selecting a different entity with a TimelinePlayer must resume \
              following the selection"
+        );
+    }
+
+    /// The boundary this sub-step is defined by. Editing and saving are
+    /// sub-step 2/2b; until then a scrub must not be able to reach the file.
+    ///
+    /// Asserts the bytes rather than the modification time, because a write
+    /// that happens to produce identical content is still a write path that
+    /// should not exist yet -- and mtime granularity is coarse enough on some
+    /// filesystems to miss a fast one.
+    #[test]
+    fn scrubbing_never_writes_to_the_timeline_file() {
+        let file = write_timeline(&four_track_timeline());
+        let before = std::fs::read(&file.0).expect("read back");
+
+        let mut h = Harness::new(empty_timeline());
+        h.panel.open_for_test(&file.0);
+        h.panel.preview = true;
+        h.settle();
+
+        let y = h.panel.last_lane_rects[0].center().y;
+        for t in [0.5_f32, 2.5, 4.0, 5.9] {
+            let x = h.panel.time_to_x(t);
+            h.press(egui::pos2(x, y));
+            h.drag_to(egui::pos2(x, y));
+            h.release(egui::pos2(x, y));
+        }
+
+        let after = std::fs::read(&file.0).expect("read back");
+        assert_eq!(
+            before, after,
+            "sub-step 2/2a is read-only: scrubbing must not touch the file"
         );
     }
 


### PR DESCRIPTION
ENGINE_ROADMAP item 57, sub-step 2/2a. The editor Timeline panel: a track view, a
scrubbable playhead, and a cutscene preview. **Writes nothing to disk** — keyframe
editing and saving are 2/2b.

Item 57's last completion condition is "에디터에서 타임라인 편집 UI(트랙 뷰, 스크러빙)",
the only unchecked box left on the roadmap. The full editor was too large for one PR,
so it splits by whether the panel writes. That boundary is what will make 2/2b's diff
attributable, and it is asserted rather than intended — see the read-only test below.

## The bug this cleared first

`update_skinned_meshes` — the only system that turns an `AnimationPlayer` into a posed
skeleton — is registered **exclusively** by `SkinnedMeshPlugin`, which the editor app
never registered. **Skinned characters have been rendering in bind pose in the editor
and never posing at all.** Animation preview would have shipped silently inert.

That is a standing editor bug rather than a timeline one, so it lands alone
(`76abbfb0`), and it is the third instance of one shape: item 44's `TerrainPlugin` and
item 57 sub-step 1/2's own `TimelinePlugin` were both absent from a host that needed
them, while every unit test passed because the tests build their own app.

## How preview reaches the world

The panel has no `World` — `EditorPanelContext` carries an `InspectorState`, a
read-only entity snapshot, a cursor and a type registry, and nothing else. So it
publishes a request into a new `InspectorState.timeline_preview`, and two consumers
apply it.

**The camera mutates nothing.** `update_editor_camera` already owns `editor_view_proj`
and assigns it unconditionally every frame, so the preview replaces its answer *inside*
that system rather than racing it as a second writer. The scene's camera entity is never
touched, so there is nothing to restore, no undo contamination, and no path from a scrub
to a saved file. The orbit parameters are deliberately left alone, which is what makes
ending a preview return the exact viewpoint the user had. **No scheduling changed** —
which matters, because ordering constraints here compose transitively.

**Animation writes `AnimationPlayer.time` directly** rather than starting playback. That
is what scrubbing means, and it is also why the editor needs no `advance_animations`.
Touched players are snapshotted on entry and restored on exit. Sub-step 1/2 documented
"stopping restores nothing" as a deliberate *runtime* decision; an authoring tool is the
opposite case, because looking at a cutscene must not be a way to edit the scene.

## Testability decided the API

A track view is almost entirely painter-drawn — lanes are rects, keys are circles, the
playhead is a line — and this project forbids hardcoded click coordinates, while the
helper that finds widgets walks text galleys and finds none of that. `shadergraph.rs`
solved it by recording its geometry; this panel does the same and one thing more: it
exposes the **time↔x mapping**, so the central test is a round trip. Press at
`time_to_x(2.5)`, read 2.5 back.

That mattered. Adding a constant offset inside `x_to_time` fails all four scrub tests.
A one-way "the playhead moved right" assertion passes that mutation, and passes for any
mapping that is merely monotonic — which is exactly how a time axis goes wrong.

## What the tests are paired against

- Preview on → the camera follows `evaluate`. **Preview off → the orbit state wins**, and
  ending a preview returns the exact prior viewpoint. Without both, an override that
  never turns off passes.
- A cut lands on the shot entity's pose, bounded on both sides — "past where the dolly
  was" is not "at the shot".
- The precedence rule in both directions: an explicit path wins, *and* selecting a
  different timeline entity clears it. Without the second, the override would be a trap
  the first test cannot see.
- **Restore takes three tests, not two.** Disabling restore fails two of them. But making
  the snapshot retake every frame — which breaks every preview lasting longer than one
  frame, i.e. every real one — leaves the single-frame restore test **passing**, and only
  the multi-frame test catches it.
- **Scrubbing does not change the file's bytes.** This is the 2a/2b boundary, and an
  assertion is the only thing that makes it a fact.

## Two things found during verification

**The coverage audit did its job.** Enumerating the public surface and asking which items
had a *consumer-side* assertion found `CameraShot` drawn, published, and checked by
nothing. That is precisely the gap sub-step 1/2 shipped with — one track kind and two
scripting ops observed by nothing — while its commits already said "mutation-verified".
Confirmed by making `build_preview` ignore the shot track: the new test is the only one
that fails.

**A workspace failure that looked like the known flake wasn't.**
`ensure_builtin_panels_registers_six_panels` failed in the `bsengine-rhi-wgpu` suite,
which is where this repo's known `profiler` flake lives, and this branch touches that
crate. Reading the failure instead of re-running it named the cause in one line: the
panel count is seven now. The count is asserted alongside `contains_key("timeline")`,
since a count alone passes for any seventh panel.

## Verification

fmt clean · catalogue **71 components / 273 ops** unchanged · clippy exactly the 8
baseline non-`rhi-wgpu` locations, **no new warnings** · workspace 79 result lines, 0
failures · editor **941** · **all 11 E2E replays** · **11 projects × 2 package modes**

## Not in this sub-step

Key drag, add and delete; track add/delete; value editing; saving — all 2/2b, which this
PR's read-only guarantee is designed to make safely reviewable. Also not planned: playing
a timeline at real time in the editor (scrubbing covers authoring, and the runtime already
plays), and previewing the `Event` track, since the editor runs no gameplay scripts to
receive events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
