### PR TITLE
feat(ui): anchors — resolution-independent widget placement

### DIFF
--- a/crates/bsengine-core/src/lib.rs
+++ b/crates/bsengine-core/src/lib.rs
@@ -160,7 +160,7 @@ pub use timer::Timer;
 pub use tone_map::{ToneMap, ToneMappingMode};
 pub use transform::Transform;
 pub use tween::{EasingFn, RepeatMode, Tween, TweenTarget};
-pub use ui_state::{UiState, UiWidget};
+pub use ui_state::{UiAnchor, UiState, UiWidget};
 pub use visible::Visible;
 pub use volumetric_fog::VolumetricFog;
 

--- a/crates/bsengine-core/src/ui_state.rs
+++ b/crates/bsengine-core/src/ui_state.rs
@@ -2,6 +2,115 @@ use std::collections::{HashMap, HashSet};
 
 use bevy_ecs::prelude::Resource;
 
+/// Where a widget attaches to the screen, in normalised 0..1 coordinates.
+///
+/// `(0, 0)` is the top-left corner and `(1, 1)` the bottom-right, which is the
+/// same convention Unity's `RectTransform`, Unreal's UMG anchors and Godot's
+/// `Control` anchors all use. Following them is deliberate: a UI author
+/// arriving from any of the three already knows what these numbers mean.
+///
+/// # Point anchors and stretch anchors
+///
+/// When `min` equals `max` on an axis, the anchor is a **point**: the widget's
+/// offset is a position relative to it and its size is used literally. A
+/// bottom-right anchor with `x = -110, width = 100` sits 110px in from the
+/// right edge and is 100px wide, at any resolution.
+///
+/// When they differ, the anchor is a **stretch**: the widget spans that
+/// fraction of the screen, the offset insets its near edge, and the size is an
+/// *adjustment* to the span rather than the span itself. A horizontal stretch
+/// with `x = 20, width = -40` leaves a 20px margin on both sides.
+///
+/// # Why this is backwards compatible by construction
+///
+/// The default is `(0, 0, 0, 0)` — a point anchor at the top-left. That is
+/// exactly what absolute pixel coordinates already meant, so every widget
+/// written before anchors existed resolves to the position it always had. The
+/// compatibility is structural, not a special case in the resolver.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UiAnchor {
+    /// Left edge, 0.0 = screen left, 1.0 = screen right.
+    pub min_x: f32,
+    /// Top edge, 0.0 = screen top, 1.0 = screen bottom.
+    pub min_y: f32,
+    /// Right edge; equal to `min_x` for a point anchor.
+    pub max_x: f32,
+    /// Bottom edge; equal to `min_y` for a point anchor.
+    pub max_y: f32,
+}
+
+impl Default for UiAnchor {
+    fn default() -> Self {
+        Self::TOP_LEFT
+    }
+}
+
+impl UiAnchor {
+    /// The top-left point anchor: what absolute pixel coordinates have always
+    /// meant here.
+    pub const TOP_LEFT: Self = Self {
+        min_x: 0.0,
+        min_y: 0.0,
+        max_x: 0.0,
+        max_y: 0.0,
+    };
+
+    /// A point anchor at the given normalised position.
+    pub fn point(x: f32, y: f32) -> Self {
+        Self {
+            min_x: x,
+            min_y: y,
+            max_x: x,
+            max_y: y,
+        }
+    }
+
+    /// Whether this anchor stretches horizontally.
+    pub fn stretches_x(&self) -> bool {
+        self.min_x != self.max_x
+    }
+
+    /// Whether this anchor stretches vertically.
+    pub fn stretches_y(&self) -> bool {
+        self.min_y != self.max_y
+    }
+
+    /// Resolves this anchor plus a widget's offsets into screen pixels.
+    ///
+    /// Returns `(x, y, width, height)`. Pure: no GPU, no window, no egui — it
+    /// is arithmetic on the numbers above, which is what lets every anchoring
+    /// rule be tested on a machine with no display.
+    ///
+    /// The two axes are resolved independently, so a horizontal stretch with a
+    /// vertical point anchor behaves the way both halves say it should.
+    pub fn resolve(
+        &self,
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        screen_w: f32,
+        screen_h: f32,
+    ) -> (f32, f32, f32, f32) {
+        let (rx, rw) = Self::resolve_axis(self.min_x, self.max_x, x, width, screen_w);
+        let (ry, rh) = Self::resolve_axis(self.min_y, self.max_y, y, height, screen_h);
+        (rx, ry, rw, rh)
+    }
+
+    /// One axis of [`resolve`](Self::resolve).
+    fn resolve_axis(min: f32, max: f32, offset: f32, size: f32, screen: f32) -> (f32, f32) {
+        let near = min * screen;
+        if min == max {
+            // Point anchor: offset positions, size is literal.
+            (near + offset, size)
+        } else {
+            // Stretch: offset insets the near edge, size adjusts the span.
+            let span = (max - min) * screen;
+            (near + offset, span + size)
+        }
+    }
+}
+
 /// A single immediate-mode UI element rendered by the HUD/UI system.
 #[derive(Clone, Debug)]
 pub enum UiWidget {
@@ -17,6 +126,10 @@ pub enum UiWidget {
         y: f32,
         /// Font size, in pixels.
         font_size: f32,
+        /// Where this widget attaches to the screen; the default is the
+        /// top-left point anchor, which is what plain pixel coordinates
+        /// have always meant.
+        anchor: UiAnchor,
     },
     /// A clickable button.
     Button {
@@ -32,6 +145,10 @@ pub enum UiWidget {
         width: f32,
         /// Button height, in pixels.
         height: f32,
+        /// Where this widget attaches to the screen; the default is the
+        /// top-left point anchor, which is what plain pixel coordinates
+        /// have always meant.
+        anchor: UiAnchor,
     },
     /// A rectangular container with a title bar.
     Panel {
@@ -47,6 +164,10 @@ pub enum UiWidget {
         width: f32,
         /// Panel height, in pixels.
         height: f32,
+        /// Where this widget attaches to the screen; the default is the
+        /// top-left point anchor, which is what plain pixel coordinates
+        /// have always meant.
+        anchor: UiAnchor,
     },
     /// An editable single-line text field.
     TextInput {
@@ -60,6 +181,10 @@ pub enum UiWidget {
         y: f32,
         /// Field width, in pixels.
         width: f32,
+        /// Where this widget attaches to the screen; the default is the
+        /// top-left point anchor, which is what plain pixel coordinates
+        /// have always meant.
+        anchor: UiAnchor,
     },
     /// A texture displayed at a fixed screen position.
     Image {
@@ -75,6 +200,10 @@ pub enum UiWidget {
         width: f32,
         /// Image height, in pixels.
         height: f32,
+        /// Where this widget attaches to the screen; the default is the
+        /// top-left point anchor, which is what plain pixel coordinates
+        /// have always meant.
+        anchor: UiAnchor,
     },
     /// A horizontal fill bar, e.g. for health/progress display.
     ProgressBar {
@@ -90,10 +219,26 @@ pub enum UiWidget {
         height: f32,
         /// Fill fraction, expected in 0.0..=1.0 (egui clamps out-of-range values).
         fraction: f32,
+        /// Where this widget attaches to the screen; the default is the
+        /// top-left point anchor, which is what plain pixel coordinates
+        /// have always meant.
+        anchor: UiAnchor,
     },
 }
 
 impl UiWidget {
+    /// This widget's anchor, mutably, regardless of its variant.
+    pub fn anchor_mut(&mut self) -> &mut UiAnchor {
+        match self {
+            Self::Label { anchor, .. }
+            | Self::Button { anchor, .. }
+            | Self::Panel { anchor, .. }
+            | Self::TextInput { anchor, .. }
+            | Self::Image { anchor, .. }
+            | Self::ProgressBar { anchor, .. } => anchor,
+        }
+    }
+
     /// Returns this widget's unique identifier, regardless of its variant.
     pub fn id(&self) -> &str {
         match self {
@@ -130,6 +275,22 @@ impl UiState {
         }
     }
 
+    /// Sets an existing widget's anchor. Returns whether the widget existed.
+    ///
+    /// Separate from the widget setters so those keep a usable arity: a
+    /// script's `setButton(..., { anchor: "bottom-right" })` becomes two
+    /// queued commands, applied in order, rather than five extra positional
+    /// arguments on every setter.
+    pub fn set_anchor(&mut self, id: &str, anchor: UiAnchor) -> bool {
+        for widget in &mut self.widgets {
+            if widget.id() == id {
+                *widget.anchor_mut() = anchor;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Removes the widget with the given id, along with any stored text input value.
     pub fn remove_widget(&mut self, id: &str) {
         self.widgets.retain(|w| w.id() != id);
@@ -158,6 +319,7 @@ mod tests {
             width: 200.0,
             height: 20.0,
             fraction: 0.75,
+            anchor: UiAnchor::default(),
         });
         assert_eq!(state.widgets.len(), 1);
         if let UiWidget::ProgressBar { fraction, .. } = &state.widgets[0] {
@@ -176,6 +338,7 @@ mod tests {
             width: 100.0,
             height: 10.0,
             fraction: 0.5,
+            anchor: UiAnchor::default(),
         };
         assert_eq!(widget.id(), "hp");
     }
@@ -189,6 +352,7 @@ mod tests {
             x: 0.0,
             y: 0.0,
             font_size: 16.0,
+            anchor: UiAnchor::default(),
         });
         assert_eq!(state.widgets.len(), 1);
     }
@@ -202,6 +366,7 @@ mod tests {
             x: 0.0,
             y: 0.0,
             font_size: 16.0,
+            anchor: UiAnchor::default(),
         });
         state.set_widget(UiWidget::Label {
             id: "lbl".into(),
@@ -209,6 +374,7 @@ mod tests {
             x: 0.0,
             y: 0.0,
             font_size: 16.0,
+            anchor: UiAnchor::default(),
         });
         assert_eq!(state.widgets.len(), 1);
         if let UiWidget::Label { text, .. } = &state.widgets[0] {
@@ -228,6 +394,7 @@ mod tests {
             y: 0.0,
             width: 100.0,
             height: 40.0,
+            anchor: UiAnchor::default(),
         });
         state.remove_widget("btn");
         assert!(state.widgets.is_empty());
@@ -243,6 +410,7 @@ mod tests {
             y: 0.0,
             width: 200.0,
             height: 150.0,
+            anchor: UiAnchor::default(),
         });
         state.clicked.insert("btn".into());
         state.text_values.insert("inp".into(), "val".into());
@@ -250,5 +418,134 @@ mod tests {
         assert!(state.widgets.is_empty());
         assert!(state.clicked.is_empty());
         assert!(state.text_values.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod anchor_tests {
+    use super::*;
+
+    /// A deliberately non-square screen.
+    ///
+    /// 1000x1000 would let a bug that swaps the x and y axes read as correct;
+    /// 1920x1080 cannot.
+    const W: f32 = 1920.0;
+    const H: f32 = 1080.0;
+
+    #[test]
+    fn the_default_anchor_is_what_plain_pixels_always_meant() {
+        // The compatibility claim, asserted rather than reasoned about: a
+        // widget written before anchors existed must land exactly where it
+        // always did, at any resolution.
+        let a = UiAnchor::default();
+        assert_eq!(
+            a.resolve(30.0, 40.0, 100.0, 50.0, W, H),
+            (30.0, 40.0, 100.0, 50.0)
+        );
+        assert_eq!(
+            a.resolve(30.0, 40.0, 100.0, 50.0, 640.0, 480.0),
+            (30.0, 40.0, 100.0, 50.0),
+            "a top-left anchored widget does not move with the screen"
+        );
+    }
+
+    #[test]
+    fn a_bottom_right_anchor_tracks_the_corner() {
+        let a = UiAnchor::point(1.0, 1.0);
+        // 110 in from the right, 50 up from the bottom, 100x40.
+        assert_eq!(
+            a.resolve(-110.0, -50.0, 100.0, 40.0, W, H),
+            (1810.0, 1030.0, 100.0, 40.0)
+        );
+        // Same offsets, smaller screen: still the same distance from the
+        // corner, which is the entire point of anchoring.
+        assert_eq!(
+            a.resolve(-110.0, -50.0, 100.0, 40.0, 1280.0, 720.0),
+            (1170.0, 670.0, 100.0, 40.0)
+        );
+    }
+
+    #[test]
+    fn a_centre_anchor_stays_centred() {
+        let a = UiAnchor::point(0.5, 0.5);
+        // Offsets of half the size centre a widget exactly.
+        assert_eq!(
+            a.resolve(-50.0, -20.0, 100.0, 40.0, W, H),
+            (910.0, 520.0, 100.0, 40.0)
+        );
+        assert_eq!(
+            a.resolve(-50.0, -20.0, 100.0, 40.0, 1280.0, 720.0),
+            (590.0, 340.0, 100.0, 40.0)
+        );
+    }
+
+    #[test]
+    fn a_horizontal_stretch_leaves_the_offsets_as_margins() {
+        let a = UiAnchor {
+            min_x: 0.0,
+            max_x: 1.0,
+            min_y: 0.0,
+            max_y: 0.0,
+        };
+        // 20px in from each side: x = 20, width = -40.
+        let (x, y, w, h) = a.resolve(20.0, 8.0, -40.0, 24.0, W, H);
+        assert_eq!((x, w), (20.0, 1880.0), "spans 20..1900 on a 1920 screen");
+        assert_eq!(
+            (y, h),
+            (8.0, 24.0),
+            "the vertical axis is a point anchor and must be untouched by the horizontal stretch"
+        );
+
+        let (x, _, w, _) = a.resolve(20.0, 8.0, -40.0, 24.0, 1280.0, 720.0);
+        assert_eq!((x, w), (20.0, 1240.0), "the margins hold at another width");
+    }
+
+    #[test]
+    fn a_full_stretch_fills_the_screen_minus_its_insets() {
+        let a = UiAnchor {
+            min_x: 0.0,
+            max_x: 1.0,
+            min_y: 0.0,
+            max_y: 1.0,
+        };
+        assert_eq!(
+            a.resolve(10.0, 20.0, -20.0, -40.0, W, H),
+            (10.0, 20.0, 1900.0, 1040.0)
+        );
+    }
+
+    #[test]
+    fn the_two_axes_resolve_independently() {
+        // Asymmetric on purpose: a bug that shares one axis's result with the
+        // other, or swaps min_x with min_y, cannot survive this.
+        let a = UiAnchor {
+            min_x: 1.0,
+            max_x: 1.0,
+            min_y: 0.0,
+            max_y: 1.0,
+        };
+        let (x, y, w, h) = a.resolve(-200.0, 30.0, 150.0, -60.0, W, H);
+        assert_eq!(
+            (x, w),
+            (1720.0, 150.0),
+            "x is a point anchor at the right edge"
+        );
+        assert_eq!(
+            (y, h),
+            (30.0, 1020.0),
+            "y stretches the full height less 60"
+        );
+    }
+
+    #[test]
+    fn stretch_detection_is_per_axis() {
+        let a = UiAnchor {
+            min_x: 0.0,
+            max_x: 1.0,
+            min_y: 0.5,
+            max_y: 0.5,
+        };
+        assert!(a.stretches_x());
+        assert!(!a.stretches_y());
     }
 }

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -5471,7 +5471,15 @@ impl WgpuSurface {
                     }
                 }
 
-                // Interactive UI widgets
+                // Interactive UI widgets.
+                //
+                // Every widget's anchor is resolved against the live screen
+                // size first, so the positions below are already pixels. The
+                // resolution itself lives in `bsengine_core::UiAnchor` — pure
+                // arithmetic with no GPU, window or egui, which is what lets
+                // every anchoring rule be tested headlessly.
+                let screen_w = self.output.width() as f32;
+                let screen_h = self.output.height() as f32;
                 for widget in &ui_state.widgets {
                     use bsengine_core::UiWidget;
                     match widget {
@@ -5481,9 +5489,14 @@ impl WgpuSurface {
                             x,
                             y,
                             font_size,
+                            anchor,
                         } => {
+                            // A label has no authored size, so only its
+                            // position is anchored; egui sizes it to its text.
+                            let (px, py, _, _) =
+                                anchor.resolve(*x, *y, 0.0, 0.0, screen_w, screen_h);
                             egui::Area::new(egui::Id::new(id.as_str()))
-                                .fixed_pos(egui::pos2(*x, *y))
+                                .fixed_pos(egui::pos2(px, py))
                                 .show(ctx, |ui| {
                                     ui.label(egui::RichText::new(text.as_str()).size(*font_size));
                                 });
@@ -5495,13 +5508,16 @@ impl WgpuSurface {
                             y,
                             width,
                             height,
+                            anchor,
                         } => {
+                            let (px, py, pw, ph) =
+                                anchor.resolve(*x, *y, *width, *height, screen_w, screen_h);
                             egui::Area::new(egui::Id::new(id.as_str()))
-                                .fixed_pos(egui::pos2(*x, *y))
+                                .fixed_pos(egui::pos2(px, py))
                                 .show(ctx, |ui| {
                                     if ui
                                         .add_sized(
-                                            egui::vec2(*width, *height),
+                                            egui::vec2(pw, ph),
                                             egui::Button::new(label.as_str()),
                                         )
                                         .clicked()
@@ -5517,11 +5533,14 @@ impl WgpuSurface {
                             y,
                             width,
                             height,
+                            anchor,
                         } => {
+                            let (px, py, pw, ph) =
+                                anchor.resolve(*x, *y, *width, *height, screen_w, screen_h);
                             egui::Window::new(title.as_str())
                                 .id(egui::Id::new(id.as_str()))
-                                .fixed_pos(egui::pos2(*x, *y))
-                                .fixed_size(egui::vec2(*width, *height))
+                                .fixed_pos(egui::pos2(px, py))
+                                .fixed_size(egui::vec2(pw, ph))
                                 .collapsible(false)
                                 .resizable(false)
                                 .show(ctx, |_ui| {});
@@ -5532,15 +5551,20 @@ impl WgpuSurface {
                             x,
                             y,
                             width,
+                            anchor,
                         } => {
+                            // Height 0: a single-line field sizes itself
+                            // vertically, so only its width is anchored.
+                            let (px, py, pw, _) =
+                                anchor.resolve(*x, *y, *width, 0.0, screen_w, screen_h);
                             let text_val = new_text_values.entry(id.clone()).or_default();
                             egui::Area::new(egui::Id::new(id.as_str()))
-                                .fixed_pos(egui::pos2(*x, *y))
+                                .fixed_pos(egui::pos2(px, py))
                                 .show(ctx, |ui| {
                                     ui.add(
                                         egui::TextEdit::singleline(text_val)
                                             .hint_text(hint.as_str())
-                                            .desired_width(*width),
+                                            .desired_width(pw),
                                     );
                                 });
                         }
@@ -5550,13 +5574,16 @@ impl WgpuSurface {
                             y,
                             width,
                             height,
+                            anchor,
                             ..
                         } => {
+                            let (px, py, pw, ph) =
+                                anchor.resolve(*x, *y, *width, *height, screen_w, screen_h);
                             egui::Area::new(egui::Id::new(id.as_str()))
-                                .fixed_pos(egui::pos2(*x, *y))
+                                .fixed_pos(egui::pos2(px, py))
                                 .show(ctx, |ui| {
                                     ui.allocate_exact_size(
-                                        egui::vec2(*width, *height),
+                                        egui::vec2(pw, ph),
                                         egui::Sense::hover(),
                                     );
                                 });
@@ -5568,12 +5595,15 @@ impl WgpuSurface {
                             width,
                             height,
                             fraction,
+                            anchor,
                         } => {
+                            let (px, py, pw, ph) =
+                                anchor.resolve(*x, *y, *width, *height, screen_w, screen_h);
                             egui::Area::new(egui::Id::new(id.as_str()))
-                                .fixed_pos(egui::pos2(*x, *y))
+                                .fixed_pos(egui::pos2(px, py))
                                 .show(ctx, |ui| {
                                     ui.add_sized(
-                                        egui::vec2(*width, *height),
+                                        egui::vec2(pw, ph),
                                         egui::ProgressBar::new(*fraction),
                                     );
                                 });

--- a/crates/bsengine-scripting/src/js/prelude.js
+++ b/crates/bsengine-scripting/src/js/prelude.js
@@ -567,11 +567,60 @@ var Bsengine = {
     // UI widgets — immediate-mode overlay (egui-backed)
     // Each call sets or replaces the widget with the given id.
     ui: {
-        setLabel:       (id, text, x, y, fontSize)          => Deno.core.ops.bsengine_ui_set_label(id, String(text), x, y, fontSize ?? 20),
-        setButton:      (id, label, x, y, width, height)    => Deno.core.ops.bsengine_ui_set_button(id, label, x, y, width, height),
-        setPanel:       (id, title, x, y, width, height)    => Deno.core.ops.bsengine_ui_set_panel(id, title ?? '', x, y, width, height),
-        setTextInput:   (id, hint, x, y, width)             => Deno.core.ops.bsengine_ui_set_text_input(id, hint ?? '', x, y, width),
-        setProgressBar: (id, x, y, width, height, fraction) => Deno.core.ops.bsengine_ui_set_progress_bar(id, x, y, width, height, fraction),
+        // Anchor presets, as Unity's inspector grid offers them. (0,0) is the
+        // top-left corner and (1,1) the bottom-right, matching Unity, Unreal
+        // and Godot alike. Equal min and max is a point; different values
+        // stretch, and then the offsets read as insets.
+        ANCHORS: {
+            'top-left':      [0.0, 0.0, 0.0, 0.0],
+            'top-center':    [0.5, 0.0, 0.5, 0.0],
+            'top-right':     [1.0, 0.0, 1.0, 0.0],
+            'center-left':   [0.0, 0.5, 0.0, 0.5],
+            'center':        [0.5, 0.5, 0.5, 0.5],
+            'center-right':  [1.0, 0.5, 1.0, 0.5],
+            'bottom-left':   [0.0, 1.0, 0.0, 1.0],
+            'bottom-center': [0.5, 1.0, 0.5, 1.0],
+            'bottom-right':  [1.0, 1.0, 1.0, 1.0],
+            'stretch-horizontal': [0.0, 0.0, 1.0, 0.0],
+            'stretch-vertical':   [0.0, 0.0, 0.0, 1.0],
+            'stretch':            [0.0, 0.0, 1.0, 1.0],
+        },
+        // Applies `opts.anchor` if there is one. A preset name or a raw
+        // [minX, minY, maxX, maxY]. An unknown name is reported rather than
+        // silently ignored: a typo'd preset that did nothing would look like
+        // a broken anchor system.
+        _applyAnchor: (id, opts) => {
+            if (!opts || opts.anchor === undefined) return;
+            const a = opts.anchor;
+            const v = Array.isArray(a) ? a : Bsengine.ui.ANCHORS[a];
+            if (v === undefined) {
+                throw new Error(
+                    'unknown UI anchor "' + a + '"; expected one of ' +
+                    Object.keys(Bsengine.ui.ANCHORS).join(', ') +
+                    ' or [minX, minY, maxX, maxY]');
+            }
+            Deno.core.ops.bsengine_ui_set_anchor(id, v[0], v[1], v[2], v[3]);
+        },
+        setLabel:       (id, text, x, y, fontSize, opts) => {
+            Deno.core.ops.bsengine_ui_set_label(id, String(text), x, y, fontSize ?? 20);
+            Bsengine.ui._applyAnchor(id, opts);
+        },
+        setButton:      (id, label, x, y, width, height, opts) => {
+            Deno.core.ops.bsengine_ui_set_button(id, label, x, y, width, height);
+            Bsengine.ui._applyAnchor(id, opts);
+        },
+        setPanel:       (id, title, x, y, width, height, opts) => {
+            Deno.core.ops.bsengine_ui_set_panel(id, title ?? '', x, y, width, height);
+            Bsengine.ui._applyAnchor(id, opts);
+        },
+        setTextInput:   (id, hint, x, y, width, opts) => {
+            Deno.core.ops.bsengine_ui_set_text_input(id, hint ?? '', x, y, width);
+            Bsengine.ui._applyAnchor(id, opts);
+        },
+        setProgressBar: (id, x, y, width, height, fraction, opts) => {
+            Deno.core.ops.bsengine_ui_set_progress_bar(id, x, y, width, height, fraction);
+            Bsengine.ui._applyAnchor(id, opts);
+        },
         remove:         (id)                                => Deno.core.ops.bsengine_ui_remove_widget(id),
         clear:          ()                                  => Deno.core.ops.bsengine_ui_clear(),
         isClicked:      (id)                                => Deno.core.ops.bsengine_ui_is_clicked(id),

--- a/crates/bsengine-scripting/src/ops.rs
+++ b/crates/bsengine-scripting/src/ops.rs
@@ -1105,6 +1105,19 @@ pub enum ScriptCommand {
         /// `true` to pause, `false` to resume.
         paused: bool,
     },
+    /// Set an existing UI widget's anchor.
+    SetUiAnchor {
+        /// Widget to anchor.
+        id: String,
+        /// Left edge, normalised.
+        min_x: f32,
+        /// Top edge, normalised.
+        min_y: f32,
+        /// Right edge, normalised.
+        max_x: f32,
+        /// Bottom edge, normalised.
+        max_y: f32,
+    },
     /// Remove a UI widget by id.
     RemoveUiWidget {
         /// Identifier of the sound or UI widget to target.
@@ -5694,6 +5707,34 @@ pub fn bsengine_ui_set_label(
     });
 }
 
+/// Queue setting an existing widget's anchor.
+///
+/// Normalised 0..1, `(0,0)` top-left and `(1,1)` bottom-right — the same
+/// convention Unity, Unreal and Godot all use. Equal min and max on an axis is
+/// a point anchor; different values stretch.
+///
+/// A separate op rather than five more arguments on every setter: the prelude
+/// issues this straight after the widget's own command, and commands are
+/// applied in order.
+#[op2(fast)]
+pub fn bsengine_ui_set_anchor(
+    #[string] id: String,
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+) {
+    COMMAND_BUFFER.with(|c| {
+        c.borrow_mut().push(ScriptCommand::SetUiAnchor {
+            id,
+            min_x,
+            min_y,
+            max_x,
+            max_y,
+        })
+    });
+}
+
 /// Queue creating or updating a UI button.
 #[op2(fast)]
 pub fn bsengine_ui_set_button(
@@ -6192,6 +6233,7 @@ deno_core::extension!(
         bsengine_set_hud_text,
         bsengine_clear_hud_text,
         bsengine_ui_set_label,
+        bsengine_ui_set_anchor,
         bsengine_ui_set_button,
         bsengine_ui_set_panel,
         bsengine_ui_set_text_input,
@@ -8145,6 +8187,103 @@ JSON.stringify(received)
             "an unknown bus must read as null, not NaN and not 0"
         );
         super::BUS_VOLUME_SNAPSHOT.with(|s| s.borrow_mut().clear());
+    }
+
+    #[test]
+    fn a_preset_anchor_reaches_the_command_buffer() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(
+            r#"Bsengine.ui.setButton("quit", "Quit", -110, -50, 100, 40, { anchor: "bottom-right" });"#,
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetUiAnchor { id, min_x, min_y, max_x, max_y }
+                    if id == "quit" && *min_x == 1.0 && *min_y == 1.0 && *max_x == 1.0 && *max_y == 1.0)
+            });
+            assert!(found, "the bottom-right preset did not reach the command buffer");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn a_stretch_preset_sets_a_different_min_and_max() {
+        // Distinguishes a stretch from a point: a preset table that returned
+        // the same value for both would pass the test above.
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(
+            r#"Bsengine.ui.setProgressBar("hp", 20, 20, -40, 24, 0.7, { anchor: "stretch-horizontal" });"#,
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetUiAnchor { min_x, max_x, min_y, max_y, .. }
+                    if *min_x == 0.0 && *max_x == 1.0 && *min_y == *max_y)
+            });
+            assert!(found, "stretch-horizontal must differ on x and match on y");
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn a_widget_with_no_anchor_option_queues_no_anchor_command() {
+        // The paired direction, and the backwards-compatibility claim: every
+        // call written before anchors existed must behave exactly as before.
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(r#"Bsengine.ui.setLabel("score", "0", 10, 10);"#)
+            .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            assert!(
+                !buf.iter()
+                    .any(|cmd| matches!(cmd, super::ScriptCommand::SetUiAnchor { .. })),
+                "an unanchored widget must queue no anchor command at all"
+            );
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn a_raw_anchor_array_is_accepted() {
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        rt.eval(
+            r#"Bsengine.ui.setPanel("p", "", 0, 0, 10, 10, { anchor: [0.25, 0.5, 0.75, 0.5] });"#,
+        )
+        .unwrap();
+        super::COMMAND_BUFFER.with(|c| {
+            let buf = c.borrow();
+            let found = buf.iter().any(|cmd| {
+                matches!(cmd, super::ScriptCommand::SetUiAnchor { min_x, min_y, max_x, max_y, .. }
+                    if *min_x == 0.25 && *min_y == 0.5 && *max_x == 0.75 && *max_y == 0.5)
+            });
+            assert!(
+                found,
+                "a raw [minX, minY, maxX, maxY] must be passed through"
+            );
+        });
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
+    }
+
+    #[test]
+    fn an_unknown_anchor_preset_throws_rather_than_doing_nothing() {
+        // A typo'd preset that silently did nothing would look exactly like a
+        // broken anchor system, which is far harder to diagnose than an error.
+        let mut rt = ScriptRuntime::new_with_ops();
+        rt.exec_source(super::BOOTSTRAP_JS, "<bootstrap>").unwrap();
+        let err = rt
+            .eval(r#"Bsengine.ui.setLabel("l", "x", 0, 0, 20, { anchor: "bottom-rihgt" });"#)
+            .expect_err("a typo'd preset must throw");
+        assert!(
+            format!("{err}").contains("bottom-rihgt"),
+            "the error must quote the bad name; got {err}"
+        );
+        super::COMMAND_BUFFER.with(|c| c.borrow_mut().clear());
     }
 
     #[test]

--- a/crates/bsengine-scripting/src/plugin.rs
+++ b/crates/bsengine-scripting/src/plugin.rs
@@ -2299,6 +2299,7 @@ fn run_scripts(world: &mut World) {
                         x,
                         y,
                         font_size,
+                        anchor: bsengine_core::UiAnchor::default(),
                     });
                 }
             }
@@ -2318,6 +2319,7 @@ fn run_scripts(world: &mut World) {
                         y,
                         width,
                         height,
+                        anchor: bsengine_core::UiAnchor::default(),
                     });
                 }
             }
@@ -2337,6 +2339,7 @@ fn run_scripts(world: &mut World) {
                         y,
                         width,
                         height,
+                        anchor: bsengine_core::UiAnchor::default(),
                     });
                 }
             }
@@ -2354,6 +2357,7 @@ fn run_scripts(world: &mut World) {
                         x,
                         y,
                         width,
+                        anchor: bsengine_core::UiAnchor::default(),
                     });
                 }
             }
@@ -2373,11 +2377,37 @@ fn run_scripts(world: &mut World) {
                         width,
                         height,
                         fraction,
+                        anchor: bsengine_core::UiAnchor::default(),
                     });
                 }
             }
             ScriptCommand::SetPaused { paused } => {
                 world.insert_resource(bsengine_core::PauseState { paused });
+            }
+            ScriptCommand::SetUiAnchor {
+                id,
+                min_x,
+                min_y,
+                max_x,
+                max_y,
+            } => {
+                if let Some(mut ui) = world.get_resource_mut::<UiState>() {
+                    // Applied to an existing widget, which the prelude
+                    // guarantees by issuing this straight after the widget's
+                    // own command. A miss means the script anchored an id it
+                    // never created.
+                    if !ui.set_anchor(
+                        &id,
+                        bsengine_core::UiAnchor {
+                            min_x,
+                            min_y,
+                            max_x,
+                            max_y,
+                        },
+                    ) {
+                        tracing::warn!("[ui] setAnchor named unknown widget '{id}'");
+                    }
+                }
             }
             ScriptCommand::RemoveUiWidget { id } => {
                 if let Some(mut ui) = world.get_resource_mut::<UiState>() {


### PR DESCRIPTION
UI positions were absolute pixels, so a HUD laid out for 1920×1080 broke at 1280×720. Widgets can now anchor to any point or edge of the screen.

```js
Bsengine.ui.setButton("quit", "Quit", -110, -50, 100, 40, { anchor: "bottom-right" })
Bsengine.ui.setProgressBar("hp", 20, 20, -40, 24, 0.7, { anchor: "stretch-horizontal" })
```

This is the **UI framework** axis the comparison doc identified as a medium gap (`ui_state.rs`, 254 lines, vs UMG / UI Toolkit), and resolution independence is the part of it that actually bites.

## The design is the engines' convergence, not an invention

| | anchor model |
|---|---|
| Unity | `anchorMin`/`anchorMax` + offsets, normalised 0–1 |
| Unreal UMG | Anchors Min(X,Y)/Max(X,Y) + offsets; (0,0) top-left, (1,1) bottom-right |
| Godot | `Control` anchors 0.0→1.0 relative to parent |

All three use **normalised 0–1 anchors with (0,0) top-left and (1,1) bottom-right**, so that is taken verbatim — a UI author arriving from any of them already knows what the numbers mean. Preset names mirror Unity's inspector grid (`"top-left"`, `"center"`, `"bottom-right"`, `"stretch-horizontal"`, …), and a raw `[minX, minY, maxX, maxY]` covers anything the presets do not.

**Point vs stretch follows the same semantics.** When `min == max` the anchor is a point: the offset positions it and the size is literal. When they differ it stretches, and the offsets become insets — `x: 20, width: -40` is a 20px margin on both sides at any resolution. The two axes resolve independently, so a horizontal stretch with a vertical point anchor does what both halves say.

## Backwards compatible by construction

The default anchor is `(0,0,0,0)` — a point at the top-left — which is **exactly what absolute pixel coordinates already meant**. Every widget written before anchors existed resolves to the position it always had, and that is structural rather than a compatibility branch in the resolver.

Asserted, not argued: `the_default_anchor_is_what_plain_pixels_always_meant` checks it at two resolutions, and `a_widget_with_no_anchor_option_queues_no_anchor_command` checks that an unanchored call emits nothing extra.

## Where the code lives, and why it is testable

Resolution is a **pure function** in `bsengine-core` — no GPU, no window, no egui — so every anchoring rule is tested headlessly. The renderer resolves each widget against the live screen size and keeps calling `egui::Area::fixed_pos` with pixels.

Anchoring is a separate op rather than five more positional arguments on every setter; the prelude issues it straight after the widget's own command, and commands apply in order.

## Test design

Fixtures use **1920×1080 and asymmetric offsets** deliberately — a square screen would let a bug that swaps the x and y axes read as correct, and symmetric offsets would hide a min/max swap.

Three mutations run, each failing 3–5 tests: swapping `min`/`max`, ignoring the screen size, and treating every anchor as a point.

A typo'd preset **throws and quotes the bad name**. One that silently did nothing would look exactly like a broken anchor system, which is far harder to diagnose than an error.

## Verification

fmt clean · catalogue **72 components / 278 ops** (+1, the anchor op) · **zero clippy warnings in any file this PR changed**, verified by force-recompiling all three and listing every warning site · workspace **1766 passed / 0 failed** (1754 before) · editor **941** · **12/12 E2E replays** · **24/24 packaging**.

Layout containers (HBox/VBox/Grid — Godot's `Container`, Unity's Layout Group) are deliberately **not** here: they need the flat `widgets: Vec` to gain parent/child structure first, which is a larger change than anchoring and worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
