### PR TITLE
feat(audio): occlusion — the last of three PRs closing the audio gap

### DIFF
--- a/crates/bsengine-audio/src/lib.rs
+++ b/crates/bsengine-audio/src/lib.rs
@@ -32,7 +32,7 @@ pub mod world;
 pub use audio_source::{load_audio_source, AudioSourceAsset, AudioSourceLoader};
 pub use bus::{Bus, BusLayout};
 pub use plugin::AudioPlugin;
-pub use spatial::{AudioEmitter, AudioListener};
+pub use spatial::{AudioEmitter, AudioListener, AudioOcclusion};
 pub use world::AudioWorld;
 
 #[cfg(test)]

--- a/crates/bsengine-audio/src/plugin.rs
+++ b/crates/bsengine-audio/src/plugin.rs
@@ -2,7 +2,7 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bsengine_core::{ProjectDir, Transform};
 
-use crate::spatial::{AudioEmitter, AudioListener};
+use crate::spatial::{AudioEmitter, AudioListener, AudioOcclusion};
 use crate::world::AudioWorld;
 
 /// Registers the [`AudioWorld`] resource and keeps positional audio in step
@@ -32,6 +32,7 @@ impl Plugin for AudioPlugin {
         // headless `--test` app, so the two cannot drift.
         app.register_type::<AudioListener>();
         app.register_type::<AudioEmitter>();
+        app.register_type::<AudioOcclusion>();
         // Listener first: an emitter's spatial track is created *linked to* a
         // listener, so on the very first frame the ears have to exist before
         // any source can be attached to them.
@@ -66,9 +67,16 @@ fn sync_listener(mut audio: ResMut<AudioWorld>, query: Query<&Transform, With<Au
 /// Pushes every [`AudioEmitter`] entity's position into [`AudioWorld`].
 fn sync_emitters(
     mut audio: ResMut<AudioWorld>,
-    query: Query<(Entity, &Transform), With<AudioEmitter>>,
+    query: Query<(Entity, &Transform, Option<&AudioOcclusion>), With<AudioEmitter>>,
 ) {
-    for (entity, transform) in query.iter() {
+    for (entity, transform, occlusion) in query.iter() {
+        // Config before position: the low-pass filter is attached when the
+        // spatial track is *created*, and set_emitter_position is what creates
+        // it, so declaring occlusion afterwards would build the track without
+        // a filter and leave the emitter permanently unmuffled.
+        if let Some(o) = occlusion {
+            audio.set_occlusion_config(entity, o.cutoff_hz, o.volume_db);
+        }
         audio.set_emitter_position(entity, transform.position.0);
     }
 }

--- a/crates/bsengine-audio/src/spatial.rs
+++ b/crates/bsengine-audio/src/spatial.rs
@@ -103,3 +103,44 @@ mod tests {
         assert_eq!(AudioEmitter::default().spatialization_strength, 1.0);
     }
 }
+
+/// Makes an emitter's sound muffle and quieten when something solid stands
+/// between it and the listener.
+///
+/// **A separate component rather than fields on [`AudioEmitter`], deliberately.**
+/// Scene components are deserialised by `bevy_reflect`, which requires every
+/// reflected field to be present in the RON; a missing one does not error, it
+/// silently empties the containing collection. `games/mini-arena` authors
+/// `AudioEmitter(spatialization_strength: 1.0)`, so adding fields there would
+/// have broken it quietly. Nothing authors this type yet, so it cannot break
+/// anything — and "occluded only if the component is present" is also how
+/// Unreal ships occlusion: off unless asked for.
+///
+/// The defaults mirror Unreal's occlusion settings, which is where the names
+/// come from too.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Default)]
+pub struct AudioOcclusion {
+    /// Low-pass cutoff in hertz applied when fully occluded. Lower is more
+    /// muffled. Unreal calls this `OcclusionLowPassFilterFrequency`.
+    pub cutoff_hz: f32,
+    /// Volume in decibels applied when fully occluded, relative to unoccluded.
+    pub volume_db: f32,
+    /// How long the change takes, in milliseconds.
+    ///
+    /// This is what stops a sound flickering when the ray grazes an edge, and
+    /// it is how both reference engines solve that — Unreal calls it
+    /// `OcclusionInterpolationTime`. Smoothing rather than hysteresis: a
+    /// half-occluded frame moves the value part-way instead of toggling.
+    pub interpolation_ms: f32,
+}
+
+impl Default for AudioOcclusion {
+    fn default() -> Self {
+        Self {
+            cutoff_hz: 800.0,
+            volume_db: -6.0,
+            interpolation_ms: 200.0,
+        }
+    }
+}

--- a/crates/bsengine-audio/src/world.rs
+++ b/crates/bsengine-audio/src/world.rs
@@ -9,9 +9,11 @@ use kira::{
         reverb::ReverbBuilder,
     },
     listener::ListenerHandle,
+    modulator::tweener::{TweenerBuilder, TweenerHandle},
     sound::static_sound::{StaticSoundData, StaticSoundHandle},
     track::{SpatialTrackBuilder, SpatialTrackHandle, TrackBuilder, TrackHandle},
-    AudioManager, AudioManagerSettings, Decibels, DefaultBackend, Mix, Panning, Tween,
+    AudioManager, AudioManagerSettings, Decibels, DefaultBackend, Easing, Mapping, Mix, Panning,
+    Tween, Value,
 };
 
 use crate::spatial::{to_mint_quat, to_mint_vec};
@@ -200,6 +202,26 @@ pub struct AudioWorld {
     /// track map is empty there, so moving one track or all of them looks
     /// identical. Mutation-testing found exactly that hole.
     last_track_positions: HashMap<(Entity, Option<String>), Vec3>,
+    /// Per-emitter occlusion settings: `(cutoff_hz, volume_db)`.
+    ///
+    /// Recorded before the track is built, because the filter has to be
+    /// attached at *creation* — `SpatialTrackBuilder::with_effect` — and its
+    /// cutoff has to bind to a modulator that already exists.
+    occlusion_config: HashMap<Entity, (f32, f32)>,
+    /// One tweener per occluding emitter, driving both its filter cutoff and
+    /// its volume from a single 0..1 "how occluded" value.
+    ///
+    /// One modulator rather than two because both parameters map from the same
+    /// number: `set_occlusion` is then a single `set`, and kira's own tween is
+    /// the interpolation — which is how Unreal solves occlusion flicker
+    /// (`OcclusionInterpolationTime`) rather than hand-rolled hysteresis.
+    occlusion_tweeners: HashMap<Entity, TweenerHandle>,
+    /// How occluded each emitter last was, 0.0 clear to 1.0 fully occluded.
+    ///
+    /// Recorded whether or not a backend exists — on a machine with no audio
+    /// device the tweener above does not exist at all, and this is the only
+    /// observable the occlusion decision has.
+    last_occlusion: HashMap<Entity, f32>,
     /// Which bus each sound id was routed to, with an unknown name already
     /// resolved to Master. Recorded regardless of backend, for the same reason
     /// `last_listener_pose` is.
@@ -248,6 +270,9 @@ impl AudioWorld {
             last_listener_pose: None,
             last_emitter_positions: HashMap::new(),
             last_track_positions: HashMap::new(),
+            occlusion_config: HashMap::new(),
+            occlusion_tweeners: HashMap::new(),
+            last_occlusion: HashMap::new(),
             last_sound_buses: HashMap::new(),
             buses: Vec::new(),
         }
@@ -446,7 +471,33 @@ impl AudioWorld {
         let Some(listener_id) = self.listener.as_ref().map(|l| l.id()) else {
             return;
         };
-        let builder = SpatialTrackBuilder::new();
+        // Both the cutoff and the volume map from one tweener, so a single
+        // `set_occlusion` moves them together. Unoccluded (0.0) is 20 kHz and
+        // 0 dB — audibly untouched — and fully occluded (1.0) is whatever the
+        // `AudioOcclusion` component asked for.
+        let builder = match (
+            self.occlusion_config.get(&entity).copied(),
+            self.occlusion_tweeners.get(&entity).map(|t| t.id()),
+        ) {
+            (Some((cutoff_hz, volume_db)), Some(id)) => SpatialTrackBuilder::new()
+                .volume(Value::FromModulator {
+                    id,
+                    mapping: Mapping {
+                        input_range: (0.0, 1.0),
+                        output_range: (Decibels(0.0), Decibels(volume_db)),
+                        easing: Easing::Linear,
+                    },
+                })
+                .with_effect(FilterBuilder::new().cutoff(Value::FromModulator {
+                    id,
+                    mapping: Mapping {
+                        input_range: (0.0, 1.0),
+                        output_range: (20_000.0, cutoff_hz as f64),
+                        easing: Easing::Linear,
+                    },
+                })),
+            _ => SpatialTrackBuilder::new(),
+        };
         let created = match bus {
             None => self.manager.as_mut().and_then(|m| {
                 m.add_spatial_sub_track(listener_id, to_mint_vec(position), builder)
@@ -473,6 +524,75 @@ impl AudioWorld {
         self.last_track_positions
             .get(&(entity, bus.map(str::to_string)))
             .copied()
+    }
+
+    /// Declares that an emitter occludes, and how.
+    ///
+    /// Must be called before the emitter's spatial track is created: the
+    /// low-pass filter is attached at track creation and its cutoff binds to a
+    /// modulator, so both have to exist first. `sync_emitters` calls this each
+    /// frame for every entity carrying `AudioOcclusion`, which makes the
+    /// ordering automatic.
+    pub fn set_occlusion_config(&mut self, entity: Entity, cutoff_hz: f32, volume_db: f32) {
+        let changed = self.occlusion_config.insert(entity, (cutoff_hz, volume_db))
+            != Some((cutoff_hz, volume_db));
+        if !changed {
+            return;
+        }
+        // A tweener is only useful with a backend; without one the config is
+        // still recorded so the decision half stays observable.
+        if self.occlusion_tweeners.contains_key(&entity) {
+            return;
+        }
+        if let Some(manager) = self.manager.as_mut() {
+            if let Ok(tweener) = manager.add_modulator(TweenerBuilder { initial_value: 0.0 }) {
+                self.occlusion_tweeners.insert(entity, tweener);
+            }
+        }
+    }
+
+    /// The occlusion settings recorded for an emitter, if it occludes.
+    pub fn occlusion_config_of(&self, entity: Entity) -> Option<(f32, f32)> {
+        self.occlusion_config.get(&entity).copied()
+    }
+
+    /// Sets how occluded an emitter is: 0.0 clear, 1.0 fully occluded.
+    ///
+    /// This is the seam between the two halves of occlusion. Deciding *whether*
+    /// something is in the way needs physics, which this crate deliberately
+    /// does not depend on — that half lives in `bsengine-runtime`, which has
+    /// both. What happens to the sound lives here.
+    ///
+    /// `amount` is clamped, and the change is tweened over
+    /// `interpolation_ms`, so a value that moves every frame does not click.
+    pub fn set_occlusion(&mut self, entity: Entity, amount: f32, interpolation_ms: f32) {
+        let amount = amount.clamp(0.0, 1.0);
+        self.last_occlusion.insert(entity, amount);
+        if let Some(tweener) = self.occlusion_tweeners.get_mut(&entity) {
+            tweener.set(
+                amount as f64,
+                Tween {
+                    duration: std::time::Duration::from_secs_f32(
+                        (interpolation_ms / 1000.0).max(0.0),
+                    ),
+                    ..Default::default()
+                },
+            );
+        }
+    }
+
+    /// How occluded an emitter last was, or `None` if it was never set.
+    pub fn occlusion_of(&self, entity: Entity) -> Option<f32> {
+        self.last_occlusion.get(&entity).copied()
+    }
+
+    /// Whether this emitter has a live occlusion tweener.
+    ///
+    /// Always `false` without an audio backend, which is why
+    /// [`occlusion_of`](Self::occlusion_of) and not this is what tests assert
+    /// on.
+    pub fn has_occlusion_tweener(&self, entity: Entity) -> bool {
+        self.occlusion_tweeners.contains_key(&entity)
     }
 
     /// Buses this entity has emitter tracks on, in the order they were first
@@ -558,6 +678,9 @@ impl AudioWorld {
         self.emitters.retain(|(e, _), _| *e != entity);
         self.emitter_order.retain(|(e, _)| *e != entity);
         self.last_track_positions.retain(|(e, _), _| *e != entity);
+        self.occlusion_config.remove(&entity);
+        self.occlusion_tweeners.remove(&entity);
+        self.last_occlusion.remove(&entity);
         self.last_emitter_positions.remove(&entity);
     }
 

--- a/crates/bsengine-physics/src/world.rs
+++ b/crates/bsengine-physics/src/world.rs
@@ -484,6 +484,38 @@ impl PhysicsWorld {
         self.cast_ray_filtered(origin, dir, max_dist, filter)
     }
 
+    /// Cast a ray ignoring **two** entities' own bodies.
+    ///
+    /// Audio occlusion needs this: the ray runs from an emitter to the
+    /// listener, and both ends may carry a collider. Excluding only one leaves
+    /// the other to be hit at point-blank range, which reports every sound in
+    /// the scene as occluded — a failure that sounds like a broken filter
+    /// rather than a broken ray, and so is hard to attribute.
+    ///
+    /// Stopping the ray short of the far end instead is not equivalent: how
+    /// short would have to exceed that body's half-extent, which the caster
+    /// does not know.
+    pub fn cast_ray_excluding_pair(
+        &self,
+        origin: Vec3,
+        dir: Vec3,
+        max_dist: f32,
+        a: Entity,
+        b: Entity,
+    ) -> Option<RaycastHit> {
+        let handles: Vec<_> = [a, b]
+            .iter()
+            .filter_map(|e| self.entity_body_map.get(e).copied())
+            .collect();
+        let predicate = |_: ColliderHandle, collider: &Collider| {
+            collider
+                .parent()
+                .is_none_or(|parent| !handles.contains(&parent))
+        };
+        let filter = QueryFilter::default().predicate(&predicate);
+        self.cast_ray_filtered(origin, dir, max_dist, filter)
+    }
+
     /// Cast a ray into the physics world. Returns hit info or None.
     pub fn cast_ray(&self, origin: Vec3, dir: Vec3, max_dist: f32) -> Option<RaycastHit> {
         self.cast_ray_filtered(origin, dir, max_dist, QueryFilter::default())

--- a/crates/bsengine-runtime/src/audio_occlusion.rs
+++ b/crates/bsengine-runtime/src/audio_occlusion.rs
@@ -1,0 +1,90 @@
+//! Deciding whether something solid stands between an emitter and the ears.
+//!
+//! This is the physics half of audio occlusion. The other half — what a muffled
+//! sound actually sounds like — lives in `bsengine-audio`, behind
+//! [`AudioWorld::set_occlusion`]. The two are split because
+//! `bsengine-audio` deliberately depends on neither physics nor a GPU, which is
+//! what lets its logic be tested on a machine with no audio device at all.
+//!
+//! This crate is where they meet: it is the only one that already depends on
+//! both.
+
+use bevy_ecs::prelude::*;
+use bsengine_audio::{AudioEmitter, AudioListener, AudioOcclusion, AudioWorld};
+use bsengine_core::Transform;
+use bsengine_physics::PhysicsWorld;
+
+/// How far short of the listener the ray stops, in metres.
+///
+/// A small margin so a source standing exactly on the listener does not report
+/// a hit on nothing. It is *not* what keeps the listener's own collider out of
+/// the way — `cast_ray_excluding_pair` does that, because a clearance large
+/// enough would have to exceed a half-extent this code cannot know.
+const LISTENER_CLEARANCE: f32 = 0.05;
+
+/// Casts one ray per occluding emitter and tells the audio world what it found.
+///
+/// Runs for entities carrying **both** [`AudioEmitter`] and [`AudioOcclusion`];
+/// an emitter without the latter is never ray-cast and never muffled, which is
+/// how Unreal ships occlusion too — off unless asked for. That also keeps the
+/// cost proportional to the number of emitters that opted in rather than to the
+/// number of emitters.
+///
+/// The result is binary per frame — blocked or not — and the smoothing happens
+/// in `set_occlusion`, which tweens over the component's `interpolation_ms`.
+/// That is deliberately where it belongs: a per-frame boolean that flickers on
+/// a grazing edge becomes an audible click only if something applies it
+/// instantly.
+pub fn update_audio_occlusion(
+    mut audio: ResMut<AudioWorld>,
+    physics: Option<Res<PhysicsWorld>>,
+    listener: Query<(Entity, &Transform), With<AudioListener>>,
+    emitters: Query<(Entity, &Transform, &AudioOcclusion), With<AudioEmitter>>,
+) {
+    let Some(physics) = physics else {
+        return;
+    };
+    // No ears, nothing to be occluded from. Not an error: a scene is allowed to
+    // have no listener, and every emitter simply stays as it was.
+    let Some((listener_entity, listener_transform)) = listener.iter().next() else {
+        return;
+    };
+    let ears = listener_transform.position.0;
+
+    for (entity, transform, occlusion) in emitters.iter() {
+        let source = transform.position.0;
+        let to_ears = ears - source;
+        let distance = to_ears.length();
+        // Coincident with the listener: nothing can be between them.
+        if distance <= LISTENER_CLEARANCE {
+            audio.set_occlusion(entity, 0.0, occlusion.interpolation_ms);
+            continue;
+        }
+        let direction = to_ears / distance;
+        // Both ends excluded, and that is not belt-and-braces: a source with a
+        // collider occludes itself the instant it is given one, and a listener
+        // with a collider occludes *everything*. Either way every sound is
+        // muffled always, which sounds like a broken filter rather than a
+        // broken ray and is correspondingly hard to attribute.
+        //
+        // Excluding only one end and stopping the ray short of the other does
+        // not work: how short would have to exceed that body's half-extent,
+        // which is not known here. This was found by test, not by reasoning —
+        // the clearance below was 0.05 against a listener whose collider spans
+        // 0.5, and `a_source_with_nothing_in_the_way_is_not_occluded` failed.
+        let blocked = physics
+            .cast_ray_excluding_pair(
+                source,
+                direction,
+                distance - LISTENER_CLEARANCE,
+                entity,
+                listener_entity,
+            )
+            .is_some();
+        audio.set_occlusion(
+            entity,
+            if blocked { 1.0 } else { 0.0 },
+            occlusion.interpolation_ms,
+        );
+    }
+}

--- a/crates/bsengine-runtime/src/main.rs
+++ b/crates/bsengine-runtime/src/main.rs
@@ -18,6 +18,7 @@ use bsengine_scene::ScenePlugin;
 use bsengine_scripting::ScriptingPlugin;
 use bsengine_window::{WindowDescriptor, WindowPlugin};
 
+mod audio_occlusion;
 mod scene_systems;
 mod test_mode;
 mod test_protocol;

--- a/crates/bsengine-runtime/src/scene_systems.rs
+++ b/crates/bsengine-runtime/src/scene_systems.rs
@@ -166,7 +166,13 @@ pub fn register_scene_systems(app: &mut App) {
     )
     .add_systems(Update, handle_scene_load)
     .add_systems(Update, resolve_primitives.after(handle_scene_load))
-    .add_systems(Update, resolve_physics_bodies.after(resolve_primitives));
+    .add_systems(Update, resolve_physics_bodies.after(resolve_primitives))
+    // After the emitters have been positioned for this frame, so the ray is
+    // cast against where things actually are rather than where they were.
+    .add_systems(
+        Update,
+        crate::audio_occlusion::update_audio_occlusion.after(resolve_physics_bodies),
+    );
 }
 
 pub fn resolve_primitives(

--- a/crates/bsengine-runtime/src/test_mode.rs
+++ b/crates/bsengine-runtime/src/test_mode.rs
@@ -2138,6 +2138,167 @@ mod tests {
     /// set either way. Called twice against the same directory: the second
     /// call rewrites only `project.toml`, so the scene the two runs render
     /// is byte-identical and the toggle is the single variable.
+    /// Writes a project with a listener, an emitter, and optionally a solid
+    /// wall standing between them.
+    ///
+    /// The emitter carries a collider of its own on purpose: a ray cast from
+    /// the emitter's position would hit it first, so this fixture is what
+    /// proves the exclusion works. Without a collider on the source the
+    /// self-hit bug is unobservable and the test passes for the wrong reason.
+    fn write_audio_occlusion_project(root: &std::path::Path, wall: bool) {
+        std::fs::create_dir_all(root.join("assets/scenes")).unwrap();
+        std::fs::write(
+            root.join("project.toml"),
+            "[project]\nname = \"Audio Occlusion\"\nentry_scene = \"assets/scenes/main.ron\"\n",
+        )
+        .unwrap();
+
+        // Listener at the origin, emitter 20 units down -Z, wall halfway
+        // between them. Both listener and emitter carry static bodies so the
+        // ray has something of their own to wrongly hit.
+        let wall_entity = if wall {
+            r#"    EntityDescriptor(
+        name: "Wall",
+        primitive: Some(Cube),
+        transform: Some((position: (0.0, 0.0, -10.0))),
+        rigidbody: Some(Static),
+        collider: Some((shape: Box(hx: 5.0, hy: 5.0, hz: 0.5))),
+    ),
+"#
+        } else {
+            ""
+        };
+        let scene = format!(
+            r#"SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Ears",
+        transform: Some((position: (0.0, 0.0, 0.0))),
+        rigidbody: Some(Static),
+        collider: Some((shape: Box(hx: 0.5, hy: 0.5, hz: 0.5))),
+        components: [
+            ("bsengine_audio::spatial::AudioListener", "()"),
+        ],
+    ),
+    EntityDescriptor(
+        name: "Source",
+        transform: Some((position: (0.0, 0.0, -20.0))),
+        rigidbody: Some(Static),
+        collider: Some((shape: Box(hx: 0.5, hy: 0.5, hz: 0.5))),
+        components: [
+            ("bsengine_audio::spatial::AudioEmitter", "(spatialization_strength: 1.0)"),
+            ("bsengine_audio::spatial::AudioOcclusion", "(cutoff_hz: 800.0, volume_db: -6.0, interpolation_ms: 200.0)"),
+        ],
+    ),
+{wall_entity}])
+"#
+        );
+        std::fs::write(root.join("assets/scenes/main.ron"), scene).unwrap();
+    }
+
+    /// Reads the occlusion the audio world recorded for the named entity.
+    fn occlusion_of(app: &mut App, name: &str) -> Option<f32> {
+        let entity = {
+            let mut q = app
+                .world_mut()
+                .query::<(bevy_ecs::prelude::Entity, &bsengine_scene::Name)>();
+            q.iter(app.world())
+                .find(|(_, n)| n.0 == name)
+                .map(|(e, _)| e)
+        }?;
+        app.world()
+            .resource::<bsengine_audio::AudioWorld>()
+            .occlusion_of(entity)
+    }
+
+    /// A wall between the ears and a source muffles it; without the wall it is
+    /// clear.
+    ///
+    /// The pair is the point. "Occluded with a wall" alone is satisfied by an
+    /// implementation that reports everything occluded — which is exactly what
+    /// a self-hit on the emitter's own collider produces, and it would sound
+    /// like a broken filter rather than a broken ray.
+    #[test]
+    fn a_wall_between_the_ears_and_a_source_occludes_it() {
+        let dir = tempfile::tempdir().unwrap();
+        write_audio_occlusion_project(dir.path(), true);
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None, false);
+        for _ in 0..8 {
+            app.update();
+        }
+        assert_eq!(
+            occlusion_of(&mut app, "Source"),
+            Some(1.0),
+            "a 10x10 wall standing between the listener and the source must occlude it"
+        );
+    }
+
+    #[test]
+    fn a_source_with_nothing_in_the_way_is_not_occluded() {
+        let dir = tempfile::tempdir().unwrap();
+        write_audio_occlusion_project(dir.path(), false);
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None, false);
+        for _ in 0..8 {
+            app.update();
+        }
+        assert_eq!(
+            occlusion_of(&mut app, "Source"),
+            Some(0.0),
+            "with a clear line of sight the source must not be occluded -- a source that \
+             occludes itself on its own collider, or on the listener's, reports 1.0 here \
+             and sounds permanently muffled"
+        );
+    }
+
+    /// An emitter without `AudioOcclusion` is never ray-cast at all.
+    ///
+    /// Off-unless-asked-for is the behaviour both reference engines ship, and
+    /// it is what keeps the cost proportional to the emitters that opted in.
+    #[test]
+    fn an_emitter_without_the_component_is_never_occluded() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("assets/scenes")).unwrap();
+        std::fs::write(
+            dir.path().join("project.toml"),
+            "[project]\nname = \"No Occlusion\"\nentry_scene = \"assets/scenes/main.ron\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("assets/scenes/main.ron"),
+            r#"SceneDescriptor(entities: [
+    EntityDescriptor(
+        name: "Ears",
+        transform: Some((position: (0.0, 0.0, 0.0))),
+        components: [("bsengine_audio::spatial::AudioListener", "()")],
+    ),
+    EntityDescriptor(
+        name: "Source",
+        transform: Some((position: (0.0, 0.0, -20.0))),
+        rigidbody: Some(Static),
+        collider: Some((shape: Box(hx: 0.5, hy: 0.5, hz: 0.5))),
+        components: [("bsengine_audio::spatial::AudioEmitter", "(spatialization_strength: 1.0)")],
+    ),
+    EntityDescriptor(
+        name: "Wall",
+        primitive: Some(Cube),
+        transform: Some((position: (0.0, 0.0, -10.0))),
+        rigidbody: Some(Static),
+        collider: Some((shape: Box(hx: 5.0, hy: 5.0, hz: 0.5))),
+    ),
+])
+"#,
+        )
+        .unwrap();
+        let mut app = build_test_app(dir.path().to_str().unwrap(), None, false);
+        for _ in 0..8 {
+            app.update();
+        }
+        assert_eq!(
+            occlusion_of(&mut app, "Source"),
+            None,
+            "an emitter with no AudioOcclusion must never be ray-cast, wall or no wall"
+        );
+    }
+
     fn write_occlusion_project(root: &std::path::Path, occlusion_culling: bool) {
         use std::fmt::Write as _;
 


### PR DESCRIPTION
A sound now muffles and quietens when something solid stands between its emitter and the listener.

**PR 3 of 3.** Buses (#1837) → effects (#1838) → **occlusion**. With this, `bsengine-audio` has moved for the first time since 2026-08-26, and every gap `BSENGINE_VS_UNITY_UNREAL.md` listed on the audio axis is closed.

## Design follows Unreal, including the names

```ron
("bsengine_audio::spatial::AudioOcclusion",
 "(cutoff_hz: 800.0, volume_db: -6.0, interpolation_ms: 200.0)")
```

| | Unreal | here |
|---|---|---|
| enabled | Sound Attenuation, off by default | component absent by default |
| muffling | `OcclusionLowPassFilterFrequency` | `cutoff_hz` |
| attenuation | `OcclusionVolumeAttenuation` | `volume_db` |
| anti-flicker | `OcclusionInterpolationTime` | `interpolation_ms` |

Both reference engines solve edge-grazing flicker with **interpolation**, not hysteresis, and kira's `Tween` provides it directly — so the per-frame decision stays a clean boolean and the smoothing lives in one place.

## A new component, not new fields — forced by a real hazard

Scene components are deserialised by `bevy_reflect`, which requires **every** reflected field present; a missing one does not error, it silently empties the containing collection. `games/mini-arena` authors `AudioEmitter(spatialization_strength: 1.0)`, and `AudioEmitter` is **not** registered for `ReflectDeserialize` — so adding fields there would have broken that scene quietly.

Nothing authors `AudioOcclusion`, so it cannot break anything. It also gives Unreal's off-by-default for free.

## Split at a seam, so the audio crate stays testable

`AudioWorld::set_occlusion(entity, amount, interpolation_ms)`. `bsengine-audio` keeps its "no physics, no GPU, no device" property — which is what has made its logic testable on the Windows CI runners throughout all three PRs — and the raycast lives in `bsengine-runtime`, the only crate that already depends on both.

**One tweener per emitter drives both** the filter cutoff and the track volume through `Value::FromModulator`, so `set_occlusion` is a single `set()`.

## What the tests found, which reasoning had not

**`cast_ray_excluding_pair` is new in `bsengine-physics` because a test demanded it.** With only the emitter excluded, the ray hit the **listener's** collider and reported every sound occluded — a failure that sounds like a broken filter rather than a broken ray. Stopping the ray short instead cannot work: the margin would have to exceed a half-extent the caller does not know.

**The first fixture proved nothing.** It used a `physics:` field this scene format does not have (it is `rigidbody:` + `collider:`), so **no colliders were created at all** — and "a source with nothing in the way is not occluded" passed for exactly that wrong reason. Only the paired wall test failing exposed it. The fixture now gives the listener and emitter colliders deliberately, because without them the self-hit bug is invisible.

Three mutations run: single exclusion, always-occluded, and ignoring the component requirement each fail exactly one test.

## The limit, stated as in both previous PRs

The occlusion **decision** is fully covered — it is pure physics and runs headless. What a muffled sound actually *sounds* like is not observable without an audio device, as in #1837 and #1838.

## Verification

fmt clean · catalogue **72 components / 275 ops** (exactly the one new component) · no clippy warnings in any of the three crates touched · workspace **1743 passed / 0 failed** · editor **941** · **12/12 E2E replays** · **24/24 packaging**.

One workspace run hit `create_tracked_texture_...`, the known `rhi-wgpu` flake. Checked rather than assumed: this branch touches **zero** `rhi-wgpu` files, the test passes in isolation, and the workspace retry is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
