### PR TITLE
feat(audio): runtime effect parameters — the piece #1838 deferred

### DIFF
--- a/crates/bsengine-audio/src/bus.rs
+++ b/crates/bsengine-audio/src/bus.rs
@@ -8,6 +8,168 @@
 
 use serde::Deserialize;
 
+/// A numeric effect parameter: a fixed number, or one a script can change at
+/// runtime by name.
+///
+/// ```ron
+/// Filter(cutoff: 2000.0)                                          // fixed
+/// Filter(cutoff: (name: "muffle", min: 200.0, max: 20000.0, initial: 2000.0))
+/// ```
+///
+/// This is Unity's exposed-parameter model: the author picks which parameters
+/// a script may reach and names them, rather than the script addressing an
+/// effect by position. Godot addresses by chain index, which silently
+/// re-points every name when the chain is reordered; naming at the parameter
+/// cannot be misaddressed at all.
+///
+/// `min`/`max` are required because kira clamps a modulated value to the
+/// mapping's input range. They are the guard rail: a script that sets a cutoff
+/// of -5 gets `min`, not an undefined filter.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Param {
+    /// A constant, written as a bare number.
+    Fixed(f64),
+    /// A value a script sets by name, clamped to `min..=max`.
+    Exposed {
+        /// Name scripts use with `Bsengine.setAudioParam`.
+        name: String,
+        /// Lowest value the parameter can take.
+        min: f64,
+        /// Highest value the parameter can take.
+        max: f64,
+        /// Value before any script sets it.
+        initial: f64,
+    },
+}
+
+impl Param {
+    /// The value this parameter starts at, whichever form it takes.
+    pub fn initial(&self) -> f64 {
+        match self {
+            Self::Fixed(v) => *v,
+            Self::Exposed { initial, .. } => *initial,
+        }
+    }
+
+    /// The name a script reaches this parameter by, if it is exposed.
+    pub fn exposed_name(&self) -> Option<&str> {
+        match self {
+            Self::Fixed(_) => None,
+            Self::Exposed { name, .. } => Some(name),
+        }
+    }
+
+    /// The range an exposed value is clamped to.
+    pub fn range(&self) -> Option<(f64, f64)> {
+        match self {
+            Self::Fixed(_) => None,
+            Self::Exposed { min, max, .. } => Some((*min, *max)),
+        }
+    }
+}
+
+impl From<f64> for Param {
+    fn from(v: f64) -> Self {
+        Self::Fixed(v)
+    }
+}
+
+const PARAM_EXPECTING: &str = "a number such as 2000.0, or an exposed parameter such as \
+     (name: \"muffle\", min: 200.0, max: 20000.0, initial: 2000.0)";
+
+/// Hand-written rather than `#[serde(untagged)]`, for the reason `AssetRef` in
+/// `bsengine-scene` is: untagged parses both forms correctly under `ron` 0.8,
+/// but every failure — an unknown field, a missing `max`, a typo'd `name` —
+/// collapses to "data did not match any variant", and an unknown field
+/// alongside valid ones is *silently dropped*. In a mixer file that means a
+/// parameter quietly not being exposed, which surfaces much later as "why does
+/// my script do nothing".
+impl<'de> Deserialize<'de> for Param {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(ParamVisitor)
+    }
+}
+
+struct ParamVisitor;
+
+#[derive(Deserialize)]
+#[serde(field_identifier, rename_all = "lowercase")]
+enum ParamField {
+    Name,
+    Min,
+    Max,
+    Initial,
+}
+
+impl<'de> serde::de::Visitor<'de> for ParamVisitor {
+    type Value = Param;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(PARAM_EXPECTING)
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Param, E> {
+        Ok(Param::Fixed(v))
+    }
+
+    fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Param, E> {
+        Ok(Param::Fixed(v as f64))
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Param, E> {
+        Ok(Param::Fixed(v as f64))
+    }
+
+    fn visit_map<A: serde::de::MapAccess<'de>>(self, mut map: A) -> Result<Param, A::Error> {
+        use serde::de::Error as _;
+        let mut name: Option<String> = None;
+        let mut min: Option<f64> = None;
+        let mut max: Option<f64> = None;
+        let mut initial: Option<f64> = None;
+        while let Some(key) = map.next_key::<ParamField>()? {
+            match key {
+                ParamField::Name => {
+                    if name.is_some() {
+                        return Err(A::Error::duplicate_field("name"));
+                    }
+                    name = Some(map.next_value()?);
+                }
+                ParamField::Min => {
+                    if min.is_some() {
+                        return Err(A::Error::duplicate_field("min"));
+                    }
+                    min = Some(map.next_value()?);
+                }
+                ParamField::Max => {
+                    if max.is_some() {
+                        return Err(A::Error::duplicate_field("max"));
+                    }
+                    max = Some(map.next_value()?);
+                }
+                ParamField::Initial => {
+                    if initial.is_some() {
+                        return Err(A::Error::duplicate_field("initial"));
+                    }
+                    initial = Some(map.next_value()?);
+                }
+            }
+        }
+        let name = name.ok_or_else(|| A::Error::missing_field("name"))?;
+        let min = min.ok_or_else(|| A::Error::missing_field("min"))?;
+        let max = max.ok_or_else(|| A::Error::missing_field("max"))?;
+        // `initial` defaults to `min` rather than being required: a parameter
+        // whose starting value is its floor is the common case (a muffle that
+        // starts off), and requiring it adds noise to every declaration.
+        let initial = initial.unwrap_or(min);
+        Ok(Param::Exposed {
+            name,
+            min,
+            max,
+            initial,
+        })
+    }
+}
+
 /// One DSP effect in a bus's chain.
 ///
 /// Every variant maps to a `kira` effect builder that already exists upstream —
@@ -29,16 +191,16 @@ pub enum BusEffect {
     Reverb {
         /// How much signal is fed back, 0.0 to 1.0.
         #[serde(default = "reverb_feedback")]
-        feedback: f64,
+        feedback: Param,
         /// High-frequency damping, 0.0 to 1.0.
         #[serde(default = "reverb_damping")]
-        damping: f64,
+        damping: Param,
         /// Stereo spread, 0.0 to 1.0.
         #[serde(default = "one")]
-        stereo_width: f64,
+        stereo_width: Param,
         /// Dry/wet balance: 0.0 dry, 1.0 wet.
         #[serde(default = "half")]
-        mix: f32,
+        mix: Param,
     },
     /// A resonant filter — the effect occlusion will later drive.
     Filter {
@@ -47,46 +209,51 @@ pub enum BusEffect {
         mode: FilterMode,
         /// Corner frequency in hertz.
         #[serde(default = "filter_cutoff")]
-        cutoff: f64,
+        cutoff: Param,
         /// Resonance at the cutoff.
-        #[serde(default)]
-        resonance: f64,
+        #[serde(default = "zero")]
+        resonance: Param,
         /// Dry/wet balance: 0.0 dry, 1.0 wet.
-        #[serde(default = "one_f32")]
-        mix: f32,
+        #[serde(default = "one")]
+        mix: Param,
     },
     /// Dynamic range compression.
     Compressor {
         /// Level above which gain starts being reduced, in decibels.
-        #[serde(default)]
-        threshold: f64,
+        #[serde(default = "zero")]
+        threshold: Param,
         /// Compression ratio; 1.0 is no compression.
         #[serde(default = "one")]
-        ratio: f64,
+        ratio: Param,
         /// How quickly compression engages, in milliseconds.
         #[serde(default = "compressor_attack_ms")]
-        attack_ms: f64,
+        attack_ms: Param,
         /// How quickly compression releases, in milliseconds.
         #[serde(default = "compressor_release_ms")]
-        release_ms: f64,
+        release_ms: Param,
         /// Gain applied after compression, in decibels.
-        #[serde(default)]
-        makeup_gain_db: f32,
+        #[serde(default = "zero")]
+        makeup_gain_db: Param,
         /// Dry/wet balance: 0.0 dry, 1.0 wet.
-        #[serde(default = "one_f32")]
-        mix: f32,
+        #[serde(default = "one")]
+        mix: Param,
     },
     /// An echo.
     Delay {
         /// Time between repeats, in milliseconds.
+        ///
+        /// The one effect parameter that cannot be exposed to scripts: kira's
+        /// `DelayBuilder::delay_time` takes a plain `Duration`, not a `Value`,
+        /// so there is nothing for a modulator to drive. Stated here rather
+        /// than left to be discovered.
         #[serde(default = "delay_ms")]
         delay_ms: f64,
         /// Level of each repeat relative to the last, in decibels.
         #[serde(default = "delay_feedback_db")]
-        feedback_db: f32,
+        feedback_db: Param,
         /// Dry/wet balance: 0.0 dry, 1.0 wet.
         #[serde(default = "half")]
-        mix: f32,
+        mix: Param,
     },
     /// Waveshaping distortion.
     Distortion {
@@ -94,11 +261,11 @@ pub enum BusEffect {
         #[serde(default)]
         kind: DistortionKind,
         /// Gain applied before the curve, in decibels.
-        #[serde(default)]
-        drive_db: f32,
+        #[serde(default = "zero")]
+        drive_db: Param,
         /// Dry/wet balance: 0.0 dry, 1.0 wet.
-        #[serde(default = "one_f32")]
-        mix: f32,
+        #[serde(default = "one")]
+        mix: Param,
     },
     /// A single parametric EQ band.
     ///
@@ -109,17 +276,17 @@ pub enum BusEffect {
         /// Which band shape to apply.
         kind: EqFilterKind,
         /// Centre or corner frequency in hertz.
-        frequency: f64,
+        frequency: Param,
         /// Gain applied to the band, in decibels.
-        gain_db: f32,
+        gain_db: Param,
         /// Bandwidth control; higher is narrower.
-        q: f64,
+        q: Param,
     },
     /// Static stereo placement for the whole bus.
     Panning {
         /// -1.0 hard left, 0.0 centre, 1.0 hard right.
-        #[serde(default)]
-        panning: f32,
+        #[serde(default = "zero")]
+        panning: Param,
     },
 }
 
@@ -162,35 +329,35 @@ pub enum EqFilterKind {
 
 // serde needs functions for non-zero defaults. Each value is kira's own,
 // read from its `Default` impls rather than chosen here.
-fn one() -> f64 {
-    1.0
+fn zero() -> Param {
+    Param::Fixed(0.0)
 }
-fn one_f32() -> f32 {
-    1.0
+fn one() -> Param {
+    Param::Fixed(1.0)
 }
-fn half() -> f32 {
-    0.5
+fn half() -> Param {
+    Param::Fixed(0.5)
 }
-fn reverb_feedback() -> f64 {
-    0.9
+fn reverb_feedback() -> Param {
+    Param::Fixed(0.9)
 }
-fn reverb_damping() -> f64 {
-    0.1
+fn reverb_damping() -> Param {
+    Param::Fixed(0.1)
 }
-fn filter_cutoff() -> f64 {
-    1000.0
+fn filter_cutoff() -> Param {
+    Param::Fixed(1000.0)
 }
-fn compressor_attack_ms() -> f64 {
-    10.0
+fn compressor_attack_ms() -> Param {
+    Param::Fixed(10.0)
 }
-fn compressor_release_ms() -> f64 {
-    100.0
+fn compressor_release_ms() -> Param {
+    Param::Fixed(100.0)
 }
 fn delay_ms() -> f64 {
     500.0
 }
-fn delay_feedback_db() -> f32 {
-    -6.0
+fn delay_feedback_db() -> Param {
+    Param::Fixed(-6.0)
 }
 
 /// One declared mixer bus.
@@ -567,10 +734,10 @@ mod tests {
                 stereo_width,
                 mix,
             } => {
-                assert_eq!(*feedback, 0.5);
-                assert_eq!(*damping, 0.25);
-                assert_eq!(*stereo_width, 0.125);
-                assert_eq!(*mix, 0.0625);
+                assert_eq!(*feedback, Param::Fixed(0.5));
+                assert_eq!(*damping, Param::Fixed(0.25));
+                assert_eq!(*stereo_width, Param::Fixed(0.125));
+                assert_eq!(*mix, Param::Fixed(0.0625));
             }
             other => panic!("expected Reverb, got {other:?}"),
         }
@@ -594,7 +761,12 @@ mod tests {
                 mix,
             } => {
                 assert_eq!(
-                    (*feedback, *damping, *stereo_width, *mix),
+                    (
+                        feedback.initial(),
+                        damping.initial(),
+                        stereo_width.initial(),
+                        mix.initial()
+                    ),
                     (0.9, 0.1, 1.0, 0.5)
                 );
             }
@@ -606,10 +778,97 @@ mod tests {
                 feedback_db,
                 mix,
             } => {
-                assert_eq!((*delay_ms, *feedback_db, *mix), (500.0, -6.0, 0.5));
+                assert_eq!(
+                    (*delay_ms, feedback_db.initial(), mix.initial()),
+                    (500.0, -6.0, 0.5)
+                );
             }
             other => panic!("expected Delay, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn a_parameter_can_be_written_as_a_bare_number_or_exposed() {
+        let l = layout(
+            r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                Filter(
+                    cutoff: (name: "muffle", min: 200.0, max: 20000.0, initial: 2000.0),
+                    resonance: 0.25,
+                ),
+            ])])"#,
+        );
+        match &l.get("b").unwrap().effects[0] {
+            BusEffect::Filter {
+                cutoff, resonance, ..
+            } => {
+                assert_eq!(cutoff.exposed_name(), Some("muffle"));
+                assert_eq!(cutoff.range(), Some((200.0, 20000.0)));
+                assert_eq!(cutoff.initial(), 2000.0);
+                assert_eq!(
+                    *resonance,
+                    Param::Fixed(0.25),
+                    "a bare number beside an exposed one must still be fixed"
+                );
+                assert_eq!(
+                    resonance.exposed_name(),
+                    None,
+                    "a fixed parameter has no name for a script to reach"
+                );
+            }
+            other => panic!("expected Filter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_exposed_parameter_defaults_its_initial_to_min() {
+        // The common case is a parameter that starts at its floor -- a muffle
+        // that starts off -- so requiring `initial` would be noise.
+        let l = layout(
+            r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                Filter(cutoff: (name: "m", min: 500.0, max: 20000.0)),
+            ])])"#,
+        );
+        match &l.get("b").unwrap().effects[0] {
+            BusEffect::Filter { cutoff, .. } => assert_eq!(cutoff.initial(), 500.0),
+            other => panic!("expected Filter, got {other:?}"),
+        }
+    }
+
+    /// A malformed exposure must name what it accepts.
+    ///
+    /// This is why `Param` hand-writes `Deserialize` instead of using
+    /// `#[serde(untagged)]`: untagged parses both forms correctly, but a
+    /// missing field collapses to "data did not match any variant" and an
+    /// unknown field beside valid ones is *silently dropped* -- which in a
+    /// mixer file means a parameter quietly not being exposed.
+    #[test]
+    fn a_malformed_exposed_parameter_says_what_it_expected() {
+        let err = BusLayout::from_ron(
+            r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                Filter(cutoff: (name: "m", min: 200.0)),
+            ])])"#,
+        )
+        .expect_err("a missing `max` must be an error");
+        let text = err.to_string();
+        assert!(
+            text.contains("max"),
+            "the error must name the missing field; got {text}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_field_in_an_exposure_is_reported_not_dropped() {
+        let err = BusLayout::from_ron(
+            r#"BusLayout(buses: [Bus(name: "b", parent: None, volume_db: 0.0, effects: [
+                Filter(cutoff: (name: "m", min: 200.0, max: 2000.0, wobble: 3.0)),
+            ])])"#,
+        )
+        .expect_err("an unknown field must be an error, not silently dropped");
+        let text = err.to_string();
+        assert!(
+            text.contains("wobble") || text.to_lowercase().contains("unknown"),
+            "the error must point at the unknown field; got {text}"
+        );
     }
 
     #[test]
@@ -641,9 +900,9 @@ mod tests {
                 q,
             } => {
                 assert_eq!(*kind, EqFilterKind::LowShelf);
-                assert_eq!(*frequency, 220.0);
-                assert_eq!(*gain_db, -4.0);
-                assert_eq!(*q, 0.7);
+                assert_eq!(frequency.initial(), 220.0);
+                assert_eq!(gain_db.initial(), -4.0);
+                assert_eq!(q.initial(), 0.7);
             }
             other => panic!("expected EqFilter, got {other:?}"),
         }

--- a/crates/bsengine-audio/src/world.rs
+++ b/crates/bsengine-audio/src/world.rs
@@ -25,20 +25,25 @@ use crate::spatial::{to_mint_quat, to_mint_vec};
 /// is what makes the *parameter routing* observable rather than merely
 /// non-panicking. Mutation-testing showed why that matters — swapping
 /// `feedback` and `damping` inside a monolithic mapping failed no test at all.
-fn reverb_builder(feedback: f64, damping: f64, stereo_width: f64, mix: f32) -> ReverbBuilder {
+fn reverb_builder(
+    feedback: Value<f64>,
+    damping: Value<f64>,
+    stereo_width: Value<f64>,
+    mix: Value<Mix>,
+) -> ReverbBuilder {
     ReverbBuilder::new()
         .feedback(feedback)
         .damping(damping)
         .stereo_width(stereo_width)
-        .mix(Mix(mix))
+        .mix(mix)
 }
 
 /// Builds kira's filter from authored parameters.
 fn filter_builder(
     mode: crate::bus::FilterMode,
-    cutoff: f64,
-    resonance: f64,
-    mix: f32,
+    cutoff: Value<f64>,
+    resonance: Value<f64>,
+    mix: Value<Mix>,
 ) -> FilterBuilder {
     use crate::bus::FilterMode as M;
     FilterBuilder::new()
@@ -50,14 +55,14 @@ fn filter_builder(
         })
         .cutoff(cutoff)
         .resonance(resonance)
-        .mix(Mix(mix))
+        .mix(mix)
 }
 
 /// Builds kira's distortion from authored parameters.
 fn distortion_builder(
     kind: crate::bus::DistortionKind,
-    drive_db: f32,
-    mix: f32,
+    drive_db: Value<Decibels>,
+    mix: Value<Mix>,
 ) -> DistortionBuilder {
     use crate::bus::DistortionKind as K;
     DistortionBuilder::new()
@@ -65,13 +70,13 @@ fn distortion_builder(
             K::HardClip => kira::effect::distortion::DistortionKind::HardClip,
             K::SoftClip => kira::effect::distortion::DistortionKind::SoftClip,
         })
-        .drive(Decibels(drive_db))
-        .mix(Mix(mix))
+        .drive(drive_db)
+        .mix(mix)
 }
 
 /// Builds kira's panning control from an authored position.
-fn panning_builder(panning: f32) -> PanningControlBuilder {
-    PanningControlBuilder(Panning(panning).into())
+fn panning_builder(panning: Value<Panning>) -> PanningControlBuilder {
+    PanningControlBuilder(panning)
 }
 
 /// Attaches an authored effect chain to a track builder, in order.
@@ -84,74 +89,191 @@ fn panning_builder(panning: f32) -> PanningControlBuilder {
 /// This crate writes no DSP. Every arm hands parameters to a `kira` builder
 /// that already exists upstream; the conversions are `Mix`, `Decibels`,
 /// `Panning` and milliseconds-to-`Duration`.
-fn with_effects(mut builder: TrackBuilder, effects: &[crate::bus::BusEffect]) -> TrackBuilder {
-    use crate::bus::{BusEffect, EqFilterKind};
-    use std::time::Duration;
-
-    for effect in effects {
-        builder = match effect {
-            BusEffect::Reverb {
-                feedback,
-                damping,
-                stereo_width,
-                mix,
-            } => builder.with_effect(reverb_builder(*feedback, *damping, *stereo_width, *mix)),
-            BusEffect::Filter {
-                mode,
-                cutoff,
-                resonance,
-                mix,
-            } => builder.with_effect(filter_builder(*mode, *cutoff, *resonance, *mix)),
-            BusEffect::Compressor {
-                threshold,
-                ratio,
-                attack_ms,
-                release_ms,
-                makeup_gain_db,
-                mix,
-            } => builder.with_effect(
-                CompressorBuilder::new()
-                    .threshold(*threshold)
-                    .ratio(*ratio)
-                    .attack_duration(Duration::from_secs_f64(attack_ms / 1000.0))
-                    .release_duration(Duration::from_secs_f64(release_ms / 1000.0))
-                    .makeup_gain(Decibels(*makeup_gain_db))
-                    .mix(Mix(*mix)),
-            ),
-            BusEffect::Delay {
-                delay_ms,
-                feedback_db,
-                mix,
-            } => builder.with_effect(
-                DelayBuilder::new()
-                    .delay_time(Duration::from_secs_f64(delay_ms / 1000.0))
-                    .feedback(Decibels(*feedback_db))
-                    .mix(Mix(*mix)),
-            ),
-            BusEffect::Distortion {
-                kind,
-                drive_db,
-                mix,
-            } => builder.with_effect(distortion_builder(*kind, *drive_db, *mix)),
-            BusEffect::EqFilter {
-                kind,
-                frequency,
-                gain_db,
-                q,
-            } => builder.with_effect(EqFilterBuilder::new(
-                match kind {
-                    EqFilterKind::Bell => kira::effect::eq_filter::EqFilterKind::Bell,
-                    EqFilterKind::LowShelf => kira::effect::eq_filter::EqFilterKind::LowShelf,
-                    EqFilterKind::HighShelf => kira::effect::eq_filter::EqFilterKind::HighShelf,
-                },
-                *frequency,
-                Decibels(*gain_db),
-                *q,
-            )),
-            BusEffect::Panning { panning } => builder.with_effect(panning_builder(*panning)),
+impl AudioWorld {
+    /// Turns an authored [`Param`](crate::bus::Param) into a kira value,
+    /// registering a tweener for an exposed one.
+    ///
+    /// Generic in the output type because kira's parameters are variously
+    /// `f64`, `Decibels`, `Mix`, `Panning` and `Duration`, and all of them need
+    /// the same treatment: one tweener carrying the *real* number, mapped
+    /// identity so a script sets 2000 Hz rather than 0.37.
+    ///
+    /// kira clamps to `input_range`, which is what makes the authored
+    /// `min`/`max` a guard rail rather than decoration — a script asking for a
+    /// negative cutoff gets `min`, not an undefined filter.
+    fn resolve<T: kira::Tweenable>(
+        &mut self,
+        param: &crate::bus::Param,
+        to: impl Fn(f64) -> T,
+    ) -> Value<T> {
+        let crate::bus::Param::Exposed {
+            name,
+            min,
+            max,
+            initial,
+        } = param
+        else {
+            return Value::Fixed(to(param.initial()));
         };
+        // Recorded whether or not a backend exists: without a device there is
+        // no tweener at all, and a test asserting through one would be
+        // asserting on nothing.
+        self.last_param_values
+            .entry(name.clone())
+            .or_insert((*initial, *min, *max));
+        let id = match self.audio_params.get(name) {
+            Some(handle) => handle.id(),
+            None => {
+                let Some(manager) = self.manager.as_mut() else {
+                    return Value::Fixed(to(*initial));
+                };
+                let Ok(handle) = manager.add_modulator(TweenerBuilder {
+                    initial_value: *initial,
+                }) else {
+                    return Value::Fixed(to(*initial));
+                };
+                let id = handle.id();
+                self.audio_params.insert(name.clone(), handle);
+                id
+            }
+        };
+        Value::FromModulator {
+            id,
+            mapping: Mapping {
+                input_range: (*min, *max),
+                output_range: (to(*min), to(*max)),
+                easing: Easing::Linear,
+            },
+        }
     }
-    builder
+
+    /// Attaches an authored effect chain to a track builder, in order.
+    ///
+    /// A method rather than a free function because resolving an exposed
+    /// parameter may create a modulator, which needs the manager.
+    ///
+    /// This crate writes no DSP. Every arm hands values to a `kira` builder
+    /// that already exists upstream.
+    fn with_effects(
+        &mut self,
+        mut builder: TrackBuilder,
+        effects: &[crate::bus::BusEffect],
+    ) -> TrackBuilder {
+        use crate::bus::{BusEffect, EqFilterKind};
+        use std::time::Duration;
+
+        let db = |v: f64| Decibels(v as f32);
+        let mix = |v: f64| Mix(v as f32);
+        let pan = |v: f64| Panning(v as f32);
+        let ms = |v: f64| Duration::from_secs_f64((v / 1000.0).max(0.0));
+
+        for effect in effects {
+            builder = match effect {
+                BusEffect::Reverb {
+                    feedback,
+                    damping,
+                    stereo_width,
+                    mix: m,
+                } => {
+                    let f = self.resolve(feedback, |v| v);
+                    let d = self.resolve(damping, |v| v);
+                    let w = self.resolve(stereo_width, |v| v);
+                    let m = self.resolve(m, mix);
+                    builder.with_effect(reverb_builder(f, d, w, m))
+                }
+                BusEffect::Filter {
+                    mode,
+                    cutoff,
+                    resonance,
+                    mix: m,
+                } => {
+                    let c = self.resolve(cutoff, |v| v);
+                    let r = self.resolve(resonance, |v| v);
+                    let m = self.resolve(m, mix);
+                    builder.with_effect(filter_builder(*mode, c, r, m))
+                }
+                BusEffect::Compressor {
+                    threshold,
+                    ratio,
+                    attack_ms,
+                    release_ms,
+                    makeup_gain_db,
+                    mix: m,
+                } => {
+                    let t = self.resolve(threshold, |v| v);
+                    let ra = self.resolve(ratio, |v| v);
+                    let a = self.resolve(attack_ms, ms);
+                    let re = self.resolve(release_ms, ms);
+                    let g = self.resolve(makeup_gain_db, db);
+                    let m = self.resolve(m, mix);
+                    builder.with_effect(
+                        CompressorBuilder::new()
+                            .threshold(t)
+                            .ratio(ra)
+                            .attack_duration(a)
+                            .release_duration(re)
+                            .makeup_gain(g)
+                            .mix(m),
+                    )
+                }
+                BusEffect::Delay {
+                    delay_ms,
+                    feedback_db,
+                    mix: m,
+                } => {
+                    let fb = self.resolve(feedback_db, db);
+                    let m = self.resolve(m, mix);
+                    builder.with_effect(
+                        DelayBuilder::new()
+                            // The one parameter that is a plain number here:
+                            // kira's `delay_time` takes a `Duration`, not a
+                            // `Value`, so there is nothing to modulate.
+                            .delay_time(ms(*delay_ms))
+                            .feedback(fb)
+                            .mix(m),
+                    )
+                }
+                BusEffect::Distortion {
+                    kind,
+                    drive_db,
+                    mix: m,
+                } => {
+                    let d = self.resolve(drive_db, db);
+                    let m = self.resolve(m, mix);
+                    builder.with_effect(distortion_builder(*kind, d, m))
+                }
+                BusEffect::EqFilter {
+                    kind,
+                    frequency,
+                    gain_db,
+                    q,
+                } => {
+                    let f = self.resolve(frequency, |v| v);
+                    let g = self.resolve(gain_db, db);
+                    let q = self.resolve(q, |v| v);
+                    builder.with_effect(EqFilterBuilder::new(
+                        match kind {
+                            EqFilterKind::Bell => kira::effect::eq_filter::EqFilterKind::Bell,
+                            EqFilterKind::LowShelf => {
+                                kira::effect::eq_filter::EqFilterKind::LowShelf
+                            }
+                            EqFilterKind::HighShelf => {
+                                kira::effect::eq_filter::EqFilterKind::HighShelf
+                            }
+                        },
+                        f,
+                        g,
+                        q,
+                    ))
+                }
+                BusEffect::Panning { panning } => {
+                    let p = self.resolve(panning, pan);
+                    builder.with_effect(panning_builder(p))
+                }
+            };
+        }
+        builder
+    }
 }
 
 /// One live mixer bus.
@@ -202,6 +324,19 @@ pub struct AudioWorld {
     /// track map is empty there, so moving one track or all of them looks
     /// identical. Mutation-testing found exactly that hole.
     last_track_positions: HashMap<(Entity, Option<String>), Vec3>,
+    /// One tweener per *exposed* effect parameter, keyed by its authored name.
+    ///
+    /// Unity's exposed-parameter model: the author names which parameters a
+    /// script may reach, and the name is the whole address — nothing here
+    /// depends on an effect's position in a chain, so reordering a chain
+    /// cannot silently re-point a name.
+    audio_params: HashMap<String, TweenerHandle>,
+    /// The last value set for each exposed parameter, and its clamp range.
+    ///
+    /// Recorded whether or not a backend exists, for the same reason every
+    /// other observable in this file is: without a device there is no tweener
+    /// at all, and a test asserting through one would pass on nothing.
+    last_param_values: HashMap<String, (f64, f64, f64)>,
     /// Per-emitter occlusion settings: `(cutoff_hz, volume_db)`.
     ///
     /// Recorded before the track is built, because the filter has to be
@@ -270,6 +405,8 @@ impl AudioWorld {
             last_listener_pose: None,
             last_emitter_positions: HashMap::new(),
             last_track_positions: HashMap::new(),
+            audio_params: HashMap::new(),
+            last_param_values: HashMap::new(),
             occlusion_config: HashMap::new(),
             occlusion_tweeners: HashMap::new(),
             last_occlusion: HashMap::new(),
@@ -315,7 +452,7 @@ impl AudioWorld {
         volume_db: f32,
         effects: &[crate::bus::BusEffect],
     ) -> Option<TrackHandle> {
-        let builder = with_effects(TrackBuilder::new().volume(Decibels(volume_db)), effects);
+        let builder = self.with_effects(TrackBuilder::new().volume(Decibels(volume_db)), effects);
         match parent {
             None => self.manager.as_mut()?.add_sub_track(builder).ok(),
             Some(name) => {
@@ -554,6 +691,45 @@ impl AudioWorld {
     /// The occlusion settings recorded for an emitter, if it occludes.
     pub fn occlusion_config_of(&self, entity: Entity) -> Option<(f32, f32)> {
         self.occlusion_config.get(&entity).copied()
+    }
+
+    /// Sets an exposed effect parameter by name. Returns whether it exists.
+    ///
+    /// This is the thing #1838 deferred: kira's effect handles have almost no
+    /// setters, so a parameter is changed by moving the modulator it was bound
+    /// to when its track was built.
+    pub fn set_audio_param(&mut self, name: &str, value: f64, tween_ms: f32) -> bool {
+        let Some((current, min, max)) = self.last_param_values.get_mut(name) else {
+            tracing::warn!("[audio] setAudioParam named unknown parameter '{name}'");
+            return false;
+        };
+        let clamped = value.clamp(*min, *max);
+        *current = clamped;
+        if let Some(tweener) = self.audio_params.get_mut(name) {
+            tweener.set(
+                clamped,
+                Tween {
+                    duration: std::time::Duration::from_secs_f32((tween_ms / 1000.0).max(0.0)),
+                    ..Default::default()
+                },
+            );
+        }
+        true
+    }
+
+    /// The last value set for an exposed parameter, or `None` if no parameter
+    /// of that name was declared.
+    pub fn audio_param(&self, name: &str) -> Option<f64> {
+        self.last_param_values.get(name).map(|(v, _, _)| *v)
+    }
+
+    /// Every exposed parameter's name and current value, for the scripting
+    /// snapshot.
+    pub fn audio_params(&self) -> Vec<(String, f64)> {
+        self.last_param_values
+            .iter()
+            .map(|(name, (v, _, _))| (name.clone(), *v))
+            .collect()
     }
 
     /// Sets how occluded an emitter is: 0.0 clear, 1.0 fully occluded.
@@ -872,46 +1048,48 @@ mod bus_tests {
     /// eighth effect without mapping it is a compile error in this test.
     #[test]
     fn every_effect_variant_maps_onto_a_kira_builder() {
-        use crate::bus::{BusEffect, DistortionKind, EqFilterKind, FilterMode};
+        use crate::bus::{BusEffect, DistortionKind, EqFilterKind, FilterMode, Param};
 
         let all = vec![
             BusEffect::Reverb {
-                feedback: 0.5,
-                damping: 0.25,
-                stereo_width: 0.125,
-                mix: 0.0625,
+                feedback: Param::Fixed(0.5),
+                damping: Param::Fixed(0.25),
+                stereo_width: Param::Fixed(0.125),
+                mix: Param::Fixed(0.0625),
             },
             BusEffect::Filter {
                 mode: FilterMode::Notch,
-                cutoff: 800.0,
-                resonance: 0.25,
-                mix: 0.75,
+                cutoff: Param::Fixed(800.0),
+                resonance: Param::Fixed(0.25),
+                mix: Param::Fixed(0.75),
             },
             BusEffect::Compressor {
-                threshold: -12.0,
-                ratio: 4.0,
-                attack_ms: 5.0,
-                release_ms: 250.0,
-                makeup_gain_db: 3.0,
-                mix: 0.9,
+                threshold: Param::Fixed(-12.0),
+                ratio: Param::Fixed(4.0),
+                attack_ms: Param::Fixed(5.0),
+                release_ms: Param::Fixed(250.0),
+                makeup_gain_db: Param::Fixed(3.0),
+                mix: Param::Fixed(0.9),
             },
             BusEffect::Delay {
                 delay_ms: 125.0,
-                feedback_db: -9.0,
-                mix: 0.3,
+                feedback_db: Param::Fixed(-9.0),
+                mix: Param::Fixed(0.3),
             },
             BusEffect::Distortion {
                 kind: DistortionKind::SoftClip,
-                drive_db: 6.0,
-                mix: 0.8,
+                drive_db: Param::Fixed(6.0),
+                mix: Param::Fixed(0.8),
             },
             BusEffect::EqFilter {
                 kind: EqFilterKind::HighShelf,
-                frequency: 4000.0,
-                gain_db: -3.0,
-                q: 1.2,
+                frequency: Param::Fixed(4000.0),
+                gain_db: Param::Fixed(-3.0),
+                q: Param::Fixed(1.2),
             },
-            BusEffect::Panning { panning: -0.5 },
+            BusEffect::Panning {
+                panning: Param::Fixed(-0.5),
+            },
         ];
         assert_eq!(
             all.len(),
@@ -921,11 +1099,12 @@ mod bus_tests {
 
         // The assertion is that this runs at all: a panic or an unhandled
         // variant is the failure this catches.
-        let _builder = with_effects(TrackBuilder::new(), &all);
+        let mut world = AudioWorld::silent();
+        let _builder = world.with_effects(TrackBuilder::new(), &all);
 
         // And each one on its own, so a panic names the culprit.
         for effect in &all {
-            let _ = with_effects(TrackBuilder::new(), std::slice::from_ref(effect));
+            let _ = world.with_effects(TrackBuilder::new(), std::slice::from_ref(effect));
         }
     }
 
@@ -944,7 +1123,12 @@ mod bus_tests {
     #[test]
     fn reverb_parameters_reach_their_own_kira_fields() {
         assert_eq!(
-            reverb_builder(0.5, 0.25, 0.125, 0.0625),
+            reverb_builder(
+                Value::Fixed(0.5),
+                Value::Fixed(0.25),
+                Value::Fixed(0.125),
+                Value::Fixed(Mix(0.0625)),
+            ),
             ReverbBuilder::new()
                 .feedback(0.5)
                 .damping(0.25)
@@ -958,7 +1142,12 @@ mod bus_tests {
     fn filter_parameters_reach_their_own_kira_fields() {
         use crate::bus::FilterMode;
         assert_eq!(
-            filter_builder(FilterMode::Notch, 800.0, 0.25, 0.75),
+            filter_builder(
+                FilterMode::Notch,
+                Value::Fixed(800.0),
+                Value::Fixed(0.25),
+                Value::Fixed(Mix(0.75)),
+            ),
             FilterBuilder::new()
                 .mode(kira::effect::filter::FilterMode::Notch)
                 .cutoff(800.0)
@@ -969,8 +1158,18 @@ mod bus_tests {
         // And the mode really is translated, not defaulted: LowPass is kira's
         // default, so only a non-default mode proves the match arm runs.
         assert_ne!(
-            filter_builder(FilterMode::HighPass, 800.0, 0.25, 0.75),
-            filter_builder(FilterMode::LowPass, 800.0, 0.25, 0.75),
+            filter_builder(
+                FilterMode::HighPass,
+                Value::Fixed(800.0),
+                Value::Fixed(0.25),
+                Value::Fixed(Mix(0.75))
+            ),
+            filter_builder(
+                FilterMode::LowPass,
+                Value::Fixed(800.0),
+                Value::Fixed(0.25),
+                Value::Fixed(Mix(0.75))
+            ),
             "FilterMode is being ignored"
         );
     }
@@ -979,7 +1178,11 @@ mod bus_tests {
     fn distortion_parameters_reach_their_own_kira_fields() {
         use crate::bus::DistortionKind;
         assert_eq!(
-            distortion_builder(DistortionKind::SoftClip, 6.0, 0.8),
+            distortion_builder(
+                DistortionKind::SoftClip,
+                Value::Fixed(Decibels(6.0)),
+                Value::Fixed(Mix(0.8)),
+            ),
             DistortionBuilder::new()
                 .kind(kira::effect::distortion::DistortionKind::SoftClip)
                 .drive(Decibels(6.0))
@@ -987,8 +1190,16 @@ mod bus_tests {
             "a parameter reached the wrong kira field"
         );
         assert_ne!(
-            distortion_builder(DistortionKind::HardClip, 6.0, 0.8),
-            distortion_builder(DistortionKind::SoftClip, 6.0, 0.8),
+            distortion_builder(
+                DistortionKind::HardClip,
+                Value::Fixed(Decibels(6.0)),
+                Value::Fixed(Mix(0.8))
+            ),
+            distortion_builder(
+                DistortionKind::SoftClip,
+                Value::Fixed(Decibels(6.0)),
+                Value::Fixed(Mix(0.8))
+            ),
             "DistortionKind is being ignored"
         );
     }
@@ -996,13 +1207,90 @@ mod bus_tests {
     #[test]
     fn panning_reaches_its_own_kira_field() {
         assert_eq!(
-            panning_builder(-0.5),
+            panning_builder(Value::Fixed(Panning(-0.5))),
             PanningControlBuilder(Panning(-0.5).into())
         );
         assert_ne!(
-            panning_builder(-0.5),
-            panning_builder(0.5),
+            panning_builder(Value::Fixed(Panning(-0.5))),
+            panning_builder(Value::Fixed(Panning(0.5))),
             "panning is being ignored"
+        );
+    }
+
+    /// An exposed parameter is registered when its bus is built, and settable
+    /// by name afterwards.
+    ///
+    /// Runs against `silent()` — the state every Windows CI runner is in — so
+    /// what is asserted is the bookkeeping, not kira's modulator.
+    #[test]
+    fn an_exposed_parameter_is_registered_and_settable() {
+        let mut world = AudioWorld::silent();
+        world.apply_bus_layout(
+            &BusLayout::from_ron(
+                r#"BusLayout(buses: [Bus(name: "sfx", parent: None, volume_db: 0.0, effects: [
+                    Filter(cutoff: (name: "muffle", min: 200.0, max: 20000.0, initial: 2000.0)),
+                ])])"#,
+            )
+            .expect("parses"),
+        );
+
+        assert_eq!(
+            world.audio_param("muffle"),
+            Some(2000.0),
+            "the parameter starts at its authored initial"
+        );
+        assert!(world.set_audio_param("muffle", 500.0, 0.0));
+        assert_eq!(world.audio_param("muffle"), Some(500.0));
+    }
+
+    #[test]
+    fn setting_an_exposed_parameter_clamps_to_its_authored_range() {
+        // kira clamps a modulated value to the mapping's input range, so the
+        // authored min/max are a guard rail. This asserts the same bound on
+        // the recorded value, which is what a script reads back.
+        let mut world = AudioWorld::silent();
+        world.apply_bus_layout(
+            &BusLayout::from_ron(
+                r#"BusLayout(buses: [Bus(name: "sfx", parent: None, volume_db: 0.0, effects: [
+                    Filter(cutoff: (name: "muffle", min: 200.0, max: 20000.0, initial: 2000.0)),
+                ])])"#,
+            )
+            .expect("parses"),
+        );
+
+        world.set_audio_param("muffle", -5.0, 0.0);
+        assert_eq!(world.audio_param("muffle"), Some(200.0), "clamped to min");
+        world.set_audio_param("muffle", 1.0e9, 0.0);
+        assert_eq!(world.audio_param("muffle"), Some(20000.0), "clamped to max");
+    }
+
+    #[test]
+    fn an_unknown_parameter_name_is_reported_as_failure() {
+        let mut world = AudioWorld::silent();
+        assert!(
+            !world.set_audio_param("nope", 1.0, 0.0),
+            "an unknown name must report failure rather than silently succeeding"
+        );
+        assert_eq!(world.audio_param("nope"), None);
+    }
+
+    #[test]
+    fn a_fixed_parameter_registers_no_name() {
+        // The paired direction: without it, an implementation that exposed
+        // every parameter regardless would pass the tests above.
+        let mut world = AudioWorld::silent();
+        world.apply_bus_layout(
+            &BusLayout::from_ron(
+                r#"BusLayout(buses: [Bus(name: "sfx", parent: None, volume_db: 0.0, effects: [
+                    Filter(cutoff: 2000.0, resonance: 0.5),
+                ])])"#,
+            )
+            .expect("parses"),
+        );
+        assert!(
+            world.audio_params().is_empty(),
+            "a chain of fixed parameters must expose nothing, got {:?}",
+            world.audio_params()
         );
     }
 

--- a/crates/bsengine-scripting/src/js/prelude.js
+++ b/crates/bsengine-scripting/src/js/prelude.js
@@ -528,6 +528,13 @@ var Bsengine = {
     getSoundState:        (id)          => Deno.core.ops.bsengine_get_sound_state(id),
     getSoundPosition:     (id)          => Deno.core.ops.bsengine_get_sound_position(id),
     setBusVolume:         (bus, db)     => Deno.core.ops.bsengine_set_bus_volume(bus, db),
+    setAudioParam:        (name, value, tweenMs) =>
+        Deno.core.ops.bsengine_set_audio_param(name, value, tweenMs === undefined ? 0.0 : tweenMs),
+    getAudioParam:        (name)        => {
+        // NaN is the op's "no such parameter"; null is what a script expects.
+        const v = Deno.core.ops.bsengine_get_audio_param(name);
+        return Number.isNaN(v) ? null : v;
+    },
     getBusVolume:         (bus)         => {
         // NaN is the op's "no such bus"; null is what a script expects.
         const v = Deno.core.ops.bsengine_get_bus_volume(bus);

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -958,6 +958,15 @@ pub enum ScriptCommand {
         /// that misroutes it.
         bus: Option<String>,
     },
+    /// Set an exposed effect parameter by its authored name.
+    SetAudioParam {
+        /// Name declared in `buses.ron`.
+        name: String,
+        /// New value, clamped to the authored range.
+        value: f64,
+        /// How long the change takes, in milliseconds.
+        tween_ms: f32,
+    },
     /// Set a mixer bus's volume in decibels.
     SetBusVolume {
         /// Name of the bus.
@@ -1702,6 +1711,11 @@ thread_local! {
     // with no `World`. Same mechanism as `SOUND_STATE_SNAPSHOT`; a second one
     // would be a second source of truth.
     pub(crate) static BUS_VOLUME_SNAPSHOT: RefCell<HashMap<String, f32>> =
+        RefCell::new(HashMap::new());
+
+    // exposed effect parameter name → current value. Same mechanism again;
+    // a third one would be a third source of truth.
+    pub(crate) static AUDIO_PARAM_SNAPSHOT: RefCell<HashMap<String, f64>> =
         RefCell::new(HashMap::new());
 
     // sound id → playback position in seconds
@@ -5498,6 +5512,36 @@ pub fn bsengine_get_bus_volume(#[string] bus: String) -> f32 {
     BUS_VOLUME_SNAPSHOT.with(|s| s.borrow().get(&bus).copied().unwrap_or(f32::NAN))
 }
 
+/// Queue setting an effect parameter the mixer declared as exposed.
+///
+/// This is the runtime half of the mixer: `buses.ron` names which parameters a
+/// script may reach, and this moves one. The value is clamped to the authored
+/// range, and `tween_ms` is how long it takes — 0 for an immediate jump.
+///
+/// Unity's exposed-parameter model. Addressing by name rather than by position
+/// in an effect chain means reordering a chain cannot silently re-point a
+/// script at a different parameter.
+#[op2(fast)]
+pub fn bsengine_set_audio_param(#[string] name: String, value: f64, tween_ms: f32) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::SetAudioParam {
+            name,
+            value,
+            tween_ms,
+        })
+    });
+}
+
+/// Read an exposed effect parameter's current value, or NaN if no parameter of
+/// that name was declared.
+///
+/// NaN rather than an `Option` because `#[op2(fast)]` returns plain scalars;
+/// the prelude turns it into `null`.
+#[op2(fast)]
+pub fn bsengine_get_audio_param(#[string] name: String) -> f64 {
+    AUDIO_PARAM_SNAPSHOT.with(|s| s.borrow().get(&name).copied().unwrap_or(f64::NAN))
+}
+
 /// What [`bsengine_get_asset_status`] answers for a path nothing ever asked
 /// for. Every other answer is one of the three below, so this one — and only
 /// this one — means "no engine ever looked".
@@ -6142,6 +6186,8 @@ deno_core::extension!(
         bsengine_get_sound_position,
         bsengine_set_bus_volume,
         bsengine_get_bus_volume,
+        bsengine_set_audio_param,
+        bsengine_get_audio_param,
         bsengine_get_asset_status,
         bsengine_set_hud_text,
         bsengine_clear_hud_text,
@@ -7991,6 +8037,71 @@ JSON.stringify(received)
             assert!(found, "playSound3D lost the bus, the emitter, or both");
         });
         super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn set_audio_param_reaches_the_command_buffer() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setAudioParam("muffle", 500.0, 250.0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetAudioParam { name, value, tween_ms }
+                    if name == "muffle"
+                        && (*value - 500.0).abs() < 1e-9
+                        && (*tween_ms - 250.0).abs() < 1e-6)
+            });
+            assert!(found, "setAudioParam did not reach the command buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn an_omitted_tween_is_an_immediate_change() {
+        // The paired direction: without it, a prelude that dropped the
+        // argument entirely would pass the test above.
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.setAudioParam("muffle", 500.0);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetAudioParam { tween_ms, .. }
+                    if *tween_ms == 0.0)
+            });
+            assert!(found, "an omitted tween must mean 0, not NaN or undefined");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn get_audio_param_reads_the_snapshot_and_reports_unknown_as_null() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        super::AUDIO_PARAM_SNAPSHOT.with(|s| {
+            // Distinct values so reading the wrong one cannot look correct.
+            s.borrow_mut().insert("muffle".to_string(), 500.0);
+            s.borrow_mut().insert("wet".to_string(), 0.25);
+        });
+        assert_eq!(
+            rt.eval(r#"String(Bsengine.getAudioParam("muffle"))"#)
+                .unwrap(),
+            "500"
+        );
+        assert_eq!(
+            rt.eval(r#"String(Bsengine.getAudioParam("wet"))"#).unwrap(),
+            "0.25"
+        );
+        assert_eq!(
+            rt.eval(r#"String(Bsengine.getAudioParam("nope"))"#)
+                .unwrap(),
+            "null",
+            "an undeclared parameter must read as null, not NaN and not 0"
+        );
+        super::AUDIO_PARAM_SNAPSHOT.with(|s| s.borrow_mut().clear());
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -18,9 +18,9 @@ use glam::{EulerRot, Quat, Vec3};
 use crate::ops::{
     render_asset_status, ScriptCommand, SpawnParams, AMBIENT_OCCLUSION_SNAPSHOT,
     ANGULAR_DAMPING_SNAPSHOT, ANGULAR_VELOCITY_SNAPSHOT, ANIMATION_SNAPSHOT, ASM_STATE_SNAPSHOT,
-    ASSET_STATUS_SNAPSHOT, BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS, BUS_VOLUME_SNAPSHOT,
-    CHILDREN_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT, COMMAND_BUFFER,
-    ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, FOLLOW_SNAPSHOT, FRICTION_SNAPSHOT,
+    ASSET_STATUS_SNAPSHOT, AUDIO_PARAM_SNAPSHOT, BLOOM_SNAPSHOT, BODY_TYPE_SNAPSHOT, BOOTSTRAP_JS,
+    BUS_VOLUME_SNAPSHOT, CHILDREN_SNAPSHOT, COLLIDER_SENSOR_SNAPSHOT, COLLISION_SNAPSHOT,
+    COMMAND_BUFFER, ENTITY_NAMES_SNAPSHOT, ENTITY_NAME_MAP, FOLLOW_SNAPSHOT, FRICTION_SNAPSHOT,
     GAMEPAD_BUTTON_JUST_PRESSED_SNAPSHOT, GAMEPAD_BUTTON_JUST_RELEASED_SNAPSHOT,
     GAMEPAD_BUTTON_SNAPSHOT, GAMEPAD_STICKS_SNAPSHOT, GRAVITY_SCALE_SNAPSHOT, GRAVITY_SNAPSHOT,
     KEY_JUST_PRESSED_SNAPSHOT, KEY_JUST_RELEASED_SNAPSHOT, KEY_SNAPSHOT, LIFETIME_SNAPSHOT,
@@ -2178,6 +2178,15 @@ fn run_scripts(world: &mut World) {
                     });
                 }
             }
+            ScriptCommand::SetAudioParam {
+                name,
+                value,
+                tween_ms,
+            } => {
+                if let Some(mut audio) = world.get_resource_mut::<AudioWorld>() {
+                    audio.set_audio_param(&name, value, tween_ms);
+                }
+            }
             ScriptCommand::SetBusVolume { bus, db } => {
                 if let Some(mut audio) = world.get_resource_mut::<AudioWorld>() {
                     audio.set_bus_volume(&bus, db);
@@ -3582,6 +3591,11 @@ fn collect_world_snapshots(world: &mut World) -> (Vec<(String, String)>, String)
             .map(|a| a.bus_volumes().into_iter().collect())
             .unwrap_or_default();
         BUS_VOLUME_SNAPSHOT.with(|s| *s.borrow_mut() = bus_volumes);
+        let audio_params: HashMap<String, f64> = world
+            .get_resource::<AudioWorld>()
+            .map(|a| a.audio_params().into_iter().collect())
+            .unwrap_or_default();
+        AUDIO_PARAM_SNAPSHOT.with(|s| *s.borrow_mut() = audio_params);
     }
     {
         // Mirrors `AssetStatuses` wholesale for `Bsengine.getAssetStatus`,


### PR DESCRIPTION
A mixer parameter can be named in `buses.ron` and moved from script:

```ron
Filter(cutoff: (name: "muffle", min: 200.0, max: 20000.0, initial: 2000.0))
```
```js
Bsengine.setAudioParam("muffle", 500.0, 250.0)   // value, tween ms
Bsengine.getAudioParam("muffle")                 // 500.0, or null
```

That is "underwater muffles everything" and "duck the music during dialogue" — the dynamic half of a mixer, and the one thing #1838 explicitly set aside.

## Why it was deferred, and what unblocks it

kira 0.12's effect handles have almost no setters: `ReverbHandle` has **zero** methods, `FilterHandle` has only `set_mode`. A parameter is changed by moving the **modulator** it was bound to when its track was built.

The mapping is **identity** — `input_range == output_range` — so a script sets the real number (2000 Hz, not 0.37). kira clamps to the input range, which is what makes the authored `min`/`max` a guard rail rather than decoration: a script asking for a negative cutoff gets `min`.

## Unity's model, for a concrete reason

| | Unity | Unreal | Godot |
|---|---|---|---|
| addressing | **exposed parameter, named by the author** | AudioModulation control buses | `get_bus_effect(bus, index)` |

Godot addresses by position in the chain, so reordering a chain silently re-points every name at a different parameter. Naming at the parameter cannot be misaddressed at all, which is why this follows Unity.

## 21 of 22 parameters, and the type says why the 22nd is out

Every numeric effect parameter became a `Param` — either a bare number or an exposure. `delay_ms` is the exception, documented in place: kira's `DelayBuilder::delay_time` takes a plain `Duration`, not a `Value`, so there is nothing for a modulator to drive.

One generic resolver handles all of them, because kira's parameters are variously `f64`, `Decibels`, `Mix`, `Panning` and `Duration` and all need the same treatment.

## Following a precedent this repo already paid for

`Param` hand-writes `Deserialize` rather than using `#[serde(untagged)]`. `AssetRef` in `bsengine-scene` documents why: untagged parses both forms correctly under `ron` 0.8, but a missing field collapses to *"data did not match any variant"* and **an unknown field beside valid ones is silently dropped**. In a mixer file that means a parameter quietly not being exposed, surfacing much later as "why does my script do nothing". Two tests pin the error messages — one for a missing `max`, one for an unknown `wobble`.

## Verification

**All 44 pre-existing audio tests pass unchanged**, which is what makes the 21-parameter conversion verifiably behaviour-preserving rather than merely compiling.

Three mutations run, each failing exactly the intended test: never registering an exposed parameter, ignoring the clamp, and registering fixed parameters too. Paired assertions throughout — `a_fixed_parameter_registers_no_name` exists so that exposing *everything* cannot pass, and `an_omitted_tween_is_an_immediate_change` so that a prelude dropping the argument cannot pass.

fmt clean · catalogue **72 components / 277 ops** (+2, exactly the two added) · no clippy warnings in either crate touched · workspace **1754 passed / 0 failed** (1743 before) · editor **941** · **12/12 E2E replays** · **24/24 packaging**.

As in #1837–#1839: the bookkeeping is covered; what a modulated parameter actually *sounds* like is not observable without an audio device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
