### PR TITLE
feat(audio): DSP effect chains on mixer buses (PR 2 of 3)

### DIFF
--- a/crates/bsengine-audio/src/bus.rs
+++ b/crates/bsengine-audio/src/bus.rs
@@ -8,6 +8,191 @@
 
 use serde::Deserialize;
 
+/// One DSP effect in a bus's chain.
+///
+/// Every variant maps to a `kira` effect builder that already exists upstream —
+/// this crate writes no DSP. Defaults mirror kira's own `Default` impls exactly
+/// (read from its source), so omitting a field gives what kira would have given
+/// rather than a number invented here.
+///
+/// Units are in the field names (`attack_ms`, `gain_db`) because RON has no
+/// `Duration` literal, and a bare `attack: 0.01` invites a 1000x error that no
+/// test would catch — both values parse.
+///
+/// kira's `volume_control` is deliberately absent: [`Bus::volume_db`] already
+/// *is* a volume control on that track, and this crate's `lib.rs` records
+/// removing a redundant second path rather than leaving two ways to do one
+/// thing.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum BusEffect {
+    /// Reverberation.
+    Reverb {
+        /// How much signal is fed back, 0.0 to 1.0.
+        #[serde(default = "reverb_feedback")]
+        feedback: f64,
+        /// High-frequency damping, 0.0 to 1.0.
+        #[serde(default = "reverb_damping")]
+        damping: f64,
+        /// Stereo spread, 0.0 to 1.0.
+        #[serde(default = "one")]
+        stereo_width: f64,
+        /// Dry/wet balance: 0.0 dry, 1.0 wet.
+        #[serde(default = "half")]
+        mix: f32,
+    },
+    /// A resonant filter — the effect occlusion will later drive.
+    Filter {
+        /// Which frequencies to remove.
+        #[serde(default)]
+        mode: FilterMode,
+        /// Corner frequency in hertz.
+        #[serde(default = "filter_cutoff")]
+        cutoff: f64,
+        /// Resonance at the cutoff.
+        #[serde(default)]
+        resonance: f64,
+        /// Dry/wet balance: 0.0 dry, 1.0 wet.
+        #[serde(default = "one_f32")]
+        mix: f32,
+    },
+    /// Dynamic range compression.
+    Compressor {
+        /// Level above which gain starts being reduced, in decibels.
+        #[serde(default)]
+        threshold: f64,
+        /// Compression ratio; 1.0 is no compression.
+        #[serde(default = "one")]
+        ratio: f64,
+        /// How quickly compression engages, in milliseconds.
+        #[serde(default = "compressor_attack_ms")]
+        attack_ms: f64,
+        /// How quickly compression releases, in milliseconds.
+        #[serde(default = "compressor_release_ms")]
+        release_ms: f64,
+        /// Gain applied after compression, in decibels.
+        #[serde(default)]
+        makeup_gain_db: f32,
+        /// Dry/wet balance: 0.0 dry, 1.0 wet.
+        #[serde(default = "one_f32")]
+        mix: f32,
+    },
+    /// An echo.
+    Delay {
+        /// Time between repeats, in milliseconds.
+        #[serde(default = "delay_ms")]
+        delay_ms: f64,
+        /// Level of each repeat relative to the last, in decibels.
+        #[serde(default = "delay_feedback_db")]
+        feedback_db: f32,
+        /// Dry/wet balance: 0.0 dry, 1.0 wet.
+        #[serde(default = "half")]
+        mix: f32,
+    },
+    /// Waveshaping distortion.
+    Distortion {
+        /// Which waveshaping curve to use.
+        #[serde(default)]
+        kind: DistortionKind,
+        /// Gain applied before the curve, in decibels.
+        #[serde(default)]
+        drive_db: f32,
+        /// Dry/wet balance: 0.0 dry, 1.0 wet.
+        #[serde(default = "one_f32")]
+        mix: f32,
+    },
+    /// A single parametric EQ band.
+    ///
+    /// The only effect with no defaults: kira's `EqFilterBuilder::new` takes
+    /// all four positionally, so there is no upstream default to mirror and
+    /// inventing one here would be exactly the drift the other variants avoid.
+    EqFilter {
+        /// Which band shape to apply.
+        kind: EqFilterKind,
+        /// Centre or corner frequency in hertz.
+        frequency: f64,
+        /// Gain applied to the band, in decibels.
+        gain_db: f32,
+        /// Bandwidth control; higher is narrower.
+        q: f64,
+    },
+    /// Static stereo placement for the whole bus.
+    Panning {
+        /// -1.0 hard left, 0.0 centre, 1.0 hard right.
+        #[serde(default)]
+        panning: f32,
+    },
+}
+
+/// Which frequencies a [`BusEffect::Filter`] removes. Mirrors kira's `FilterMode`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+pub enum FilterMode {
+    /// Removes frequencies above the cutoff.
+    #[default]
+    LowPass,
+    /// Removes frequencies above and below the cutoff.
+    BandPass,
+    /// Removes frequencies below the cutoff.
+    HighPass,
+    /// Removes frequencies around the cutoff.
+    Notch,
+}
+
+/// Which waveshaping curve a [`BusEffect::Distortion`] uses. Mirrors kira's
+/// `DistortionKind`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+pub enum DistortionKind {
+    /// Clamps hard at the signal limits.
+    #[default]
+    HardClip,
+    /// Eases towards the limits instead of clamping.
+    SoftClip,
+}
+
+/// Which band shape a [`BusEffect::EqFilter`] applies. Mirrors kira's
+/// `EqFilterKind`.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+pub enum EqFilterKind {
+    /// Adjusts frequencies around the given frequency.
+    Bell,
+    /// Adjusts the given frequency and everything below it.
+    LowShelf,
+    /// Adjusts the given frequency and everything above it.
+    HighShelf,
+}
+
+// serde needs functions for non-zero defaults. Each value is kira's own,
+// read from its `Default` impls rather than chosen here.
+fn one() -> f64 {
+    1.0
+}
+fn one_f32() -> f32 {
+    1.0
+}
+fn half() -> f32 {
+    0.5
+}
+fn reverb_feedback() -> f64 {
+    0.9
+}
+fn reverb_damping() -> f64 {
+    0.1
+}
+fn filter_cutoff() -> f64 {
+    1000.0
+}
+fn compressor_attack_ms() -> f64 {
+    10.0
+}
+fn compressor_release_ms() -> f64 {
+    100.0
+}
+fn delay_ms() -> f64 {
+    500.0
+}
+fn delay_feedback_db() -> f32 {
+    -6.0
+}
+
 /// One declared mixer bus.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Bus {
@@ -21,6 +206,15 @@ pub struct Bus {
     /// Volume of this bus in decibels, matching `setSoundVolume`'s unit
     /// rather than introducing a second one.
     pub volume_db: f32,
+    /// DSP effects applied to this bus, in order.
+    ///
+    /// `#[serde(default)]` so every layout written before effects existed
+    /// keeps parsing with the field absent. Note this is plain serde through
+    /// `ron::from_str`, not the scene/`bevy_reflect` path where `default` is
+    /// inert — a distinction close enough to a known hazard here that
+    /// `a_bus_with_no_effects_field_parses` asserts it rather than trusting it.
+    #[serde(default)]
+    pub effects: Vec<BusEffect>,
 }
 
 /// A parsed and validated `buses.ron`.
@@ -313,6 +507,155 @@ mod tests {
         let l = layout("BusLayout(buses: [])");
         assert!(l.creation_order().is_empty());
         assert!(l.problems().is_empty());
+    }
+
+    /// A layout written before effects existed must still parse.
+    ///
+    /// Asserted rather than reasoned about: this repo has a recorded hazard
+    /// that `#[serde(default)]` is inert on the scene/`bevy_reflect` path.
+    /// `BusLayout` is plain serde through `ron::from_str`, where it works --
+    /// but the distinction is close enough to be worth a test rather than a
+    /// belief.
+    #[test]
+    fn a_bus_with_no_effects_field_parses() {
+        let l = layout(r#"BusLayout(buses: [Bus(name: "sfx", parent: None, volume_db: -6.0)])"#);
+        assert!(
+            l.get("sfx").unwrap().effects.is_empty(),
+            "an absent effects field must mean an empty chain, not a parse error"
+        );
+        assert!(l.problems().is_empty());
+    }
+
+    #[test]
+    fn an_effect_chain_keeps_its_authored_order() {
+        // Order is the contract: a chain is applied front to back, so Filter
+        // then Reverb is not the same sound as Reverb then Filter.
+        let l = layout(
+            r#"BusLayout(buses: [Bus(name: "sfx", parent: None, volume_db: 0.0, effects: [
+                Filter(mode: HighPass, cutoff: 800.0, resonance: 0.25, mix: 0.75),
+                Reverb(feedback: 0.5, damping: 0.25, stereo_width: 0.125, mix: 0.0625),
+            ])])"#,
+        );
+        let fx = &l.get("sfx").unwrap().effects;
+        assert_eq!(fx.len(), 2);
+        assert!(
+            matches!(fx[0], BusEffect::Filter { .. }),
+            "Filter was authored first; got {:?}",
+            fx[0]
+        );
+        assert!(
+            matches!(fx[1], BusEffect::Reverb { .. }),
+            "Reverb was authored second; got {:?}",
+            fx[1]
+        );
+    }
+
+    /// Every field a *different* value, so a mapping that reads the wrong one
+    /// cannot read as correct. This is the assertion the parameter-swap
+    /// mutation exists to trip.
+    #[test]
+    fn every_parameter_lands_in_its_own_field() {
+        let l = layout(
+            r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                Reverb(feedback: 0.5, damping: 0.25, stereo_width: 0.125, mix: 0.0625),
+            ])])"#,
+        );
+        match &l.get("b").unwrap().effects[0] {
+            BusEffect::Reverb {
+                feedback,
+                damping,
+                stereo_width,
+                mix,
+            } => {
+                assert_eq!(*feedback, 0.5);
+                assert_eq!(*damping, 0.25);
+                assert_eq!(*stereo_width, 0.125);
+                assert_eq!(*mix, 0.0625);
+            }
+            other => panic!("expected Reverb, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn omitted_effect_parameters_take_kiras_defaults() {
+        // Not values chosen here -- kira's own, read from its Default impls.
+        let l = layout(
+            r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                Reverb(),
+                Delay(),
+            ])])"#,
+        );
+        let fx = &l.get("b").unwrap().effects;
+        match &fx[0] {
+            BusEffect::Reverb {
+                feedback,
+                damping,
+                stereo_width,
+                mix,
+            } => {
+                assert_eq!(
+                    (*feedback, *damping, *stereo_width, *mix),
+                    (0.9, 0.1, 1.0, 0.5)
+                );
+            }
+            other => panic!("expected Reverb, got {other:?}"),
+        }
+        match &fx[1] {
+            BusEffect::Delay {
+                delay_ms,
+                feedback_db,
+                mix,
+            } => {
+                assert_eq!((*delay_ms, *feedback_db, *mix), (500.0, -6.0, 0.5));
+            }
+            other => panic!("expected Delay, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unknown_effect_name_is_a_parse_error() {
+        // Loud rather than silently dropped: a typo'd effect that vanished
+        // would leave an author wondering why their bus sounds dry.
+        assert!(BusLayout::from_ron(
+            r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                Flanger(depth: 1.0),
+            ])])"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn eq_filter_requires_all_four_parameters() {
+        // The one effect with no defaults, because kira's own constructor
+        // takes all four positionally.
+        let l = layout(
+            r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                EqFilter(kind: LowShelf, frequency: 220.0, gain_db: -4.0, q: 0.7),
+            ])])"#,
+        );
+        match &l.get("b").unwrap().effects[0] {
+            BusEffect::EqFilter {
+                kind,
+                frequency,
+                gain_db,
+                q,
+            } => {
+                assert_eq!(*kind, EqFilterKind::LowShelf);
+                assert_eq!(*frequency, 220.0);
+                assert_eq!(*gain_db, -4.0);
+                assert_eq!(*q, 0.7);
+            }
+            other => panic!("expected EqFilter, got {other:?}"),
+        }
+        assert!(
+            BusLayout::from_ron(
+                r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                    EqFilter(kind: Bell, frequency: 220.0),
+                ])])"#
+            )
+            .is_err(),
+            "a missing required EqFilter parameter must be an error, not a silent default"
+        );
     }
 
     #[test]

--- a/crates/bsengine-audio/src/world.rs
+++ b/crates/bsengine-audio/src/world.rs
@@ -3,13 +3,154 @@ use std::collections::HashMap;
 use bevy_ecs::prelude::{Entity, Resource};
 use glam::{Quat, Vec3};
 use kira::{
+    effect::{
+        compressor::CompressorBuilder, delay::DelayBuilder, distortion::DistortionBuilder,
+        eq_filter::EqFilterBuilder, filter::FilterBuilder, panning_control::PanningControlBuilder,
+        reverb::ReverbBuilder,
+    },
     listener::ListenerHandle,
     sound::static_sound::{StaticSoundData, StaticSoundHandle},
     track::{SpatialTrackBuilder, SpatialTrackHandle, TrackBuilder, TrackHandle},
-    AudioManager, AudioManagerSettings, Decibels, DefaultBackend, Tween,
+    AudioManager, AudioManagerSettings, Decibels, DefaultBackend, Mix, Panning, Tween,
 };
 
 use crate::spatial::{to_mint_quat, to_mint_vec};
+
+/// Builds kira's reverb from authored parameters.
+///
+/// Extracted, like the three below, because `ReverbBuilder` derives
+/// `PartialEq`: a test can hand-build the expected builder and compare, which
+/// is what makes the *parameter routing* observable rather than merely
+/// non-panicking. Mutation-testing showed why that matters — swapping
+/// `feedback` and `damping` inside a monolithic mapping failed no test at all.
+fn reverb_builder(feedback: f64, damping: f64, stereo_width: f64, mix: f32) -> ReverbBuilder {
+    ReverbBuilder::new()
+        .feedback(feedback)
+        .damping(damping)
+        .stereo_width(stereo_width)
+        .mix(Mix(mix))
+}
+
+/// Builds kira's filter from authored parameters.
+fn filter_builder(
+    mode: crate::bus::FilterMode,
+    cutoff: f64,
+    resonance: f64,
+    mix: f32,
+) -> FilterBuilder {
+    use crate::bus::FilterMode as M;
+    FilterBuilder::new()
+        .mode(match mode {
+            M::LowPass => kira::effect::filter::FilterMode::LowPass,
+            M::BandPass => kira::effect::filter::FilterMode::BandPass,
+            M::HighPass => kira::effect::filter::FilterMode::HighPass,
+            M::Notch => kira::effect::filter::FilterMode::Notch,
+        })
+        .cutoff(cutoff)
+        .resonance(resonance)
+        .mix(Mix(mix))
+}
+
+/// Builds kira's distortion from authored parameters.
+fn distortion_builder(
+    kind: crate::bus::DistortionKind,
+    drive_db: f32,
+    mix: f32,
+) -> DistortionBuilder {
+    use crate::bus::DistortionKind as K;
+    DistortionBuilder::new()
+        .kind(match kind {
+            K::HardClip => kira::effect::distortion::DistortionKind::HardClip,
+            K::SoftClip => kira::effect::distortion::DistortionKind::SoftClip,
+        })
+        .drive(Decibels(drive_db))
+        .mix(Mix(mix))
+}
+
+/// Builds kira's panning control from an authored position.
+fn panning_builder(panning: f32) -> PanningControlBuilder {
+    PanningControlBuilder(Panning(panning).into())
+}
+
+/// Attaches an authored effect chain to a track builder, in order.
+///
+/// A free function rather than a method: it reads no [`AudioWorld`] state and
+/// needs no audio device, because `TrackBuilder` is constructible without an
+/// `AudioManager`. That is what makes the enum-to-builder mapping testable on
+/// a machine with no sound card — which is every Windows CI runner here.
+///
+/// This crate writes no DSP. Every arm hands parameters to a `kira` builder
+/// that already exists upstream; the conversions are `Mix`, `Decibels`,
+/// `Panning` and milliseconds-to-`Duration`.
+fn with_effects(mut builder: TrackBuilder, effects: &[crate::bus::BusEffect]) -> TrackBuilder {
+    use crate::bus::{BusEffect, EqFilterKind};
+    use std::time::Duration;
+
+    for effect in effects {
+        builder = match effect {
+            BusEffect::Reverb {
+                feedback,
+                damping,
+                stereo_width,
+                mix,
+            } => builder.with_effect(reverb_builder(*feedback, *damping, *stereo_width, *mix)),
+            BusEffect::Filter {
+                mode,
+                cutoff,
+                resonance,
+                mix,
+            } => builder.with_effect(filter_builder(*mode, *cutoff, *resonance, *mix)),
+            BusEffect::Compressor {
+                threshold,
+                ratio,
+                attack_ms,
+                release_ms,
+                makeup_gain_db,
+                mix,
+            } => builder.with_effect(
+                CompressorBuilder::new()
+                    .threshold(*threshold)
+                    .ratio(*ratio)
+                    .attack_duration(Duration::from_secs_f64(attack_ms / 1000.0))
+                    .release_duration(Duration::from_secs_f64(release_ms / 1000.0))
+                    .makeup_gain(Decibels(*makeup_gain_db))
+                    .mix(Mix(*mix)),
+            ),
+            BusEffect::Delay {
+                delay_ms,
+                feedback_db,
+                mix,
+            } => builder.with_effect(
+                DelayBuilder::new()
+                    .delay_time(Duration::from_secs_f64(delay_ms / 1000.0))
+                    .feedback(Decibels(*feedback_db))
+                    .mix(Mix(*mix)),
+            ),
+            BusEffect::Distortion {
+                kind,
+                drive_db,
+                mix,
+            } => builder.with_effect(distortion_builder(*kind, *drive_db, *mix)),
+            BusEffect::EqFilter {
+                kind,
+                frequency,
+                gain_db,
+                q,
+            } => builder.with_effect(EqFilterBuilder::new(
+                match kind {
+                    EqFilterKind::Bell => kira::effect::eq_filter::EqFilterKind::Bell,
+                    EqFilterKind::LowShelf => kira::effect::eq_filter::EqFilterKind::LowShelf,
+                    EqFilterKind::HighShelf => kira::effect::eq_filter::EqFilterKind::HighShelf,
+                },
+                *frequency,
+                Decibels(*gain_db),
+                *q,
+            )),
+            BusEffect::Panning { panning } => builder.with_effect(panning_builder(*panning)),
+        };
+    }
+    builder
+}
 
 /// One live mixer bus.
 ///
@@ -21,6 +162,10 @@ use crate::spatial::{to_mint_quat, to_mint_vec};
 struct BusState {
     parent: Option<String>,
     volume_db: f32,
+    /// The authored chain, recorded so the authoring contract is observable on
+    /// a machine with no audio device — where the handle below is `None` and a
+    /// running effect has no observable at all.
+    effects: Vec<crate::bus::BusEffect>,
     handle: Option<TrackHandle>,
 }
 
@@ -121,12 +266,13 @@ impl AudioWorld {
         // Dropping the old handles tears down the old tracks.
         self.buses.clear();
         for bus in layout.creation_order() {
-            let handle = self.create_bus_track(bus.parent.as_deref(), bus.volume_db);
+            let handle = self.create_bus_track(bus.parent.as_deref(), bus.volume_db, &bus.effects);
             self.buses.push((
                 bus.name.clone(),
                 BusState {
                     parent: bus.parent.clone(),
                     volume_db: bus.volume_db,
+                    effects: bus.effects.clone(),
                     handle,
                 },
             ));
@@ -138,8 +284,13 @@ impl AudioWorld {
     ///
     /// Returns `None` without a backend, which is the ordinary state on a
     /// machine with no audio device rather than an error.
-    fn create_bus_track(&mut self, parent: Option<&str>, volume_db: f32) -> Option<TrackHandle> {
-        let builder = TrackBuilder::new().volume(Decibels(volume_db));
+    fn create_bus_track(
+        &mut self,
+        parent: Option<&str>,
+        volume_db: f32,
+        effects: &[crate::bus::BusEffect],
+    ) -> Option<TrackHandle> {
+        let builder = with_effects(TrackBuilder::new().volume(Decibels(volume_db)), effects);
         match parent {
             None => self.manager.as_mut()?.add_sub_track(builder).ok(),
             Some(name) => {
@@ -166,6 +317,20 @@ impl AudioWorld {
             .iter()
             .find(|(n, _)| n == name)
             .map(|(_, b)| b.parent.clone())
+    }
+
+    /// The authored effect chain on a bus, in order, or `None` if there is no
+    /// such bus.
+    ///
+    /// This is the authoring contract, and the only part of an effect that is
+    /// observable without an audio device: what a running effect does to audio
+    /// is kira's to answer, and our wiring into a live track cannot be seen on
+    /// hardware with no sound card.
+    pub fn bus_effects(&self, name: &str) -> Option<&[crate::bus::BusEffect]> {
+        self.buses
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, b)| b.effects.as_slice())
     }
 
     /// Every bus's name and volume, for the scripting snapshot.
@@ -570,6 +735,180 @@ mod bus_tests {
             None,
             "a sound that never played has no bus"
         );
+    }
+
+    /// Every effect variant maps onto a kira builder, with no audio device.
+    ///
+    /// `TrackBuilder` is constructible without an `AudioManager`, so this
+    /// exercises the real enum-to-builder mapping rather than a stand-in. It
+    /// is the only coverage that mapping can have here: what a running effect
+    /// does to audio is kira's to answer, and our wiring into a *live* track
+    /// is invisible on hardware with no sound card.
+    ///
+    /// Every variant is listed explicitly rather than looped, so adding an
+    /// eighth effect without mapping it is a compile error in this test.
+    #[test]
+    fn every_effect_variant_maps_onto_a_kira_builder() {
+        use crate::bus::{BusEffect, DistortionKind, EqFilterKind, FilterMode};
+
+        let all = vec![
+            BusEffect::Reverb {
+                feedback: 0.5,
+                damping: 0.25,
+                stereo_width: 0.125,
+                mix: 0.0625,
+            },
+            BusEffect::Filter {
+                mode: FilterMode::Notch,
+                cutoff: 800.0,
+                resonance: 0.25,
+                mix: 0.75,
+            },
+            BusEffect::Compressor {
+                threshold: -12.0,
+                ratio: 4.0,
+                attack_ms: 5.0,
+                release_ms: 250.0,
+                makeup_gain_db: 3.0,
+                mix: 0.9,
+            },
+            BusEffect::Delay {
+                delay_ms: 125.0,
+                feedback_db: -9.0,
+                mix: 0.3,
+            },
+            BusEffect::Distortion {
+                kind: DistortionKind::SoftClip,
+                drive_db: 6.0,
+                mix: 0.8,
+            },
+            BusEffect::EqFilter {
+                kind: EqFilterKind::HighShelf,
+                frequency: 4000.0,
+                gain_db: -3.0,
+                q: 1.2,
+            },
+            BusEffect::Panning { panning: -0.5 },
+        ];
+        assert_eq!(
+            all.len(),
+            7,
+            "seven effects are exposed; kira's volume_control is deliberately absent              because Bus.volume_db already is one"
+        );
+
+        // The assertion is that this runs at all: a panic or an unhandled
+        // variant is the failure this catches.
+        let _builder = with_effects(TrackBuilder::new(), &all);
+
+        // And each one on its own, so a panic names the culprit.
+        for effect in &all {
+            let _ = with_effects(TrackBuilder::new(), std::slice::from_ref(effect));
+        }
+    }
+
+    /// Each authored parameter reaches the kira field it names.
+    ///
+    /// Only four of the seven effects can be checked this way: kira derives
+    /// `PartialEq` on `ReverbBuilder`, `FilterBuilder`, `DistortionBuilder`
+    /// and `PanningControlBuilder`, and on nothing else — `CompressorBuilder`,
+    /// `DelayBuilder` and `EqFilterBuilder` carry no derives at all, so a
+    /// built one cannot be compared to anything.
+    ///
+    /// This test exists because mutation-testing found the gap: swapping
+    /// `feedback` and `damping` inside the mapping failed **no** test, since
+    /// the only other coverage asserts that mapping does not panic. Every
+    /// value below is distinct so a swap cannot survive.
+    #[test]
+    fn reverb_parameters_reach_their_own_kira_fields() {
+        assert_eq!(
+            reverb_builder(0.5, 0.25, 0.125, 0.0625),
+            ReverbBuilder::new()
+                .feedback(0.5)
+                .damping(0.25)
+                .stereo_width(0.125)
+                .mix(Mix(0.0625)),
+            "a parameter reached the wrong kira field"
+        );
+    }
+
+    #[test]
+    fn filter_parameters_reach_their_own_kira_fields() {
+        use crate::bus::FilterMode;
+        assert_eq!(
+            filter_builder(FilterMode::Notch, 800.0, 0.25, 0.75),
+            FilterBuilder::new()
+                .mode(kira::effect::filter::FilterMode::Notch)
+                .cutoff(800.0)
+                .resonance(0.25)
+                .mix(Mix(0.75)),
+            "a parameter reached the wrong kira field"
+        );
+        // And the mode really is translated, not defaulted: LowPass is kira's
+        // default, so only a non-default mode proves the match arm runs.
+        assert_ne!(
+            filter_builder(FilterMode::HighPass, 800.0, 0.25, 0.75),
+            filter_builder(FilterMode::LowPass, 800.0, 0.25, 0.75),
+            "FilterMode is being ignored"
+        );
+    }
+
+    #[test]
+    fn distortion_parameters_reach_their_own_kira_fields() {
+        use crate::bus::DistortionKind;
+        assert_eq!(
+            distortion_builder(DistortionKind::SoftClip, 6.0, 0.8),
+            DistortionBuilder::new()
+                .kind(kira::effect::distortion::DistortionKind::SoftClip)
+                .drive(Decibels(6.0))
+                .mix(Mix(0.8)),
+            "a parameter reached the wrong kira field"
+        );
+        assert_ne!(
+            distortion_builder(DistortionKind::HardClip, 6.0, 0.8),
+            distortion_builder(DistortionKind::SoftClip, 6.0, 0.8),
+            "DistortionKind is being ignored"
+        );
+    }
+
+    #[test]
+    fn panning_reaches_its_own_kira_field() {
+        assert_eq!(
+            panning_builder(-0.5),
+            PanningControlBuilder(Panning(-0.5).into())
+        );
+        assert_ne!(
+            panning_builder(-0.5),
+            panning_builder(0.5),
+            "panning is being ignored"
+        );
+    }
+
+    #[test]
+    fn a_buss_authored_chain_is_readable_without_a_backend() {
+        use crate::bus::BusEffect;
+        let mut world = AudioWorld::silent();
+        world.apply_bus_layout(
+            &BusLayout::from_ron(
+                r#"BusLayout(buses: [
+                    Bus(name: "sfx", parent: None, volume_db: 0.0, effects: [
+                        Filter(mode: HighPass, cutoff: 800.0, resonance: 0.25, mix: 0.75),
+                        Reverb(feedback: 0.5, damping: 0.25, stereo_width: 0.125, mix: 0.0625),
+                    ]),
+                    Bus(name: "music", parent: None, volume_db: -3.0),
+                ])"#,
+            )
+            .expect("parses"),
+        );
+
+        let fx = world.bus_effects("sfx").expect("sfx exists");
+        assert_eq!(fx.len(), 2, "both authored effects must be recorded");
+        assert!(matches!(fx[0], BusEffect::Filter { .. }), "order preserved");
+        assert!(matches!(fx[1], BusEffect::Reverb { .. }), "order preserved");
+        assert!(
+            world.bus_effects("music").expect("music exists").is_empty(),
+            "a bus with no effects has an empty chain, not the other bus's"
+        );
+        assert!(world.bus_effects("nope").is_none());
     }
 
     #[test]


### PR DESCRIPTION
A bus can now declare a chain of DSP effects, applied in array order:

```ron
Bus(name: "sfx", parent: None, volume_db: 0.0, effects: [
    Filter(mode: LowPass, cutoff: 2000.0, resonance: 0.5, mix: 1.0),
    Reverb(feedback: 0.9, damping: 0.1, stereo_width: 1.0, mix: 0.4),
])
```

**PR 2 of 3** closing the audio gap: buses (#1837, merged) → **effects** → occlusion.

## No DSP is written here, and no dependency added

kira 0.12 already ships compressor, delay, distortion, EQ, filter, panning and reverb, and `pub mod effect` is **not** feature-gated — its cargo features are all codecs. `TrackBuilder::with_effect` is the attachment point. This PR is an authoring format plus a mapping onto builders that already exist.

Seven effects are exposed. kira's `volume_control` is deliberately absent: `Bus.volume_db` already *is* a volume control on that track, and this crate's `lib.rs` records removing a redundant second path rather than keeping two ways to do one thing.

Defaults mirror kira's own `Default` impls, read from its source, so an omitted field gives what kira would have given rather than a number invented here. Units live in the field names (`attack_ms`, `gain_db`) because RON has no `Duration` literal and a bare `attack: 0.01` invites a 1000× error that parses either way.

`effects` is `#[serde(default)]`, so every layout from #1837 keeps parsing — **asserted by a test rather than assumed**, because this repo has a recorded hazard that `serde(default)` is inert on the scene/reflect path. This is plain serde through `ron::from_str`, a different mechanism, but close enough to be worth pinning.

## Why runtime control is not here

kira 0.12's effect handles have almost no setters — `ReverbHandle` has **zero** methods. Changing a parameter at runtime means binding it to a modulator (`tweener`), which brings a registry and a name→parameter mapping: a separate surface from the mixer itself. Deferred deliberately, not overlooked. All three reference engines do have it (Unity's exposed parameters, Unreal's AudioModulation, Godot's `get_bus_effect`).

One find for PR 3: `Value<T>` has a **`FromListenerDistance`** variant, so kira can drive an effect parameter from listener distance natively. Occlusion may be cheaper than the gap analysis assumed.

## Mutation-testing changed the shape of this PR

Four mutations planned. **Two failed nothing** — dropping the chain, and swapping `feedback`/`damping` in the mapping — because the only mapping coverage asserted that mapping *does not panic*, which cannot see which kira field a value reached. The spec predicted both would be caught and was wrong.

Rather than record that as a blind spot, I checked whether kira's builders are comparable. `ReverbBuilder`, `FilterBuilder`, `DistortionBuilder` and `PanningControlBuilder` derive `PartialEq`; `CompressorBuilder`, `DelayBuilder` and `EqFilterBuilder` carry **no derives at all**. So those four now go through extracted constructors compared against hand-built expected builders, with every value distinct. The swap now fails `reverb_parameters_reach_their_own_kira_fields`.

## The limit, stated rather than covered

That `create_bus_track` actually attaches the chain to a **live** track remains unobservable: the handle is `None` on a machine with no audio device, so the "drop the chain" mutation still fails no test. Same boundary #1837 documented, and the same one this crate's two pre-existing Windows `#[ignore]`s live on. The three non-comparable builders likewise have "maps without panicking" coverage only.

## Verification

fmt clean · catalogue **71 components / 275 ops unchanged** (authoring-only, no new ops) · zero clippy warnings from `bsengine-audio` · workspace **1740 passed / 0 failed** (1728 before) · editor **941** · **12/12 E2E replays** · **24/24 packaging**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
