### PR TITLE
fix(render): directional shadow frustum follows the camera

### DIFF
--- a/crates/bsengine-render/src/plugin.rs
+++ b/crates/bsengine-render/src/plugin.rs
@@ -42,21 +42,6 @@ fn sphere_visible_in_frustum(view_proj: Mat4, world_center: Vec3, world_radius: 
     true
 }
 
-/// Computes an orthographic view-projection from the light's direction for shadow mapping.
-/// Uses rh_zo (0..1 depth) to match wgpu's depth buffer convention.
-fn compute_light_view_proj(light_dir: Vec3) -> Mat4 {
-    let dir = light_dir.normalize();
-    let up = if dir.y.abs() < 0.999 {
-        Vec3::Y
-    } else {
-        Vec3::Z
-    };
-    let eye = -dir * 50.0;
-    let view = Mat4::look_at_rh(eye, Vec3::ZERO, up);
-    let proj = Mat4::orthographic_rh(-30.0, 30.0, -30.0, 30.0, 0.1, 200.0);
-    proj * view
-}
-
 fn spot_light_entry(sl: &SpotLight, gt: Option<&GlobalTransform>, t: &Transform) -> SpotLightEntry {
     let pos = gt
         .map(|g| g.to_matrix().w_axis.truncate())
@@ -955,7 +940,14 @@ fn render_frame(
         })
         .collect();
 
-    let light_view_proj = compute_light_view_proj(light.direction);
+    // Fitted to the camera, not to the world origin. `unjittered_view_proj`
+    // rather than the jittered matrix: a sub-pixel TAA offset must not shift
+    // the shadow map's texel grid, which is snapped precisely to stop it
+    // moving.
+    let light_view_proj = bsengine_rhi_wgpu::shadow::directional_light_view_proj(
+        light.direction,
+        unjittered_view_proj,
+    );
     let tex_reg_ref = tex_registry.as_deref();
 
     match surface.0.render_frame(
@@ -2082,25 +2074,6 @@ mod tests {
 
         assert!((entry.inner_angle - 45_f32.to_radians()).abs() < 1e-6);
         assert!((entry.outer_angle - 60_f32.to_radians()).abs() < 1e-6);
-    }
-
-    #[test]
-    fn light_view_proj_is_invertible() {
-        use super::compute_light_view_proj;
-        let dir = Vec3::new(-0.4, -0.8, -0.4).normalize();
-        let vp = compute_light_view_proj(dir);
-        assert!(
-            vp.determinant().abs() > 1e-6,
-            "light VP should be invertible"
-        );
-    }
-
-    #[test]
-    fn light_view_proj_up_axis_does_not_degenerate() {
-        use super::compute_light_view_proj;
-        // straight-down light — should pick Z as up without NaN/zero-det
-        let vp = compute_light_view_proj(Vec3::new(0.0, -1.0, 0.0));
-        assert!(vp.determinant().abs() > 1e-6);
     }
 
     #[test]

--- a/crates/bsengine-rhi-wgpu/src/lib.rs
+++ b/crates/bsengine-rhi-wgpu/src/lib.rs
@@ -43,6 +43,8 @@ pub mod profiler;
 /// Spherical-harmonic (L2) projection, irradiance evaluation and trilinear
 /// blending for light probes.
 pub mod sh;
+/// Fitting the directional shadow map's frustum to the camera.
+pub mod shadow;
 /// Swapchain/frame lifecycle and the main scene render pass.
 pub mod surface;
 pub mod taa_jitter;

--- a/crates/bsengine-rhi-wgpu/src/shadow.rs
+++ b/crates/bsengine-rhi-wgpu/src/shadow.rs
@@ -1,0 +1,368 @@
+//! Fitting the directional shadow map's frustum to the camera.
+//!
+//! A directional light has no position, so something has to decide *which*
+//! part of the world its shadow map covers. This module makes that decision.
+//!
+//! It lives in this crate rather than in `bsengine-render`, next to the
+//! texture it is sizing itself against, for a reason worth stating: the pixel
+//! tests in `tests/pixels_lighting.rs` used to carry their own copy of this
+//! calculation, because they cannot depend on `bsengine-render`. Their own
+//! comment admitted the cost — "the shadow tests prove that the shadow
+//! pipeline darkens what *this* matrix says is occluded. They do not prove the
+//! runtime picks a good matrix." With the calculation here, the harness and
+//! the engine call the same function, and the pixel tests observe the matrix
+//! the game actually renders with.
+
+use crate::surface::SHADOW_MAP_SIZE;
+use glam::{Mat4, Vec3, Vec4};
+
+/// How far from the camera directional shadows are drawn, in world units.
+///
+/// Everything beyond this is lit as though nothing occludes it. The number is
+/// a quality-for-range trade: the shadow map is a fixed `SHADOW_MAP_SIZE`
+/// texels square, so doubling the distance roughly halves the texels per world
+/// unit and shadow edges get blockier. Covering a large world *without* paying
+/// that is what cascades do, by giving the near slice a map of its own; a
+/// single fit cannot.
+///
+/// 50 is chosen against the old behaviour rather than in the abstract. The
+/// fixed box this replaced reached 30 units from the world origin, so this is
+/// a longer reach than the engine had, not a shorter one.
+pub const SHADOW_DISTANCE: f32 = 50.0;
+
+/// Slack in front of and behind the shadowed sphere, in world units.
+///
+/// The light's near plane sits this far in front of the fitted sphere, so a
+/// caster standing between the sphere and the light is still inside the depth
+/// range instead of being clipped away and silently casting nothing.
+const SHADOW_DEPTH_MARGIN: f32 = 50.0;
+
+/// The eight world-space corners of a view-projection's frustum.
+///
+/// Near-plane corners are indices 0..4 and far-plane corners 4..8, each in the
+/// order (-x,-y), (+x,-y), (-x,+y), (+x,+y) — so `corners[i]` and
+/// `corners[i + 4]` are the two ends of one frustum edge, which is what
+/// [`slice_frustum`] relies on.
+pub fn frustum_corners_world(view_proj: Mat4) -> [Vec3; 8] {
+    let inv = view_proj.inverse();
+    let mut corners = [Vec3::ZERO; 8];
+    let mut i = 0;
+    // z spans 0..1, not -1..1: wgpu's clip space, matching the rh_zo
+    // projections the rest of the renderer builds.
+    for z in [0.0_f32, 1.0] {
+        for y in [-1.0_f32, 1.0] {
+            for x in [-1.0_f32, 1.0] {
+                let p = inv * Vec4::new(x, y, z, 1.0);
+                corners[i] = p.truncate() / p.w;
+                i += 1;
+            }
+        }
+    }
+    corners
+}
+
+/// Reslices a frustum to the depth range `near..far`, measured in world units
+/// along the view axis from the original near plane.
+///
+/// Separate from [`directional_light_view_proj`] because this is precisely
+/// what cascaded shadow maps repeat: one call per split range, each feeding
+/// its own fit. Today there is one call, for `0..`[`SHADOW_DISTANCE`].
+pub fn slice_frustum(corners: [Vec3; 8], near: f32, far: f32) -> [Vec3; 8] {
+    let near_centre = (corners[0] + corners[1] + corners[2] + corners[3]) / 4.0;
+    let far_centre = (corners[4] + corners[5] + corners[6] + corners[7]) / 4.0;
+    let depth = (far_centre - near_centre).length();
+    if !depth.is_finite() || depth <= 1e-6 {
+        return corners;
+    }
+    // The near and far planes are parallel and `depth` apart, so all four
+    // edges advance along the view axis at the same rate: one shared
+    // parameter reslices every one of them.
+    let t_near = (near / depth).clamp(0.0, 1.0);
+    let t_far = (far / depth).clamp(0.0, 1.0);
+    let mut out = [Vec3::ZERO; 8];
+    for i in 0..4 {
+        out[i] = corners[i].lerp(corners[i + 4], t_near);
+        out[i + 4] = corners[i].lerp(corners[i + 4], t_far);
+    }
+    out
+}
+
+/// The directional shadow pass's orthographic view-projection, fitted around
+/// the part of the camera's view that is close enough to shadow.
+///
+/// Uses rh_zo (0..1 depth) to match wgpu's depth buffer convention.
+///
+/// # Why this takes the camera
+///
+/// This used to look at `Vec3::ZERO` unconditionally, pinning the shadowed
+/// region to a fixed 60x60 box on the world origin however far away the player
+/// walked. `games/scale-level`'s authored entities span x = 0..152, so most of
+/// that shipped level could never receive a directional shadow — not at any
+/// resolution, because the frustum did not move.
+///
+/// # Why a sphere
+///
+/// The region is fitted as the bounding *sphere* of the sliced frustum, not as
+/// a tight box around it. A box refitted each frame changes size as the camera
+/// turns, and a shadow map whose world-per-texel ratio changes every frame
+/// makes every shadow edge crawl. Rotating the camera rotates all eight
+/// corners rigidly about it, so a sphere's radius is untouched by rotation and
+/// the ratio holds still. Unity calls this "stable fit", and it is why
+/// Unreal's whole-scene dynamic shadow also fits a sphere.
+///
+/// The cost is that a sphere is a loose fit — wider than a tight box would
+/// need — which is resolution traded for the absence of crawling.
+pub fn directional_light_view_proj(light_dir: Vec3, camera_view_proj: Mat4) -> Mat4 {
+    let dir = light_dir.normalize_or(Vec3::NEG_Y);
+    let corners = slice_frustum(
+        frustum_corners_world(camera_view_proj),
+        0.0,
+        SHADOW_DISTANCE,
+    );
+    let centre = corners.iter().copied().sum::<Vec3>() / 8.0;
+    let radius = corners
+        .iter()
+        .map(|c| c.distance(centre))
+        .fold(0.0_f32, f32::max);
+    // A degenerate camera — identity matrices before one exists, a zero-extent
+    // viewport — still has to yield an invertible matrix rather than an
+    // orthographic projection of width zero.
+    let (centre, radius) = if centre.is_finite() && radius.is_finite() && radius > 1e-3 {
+        (centre, radius)
+    } else {
+        (Vec3::ZERO, 1.0)
+    };
+    let up = if dir.y.abs() < 0.999 {
+        Vec3::Y
+    } else {
+        Vec3::Z
+    };
+    // Snapped to whole texels *in light space*, the space the shadow map is
+    // rasterized in — snapping in world space would align it to nothing.
+    // Without this the sphere slides a fraction of a texel each frame and the
+    // edges crawl even though the radius is stable.
+    //
+    // The basis is built from the light direction alone, deliberately.
+    // Measured against a view matrix that is itself aimed at the centre, the
+    // centre sits at that view's origin — where rounding it does nothing at
+    // all. This was written that way first, and the snapping stayed dead code
+    // until a mutation test deleted it and not one test failed.
+    let basis = Mat4::look_at_rh(Vec3::ZERO, dir, up);
+    let texel = 2.0 * radius / SHADOW_MAP_SIZE as f32;
+    let centre_ls = basis.transform_point3(centre);
+    let snapped_ls = Vec3::new(
+        (centre_ls.x / texel).round() * texel,
+        (centre_ls.y / texel).round() * texel,
+        centre_ls.z,
+    );
+    let centre = basis.inverse().transform_point3(snapped_ls);
+    let eye = centre - dir * (radius + SHADOW_DEPTH_MARGIN);
+    let view = Mat4::look_at_rh(eye, centre, up);
+    let proj = Mat4::orthographic_rh(
+        -radius,
+        radius,
+        -radius,
+        radius,
+        0.1,
+        2.0 * radius + 2.0 * SHADOW_DEPTH_MARGIN,
+    );
+    proj * view
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A camera at `eye` looking at `target`, with the projection the engine
+    /// builds for a 16:9 viewport.
+    fn camera(eye: Vec3, target: Vec3) -> Mat4 {
+        Mat4::perspective_rh(60.0_f32.to_radians(), 16.0 / 9.0, 0.1, 100.0)
+            * Mat4::look_at_rh(eye, target, Vec3::Y)
+    }
+
+    /// Whether a world-space point lands inside the shadow map's clip volume.
+    fn shadowed(vp: Mat4, p: Vec3) -> bool {
+        let c = vp * p.extend(1.0);
+        if c.w.abs() <= f32::EPSILON {
+            return false;
+        }
+        let n = c.truncate() / c.w;
+        (-1.0..=1.0).contains(&n.x) && (-1.0..=1.0).contains(&n.y) && (0.0..=1.0).contains(&n.z)
+    }
+
+    const SUN: Vec3 = Vec3::new(-0.3, -1.0, -0.2);
+
+    /// Whether a matrix is genuinely invertible, asserted as a round trip.
+    ///
+    /// These tests read `determinant().abs() > 1e-6` before. An orthographic
+    /// matrix's determinant shrinks with the volume it covers, so that
+    /// threshold was quietly also an assertion about the fit's *size*: a
+    /// mutation that widened the fit to the camera's whole 100-unit frustum
+    /// failed it, while the matrix inverted perfectly well. Cascades will fit
+    /// wider boxes on purpose.
+    fn inverts_cleanly(vp: Mat4) -> bool {
+        let inv = vp.inverse();
+        inv.to_cols_array().iter().all(|f| f.is_finite())
+            && (vp * inv).abs_diff_eq(Mat4::IDENTITY, 1e-3)
+    }
+
+    #[test]
+    fn light_view_proj_is_invertible() {
+        let vp = directional_light_view_proj(
+            Vec3::new(-0.4, -0.8, -0.4).normalize(),
+            camera(Vec3::new(0.0, 4.0, 7.0), Vec3::ZERO),
+        );
+        assert!(inverts_cleanly(vp), "light VP should be invertible: {vp:?}");
+    }
+
+    #[test]
+    fn light_view_proj_up_axis_does_not_degenerate() {
+        // Straight down — the up vector has to switch to Z without NaN.
+        let vp = directional_light_view_proj(
+            Vec3::new(0.0, -1.0, 0.0),
+            camera(Vec3::new(0.0, 4.0, 7.0), Vec3::ZERO),
+        );
+        assert!(inverts_cleanly(vp), "{vp:?}");
+    }
+
+    #[test]
+    fn a_degenerate_camera_still_yields_an_invertible_matrix() {
+        let vp = directional_light_view_proj(SUN, Mat4::ZERO);
+        assert!(
+            inverts_cleanly(vp),
+            "a zero camera matrix must not produce a zero-width projection: {vp:?}"
+        );
+        assert!(vp.to_cols_array().iter().all(|f| f.is_finite()), "{vp:?}");
+    }
+
+    /// The defect this module was written to fix. The old fit centred a fixed
+    /// box on the world origin, so a camera looking at the far end of a long
+    /// level shadowed nothing it could see.
+    #[test]
+    fn the_shadowed_region_follows_the_camera() {
+        // Roughly where `games/scale-level` ends: its entities span x = 0..152.
+        let far = Vec3::new(140.0, 0.0, 0.0);
+        let vp = directional_light_view_proj(SUN, camera(far + Vec3::new(0.0, 4.0, 7.0), far));
+        assert!(
+            shadowed(vp, far),
+            "what the camera is looking at must be inside the shadow frustum; \
+             at x = {} it was not",
+            far.x
+        );
+        assert!(
+            !shadowed(vp, Vec3::ZERO),
+            "and the world origin, 140 units behind the camera, must not be — \
+             otherwise the region did not move, it merely grew"
+        );
+    }
+
+    /// The converse, asserted in the same shape so neither can pass alone: a
+    /// camera at the origin must shadow the origin and *not* the far end.
+    #[test]
+    fn the_shadowed_region_leaves_what_the_camera_cannot_see() {
+        let vp = directional_light_view_proj(SUN, camera(Vec3::new(0.0, 4.0, 7.0), Vec3::ZERO));
+        assert!(shadowed(vp, Vec3::ZERO), "the origin is being looked at");
+        assert!(
+            !shadowed(vp, Vec3::new(140.0, 0.0, 0.0)),
+            "x = 140 is far outside {SHADOW_DISTANCE} units and must fall outside the fit"
+        );
+    }
+
+    /// The reason the fit is a sphere. Turning the camera on the spot must not
+    /// change how much world one shadow texel covers, or every shadow edge
+    /// crawls while the player looks around.
+    #[test]
+    fn turning_the_camera_does_not_resize_the_shadowed_region() {
+        let eye = Vec3::new(10.0, 4.0, 10.0);
+        // The projected width of a fixed world-space segment is the texel
+        // ratio, read off the matrix without needing the texture.
+        let width = |target: Vec3| {
+            let vp = directional_light_view_proj(SUN, camera(eye, target));
+            let a = vp * Vec3::new(0.0, 0.0, 0.0).extend(1.0);
+            let b = vp * Vec3::new(1.0, 0.0, 0.0).extend(1.0);
+            (b.x / b.w - a.x / a.w).abs()
+        };
+        let north = width(eye + Vec3::new(0.0, 0.0, -1.0));
+        let east = width(eye + Vec3::new(1.0, 0.0, 0.0));
+        let diagonal = width(eye + Vec3::new(0.7, -0.2, 0.7));
+        assert!(
+            (north - east).abs() < north * 0.01 && (north - diagonal).abs() < north * 0.01,
+            "one world unit must cover the same share of the shadow map whichever \
+             way the camera faces: {north} north, {east} east, {diagonal} diagonal"
+        );
+    }
+
+    /// Texel snapping, which is what stops shadow edges crawling as the player
+    /// walks: the shadow map's grid must advance in whole texels rather than
+    /// sliding continuously.
+    ///
+    /// Asserted as a staircase rather than as "a small step moves it a little".
+    /// The first version of this test nudged the camera a millimetre and
+    /// checked the grid moved less than a tenth of a texel — which an
+    /// unsnapped fit also satisfies, because a millimetre *is* a fortieth of a
+    /// texel here. It passed against an implementation whose snapping was
+    /// dead code.
+    #[test]
+    fn the_shadow_grid_advances_in_whole_texels() {
+        let eye = Vec3::new(10.0, 4.0, 10.0);
+        let look = Vec3::new(10.0, 0.0, 0.0);
+        let probe = Vec3::new(10.0, 0.0, 0.0);
+        let texel_clip = 2.0 / SHADOW_MAP_SIZE as f32;
+        // Where a fixed world point lands in the shadow map, as a fraction of
+        // one texel. Snapping quantises the map's origin, so this fraction is
+        // the same at every camera position; without it the point drifts
+        // smoothly across the texel and this sweeps 0..1.
+        let residual = |d: f32| {
+            let shift = Vec3::new(d, 0.0, d * 0.6);
+            let vp = directional_light_view_proj(SUN, camera(eye + shift, look + shift));
+            let c = vp * probe.extend(1.0);
+            (c.x / c.w / texel_clip).rem_euclid(1.0)
+        };
+        // Steps of roughly a third of a texel, over several texels' worth of
+        // travel, so an unsnapped fit cannot stay at one value by luck.
+        let first = residual(0.0);
+        for i in 1..12 {
+            let r = residual(i as f32 * 0.015);
+            let drift = (r - first).abs().min(1.0 - (r - first).abs());
+            assert!(
+                drift < 0.02,
+                "step {i} put the probe {r} of a texel into the grid where step 0 \
+                 put it {first}; a snapped grid holds this fixed and only a \
+                 continuously sliding one drifts"
+            );
+        }
+    }
+
+    #[test]
+    fn slicing_shortens_the_frustum_from_the_far_end() {
+        let vp = camera(Vec3::new(0.0, 0.0, 10.0), Vec3::ZERO);
+        let full = frustum_corners_world(vp);
+        let sliced = slice_frustum(full, 0.0, 20.0);
+        // The near plane is untouched and the far plane has come closer.
+        for i in 0..4 {
+            assert!(
+                (sliced[i] - full[i]).length() < 1e-3,
+                "slicing from 0 must leave the near corners alone"
+            );
+            assert!(
+                sliced[i + 4].distance(sliced[i]) < full[i + 4].distance(full[i]),
+                "corner {i}'s edge should be shorter after slicing to 20 of 100 units"
+            );
+        }
+    }
+
+    #[test]
+    fn slicing_beyond_the_far_plane_is_clamped_not_extrapolated() {
+        let vp = camera(Vec3::new(0.0, 0.0, 10.0), Vec3::ZERO);
+        let full = frustum_corners_world(vp);
+        // The camera's far plane is 100 units out; asking for 1000 must not
+        // invent a frustum ten times too big.
+        let sliced = slice_frustum(full, 0.0, 1000.0);
+        for i in 0..8 {
+            assert!(
+                (sliced[i] - full[i]).length() < 1e-3,
+                "corner {i} should be clamped to the camera's own far plane"
+            );
+        }
+    }
+}

--- a/crates/bsengine-rhi-wgpu/src/surface.rs
+++ b/crates/bsengine-rhi-wgpu/src/surface.rs
@@ -1332,7 +1332,13 @@ const _: () = assert!(
 );
 // Vertex stride: position(12) + color(12) + normal(12) + uv(8) = 44 bytes
 const VERTEX_STRIDE: u64 = 44;
-const SHADOW_MAP_SIZE: u32 = 2048;
+/// Edge length of the directional shadow map, in texels.
+///
+/// `pub(crate)` because [`crate::shadow`] fits the light's frustum to the
+/// camera and snaps it to whole texels of *this* texture. A second copy of the
+/// number over there would not fail loudly when the two drifted apart — the
+/// shadows would quietly start shimmering again.
+pub(crate) const SHADOW_MAP_SIZE: u32 = 2048;
 /// Deliberately much smaller than `SHADOW_MAP_SIZE` — at this size, 48 layers
 /// (`MAX_POINT_LIGHTS` * 6 faces) of `R32Float` is ~48 MiB; at 2048 it would be
 /// ~768 MiB, unreasonable for a secondary shadow feature.

--- a/crates/bsengine-rhi-wgpu/tests/common/mod.rs
+++ b/crates/bsengine-rhi-wgpu/tests/common/mod.rs
@@ -593,7 +593,7 @@ struct VertOut {{
             .render_frame(
                 view_proj,
                 scene.camera_pos,
-                light_view_proj(scene.light.direction),
+                light_view_proj(scene.light.direction, view_proj),
                 sky_vp_inv,
                 &draw_calls,
                 &[],
@@ -675,25 +675,16 @@ struct VertOut {{
     }
 }
 
-/// The directional shadow map's view-projection.
+/// The directional shadow map's view-projection: the engine's own, not a
+/// copy of it.
 ///
-/// This is the same calculation as `compute_light_view_proj` in
-/// `bsengine-render`. That function is private, and `bsengine-rhi-wgpu` does
-/// not depend on `bsengine-render` -- the dependency runs the other way -- so
-/// it is repeated here.
-///
-/// Worth being clear about what that costs: the shadow tests prove that the
-/// shadow pipeline darkens what *this* matrix says is occluded. They do not
-/// prove the runtime picks a good matrix.
-pub fn light_view_proj(light_dir: Vec3) -> Mat4 {
-    let dir = light_dir.normalize();
-    let up = if dir.y.abs() < 0.999 {
-        Vec3::Y
-    } else {
-        Vec3::Z
-    };
-    let eye = -dir * 50.0;
-    let view = Mat4::look_at_rh(eye, Vec3::ZERO, up);
-    let proj = Mat4::orthographic_rh(-30.0, 30.0, -30.0, 30.0, 0.1, 200.0);
-    proj * view
+/// This used to be a reimplementation, because the calculation lived in
+/// `bsengine-render` and the dependency runs the other way. Its comment was
+/// candid about the cost -- "the shadow tests prove that the shadow pipeline
+/// darkens what *this* matrix says is occluded. They do not prove the runtime
+/// picks a good matrix." The calculation now lives in this crate, so that
+/// caveat is retired: these tests render with the matrix the game renders
+/// with.
+pub fn light_view_proj(light_dir: Vec3, camera_view_proj: Mat4) -> Mat4 {
+    bsengine_rhi_wgpu::shadow::directional_light_view_proj(light_dir, camera_view_proj)
 }

--- a/crates/bsengine-rhi-wgpu/tests/pixels_lighting.rs
+++ b/crates/bsengine-rhi-wgpu/tests/pixels_lighting.rs
@@ -3,8 +3,10 @@
 //! These are the tests that found the bug they now guard. The shadow
 //! comparison sampler asked for `GreaterEqual` while the shadow pass writes
 //! ordinary forward-Z depth, so `shadow_factor` returned 0 for every fragment
-//! inside the shadow frustum -- and since the light matrix centres a 60-unit
-//! box on the origin, that was every object in every game here. The sun
+//! inside the shadow frustum -- and since the light matrix at the time centred
+//! a 60-unit box on the world origin, that was every object in every game
+//! here. (That box is gone: the frustum now follows the camera. The bug it
+//! helped hide is what these tests still guard.) The sun
 //! contributed nothing to any frame ever rendered, and no shadow was ever
 //! drawn.
 //!
@@ -23,7 +25,12 @@ use glam::Vec3;
 
 /// A big flat floor at the origin.
 fn floor(mesh: u64) -> Draw {
-    Draw::new(mesh, Vec3::ZERO).scaled(Vec3::new(20.0, 1.0, 20.0), Vec3::ZERO)
+    floor_at(mesh, Vec3::ZERO)
+}
+
+/// The same floor, centred anywhere.
+fn floor_at(mesh: u64, origin: Vec3) -> Draw {
+    Draw::new(mesh, origin).scaled(Vec3::new(20.0, 1.0, 20.0), origin)
 }
 
 /// A shallow camera, so a shadow lands beside its caster rather than being
@@ -130,32 +137,75 @@ fn the_sun_lights_a_surface_facing_it() {
     );
 }
 
-#[test]
-fn an_occluder_darkens_floor_it_does_not_cover() {
+/// The strongest darkening a cube casts onto floor it does not cover, with
+/// the whole fixture — floor, cube and camera — placed at `origin`.
+///
+/// Parameterised by position because that is the property at stake. The
+/// directional shadow frustum used to be a fixed box on the world origin, so
+/// this measurement was only ever taken where it happened to work. Taking the
+/// identical measurement somewhere else is what tells a shadow that follows
+/// the camera from one that does not.
+fn darkening_beside_a_caster(origin: Vec3) -> (f32, u32, u32, Pixels, Pixels) {
     let mut h = Harness::new();
     let plane = h.plane();
     let cube = h.cube();
-    let silhouette = cube_silhouette(&mut h, cube);
-
-    let open = h.render(&Scene {
-        draws: vec![floor(plane)],
+    let caster = || Draw::new(cube, origin + Vec3::new(0.0, 3.0, 0.0));
+    let scene = |draws: Vec<Draw>| Scene {
+        draws,
         light: sun_from_above(),
-        camera_pos: CAMERA,
+        camera_pos: origin + CAMERA,
+        look_at: origin,
         ..Scene::default()
-    });
-    let occluded = h.render(&Scene {
-        draws: vec![floor(plane), Draw::new(cube, Vec3::new(0.0, 3.0, 0.0))],
-        light: sun_from_above(),
-        camera_pos: CAMERA,
-        ..Scene::default()
-    });
+    };
 
+    // Which pixels the cube itself covers, so "the floor got darker" cannot be
+    // satisfied by the cube merely standing in front of it.
+    let empty = h.render(&scene(vec![]));
+    let cube_only = h.render(&scene(vec![caster()]));
+    let silhouette: Vec<bool> = (0..(empty.width * empty.height))
+        .map(|i| {
+            let (x, y) = (i % empty.width, i / empty.width);
+            empty.at(x, y) != cube_only.at(x, y)
+        })
+        .collect();
+
+    let open = h.render(&scene(vec![floor_at(plane, origin)]));
+    let occluded = h.render(&scene(vec![floor_at(plane, origin), caster()]));
     let (delta, x, y) = biggest_darkening_off_the_caster(&open, &occluded, &silhouette);
+    (delta, x, y, open, occluded)
+}
+
+#[test]
+fn an_occluder_darkens_floor_it_does_not_cover() {
+    let (delta, x, y, open, occluded) = darkening_beside_a_caster(Vec3::ZERO);
     assert!(
         delta > 60.0,
         "the cube should darken floor it is not standing in front of; the strongest \
          darkening away from its silhouette was {delta} at ({x}, {y}), open {:?} \
          occluded {:?}",
+        open.at(x, y),
+        occluded.at(x, y)
+    );
+}
+
+/// The defect that prompted the camera-following fit, at the level of pixels.
+///
+/// The shadow frustum was a 60-unit box centred on `Vec3::ZERO`, so a caster
+/// standing outside it cast nothing at all. `games/scale-level` is authored
+/// across x = 0..152 and most of it fell outside — the shipped demo had no
+/// directional shadows over four fifths of its length, at any resolution.
+#[test]
+fn a_caster_far_from_the_world_origin_still_shadows() {
+    // Beyond the old box by a wide margin, and inside the range the level
+    // actually uses.
+    let origin = Vec3::new(140.0, 0.0, -60.0);
+    let (delta, x, y, open, occluded) = darkening_beside_a_caster(origin);
+    assert!(
+        delta > 60.0,
+        "a cube at {origin:?} should shadow the floor exactly as one at the world \
+         origin does; the strongest darkening away from its silhouette was only \
+         {delta} at ({x}, {y}), open {:?} occluded {:?}. Near-zero here means the \
+         shadow frustum did not follow the camera.",
         open.at(x, y),
         occluded.at(x, y)
     );


### PR DESCRIPTION
## The defect

`compute_light_view_proj` looked at `Vec3::ZERO` unconditionally:

```rust
let eye = -dir * 50.0;
let view = Mat4::look_at_rh(eye, Vec3::ZERO, up);
let proj = Mat4::orthographic_rh(-30.0, 30.0, -30.0, 30.0, 0.1, 200.0);
```

A fixed 60×60 box on the world origin, however far away the player walked.
`games/scale-level` is authored across x = 0..152, so most of that shipped demo
could never receive a directional shadow — not at any resolution, because the
frustum did not move.

## The fit

The bounding **sphere** of the camera's shadow-distance sub-frustum. A sphere
rather than a tight box because a box refitted per frame changes size as the
camera turns, and a shadow map whose world-per-texel ratio moves every frame
makes every edge crawl. Rotating the camera rotates all eight corners rigidly
about it, so the radius is untouched by rotation.

Following precedent rather than inventing: Unity calls this **stable fit**, and
it is why Unreal's whole-scene dynamic shadow also fits a sphere. `slice_frustum`
is split out because that is precisely the per-cascade operation CSM repeats —
one call per split range.

## The pixel tests could not have caught this

`tests/common/mod.rs` carried a **second copy** of the light matrix, because the
pixel tests cannot depend on `bsengine-render`. Its own comment was candid:

> the shadow tests prove that the shadow pipeline darkens what *this* matrix
> says is occluded. They do not prove the runtime picks a good matrix.

I wrote the fix in `bsengine-render` first, where no pixel test could observe
it. The calculation now lives in `bsengine-rhi-wgpu::shadow`, next to the
texture it sizes itself against; harness and engine call one function, and
`SHADOW_MAP_SIZE` is shared instead of duplicated.

## Mutation-verified

Each mutation fails exactly its intended test:

| mutation | fails |
|---|---|
| re-centre frustum on origin | `the_shadowed_region_follows_the_camera` + pixel test — darkening collapses to **1** (163→162) |
| remove texel snapping | `the_shadow_grid_advances_in_whole_texels` |
| sphere → rotation-dependent box | `turning_the_camera_does_not_resize_the_shadowed_region` |
| never apply `SHADOW_DISTANCE` | both region tests |

**The second one found a real bug rather than confirming one.** My snapping was
dead code: it measured the centre against a view matrix aimed at that same
centre, where the centre sits at the origin and rounding it does nothing.
Deleting the entire block failed no test. It now snaps against a basis built
from the light direction alone.

The test that should have caught it was also wrong — a 1mm nudge is a fortieth
of a texel, so "moves less than a tenth of a texel" passed unsnapped too. It now
asserts the staircase: a fixed world point holds the same fractional position
across 12 camera steps.

Two inherited `determinant() > 1e-6` assertions became round-trip checks. An
orthographic determinant shrinks with the volume covered, so that threshold was
quietly an assertion about the fit's *size* — the `SHADOW_DISTANCE` mutation
tripped it spuriously, and cascades will fit wider boxes on purpose.

## Trade-off

At `SHADOW_DISTANCE = 50` the sphere is ~90 units across versus the old 60, so
near-camera shadows are somewhat blockier in exchange for existing away from the
origin at all. Recovering that resolution is what CSM is for — the next PR.

Draw counts are **unchanged**: the shadow pass does not cull against the light
frustum, so this costs texel density, not CPU.

## Verification

- workspace suite (`--exclude bsengine-editor`): exit 0, zero failures
- `bsengine-editor --lib`: 941 passed (baseline)
- `cargo +nightly fmt --all`: clean
- catalogue: 72 components / 278 ops, unchanged (no scripting surface added)
- clippy: 11 warning sites, none in code this branch wrote
- **12/12 E2E replays**, including `games/scale-level/walkthrough`
- **24/24 packaging combinations** (12 projects × loose/pak), `dist` cleared per project

Out of scope, noted while reading: shadow casters come from the camera-culled
draw list, so an object behind the camera casts nothing into view. Pre-existing
and unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)