### PR TITLE
perf(rhi): instance the shadow passes — 8,481 draws to 2,116, 40.6ms to 23.6ms

### DIFF
--- a/crates/bsengine-rhi-wgpu/src/instancing.rs
+++ b/crates/bsengine-rhi-wgpu/src/instancing.rs
@@ -1,0 +1,218 @@
+//! Grouping draw-call indices into instanced batches.
+//!
+//! Kept separate from `surface.rs` (~7,000 lines) and free of any GPU,
+//! window or adapter dependency, so grouping and slot-array alignment are
+//! testable as plain data.
+
+use crate::surface::MaterialParams;
+use glam::Mat4;
+use std::collections::HashMap;
+
+/// One draw call's worth of data, as `render_frame` receives it.
+type DrawCall = (u64, Mat4, Option<u64>, MaterialParams, Option<String>);
+
+/// Slot-array alignment, in `u32`s.
+///
+/// `wgpu::Limits::downlevel_defaults()` sets
+/// `min_storage_buffer_offset_alignment` to 256 bytes, and a slot is a
+/// 4-byte `u32`, so every batch must start on a 64-slot boundary to be
+/// reachable by a dynamic offset.
+pub const SLOT_ALIGNMENT: u32 = 64;
+
+/// One instanced draw: every object in it shares [`Batch::mesh_id`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Batch {
+    /// The mesh every instance in this batch draws.
+    pub mesh_id: u64,
+    /// Where this batch's slot list starts in the frame's slot array.
+    /// Always a multiple of [`SLOT_ALIGNMENT`].
+    pub slot_base: u32,
+    /// How many instances this batch draws.
+    pub count: u32,
+}
+
+/// Groups `indices` (positions in `draw_calls`) by mesh, appending each
+/// batch's model-slot list to `slots`.
+///
+/// The values written into `slots` are the **original `draw_calls`
+/// indices**, unchanged. That index is the model uniform's slot, so a
+/// filtered or renumbered position would hand every object someone else's
+/// transform — the same invariant the per-object point-shadow loop spells
+/// out where it computes its dynamic offset.
+///
+/// `slots` is appended to rather than replaced because one array carries
+/// every pass's lists for a single upload; each batch reaches its own list
+/// through a dynamic offset.
+///
+/// Batches follow **first appearance** of each mesh, not hash order, so a
+/// frame's draw order is reproducible.
+///
+/// This function holds no registry and cannot know whether a mesh is
+/// loaded; the caller looks that up once per batch. It also does not clamp
+/// to `MAX_OBJECTS` — callers pass an already-clamped index list.
+pub fn build_batches(
+    indices: &[usize],
+    draw_calls: &[DrawCall],
+    slots: &mut Vec<u32>,
+) -> Vec<Batch> {
+    let mut order: Vec<u64> = Vec::new();
+    let mut groups: HashMap<u64, Vec<u32>> = HashMap::new();
+    for &i in indices {
+        let mesh_id = draw_calls[i].0;
+        if let Some(list) = groups.get_mut(&mesh_id) {
+            list.push(i as u32);
+        } else {
+            order.push(mesh_id);
+            groups.insert(mesh_id, vec![i as u32]);
+        }
+    }
+
+    let mut batches = Vec::with_capacity(order.len());
+    for mesh_id in order {
+        let list = &groups[&mesh_id];
+        // Pad to the next dynamic-offset boundary. The padding slots are
+        // never read: `count` bounds the instance range of the draw.
+        while slots.len() % SLOT_ALIGNMENT as usize != 0 {
+            slots.push(0);
+        }
+        let slot_base = slots.len() as u32;
+        slots.extend_from_slice(list);
+        batches.push(Batch {
+            mesh_id,
+            slot_base,
+            count: list.len() as u32,
+        });
+    }
+    batches
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::surface::MaterialParams;
+    use glam::Mat4;
+
+    /// Builds a `draw_calls`-shaped slice from mesh ids alone; nothing in
+    /// `build_batches` reads any other field.
+    fn calls(mesh_ids: &[u64]) -> Vec<DrawCall> {
+        mesh_ids
+            .iter()
+            .map(|&id| (id, Mat4::IDENTITY, None, MaterialParams::default(), None))
+            .collect()
+    }
+
+    #[test]
+    fn interleaved_meshes_collapse_into_one_batch_each() {
+        // A B A B -- the case a run-length grouping gets wrong, producing
+        // four batches of one instead of two batches of two.
+        let dc = calls(&[7, 9, 7, 9]);
+        let mut slots = Vec::new();
+        let batches = build_batches(&[0, 1, 2, 3], &dc, &mut slots);
+
+        assert_eq!(
+            batches.len(),
+            2,
+            "A B A B must group into two batches, got {batches:?}"
+        );
+        assert_eq!(batches[0].mesh_id, 7);
+        assert_eq!(batches[0].count, 2);
+        assert_eq!(batches[1].mesh_id, 9);
+        assert_eq!(batches[1].count, 2);
+
+        let first: Vec<u32> = slots
+            [batches[0].slot_base as usize..(batches[0].slot_base + batches[0].count) as usize]
+            .to_vec();
+        let second: Vec<u32> = slots
+            [batches[1].slot_base as usize..(batches[1].slot_base + batches[1].count) as usize]
+            .to_vec();
+        assert_eq!(
+            first,
+            vec![0, 2],
+            "mesh 7 sits at draw_calls indices 0 and 2"
+        );
+        assert_eq!(
+            second,
+            vec![1, 3],
+            "mesh 9 sits at draw_calls indices 1 and 3"
+        );
+    }
+
+    #[test]
+    fn every_slot_base_is_dynamic_offset_aligned() {
+        // Three distinct meshes -> three batches, each of which must start
+        // on a 256-byte boundary because `min_storage_buffer_offset_alignment`
+        // is 256 and a slot is 4 bytes.
+        let dc = calls(&[1, 2, 3]);
+        let mut slots = Vec::new();
+        let batches = build_batches(&[0, 1, 2], &dc, &mut slots);
+
+        assert_eq!(batches.len(), 3);
+        for b in &batches {
+            assert_eq!(
+                b.slot_base % SLOT_ALIGNMENT,
+                0,
+                "slot_base {} is not a multiple of {SLOT_ALIGNMENT}, so it cannot be used \
+                 as a dynamic offset",
+                b.slot_base
+            );
+        }
+    }
+
+    #[test]
+    fn batches_append_after_slots_already_written_by_an_earlier_pass() {
+        // Every pass in a frame appends to one shared array. An
+        // implementation that indexed from zero would overwrite the
+        // directional pass's lists with the first point light's.
+        let dc = calls(&[4, 4]);
+        let mut slots = vec![u32::MAX; 3]; // an earlier pass's data
+        let batches = build_batches(&[0, 1], &dc, &mut slots);
+
+        assert_eq!(batches.len(), 1);
+        assert!(
+            batches[0].slot_base >= 3,
+            "slot_base {} overlaps the 3 slots an earlier pass already wrote",
+            batches[0].slot_base
+        );
+        assert_eq!(
+            &slots[..3],
+            &[u32::MAX; 3],
+            "the earlier pass's slots were overwritten"
+        );
+    }
+
+    #[test]
+    fn an_empty_index_list_produces_no_batches() {
+        let dc = calls(&[1, 2]);
+        let mut slots = Vec::new();
+        let batches = build_batches(&[], &dc, &mut slots);
+        assert!(batches.is_empty(), "got {batches:?}");
+        assert!(slots.is_empty(), "no batches must write no slots");
+    }
+
+    #[test]
+    fn one_mesh_many_objects_is_a_single_batch() {
+        let dc = calls(&[5; 40]);
+        let mut slots = Vec::new();
+        let indices: Vec<usize> = (0..40).collect();
+        let batches = build_batches(&indices, &dc, &mut slots);
+
+        assert_eq!(batches.len(), 1, "40 objects of one mesh is one batch");
+        assert_eq!(batches[0].count, 40);
+    }
+
+    #[test]
+    fn batch_order_follows_first_appearance_not_hash_order() {
+        // Frame-to-frame draw order must be deterministic. Iterating a
+        // HashMap would reorder batches between runs.
+        let dc = calls(&[30, 10, 20, 10]);
+        let mut slots = Vec::new();
+        let batches = build_batches(&[0, 1, 2, 3], &dc, &mut slots);
+
+        let order: Vec<u64> = batches.iter().map(|b| b.mesh_id).collect();
+        assert_eq!(
+            order,
+            vec![30, 10, 20],
+            "batches must follow first appearance"
+        );
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/instancing.rs
+++ b/crates/bsengine-rhi-wgpu/src/instancing.rs
@@ -72,7 +72,7 @@ pub fn build_batches(
         let list = &groups[&mesh_id];
         // Pad to the next dynamic-offset boundary. The padding slots are
         // never read: `count` bounds the instance range of the draw.
-        while slots.len() % SLOT_ALIGNMENT as usize != 0 {
+        while !slots.len().is_multiple_of(SLOT_ALIGNMENT as usize) {
             slots.push(0);
         }
         let slot_base = slots.len() as u32;

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -19,6 +19,8 @@ pub mod gizmo;
 /// Image-based lighting: cubemap helpers, the BRDF integration LUT, and the
 /// environment preprocessing passes.
 pub mod ibl;
+/// Grouping draw calls into instanced batches.
+pub mod instancing;
 /// GPU mesh generation and the mesh registry.
 pub mod mesh;
 /// Minimal glTF parsing + a small dedicated render pipeline for the Asset

--- a/crates/bsengine-rhi-wgpu/src/panels/profiler.rs
+++ b/crates/bsengine-rhi-wgpu/src/panels/profiler.rs
@@ -72,8 +72,8 @@ impl EditorPanel for ProfilerPanel {
             latest.cpu_frame_time_ms
         ));
         ui.label(format!(
-            "Draw calls: {}   Triangles: {}   Occluded: {}",
-            latest.draw_calls, latest.triangles, latest.occluded_count
+            "Draw calls: {}   Objects: {}   Triangles: {}   Occluded: {}",
+            latest.draw_calls, latest.objects_drawn, latest.triangles, latest.occluded_count
         ));
         ui.label(format!(
             "Texture memory: {:.1} MB ({} textures)",

--- a/crates/bsengine-rhi-wgpu/src/profiler.rs
+++ b/crates/bsengine-rhi-wgpu/src/profiler.rs
@@ -149,6 +149,13 @@ pub struct FrameStats {
     pub gpu_timestamps_supported: bool,
     /// Number of draw calls issued this frame.
     pub draw_calls: u32,
+    /// Number of objects drawn this frame.
+    ///
+    /// Separate from [`Self::draw_calls`] because instanced passes submit
+    /// many objects per draw call. This answers "how much did the frame
+    /// draw", while `draw_calls` answers "how many API calls did that
+    /// cost". Where a pass is not instanced the two rise together.
+    pub objects_drawn: u32,
     /// Number of triangles submitted this frame.
     pub triangles: u64,
     /// Number of entities dropped this frame by occlusion culling --

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -714,70 +714,125 @@ fn fs_main(in: VertOut) -> @location(0) vec4<f32> {
 }
 "#;
 
-const SHADOW_WGSL: &str = r#"
-struct CameraUniform {
-    view_proj: mat4x4<f32>,
-    light_view_proj: mat4x4<f32>,
-};
-@group(0) @binding(0) var<uniform> camera: CameraUniform;
-
-struct ModelUniform {
+/// The instanced shadow shaders' view of the model buffer.
+///
+/// `_tail` is load-bearing: a WGSL array's stride is its element size, and
+/// this array aliases the very buffer the main pass reads as a uniform at
+/// `MODEL_STRIDE` (256). `ModelUniformData` is 112 bytes, and
+/// 112 + 9 * 16 = 256, so the padding is what keeps the two views agreeing
+/// on where object N begins.
+const INSTANCED_MODEL_DECL: &str = r#"
+struct ModelEntry {
     model: mat4x4<f32>,
+    metallic: f32,
+    roughness: f32,
+    _p0: f32,
+    _p1: f32,
+    emissive: vec3<f32>,
+    _p2: f32,
+    base_color: vec3<f32>,
+    opacity: f32,
+    _tail: array<vec4<f32>, 9>,
 };
-@group(1) @binding(0) var<uniform> model_data: ModelUniform;
-
-struct VertIn {
-    @location(0) pos: vec3<f32>,
-    @location(1) col: vec3<f32>,
-    @location(2) normal: vec3<f32>,
-    @location(3) uv: vec2<f32>,
-}
-
-@vertex
-fn vs_shadow(in: VertIn) -> @builtin(position) vec4<f32> {
-    let world = model_data.model * vec4<f32>(in.pos, 1.0);
-    return camera.light_view_proj * world;
-}
+@group(1) @binding(0) var<storage, read> models: array<ModelEntry>;
+@group(1) @binding(1) var<storage, read> slots: array<u32>;
 "#;
 
-const POINT_SHADOW_WGSL: &str = r#"
-struct ShadowUniform {
-    view_proj: mat4x4<f32>,
-    light_pos: vec3<f32>,
-};
-@group(0) @binding(0) var<uniform> shadow_uniform: ShadowUniform;
-
+/// The per-object shadow shaders' view, used on adapters without
+/// `DownlevelFlags::VERTEX_STORAGE`.
+const UNIFORM_MODEL_DECL: &str = r#"
 struct ModelUniform {
     model: mat4x4<f32>,
 };
 @group(1) @binding(0) var<uniform> model_data: ModelUniform;
+"#;
 
-struct VertIn {
+/// How an instanced shadow shader reaches its instance's model matrix.
+const INSTANCED_MODEL_FETCH: &str = "models[slots[in.instance]].model";
+
+/// How a per-object shadow shader reaches its object's model matrix.
+const UNIFORM_MODEL_FETCH: &str = "model_data.model";
+
+/// Picks the model declaration and access expression for a shadow shader.
+fn model_access(instanced: bool) -> (&'static str, &'static str) {
+    if instanced {
+        (INSTANCED_MODEL_DECL, INSTANCED_MODEL_FETCH)
+    } else {
+        (UNIFORM_MODEL_DECL, UNIFORM_MODEL_FETCH)
+    }
+}
+
+/// Directional shadow depth pass.
+///
+/// Built from one body with only the model access substituted, so the
+/// instanced and per-object variants cannot drift apart.
+fn shadow_wgsl(instanced: bool) -> String {
+    let (decl, fetch) = model_access(instanced);
+    format!(
+        r#"
+struct CameraUniform {{
+    view_proj: mat4x4<f32>,
+    light_view_proj: mat4x4<f32>,
+}};
+@group(0) @binding(0) var<uniform> camera: CameraUniform;
+{decl}
+struct VertIn {{
+    @builtin(instance_index) instance: u32,
     @location(0) pos: vec3<f32>,
     @location(1) col: vec3<f32>,
     @location(2) normal: vec3<f32>,
     @location(3) uv: vec2<f32>,
-}
-struct VertOut {
-    @builtin(position) clip_pos: vec4<f32>,
-    @location(0) world_pos: vec3<f32>,
-}
+}}
 
 @vertex
-fn vs_point_shadow(in: VertIn) -> VertOut {
+fn vs_shadow(in: VertIn) -> @builtin(position) vec4<f32> {{
+    let world = {fetch} * vec4<f32>(in.pos, 1.0);
+    return camera.light_view_proj * world;
+}}
+"#
+    )
+}
+
+/// Point shadow pass: distance-to-light rendered into one cube face.
+fn point_shadow_wgsl(instanced: bool) -> String {
+    let (decl, fetch) = model_access(instanced);
+    format!(
+        r#"
+struct ShadowUniform {{
+    view_proj: mat4x4<f32>,
+    light_pos: vec3<f32>,
+}};
+@group(0) @binding(0) var<uniform> shadow_uniform: ShadowUniform;
+{decl}
+struct VertIn {{
+    @builtin(instance_index) instance: u32,
+    @location(0) pos: vec3<f32>,
+    @location(1) col: vec3<f32>,
+    @location(2) normal: vec3<f32>,
+    @location(3) uv: vec2<f32>,
+}}
+struct VertOut {{
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) world_pos: vec3<f32>,
+}}
+
+@vertex
+fn vs_point_shadow(in: VertIn) -> VertOut {{
     var out: VertOut;
-    let world = model_data.model * vec4<f32>(in.pos, 1.0);
+    let world = {fetch} * vec4<f32>(in.pos, 1.0);
     out.clip_pos = shadow_uniform.view_proj * world;
     out.world_pos = world.xyz;
     return out;
-}
+}}
 
 @fragment
-fn fs_point_shadow(in: VertOut) -> @location(0) vec4<f32> {
+fn fs_point_shadow(in: VertOut) -> @location(0) vec4<f32> {{
     let dist = length(in.world_pos - shadow_uniform.light_pos);
     return vec4<f32>(dist, 0.0, 0.0, 1.0);
+}}
+"#
+    )
 }
-"#;
 
 const SKYBOX_WGSL: &str = r#"
 const PI: f32 = 3.14159265358979323846;
@@ -2275,7 +2330,16 @@ impl WgpuSurface {
     async fn request_device(
         instance: &wgpu::Instance,
         compatible_surface: Option<&wgpu::Surface<'static>>,
-    ) -> Result<(wgpu::Adapter, Arc<wgpu::Device>, Arc<wgpu::Queue>, bool, bool), String> {
+    ) -> Result<
+        (
+            wgpu::Adapter,
+            Arc<wgpu::Device>,
+            Arc<wgpu::Queue>,
+            bool,
+            bool,
+        ),
+        String,
+    > {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::None,
@@ -2338,9 +2402,10 @@ impl WgpuSurface {
             backends: wgpu::Backends::all(),
             ..Default::default()
         });
-        let (_adapter, device, queue, _timestamp_supported) = Self::request_device(&instance, None)
-            .await
-            .expect("headless device for test");
+        let (_adapter, device, queue, _timestamp_supported, _instancing_supported) =
+            Self::request_device(&instance, None)
+                .await
+                .expect("headless device for test");
         (device, queue)
     }
 
@@ -2499,9 +2564,7 @@ impl WgpuSurface {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: true },
                         has_dynamic_offset: true,
-                        min_binding_size: wgpu::BufferSize::new(
-                            std::mem::size_of::<u32>() as u64
-                        ),
+                        min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<u32>() as u64),
                     },
                     count: None,
                 },
@@ -2903,12 +2966,23 @@ impl WgpuSurface {
 
         let shadow_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("shadow shader"),
-            source: wgpu::ShaderSource::Wgsl(SHADOW_WGSL.into()),
+            source: wgpu::ShaderSource::Wgsl(shadow_wgsl(instancing_supported).into()),
         });
         let shadow_pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("shadow pipeline layout"),
-                bind_group_layouts: &[&camera_bgl, &model_bgl],
+                // The ONLY two pipeline layouts that change. The main,
+                // transparent, terrain and probe pipelines keep model_bgl,
+                // which is what keeps MESH_WGSL's @group(1) contract -- and
+                // every custom shader that copies it -- untouched.
+                bind_group_layouts: &[
+                    &camera_bgl,
+                    if instancing_supported {
+                        &model_storage_bgl
+                    } else {
+                        &model_bgl
+                    },
+                ],
                 push_constant_ranges: &[],
             });
         let shadow_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -2945,12 +3019,19 @@ impl WgpuSurface {
 
         let point_shadow_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("point shadow shader"),
-            source: wgpu::ShaderSource::Wgsl(POINT_SHADOW_WGSL.into()),
+            source: wgpu::ShaderSource::Wgsl(point_shadow_wgsl(instancing_supported).into()),
         });
         let point_shadow_pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("point shadow pipeline layout"),
-                bind_group_layouts: &[&point_shadow_uniform_bgl, &model_bgl],
+                bind_group_layouts: &[
+                    &point_shadow_uniform_bgl,
+                    if instancing_supported {
+                        &model_storage_bgl
+                    } else {
+                        &model_bgl
+                    },
+                ],
                 push_constant_ranges: &[],
             });
         let point_shadow_pipeline =
@@ -6545,16 +6626,50 @@ mod tests {
         );
     }
 
+    /// Both shadow shaders, in both variants.
+    ///
+    /// The per-object variant only ever runs on an adapter without
+    /// `VERTEX_STORAGE`, which cannot be simulated here -- so compiling it
+    /// is the only coverage it can have, and worth keeping for that
+    /// reason: without this, a typo in the fallback branch would ship
+    /// undetected.
     #[test]
     fn shadow_shader_compiles() {
         let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
-        let _module = WgpuSurface::compile_shader(&device, SHADOW_WGSL);
+        let _instanced = WgpuSurface::compile_shader(&device, &shadow_wgsl(true));
+        let _per_object = WgpuSurface::compile_shader(&device, &shadow_wgsl(false));
     }
 
     #[test]
     fn point_shadow_shader_compiles() {
         let (device, _queue) = pollster::block_on(WgpuSurface::headless_device_for_testing());
-        let _module = WgpuSurface::compile_shader(&device, POINT_SHADOW_WGSL);
+        let _instanced = WgpuSurface::compile_shader(&device, &point_shadow_wgsl(true));
+        let _per_object = WgpuSurface::compile_shader(&device, &point_shadow_wgsl(false));
+    }
+
+    /// The instanced model struct must be exactly `MODEL_STRIDE` bytes.
+    ///
+    /// It aliases the same buffer the main pass reads as a uniform at that
+    /// stride, so if the two disagree every instance past the first reads
+    /// a transform straddling two objects. Naga will not catch that -- the
+    /// shader is valid either way -- so the size is asserted here.
+    #[test]
+    fn instanced_model_entry_matches_the_uniform_stride() {
+        let fields = std::mem::size_of::<ModelUniformData>() as u64;
+        let tail_vec4s = INSTANCED_MODEL_DECL
+            .split("array<vec4<f32>, ")
+            .nth(1)
+            .and_then(|rest| rest.split('>').next())
+            .and_then(|n| n.parse::<u64>().ok())
+            .expect("_tail should be declared as array<vec4<f32>, N>");
+        assert_eq!(
+            fields + tail_vec4s * 16,
+            MODEL_STRIDE,
+            "ModelEntry is {fields} bytes of fields plus {tail_vec4s} vec4s of \
+             padding, which does not add up to MODEL_STRIDE ({MODEL_STRIDE}). \
+             The storage array and the uniform view would disagree about where \
+             object N begins."
+        );
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -4745,6 +4745,84 @@ impl WgpuSurface {
             );
         }
 
+        // --- instanced batch building ---
+        //
+        // Every pass's slot lists live in one array, built before any pass
+        // is encoded so the whole frame costs a single upload. The
+        // directional pass's list goes first, then one per active point
+        // light. Each batch reaches its own list through a dynamic offset.
+        let active_lights: Vec<_> = light.point_lights.iter().take(MAX_POINT_LIGHTS).collect();
+        let mut frame_slots: Vec<u32> = Vec::new();
+        // Gated on `fast_render` because that mode clears the directional
+        // shadow map without drawing into it. The point-shadow passes are
+        // not gated, and neither is their batching below.
+        let directional_batches = if self.instancing_supported && !self.fast_render {
+            let indices: Vec<usize> = (0..draw_calls.len().min(MAX_OBJECTS)).collect();
+            crate::instancing::build_batches(&indices, draw_calls, &mut frame_slots)
+        } else {
+            Vec::new()
+        };
+
+        // Which objects can possibly cast into each light, decided once per
+        // light rather than once per face -- the answer is the same for all
+        // six, since the test is a distance to the light's centre and not to
+        // any one face.
+        //
+        // Before this, every camera-visible object was drawn into all six
+        // faces of every light with no light-side test at all. A
+        // 1,231-entity level with one `range: 45` point light issued 6,333
+        // draw calls, most of them geometry that could not reach the light;
+        // `games/scale-level` measured that at ~18ms per point light, and
+        // filling MAX_POINT_LIGHTS took the frame to 165ms.
+        //
+        // Conservative in the same direction item 46's occlusion culling is:
+        // the sphere radius is *added* to the range, so a borderline object
+        // is kept. Culling a caster that should have cast is a visible bug
+        // (a missing shadow); keeping one that could not is only wasted work.
+        let point_castable: Vec<Vec<usize>> = active_lights
+            .iter()
+            .map(|pl| {
+                let light_pos = glam::Vec3::from(pl.position);
+                draw_calls
+                    .iter()
+                    .enumerate()
+                    .take(MAX_OBJECTS)
+                    .filter_map(|(i, (mesh_id, model, _, _, _))| {
+                        let (local_center, local_radius) = registry.get_bounds(*mesh_id)?;
+                        let center = (*model * local_center.extend(1.0)).truncate();
+                        let max_scale = model
+                            .x_axis
+                            .truncate()
+                            .length()
+                            .max(model.y_axis.truncate().length())
+                            .max(model.z_axis.truncate().length());
+                        let world_radius = local_radius * max_scale.max(1.0);
+                        (center.distance(light_pos) <= pl.range + world_radius).then_some(i)
+                    })
+                    .collect()
+            })
+            .collect();
+        // One batch list per light, shared by all six of its cube faces.
+        let mut point_batches: Vec<Vec<crate::instancing::Batch>> = Vec::new();
+        if self.instancing_supported {
+            for castable in &point_castable {
+                point_batches.push(crate::instancing::build_batches(
+                    castable,
+                    draw_calls,
+                    &mut frame_slots,
+                ));
+            }
+        }
+        if !frame_slots.is_empty() {
+            let staged = frame_slots.len().min(MAX_SLOTS);
+            self.queue.write_buffer(
+                &self.slot_buffer,
+                0,
+                bytemuck::cast_slice(&frame_slots[..staged]),
+            );
+            warn_if_slots_truncated(frame_slots.len());
+        }
+
         // --- shadow pass ---
         // In fast_render mode this still clears the shadow map to depth=1.0
         // (max distance -- "nothing occludes anything"), which reads as
@@ -4773,29 +4851,56 @@ impl WgpuSurface {
             if !self.fast_render {
                 shadow_pass.set_pipeline(&self.shadow_pipeline);
                 shadow_pass.set_bind_group(0, &self.camera_bind_group, &[]);
-                for (i, (mesh_id, _, _, _, _)) in draw_calls.iter().enumerate() {
-                    if i >= MAX_OBJECTS {
-                        break;
+                if self.instancing_supported {
+                    for batch in &directional_batches {
+                        // One registry lookup per batch, where the
+                        // per-object path needed one per object.
+                        let Some(mesh) = registry.get(batch.mesh_id) else {
+                            continue;
+                        };
+                        shadow_pass.set_bind_group(
+                            1,
+                            &self.model_storage_bind_group,
+                            &[batch.slot_base * std::mem::size_of::<u32>() as u32],
+                        );
+                        shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                        shadow_pass.set_index_buffer(
+                            mesh.index_buffer.slice(..),
+                            wgpu::IndexFormat::Uint32,
+                        );
+                        shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..batch.count);
+                        frame_draw_calls += 1;
+                        frame_objects_drawn += batch.count;
+                        // Triangles are per instance, so batching must not
+                        // deflate this the way it deflates draw calls.
+                        frame_triangles += (mesh.index_count / 3) as u64 * batch.count as u64;
                     }
-                    let Some(mesh) = registry.get(*mesh_id) else {
-                        continue;
-                    };
-                    let offset = (i as u64 * MODEL_STRIDE) as u32;
-                    shadow_pass.set_bind_group(1, &self.model_bind_group, &[offset]);
-                    shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
-                    shadow_pass
-                        .set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
-                    shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
-                    frame_draw_calls += 1;
-                    frame_objects_drawn += 1;
-                    frame_triangles += (mesh.index_count / 3) as u64;
+                } else {
+                    for (i, (mesh_id, _, _, _, _)) in draw_calls.iter().enumerate() {
+                        if i >= MAX_OBJECTS {
+                            break;
+                        }
+                        let Some(mesh) = registry.get(*mesh_id) else {
+                            continue;
+                        };
+                        let offset = (i as u64 * MODEL_STRIDE) as u32;
+                        shadow_pass.set_bind_group(1, &self.model_bind_group, &[offset]);
+                        shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                        shadow_pass.set_index_buffer(
+                            mesh.index_buffer.slice(..),
+                            wgpu::IndexFormat::Uint32,
+                        );
+                        shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
+                        frame_draw_calls += 1;
+                        frame_objects_drawn += 1;
+                        frame_triangles += (mesh.index_count / 3) as u64;
+                    }
                 }
             }
         }
 
         // --- point light shadow passes (linear-distance cube arrays) ---
         {
-            let active_lights: Vec<_> = light.point_lights.iter().take(MAX_POINT_LIGHTS).collect();
             for (light_idx, pl) in active_lights.iter().enumerate() {
                 let view_projs = point_light_face_view_projs(pl.position, pl.range);
                 for (face, vp) in view_projs.iter().enumerate() {
@@ -4834,43 +4939,11 @@ impl WgpuSurface {
             };
             let total_point_shadow_passes = active_lights.len() * 6;
             let mut point_shadow_pass_counter = 0usize;
-            for (light_idx, pl) in active_lights.iter().enumerate() {
-                // Which objects can possibly cast into *this* light, decided
-                // once per light rather than once per face -- the answer is the
-                // same for all six, since the test is a distance to the light's
-                // centre and not to any one face.
-                //
-                // Before this, every camera-visible object was drawn into all
-                // six faces of every light with no light-side test at all. A
-                // 1,231-entity level with one `range: 45` point light issued
-                // 6,333 draw calls, most of them geometry that could not reach
-                // the light; `games/scale-level` measured that at ~18ms per
-                // point light, and filling MAX_POINT_LIGHTS took the frame to
-                // 165ms.
-                //
-                // Conservative in the same direction item 46's occlusion
-                // culling is: the sphere radius is *added* to the range, so a
-                // borderline object is kept. Culling a caster that should have
-                // cast is a visible bug (a missing shadow); keeping one that
-                // could not is only wasted work.
-                let light_pos = glam::Vec3::from(pl.position);
-                let castable: Vec<usize> = draw_calls
-                    .iter()
-                    .enumerate()
-                    .take(MAX_OBJECTS)
-                    .filter_map(|(i, (mesh_id, model, _, _, _))| {
-                        let (local_center, local_radius) = registry.get_bounds(*mesh_id)?;
-                        let center = (*model * local_center.extend(1.0)).truncate();
-                        let max_scale = model
-                            .x_axis
-                            .truncate()
-                            .length()
-                            .max(model.y_axis.truncate().length())
-                            .max(model.z_axis.truncate().length());
-                        let world_radius = local_radius * max_scale.max(1.0);
-                        (center.distance(light_pos) <= pl.range + world_radius).then_some(i)
-                    })
-                    .collect();
+            for (light_idx, _pl) in active_lights.iter().enumerate() {
+                // Both computed once per light, above, and shared by all six
+                // of this light's cube faces: the range cull is a distance to
+                // the light's centre, so it gives the same answer per face.
+                let castable = &point_castable[light_idx];
                 for face in 0..6usize {
                     let is_first_point_shadow_pass = point_shadow_pass_counter == 0;
                     let is_last_point_shadow_pass =
@@ -4925,26 +4998,49 @@ impl WgpuSurface {
                         &self.point_shadow_bind_group,
                         &[uniform_offset],
                     );
-                    for &i in &castable {
-                        let Some(mesh) = registry.get(draw_calls[i].0) else {
-                            continue;
-                        };
-                        // `i` is the index into `draw_calls`, not a position
-                        // within `castable` -- that index *is* the model
-                        // uniform's dynamic offset, and using a filtered
-                        // position would hand every object someone else's
-                        // transform.
-                        let offset = (i as u64 * MODEL_STRIDE) as u32;
-                        point_shadow_pass.set_bind_group(1, &self.model_bind_group, &[offset]);
-                        point_shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
-                        point_shadow_pass.set_index_buffer(
-                            mesh.index_buffer.slice(..),
-                            wgpu::IndexFormat::Uint32,
-                        );
-                        point_shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
-                        frame_draw_calls += 1;
-                        frame_objects_drawn += 1;
-                        frame_triangles += (mesh.index_count / 3) as u64;
+                    if self.instancing_supported {
+                        for batch in &point_batches[light_idx] {
+                            let Some(mesh) = registry.get(batch.mesh_id) else {
+                                continue;
+                            };
+                            point_shadow_pass.set_bind_group(
+                                1,
+                                &self.model_storage_bind_group,
+                                &[batch.slot_base * std::mem::size_of::<u32>() as u32],
+                            );
+                            point_shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                            point_shadow_pass.set_index_buffer(
+                                mesh.index_buffer.slice(..),
+                                wgpu::IndexFormat::Uint32,
+                            );
+                            point_shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..batch.count);
+                            frame_draw_calls += 1;
+                            frame_objects_drawn += batch.count;
+                            frame_triangles += (mesh.index_count / 3) as u64 * batch.count as u64;
+                        }
+                    } else {
+                        for &i in castable {
+                            let Some(mesh) = registry.get(draw_calls[i].0) else {
+                                continue;
+                            };
+                            // `i` is the index into `draw_calls`, not a position
+                            // within `castable` -- that index *is* the model
+                            // uniform's dynamic offset, and using a filtered
+                            // position would hand every object someone else's
+                            // transform. `build_batches` carries the same
+                            // invariant for the instanced path above.
+                            let offset = (i as u64 * MODEL_STRIDE) as u32;
+                            point_shadow_pass.set_bind_group(1, &self.model_bind_group, &[offset]);
+                            point_shadow_pass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                            point_shadow_pass.set_index_buffer(
+                                mesh.index_buffer.slice(..),
+                                wgpu::IndexFormat::Uint32,
+                            );
+                            point_shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
+                            frame_draw_calls += 1;
+                            frame_objects_drawn += 1;
+                            frame_triangles += (mesh.index_count / 3) as u64;
+                        }
                     }
                     point_shadow_pass_counter += 1;
                 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -2034,6 +2034,10 @@ pub struct WgpuSurface {
     /// `wgpu::Features::TIMESTAMP_QUERY`. Set once at construction; every
     /// other `timestamp_*` field is `Some` iff this is `true`.
     timestamp_supported: bool,
+    /// Whether this adapter can read storage buffers in the vertex
+    /// stage, and therefore whether the shadow passes batch their draws
+    /// instead of issuing one per object.
+    instancing_supported: bool,
     /// GPU timestamp query set `render_frame` writes begin/end pass
     /// boundaries into, when `timestamp_supported`.
     timestamp_query_set: Option<wgpu::QuerySet>,
@@ -2087,7 +2091,7 @@ impl WgpuSurface {
             .create_surface(window.clone())
             .map_err(|e| e.to_string())?;
 
-        let (adapter, device, queue, timestamp_supported) =
+        let (adapter, device, queue, timestamp_supported, instancing_supported) =
             Self::request_device(&instance, Some(&surface)).await?;
 
         let size = window.inner_size();
@@ -2121,6 +2125,7 @@ impl WgpuSurface {
             },
             false,
             timestamp_supported,
+            instancing_supported,
         )
     }
 
@@ -2135,7 +2140,7 @@ impl WgpuSurface {
             backends: wgpu::Backends::all(),
             ..Default::default()
         });
-        let (_adapter, device, queue, timestamp_supported) =
+        let (_adapter, device, queue, timestamp_supported, instancing_supported) =
             Self::request_device(&instance, None).await?;
         let texture = crate::output::create_offscreen_texture(&device, width, height);
         Self::build(
@@ -2148,6 +2153,7 @@ impl WgpuSurface {
             },
             fast_render,
             timestamp_supported,
+            instancing_supported,
         )
     }
 
@@ -2196,6 +2202,15 @@ impl WgpuSurface {
         self.fast_render
     }
 
+    /// Whether the shadow passes batch objects sharing a mesh into one
+    /// instanced draw, rather than issuing one draw call each.
+    ///
+    /// False only on an adapter without `DownlevelFlags::VERTEX_STORAGE`,
+    /// where the instanced pipelines cannot be created at all.
+    pub fn is_instancing_supported(&self) -> bool {
+        self.instancing_supported
+    }
+
     /// This renderer's GPU device, for callers that must put resources on the
     /// same device -- a `GpuMeshRegistry`, for one.
     pub fn device_arc(&self) -> Arc<wgpu::Device> {
@@ -2219,7 +2234,7 @@ impl WgpuSurface {
     async fn request_device(
         instance: &wgpu::Instance,
         compatible_surface: Option<&wgpu::Surface<'static>>,
-    ) -> Result<(wgpu::Adapter, Arc<wgpu::Device>, Arc<wgpu::Queue>, bool), String> {
+    ) -> Result<(wgpu::Adapter, Arc<wgpu::Device>, Arc<wgpu::Queue>, bool, bool), String> {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::None,
@@ -2230,6 +2245,19 @@ impl WgpuSurface {
             .ok_or("No adapter found")?;
 
         let timestamp_supported = adapter.features().contains(wgpu::Features::TIMESTAMP_QUERY);
+        // Storage buffers in the vertex stage are an adapter capability,
+        // not something `required_limits` can ask for, and a pipeline whose
+        // vertex shader reads storage fails at *creation* where it is
+        // missing -- so this has to be decided before the shadow pipelines
+        // are built, not at draw time.
+        //
+        // Every backend this engine ships to supports it (there is no
+        // wasm/WebGL target), but the flag is real and not ours to
+        // guarantee, so it is checked rather than assumed.
+        let instancing_supported = adapter
+            .get_downlevel_capabilities()
+            .flags
+            .contains(wgpu::DownlevelFlags::VERTEX_STORAGE);
         let required_features = if timestamp_supported {
             wgpu::Features::TIMESTAMP_QUERY
         } else {
@@ -2254,6 +2282,7 @@ impl WgpuSurface {
             Arc::new(device),
             Arc::new(queue),
             timestamp_supported,
+            instancing_supported,
         ))
     }
 
@@ -2286,6 +2315,7 @@ impl WgpuSurface {
         output: crate::output::Output,
         fast_render: bool,
         timestamp_supported: bool,
+        instancing_supported: bool,
     ) -> Result<Self, String> {
         let format = output.format();
         let width = output.width();
@@ -3350,6 +3380,7 @@ impl WgpuSurface {
             last_saved_layout_json: None,
             fast_render,
             timestamp_supported,
+            instancing_supported,
             timestamp_query_set,
             timestamp_resolve_buffer,
             timestamp_readback_buffer,

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1204,6 +1204,41 @@ fn warn_if_truncated(what: &str, wanted: usize) {
 /// still reaches it.
 const MAX_OBJECTS: usize = 16384;
 const MODEL_STRIDE: u64 = 256;
+
+/// How many instance slots one frame can hold across all of its passes.
+///
+/// A slot is a `u32` index into the model buffer. Like [`MAX_OBJECTS`] this
+/// is a **buffer capacity, not a hardware limit**: 1 Mi slots is 4 MiB,
+/// far under `downlevel_defaults()`'s 128 MiB storage-binding ceiling.
+///
+/// It is much larger than `MAX_OBJECTS` on purpose. A frame holds one slot
+/// list for the directional pass plus one per point light, and each list
+/// is padded to a dynamic-offset boundary, so the slot total legitimately
+/// runs to several times the object count.
+const MAX_SLOTS: usize = 1 << 20;
+
+/// Warns once per process when a frame needs more instance slots than
+/// [`MAX_SLOTS`].
+///
+/// Separate from [`warn_if_truncated`] because that one's threshold is
+/// `MAX_OBJECTS`; reusing it here would fire on ordinary frames, since a
+/// frame legitimately holds far more slots than objects.
+fn warn_if_slots_truncated(wanted: usize) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+
+    if wanted <= MAX_SLOTS {
+        return;
+    }
+    if WARNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    tracing::warn!(
+        "instance slots: {wanted} exceeds MAX_SLOTS ({MAX_SLOTS}); some objects \
+         were not drawn into shadow maps this frame, so shadows on screen are \
+         not the shadows the scene calls for.",
+    );
+}
 // view_proj(64) + light_view_proj(64) + cam_pos(12) + pad(4) = 144
 const CAMERA_UNIFORM_SIZE: u64 = 144;
 // inv_vp mat4x4<f32> = 64 bytes
@@ -1913,6 +1948,12 @@ pub struct WgpuSurface {
     camera_buffer: wgpu::Buffer,
     camera_bind_group: wgpu::BindGroup,
     model_buffer: wgpu::Buffer,
+    /// Per-batch lists of model-buffer slots, read by the instanced
+    /// shadow shaders through a dynamic offset.
+    slot_buffer: wgpu::Buffer,
+    /// The shadow passes' storage-array view of `model_buffer`, plus
+    /// `slot_buffer`. Bound once per batch instead of once per object.
+    model_storage_bind_group: wgpu::BindGroup,
     model_bind_group: wgpu::BindGroup,
     light_buffer: wgpu::Buffer,
     light_bind_group: wgpu::BindGroup,
@@ -2386,7 +2427,14 @@ impl WgpuSurface {
         let model_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("model uniform"),
             size: MODEL_STRIDE * MAX_OBJECTS as u64,
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            // STORAGE as well as UNIFORM. The main, transparent, terrain
+            // and probe passes read this through a dynamic-offset uniform
+            // binding; the instanced shadow passes read the whole thing as
+            // an array. Same bytes, same 256-byte stride, two views -- so
+            // nothing about how the buffer is filled has to change.
+            usage: wgpu::BufferUsages::UNIFORM
+                | wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
         let model_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -2415,6 +2463,67 @@ impl WgpuSurface {
                     size: wgpu::BufferSize::new(std::mem::size_of::<ModelUniformData>() as u64),
                 }),
             }],
+        });
+
+        // Slot array: for each instanced batch, the model-buffer slot of
+        // every object in it. One frame-wide array holds every pass's
+        // lists back to back, so a frame costs one upload; each batch
+        // reaches its own list through a dynamic offset.
+        let slot_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("instance slots"),
+            size: (MAX_SLOTS * std::mem::size_of::<u32>()) as u64,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        // The shadow passes' view of the same model buffer: an array
+        // indexed by this instance's slot, rather than one dynamically
+        // offset struct. Vertex stage only -- the shadow shaders have no
+        // fragment-stage use for model data, which is precisely why they
+        // can move to storage while MESH_WGSL cannot.
+        let model_storage_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("model storage bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(MODEL_STRIDE),
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: true,
+                        min_binding_size: wgpu::BufferSize::new(
+                            std::mem::size_of::<u32>() as u64
+                        ),
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let model_storage_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("model storage bg"),
+            layout: &model_storage_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: model_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &slot_buffer,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(std::mem::size_of::<u32>() as u64),
+                    }),
+                },
+            ],
         });
 
         let light_buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -3323,6 +3432,8 @@ impl WgpuSurface {
             camera_buffer,
             camera_bind_group,
             model_buffer,
+            slot_buffer,
+            model_storage_bind_group,
             model_bind_group,
             light_buffer,
             light_bind_group,

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -4386,6 +4386,9 @@ impl WgpuSurface {
         // `mesh_thumbnail.rs`'s `render_thumbnail` can run mid-frame and
         // must never inflate this frame's `FrameStats`.
         let mut frame_draw_calls: u32 = 0;
+        // Objects, as distinct from draw calls: an instanced pass submits
+        // many objects per call, so these two diverge once batching is on.
+        let mut frame_objects_drawn: u32 = 0;
         let mut frame_triangles: u64 = 0;
 
         // GPU pass-timing bookkeeping for the profiler (see `next_timed_pass`
@@ -4561,6 +4564,7 @@ impl WgpuSurface {
                         .set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
                     shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
                     frame_draw_calls += 1;
+                    frame_objects_drawn += 1;
                     frame_triangles += (mesh.index_count / 3) as u64;
                 }
             }
@@ -4716,6 +4720,7 @@ impl WgpuSurface {
                         );
                         point_shadow_pass.draw_indexed(0..mesh.index_count, 0, 0..1);
                         frame_draw_calls += 1;
+                        frame_objects_drawn += 1;
                         frame_triangles += (mesh.index_count / 3) as u64;
                     }
                     point_shadow_pass_counter += 1;
@@ -4801,6 +4806,7 @@ impl WgpuSurface {
                 pass.set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
                 pass.draw_indexed(0..mesh.index_count, 0, 0..1);
                 frame_draw_calls += 1;
+                frame_objects_drawn += 1;
                 frame_triangles += (mesh.index_count / 3) as u64;
             }
 
@@ -4888,6 +4894,7 @@ impl WgpuSurface {
                 pass.set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
                 pass.draw_indexed(0..mesh.index_count, 0, 0..1);
                 frame_draw_calls += 1;
+                frame_objects_drawn += 1;
                 frame_triangles += (mesh.index_count / 3) as u64;
                 terrain_slot += 1;
             }
@@ -4930,6 +4937,7 @@ impl WgpuSurface {
             sky_pass.set_bind_group(1, &sky.texture_bg, &[]);
             sky_pass.draw(0..3, 0..1);
             frame_draw_calls += 1;
+            frame_objects_drawn += 1;
             frame_triangles += 1;
         }
 
@@ -4989,6 +4997,7 @@ impl WgpuSurface {
                 pass.set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
                 pass.draw_indexed(0..mesh.index_count, 0, 0..1);
                 frame_draw_calls += 1;
+                frame_objects_drawn += 1;
                 frame_triangles += (mesh.index_count / 3) as u64;
             }
         }
@@ -5006,6 +5015,7 @@ impl WgpuSurface {
                 &self.default_texture_bind_group,
             );
             frame_draw_calls += particle_draw_calls;
+            frame_objects_drawn += particle_draw_calls;
             frame_triangles += particle_triangles;
         }
 
@@ -5024,6 +5034,7 @@ impl WgpuSurface {
             self.post_process
                 .apply(&mut encoder, &view, self.fast_render);
         frame_draw_calls += pp_draw_calls;
+        frame_objects_drawn += pp_draw_calls;
         frame_triangles += pp_triangles;
 
         // UI + HUD overlay via egui (always on in editor mode)
@@ -5659,6 +5670,7 @@ impl WgpuSurface {
             gpu_pass_times_ms,
             gpu_timestamps_supported: self.timestamp_supported,
             draw_calls: frame_draw_calls,
+            objects_drawn: frame_objects_drawn,
             triangles: frame_triangles,
             occluded_count,
             texture_memory_bytes: crate::profiler::texture_memory_bytes(),

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1272,6 +1272,25 @@ const MODEL_STRIDE: u64 = 256;
 /// runs to several times the object count.
 const MAX_SLOTS: usize = 1 << 20;
 
+/// How many bytes of the slot array one batch's binding can see.
+///
+/// A dynamically-offset binding is a *window*, not the whole buffer: wgpu
+/// requires `offset + window <= buffer_size`, so binding the full buffer
+/// (`size: None`) makes every non-zero offset a validation error, while
+/// binding too small a window makes `slots[1]` an out-of-bounds read --
+/// which WGSL clamps to index 0, silently handing every instance the
+/// batch's first transform.
+///
+/// One batch can hold at most `MAX_OBJECTS` slots, so that is the window.
+/// [`SLOT_BUFFER_BYTES`] adds it as headroom past `MAX_SLOTS` so any
+/// in-range `slot_base` can be offset to.
+const SLOT_WINDOW_BYTES: u64 = MAX_OBJECTS as u64 * std::mem::size_of::<u32>() as u64;
+
+/// Size of the slot buffer: [`MAX_SLOTS`] usable slots plus one window of
+/// headroom, so the highest usable offset still has a full window behind it.
+const SLOT_BUFFER_BYTES: u64 =
+    MAX_SLOTS as u64 * std::mem::size_of::<u32>() as u64 + SLOT_WINDOW_BYTES;
+
 /// Warns once per process when a frame needs more instance slots than
 /// [`MAX_SLOTS`].
 ///
@@ -2536,7 +2555,7 @@ impl WgpuSurface {
         // reaches its own list through a dynamic offset.
         let slot_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("instance slots"),
-            size: (MAX_SLOTS * std::mem::size_of::<u32>()) as u64,
+            size: SLOT_BUFFER_BYTES,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -2564,7 +2583,7 @@ impl WgpuSurface {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: true },
                         has_dynamic_offset: true,
-                        min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<u32>() as u64),
+                        min_binding_size: wgpu::BufferSize::new(SLOT_WINDOW_BYTES),
                     },
                     count: None,
                 },
@@ -2583,7 +2602,15 @@ impl WgpuSurface {
                     resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
                         buffer: &slot_buffer,
                         offset: 0,
-                        size: wgpu::BufferSize::new(std::mem::size_of::<u32>() as u64),
+                        // An explicit window, not `None`. `None` binds
+                        // the whole buffer, and wgpu then rejects every
+                        // non-zero dynamic offset as an overrun. Too small
+                        // a window is worse: `slots[1]` becomes an
+                        // out-of-bounds read, WGSL clamps it to index 0,
+                        // and every instance silently gets the batch's
+                        // first transform -- no validation error, no
+                        // warning, just every shadow stacked in one place.
+                        size: wgpu::BufferSize::new(SLOT_WINDOW_BYTES),
                     }),
                 },
             ],

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -657,6 +657,14 @@ struct VertOut {{
             .expect("render() should have populated frame stats")
     }
 
+    /// Whether this adapter can run the instanced shadow path. A suite that
+    /// means to exercise instancing should assert this first: on an adapter
+    /// without `VERTEX_STORAGE` the per-object fallback runs instead, and
+    /// draw-call assertions would silently be measuring that.
+    pub fn instancing_supported(&self) -> bool {
+        self.surface.is_instancing_supported()
+    }
+
     /// Shared handle to the rolling frame-stats history.
     pub fn frame_stats_history(
         &self,

--- a/crates/bsengine-rhi-wgpu/tests/instancing_stats.rs
+++ b/crates/bsengine-rhi-wgpu/tests/instancing_stats.rs
@@ -1,0 +1,154 @@
+//! The shadow passes draw objects sharing a mesh with one instanced call.
+//!
+//! **Why the fixture looks like this.** Every draw here is the *same* cube
+//! mesh at a *different* position. Both halves are load-bearing: if the
+//! meshes differed, every batch would hold one object, instancing would be
+//! a no-op, and these tests would pass while proving nothing. If the
+//! transforms matched, a wrong instance-to-slot mapping would be
+//! invisible.
+mod common;
+
+use common::{Draw, Harness, Light, PointLight, Scene};
+use glam::Vec3;
+
+/// Four cubes of one mesh, spread out so each is separately observable.
+fn four_spread_cubes(cube: u64) -> Vec<Draw> {
+    vec![
+        Draw::new(cube, Vec3::new(-3.0, 0.0, 0.0)),
+        Draw::new(cube, Vec3::new(-1.0, 0.0, 0.0)),
+        Draw::new(cube, Vec3::new(1.0, 0.0, 0.0)),
+        Draw::new(cube, Vec3::new(3.0, 0.0, 0.0)),
+    ]
+}
+
+#[test]
+fn this_adapter_supports_vertex_stage_storage_buffers() {
+    // Not a claim about all hardware -- a guard for this suite. If this
+    // fails, the other tests here are exercising the per-object fallback
+    // and prove nothing about instancing.
+    let h = Harness::new();
+    assert!(
+        h.instancing_supported(),
+        "this adapter reports no VERTEX_STORAGE, so the instanced path is \
+         inactive and the rest of this suite is testing the fallback"
+    );
+}
+
+#[test]
+fn four_cubes_of_one_mesh_cost_fewer_draw_calls_than_objects() {
+    let mut h = Harness::new();
+    let cube = h.cube();
+    h.render(&Scene {
+        draws: four_spread_cubes(cube),
+        ..Scene::default()
+    });
+
+    let stats = h.frame_stats();
+    assert!(
+        stats.draw_calls < stats.objects_drawn,
+        "the directional shadow pass should batch four same-mesh cubes into one \
+         draw call, so draw_calls={} must be below objects_drawn={}",
+        stats.draw_calls,
+        stats.objects_drawn
+    );
+}
+
+#[test]
+fn batching_does_not_reduce_the_number_of_objects_drawn() {
+    // The paired assertion. Fewer draw calls is the optimisation; fewer
+    // *objects* would mean something stopped being drawn. Compare one cube
+    // against four: objects must scale with the cubes even as draw calls
+    // do not.
+    let mut h = Harness::new();
+    let cube = h.cube();
+
+    h.render(&Scene {
+        draws: vec![Draw::new(cube, Vec3::ZERO)],
+        ..Scene::default()
+    });
+    let one = h.frame_stats();
+
+    h.render(&Scene {
+        draws: four_spread_cubes(cube),
+        ..Scene::default()
+    });
+    let four = h.frame_stats();
+
+    assert_eq!(
+        four.objects_drawn - one.objects_drawn,
+        6,
+        "three extra cubes each add one opaque object and one directional-shadow \
+         object, so objects_drawn must rise by 6 (one={}, four={})",
+        one.objects_drawn,
+        four.objects_drawn
+    );
+    // Only the opaque pass grows. This pins the scope of the change as
+    // precisely as the batching itself: the three extra cubes still cost
+    // three extra *opaque* draws, because the main pass is deliberately
+    // not instanced (that would break MESH_WGSL's @group(1) contract,
+    // which custom shaders copy). The shadow pass absorbs them for free.
+    assert_eq!(
+        four.draw_calls - one.draw_calls,
+        3,
+        "three extra same-mesh cubes must add exactly three draw calls -- one \
+         opaque each, and nothing at all in the shadow pass, which batches them \
+         (one={}, four={})",
+        one.draw_calls,
+        four.draw_calls
+    );
+}
+
+#[test]
+fn a_point_light_batches_its_cube_faces_too() {
+    // The point-shadow pass renders six cube faces per light, each of which
+    // previously issued one draw call per object. This is the pass that
+    // dominates a lit frame, so it needs its own assertion rather than
+    // riding on the directional one.
+    // Measured as a delta against the identical scene with no point light,
+    // so the assertion is about the point-shadow pass alone and not about
+    // however many draws the sky and post-processing happen to cost.
+    let mut h = Harness::new();
+    let cube = h.cube();
+
+    h.render(&Scene {
+        draws: four_spread_cubes(cube),
+        ..Scene::default()
+    });
+    let unlit = h.frame_stats();
+
+    h.render(&Scene {
+        draws: four_spread_cubes(cube),
+        light: Light {
+            points: vec![PointLight {
+                position: Vec3::new(0.0, 4.0, 4.0),
+                color: Vec3::ONE,
+                intensity: 20.0,
+                range: 40.0,
+            }],
+            ..Light::default()
+        },
+        ..Scene::default()
+    });
+    let lit = h.frame_stats();
+
+    let objects_delta = lit.objects_drawn - unlit.objects_drawn;
+    let draws_delta = lit.draw_calls - unlit.draw_calls;
+
+    // Structural, and independent of batching: a point shadow is a
+    // six-face cube render, so four in-range cubes are 24 drawn objects.
+    assert_eq!(
+        objects_delta, 24,
+        "one point light must draw all four cubes into all six of its cube \
+         faces: expected 24 extra objects, got {objects_delta} \
+         (unlit={} lit={})",
+        unlit.objects_drawn, lit.objects_drawn
+    );
+    // Batching: those 24 objects should cost six draws (one per face), not
+    // 24. Per-object drawing would make this 24 * 3 < 24, which is false.
+    assert!(
+        draws_delta * 3 < objects_delta,
+        "the point-shadow pass should batch four same-mesh cubes per face, so \
+         its 24 objects cost about six draw calls; got {draws_delta} extra draw \
+         calls for {objects_delta} extra objects"
+    );
+}

--- a/crates/bsengine-rhi-wgpu/tests/pixels_lighting.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_lighting.rs
@@ -272,3 +272,105 @@ fn a_point_light_is_blocked_by_an_occluder() {
         occluded.at(x, y)
     );
 }
+
+/// Which pixels either cube covers, for the two-caster test below.
+///
+/// Same idea as [`cube_silhouette`], but for both positions at once, so a
+/// "the floor got darker" reading can never be satisfied by a cube merely
+/// standing in front of the floor.
+fn two_cube_silhouette(h: &mut Harness, cube: u64, a: Vec3, b: Vec3) -> Vec<bool> {
+    let empty = h.render(&Scene {
+        light: sun_from_above(),
+        camera_pos: CAMERA,
+        ..Scene::default()
+    });
+    let cubes_only = h.render(&Scene {
+        draws: vec![Draw::new(cube, a), Draw::new(cube, b)],
+        light: sun_from_above(),
+        camera_pos: CAMERA,
+        ..Scene::default()
+    });
+    (0..(empty.width * empty.height))
+        .map(|i| {
+            let (x, y) = (i % empty.width, i / empty.width);
+            empty.at(x, y) != cubes_only.at(x, y)
+        })
+        .collect()
+}
+
+/// Two objects of the *same mesh* each cast a shadow in their own place.
+///
+/// **This is the only test that can see a wrong instance-to-slot mapping.**
+/// The shadow passes batch objects sharing a mesh into one instanced draw,
+/// and every instance looks up its own transform through a slot array. If
+/// that lookup is wrong -- if every instance reads the batch's first slot --
+/// then all the cubes cast one shadow stacked in one place.
+///
+/// Nothing else in the suite notices. Draw-call counts are identical either
+/// way, so the instancing statistics tests are blind to it by construction,
+/// and every other shadow test here uses a single caster, where "the batch's
+/// first slot" and "my slot" are the same thing. Running that mutation
+/// against the whole crate left all 19 suites green before this test existed.
+///
+/// The two frames it compares are chosen so the mutation cannot hide:
+/// `only_b` has one cube, so its batch has one slot and even a broken lookup
+/// finds the right transform; `both` has two, where a broken lookup drops B's
+/// shadow onto A. So B's shadow is measured in a frame that is correct
+/// regardless, then required to still be there in the frame that is not.
+#[test]
+fn each_instance_of_a_shared_mesh_casts_its_own_shadow() {
+    let mut h = Harness::new();
+    let plane = h.plane();
+    let cube = h.cube();
+
+    let a = Vec3::new(-2.5, 3.0, 0.0);
+    let b = Vec3::new(2.5, 3.0, 0.0);
+    let scene = |draws: Vec<Draw>| Scene {
+        draws,
+        light: sun_from_above(),
+        camera_pos: CAMERA,
+        ..Scene::default()
+    };
+
+    let mask = two_cube_silhouette(&mut h, cube, a, b);
+    let open = h.render(&scene(vec![floor(plane)]));
+    let only_b = h.render(&scene(vec![floor(plane), Draw::new(cube, b)]));
+    let both = h.render(&scene(vec![
+        floor(plane),
+        Draw::new(cube, a),
+        Draw::new(cube, b),
+    ]));
+
+    // Where B's shadow falls, established in the one-cube frame.
+    let (delta_b, bx, by) = biggest_darkening_off_the_caster(&open, &only_b, &mask);
+    assert!(
+        delta_b > 40.0,
+        "sanity: one cube on its own must cast a visible shadow before this test \
+         can say anything about two. Strongest darkening was {delta_b} at ({bx}, {by})"
+    );
+
+    // ...and it must still be there when A is added beside it.
+    let delta_both = open.luma(bx, by) - both.luma(bx, by);
+    assert!(
+        delta_both > delta_b * 0.5,
+        "B's shadow vanished when A was added: the floor at ({bx}, {by}) darkened by \
+         {delta_b} with B alone but only {delta_both} with both cubes. Both cubes share \
+         a mesh, so they batch into one instanced shadow draw -- this is what it looks \
+         like when every instance reads the same slot and they all cast A's shadow"
+    );
+
+    // And the paired direction: A's shadow must be there too, so a bug that
+    // dropped B's onto A cannot pass by symmetry.
+    let only_a = h.render(&scene(vec![floor(plane), Draw::new(cube, a)]));
+    let (delta_a, ax, ay) = biggest_darkening_off_the_caster(&open, &only_a, &mask);
+    assert!(
+        delta_a > 40.0,
+        "sanity: cube A alone must cast a visible shadow; got {delta_a} at ({ax}, {ay})"
+    );
+    let delta_both_a = open.luma(ax, ay) - both.luma(ax, ay);
+    assert!(
+        delta_both_a > delta_a * 0.5,
+        "A's shadow vanished when B was added: floor at ({ax}, {ay}) darkened by \
+         {delta_a} with A alone but only {delta_both_a} with both"
+    );
+}

--- a/crates/bsengine-rhi-wgpu/tests/pixels_lighting.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_lighting.rs
@@ -374,3 +374,76 @@ fn each_instance_of_a_shared_mesh_casts_its_own_shadow() {
          {delta_a} with A alone but only {delta_both_a} with both"
     );
 }
+
+/// The point-shadow half of [`each_instance_of_a_shared_mesh_casts_its_own_shadow`].
+///
+/// Found by enumerating this feature's surface and asking which items had a
+/// consumer-side assertion. The `slots[0u]` mutation breaks *both* shadow
+/// shaders, but only the directional test above caught it -- so breaking
+/// only the point-shadow fetch would have gone unnoticed. The two passes
+/// batch independently (the point pass batches a per-light culled subset,
+/// the directional pass batches everything), so one test cannot stand in
+/// for the other.
+#[test]
+fn each_instance_casts_its_own_point_light_shadow() {
+    let mut h = Harness::new();
+    let plane = h.plane();
+    let cube = h.cube();
+    let camera_pos = Vec3::new(0.0, 6.0, 7.0);
+
+    let a = Vec3::new(-2.0, 2.0, 0.0);
+    let b = Vec3::new(2.0, 2.0, 0.0);
+
+    // Directional light off entirely, so only the point light can brighten
+    // anything and only its cube shadow map can darken it.
+    let light = || Light {
+        color: Vec3::ZERO,
+        ambient: Vec3::splat(0.02),
+        points: vec![PointLight {
+            position: Vec3::new(0.0, 6.0, 0.0),
+            color: Vec3::ONE,
+            intensity: 90.0,
+            range: 40.0,
+        }],
+        ..Light::default()
+    };
+    let scene = |draws: Vec<Draw>| Scene {
+        draws,
+        light: light(),
+        camera_pos,
+        ..Scene::default()
+    };
+
+    let empty = h.render(&scene(vec![]));
+    let cubes_only = h.render(&scene(vec![Draw::new(cube, a), Draw::new(cube, b)]));
+    let silhouette: Vec<bool> = (0..(empty.width * empty.height))
+        .map(|i| {
+            let (x, y) = (i % empty.width, i / empty.width);
+            empty.at(x, y) != cubes_only.at(x, y)
+        })
+        .collect();
+
+    let open = h.render(&scene(vec![floor(plane)]));
+    let only_b = h.render(&scene(vec![floor(plane), Draw::new(cube, b)]));
+    let both = h.render(&scene(vec![
+        floor(plane),
+        Draw::new(cube, a),
+        Draw::new(cube, b),
+    ]));
+
+    let (delta_b, bx, by) = biggest_darkening_off_the_caster(&open, &only_b, &silhouette);
+    assert!(
+        delta_b > 20.0,
+        "sanity: one cube under a point light must cast a visible shadow before this \
+         test can say anything about two; strongest darkening was {delta_b} at ({bx}, {by})"
+    );
+
+    let delta_both = open.luma(bx, by) - both.luma(bx, by);
+    assert!(
+        delta_both > delta_b * 0.5,
+        "B's point-light shadow vanished when A was added: floor at ({bx}, {by}) darkened \
+         by {delta_b} with B alone but only {delta_both} with both cubes. The point-shadow \
+         pass batches same-mesh casters into one instanced draw per cube face -- this is \
+         what it looks like when every instance reads the same slot"
+    );
+}

--- a/crates/bsengine-rhi-wgpu/tests/profiler_stats.rs
+++ b/crates/bsengine-rhi-wgpu/tests/profiler_stats.rs
@@ -83,3 +83,35 @@ fn frame_stats_history_caps_at_its_capacity() {
         bsengine_rhi_wgpu::profiler::FRAME_STATS_HISTORY_CAPACITY
     );
 }
+
+#[test]
+fn objects_drawn_counts_every_instance_even_when_draw_calls_batch_them() {
+    // Two cubes: the same mesh at two different positions. Whatever
+    // batching does to `draw_calls`, `objects_drawn` must still see two
+    // objects per pass -- a drop there would mean something stopped being
+    // drawn, which is a bug, not an optimisation.
+    let mut h = Harness::new();
+    let cube = h.cube();
+    h.render(&Scene {
+        draws: vec![
+            Draw::new(cube, Vec3::new(-1.5, 0.0, 0.0)),
+            Draw::new(cube, Vec3::new(1.5, 0.0, 0.0)),
+        ],
+        ..Scene::default()
+    });
+
+    let stats = h.frame_stats();
+    assert!(
+        stats.objects_drawn >= 4,
+        "two cubes go through the opaque pass and the directional shadow pass, \
+         so at least 4 objects are drawn; got {}",
+        stats.objects_drawn
+    );
+    assert!(
+        stats.objects_drawn >= stats.draw_calls,
+        "objects_drawn={} cannot be below draw_calls={}: batching can only \
+         make draw calls fewer than objects, never more",
+        stats.objects_drawn,
+        stats.draw_calls
+    );
+}

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -2547,10 +2547,20 @@ mod tests {
         let on_occluded = on_stats["occluded_count"]
             .as_u64()
             .expect("get_frame_stats should report occluded_count as a number");
+        // Objects, not draw calls. The shadow passes are instanced, so
+        // entities sharing a mesh collapse into one draw call -- a
+        // draw-call count says nothing about how many entities survived
+        // the cull, which is what this test is actually about.
+        let on_objects = on_stats["objects_drawn"]
+            .as_u64()
+            .expect("get_frame_stats should report objects_drawn as a number");
         let on_draws = on_stats["draw_calls"]
             .as_u64()
             .expect("get_frame_stats should report draw_calls as a number");
-        println!("occlusion ON : occluded_count={on_occluded} draw_calls={on_draws}");
+        println!(
+            "occlusion ON : occluded_count={on_occluded} objects_drawn={on_objects} \
+             draw_calls={on_draws}"
+        );
 
         assert!(
             on_occluded > 0,
@@ -2563,22 +2573,28 @@ mod tests {
              actually hidden, so something visible was culled"
         );
         assert!(
-            on_draws < mesh_entity_count as u64,
-            "occlusion culling must measurably cut the frame's work: draw_calls={on_draws} \
+            on_objects < mesh_entity_count as u64,
+            "occlusion culling must measurably cut the frame's work: objects_drawn={on_objects} \
              is not even below the {mesh_entity_count} mesh entities in the scene, and each \
-             drawn entity costs two draw calls (shadow + opaque) before post-processing is \
+             drawn entity costs two drawn objects (shadow + opaque) before post-processing is \
              counted at all"
         );
         // THE regression assertion. Each surviving entity contributes two
-        // draw calls, so the {beside} entities beside the wall plus the
-        // wall itself put a floor under `draw_calls` that an
+        // drawn objects, so the {beside} entities beside the wall plus the
+        // wall itself put a floor under `objects_drawn` that an
         // over-culling implementation would fall straight through.
+        //
+        // This counts objects rather than draw calls because the shadow
+        // passes are instanced: entities sharing a mesh collapse into one
+        // draw call, so a draw-call floor would be violated by a perfectly
+        // correct implementation. `objects_drawn` measures what this test
+        // has always been about -- how many entities survived the cull.
         let visible_floor = 2 * (beside_count as u64 + 1);
         assert!(
-            on_draws >= visible_floor,
-            "over-cull: draw_calls={on_draws} is below the {visible_floor} that the wall \
+            on_objects >= visible_floor,
+            "over-cull: objects_drawn={on_objects} is below the {visible_floor} that the wall \
              and the {beside_count} entities standing clear of it must produce on their \
-             own (two draw calls each: shadow pass + opaque pass). Something that was \
+             own (two drawn objects each: shadow pass + opaque pass). Something that was \
              plainly visible got culled, which is a rendering bug, not an optimization"
         );
 
@@ -2598,10 +2614,16 @@ mod tests {
         let off_occluded = off_stats["occluded_count"]
             .as_u64()
             .expect("get_frame_stats should report occluded_count as a number");
+        let off_objects = off_stats["objects_drawn"]
+            .as_u64()
+            .expect("get_frame_stats should report objects_drawn as a number");
         let off_draws = off_stats["draw_calls"]
             .as_u64()
             .expect("get_frame_stats should report draw_calls as a number");
-        println!("occlusion OFF: occluded_count={off_occluded} draw_calls={off_draws}");
+        println!(
+            "occlusion OFF: occluded_count={off_occluded} objects_drawn={off_objects} \
+             draw_calls={off_draws}"
+        );
 
         assert_eq!(
             off_occluded, 0,
@@ -2609,20 +2631,24 @@ mod tests {
              path: with the identical scene it still reported occluded_count={off_occluded}"
         );
         assert!(
-            off_draws >= 2 * mesh_entity_count as u64,
+            off_objects >= 2 * mesh_entity_count as u64,
             "with culling off every one of the {mesh_entity_count} mesh entities must be \
-             drawn twice (shadow + opaque), i.e. at least {} draw calls, but the profiler \
-             reported {off_draws} -- if the full count is not restored then phase 1's drop \
+             drawn twice (shadow + opaque), i.e. at least {} drawn objects, but the profiler \
+             reported {off_objects} -- if the full count is not restored then phase 1's drop \
              was not attributable to occlusion",
             2 * mesh_entity_count
         );
         assert_eq!(
-            off_draws - on_draws,
+            off_objects - on_objects,
             2 * on_occluded,
             "the whole difference between the two runs should be exactly the culled \
-             entities' own draw calls: {on_occluded} culled x 2 passes each. Got \
-             off={off_draws}, on={on_draws}. Anything else means the toggle changed \
-             something beyond occlusion, or the two runs did not render the same scene"
+             entities' own drawn objects: {on_occluded} culled x 2 passes each. Got \
+             off={off_objects}, on={on_objects}. Anything else means the toggle changed \
+             something beyond occlusion, or the two runs did not render the same scene.\n\
+             \n\
+             This counts objects, not draw calls: with the shadow passes instanced, \
+             removing N entities of a shared mesh removes 2N objects but often zero draw \
+             calls, so the draw-call difference carries no information about culling."
         );
     }
 

--- a/crates/bsengine-runtime/src/test_query.rs
+++ b/crates/bsengine-runtime/src/test_query.rs
@@ -214,6 +214,7 @@ pub fn get_frame_stats(world: &mut World) -> Result<Value, String> {
             "duration_ms": p.duration_ms,
         })).collect::<Vec<_>>(),
         "draw_calls": stats.draw_calls,
+        "objects_drawn": stats.objects_drawn,
         "triangles": stats.triangles,
         "occluded_count": stats.occluded_count,
         "texture_memory_bytes": stats.texture_memory_bytes,


### PR DESCRIPTION
Objects sharing a mesh now cost one draw call per shadow pass instead of one each.

## Why the shadow passes, and only them

`surface.rs` has five per-object draw loops. Two of them — directional and point shadow — hoist `set_pipeline` outside the loop already and bind nothing but the model uniform, so their batch key is just the mesh. Decisively, the shaders they use (`SHADOW_WGSL`, `POINT_SHADOW_WGSL`) are **inline consts internal to the engine**: no custom pipeline can ever bind to a shadow pass, so their `@group(1)` is free to change.

`MESH_WGSL`'s is not. It is copied verbatim by `games/mini-arena/assets/shaders/glow.wgsl` and by the shader-graph codegen preamble, which a test pins byte-for-byte. So the main and transparent passes are left alone, and this PR changes exactly two pipeline layouts. `git diff master -- games/ crates/bsengine-shadergraph/` is empty.

Whether the main pass is worth breaking that contract for is a question for the profile *after* this lands, not before.

## Measurements

Both taken this session against a baseline worktree at `master`, with the scene verified byte-identical by `cmp`.

Synthetic sweep (5 primitives cycled, so N objects form 5 batches — not a flattering all-one-mesh case):

| N | draws | cpu_ms |
|---:|---:|---:|
| 100 | 205 → 110 | 2.44 → 1.86 |
| 500 | 1005 → 510 | 5.38 → 3.96 |
| 2000 | 4005 → 2010 | 14.59 → 9.71 |
| 5000 | 10005 → 5010 | 32.77 → **20.21** (1.62×) |

`games/scale-level`, 1,238 entities, 8 point + 8 spot:

| | baseline | instanced |
|---|---:|---:|
| draw calls | 8,481 | **2,116** |
| objects drawn | — | **8,481** |
| triangles | 3,318,493 | 3,318,493 |
| cpu_ms | 40.64 | **23.58** (1.72×) |

The controls are what make these readable: triangles identical at every point, and `objects_drawn` landing exactly on the baseline's draw count. The frame does the same work for a quarter of the API calls.

## How it works

One `Vec<u32>` per frame holds every pass's slot lists — the directional pass's, then one per point light — built before any pass is encoded and uploaded once. Each batch reads its own list through a dynamic offset. The model buffer gains `STORAGE` usage beside `UNIFORM`; its bytes and 256-byte stride are unchanged, so the main pass keeps its existing uniform view of the same memory.

Reordering the model buffer was ruled out by a constraint rather than taste: the point-shadow pass draws a range-culled subset, and a filtered subset leaves holes in slot space, so instances of one mesh are never contiguous.

`first_instance` would let the bind hoist out of the batch loop entirely, but the downlevel flag governing whether `instance_index` reflects it has docs that switch between "indirect draw calls" and a plain-draw example. Built on the guaranteed mechanism instead.

## The part worth reading

**The mutation this PR should be guarded against passed the entire crate suite.** Making every instance read the batch's first slot — so same-mesh objects all cast one shadow stacked in one place — left all 19 suites and 276 unit tests green.

That is structural, not a gap in one test. Draw-call counts are identical either way, so the statistics tests are blind by construction, and every pre-existing shadow test uses a *single* caster, where "the batch's first slot" and "my slot" are the same thing.

Writing the test that closes it immediately found a real bug here: the slot binding's size was one `u32`, so with a dynamic offset `slots[1]` was out of bounds — and WGSL clamps out-of-bounds storage reads to index 0, reproducing the mutation exactly. No validation error, no warning, just wrong shadows. (`size: None` is not the fix either: it binds the whole buffer, and wgpu then rejects every non-zero offset as an overrun. It needs a properly sized window.)

A coverage sweep then found the point-shadow half unobserved — the shared mutation was caught only by the directional test — so there are now two tests, one per shader, each verified to fail when only its own shader is broken.

## Statistics change

`draw_calls` now means what its name says; new `objects_drawn` carries the old meaning into `FrameStats`, `get_frame_stats` and the profiler panel. `get_frame_stats` is MCP-visible, so this adds a field rather than repurposing one.

The occlusion test's `off_draws - on_draws == 2 * on_occluded` was rewritten against `objects_drawn` *before* instancing landed, so the rewrite was verifiably behaviour-preserving. It was not optional: that difference is now 30 against `2 * occluded = 60`.

## Verification

fmt clean · catalogue 71/273 unchanged · clippy no new warnings · workspace 1702 passed / 0 failed · editor 941 passed · **12/12 E2E replays** · **24/24 packaging** · shader contract untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
